### PR TITLE
Build optimized application binaries in devenv

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -372,6 +372,10 @@ in {
     '{}')"
   '';
 
+  scripts.build-release.exec = ''
+    cargo +1.94.1 build --release --bin fund --bin dashboard
+  '';
+
   scripts.provision-development-application-vm.exec = "bash tools/provision-application-vm --environment development";
   scripts.provision-production-application-vm.exec = "bash tools/provision-application-vm --environment production";
   scripts.provision-development-trainer-vm.exec = "bash tools/provision-trainer-vm --environment development";
@@ -660,7 +664,7 @@ in {
       exec = ''
         set -euo pipefail
         ${runtimeEnv}
-        exec secretspec run -- cargo run --release --bin fund -- --module data
+        exec secretspec run -- ./target/release/fund --module data
       '';
       process-compose.depends_on.schema.condition = "process_completed_successfully";
       process-compose.shutdown.signal = 15;
@@ -671,7 +675,7 @@ in {
       exec = ''
         set -euo pipefail
         ${runtimeEnv}
-        exec secretspec run -- cargo run --release --bin fund -- --module inference
+        exec secretspec run -- ./target/release/fund --module inference
       '';
       process-compose.depends_on.schema.condition = "process_completed_successfully";
       process-compose.shutdown.signal = 15;
@@ -682,7 +686,7 @@ in {
       exec = ''
         set -euo pipefail
         ${runtimeEnv}
-        exec secretspec run -- cargo run --release --bin fund -- --module portfolio
+        exec secretspec run -- ./target/release/fund --module portfolio
       '';
       process-compose.depends_on.schema.condition = "process_completed_successfully";
       process-compose.shutdown.signal = 15;
@@ -693,7 +697,7 @@ in {
       exec = ''
         set -euo pipefail
         export DATABASE_URL="postgresql://dashboard_reader@localhost:5432/fund"
-        exec cargo run --release --features dashboard --bin dashboard
+        exec ./target/release/dashboard
       '';
       process-compose.depends_on.schema.condition = "process_completed_successfully";
     };


### PR DESCRIPTION
## Summary

- Add a `build-release` devenv script for the pinned Rust toolchain.
- Build the `fund` and `dashboard` release binaries explicitly.
- Run application processes from `target/release` instead of invoking `cargo run` on every process start.

## Why

The application profile should run optimized binaries while keeping the build step explicit and reproducible inside devenv.

## Validation

- Non-Nix pre-commit hooks passed or had no applicable files.
- `check-nix` was skipped because its executable is unavailable in the current environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a release build command that creates optimized binaries for the core services and dashboard.

* **Improvements**
  * Updated local service profiles to run prebuilt release binaries, improving startup consistency and avoiding repeated compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->