### PR TITLE
Keep in-code documentation concise and durable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,10 @@ This is a collection of guidelines and references.
 - AWS Secrets Manager stores secrets in secretspec format (`secretspec/{project}/{profile}/{key}`)
 - Use `devenv tasks run checks:rust` for comprehensive Rust checks
 - Document sparingly and durably - write language-appropriate docstrings for functions, types, and modules, and add
-  in-line comments only where a step is genuinely surprising; docstring says what something is for, plus any
+  in-line comments only where a step is genuinely surprising; a docstring says what something is for, plus any
   caveat, invariant, or assumption a caller cannot read off the signature — it never restates the implementation,
-  because prose duplicating the code silently falls out of sync and module documentations are a few lines of high-level
-  orientation, not an inventory of their contents
+  because prose duplicating the code silently falls out of sync and module documentation is a few lines of high-level
+  orientation, not an inventory of its contents
 - Spell identifiers out fully in code (variables, functions, fields, modules): prefer `dataframe` over
   `df`, `message` over `msg`, `error_message` over `err_msg`, `quantity` over `qty`, `index` over `idx`,
   `column` over `col`, `value` over `val`, `volatility` over `vol`, `profit_and_loss` over `pnl`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,11 @@ This is a collection of guidelines and references.
 - AWS S3 is used for blob storage
 - AWS Secrets Manager stores secrets in secretspec format (`secretspec/{project}/{profile}/{key}`)
 - Use `devenv tasks run checks:rust` for comprehensive Rust checks
-- Add in-line code comments only where necessary for clarity; include language-appropriate docstrings for functions and
-  modules
+- Document sparingly and durably - write language-appropriate docstrings for functions, types, and modules, and add
+  in-line comments only where a step is genuinely surprising; docstring says what something is for, plus any
+  caveat, invariant, or assumption a caller cannot read off the signature — it never restates the implementation,
+  because prose duplicating the code silently falls out of sync and module documentations are a few lines of high-level
+  orientation, not an inventory of their contents
 - Spell identifiers out fully in code (variables, functions, fields, modules): prefer `dataframe` over
   `df`, `message` over `msg`, `error_message` over `err_msg`, `quantity` over `qty`, `index` over `idx`,
   `column` over `col`, `value` over `val`, `volatility` over `vol`, `profit_and_loss` over `pnl`,


### PR DESCRIPTION
# Overview

## Changes

- Replace the CLAUDE.md comments-and-docstrings bullet with a single consolidated one governing how much in-code documentation to write
- Scope a docstring to what the code cannot say for itself: what a function or type is for, plus any caveat, invariant, or assumption a caller cannot read off the signature
- Reserve in-line comments for genuinely surprising steps, and module documentation for a few lines of orientation rather than an inventory of contents

## Context

Generated docstrings have tended toward restating the implementation. That prose is the first thing to fall out of sync, because it needs editing whenever the body changes even when the signature does not, and nothing forces that edit to happen.

The operative test is the drift one: if a line would need editing when the body changes but the signature does not, it does not belong. Caveats and assumptions stay explicitly in scope, since those are not recoverable by reading the code.

This governs new and modified code only. Existing docstrings are untouched; a cleanup pass over `src/` and `models/` would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation guidelines to favor concise, durable, language-appropriate docstrings.
  * Clarified that comments should focus on surprising behavior, assumptions, invariants, and important caveats.
  * Added guidance for brief, high-level module documentation without duplicating implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->