### PR TITLE
Make capital flows and snapshot gaps visible

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -152,6 +152,9 @@ CREATE TABLE IF NOT EXISTS account_activities (
     side              TEXT,
     quantity          NUMERIC,
     price             NUMERIC,
+    -- Transfers carry a net cash amount instead of a quantity and a price, and it is the only
+    -- field saying how much a deposit moved. Negative for withdrawals and fees.
+    net_amount        NUMERIC,
     order_id          TEXT,
     fetched_at        TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -13,7 +13,8 @@
 use std::collections::HashSet;
 use std::num::NonZeroU32;
 
-use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
+use chrono::{DateTime, NaiveDate, NaiveTime, TimeZone, Utc};
+use chrono_tz::America::New_York;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 use tracing::{debug, info, warn};
@@ -688,11 +689,22 @@ impl AccountSnapshot {
     }
 }
 
-/// One account activity: a fill, a fee, a dividend.
+/// The activity type carrying trade fills.
+pub const FILL_ACTIVITY_TYPE: &str = "FILL";
+
+/// Activity types that move capital into or out of the account from outside it.
+///
+/// The distinction that matters is external flow versus return, not cash versus non-cash: `INT`,
+/// `DIV`, and `FEE` also move the balance, but they are performance and must never be netted out of
+/// a return. `CSD` and `CSW` are bank deposits and withdrawals; `JNLC` is cash journalled between
+/// accounts on Alpaca's own books, which is how paper accounts are funded.
+pub const TRANSFER_ACTIVITY_TYPES: [&str; 3] = ["CSD", "CSW", "JNLC"];
+
+/// One account activity: a fill, a fee, a dividend, a transfer.
 ///
 /// Fields beyond the identity are optional because Alpaca omits rather than zeroes, and which ones
 /// are present depends on the activity type — a `FILL` carries a symbol, side, quantity, and price;
-/// a `FEE` carries none of them.
+/// a `FEE` carries none of them; a transfer carries only `net_amount`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AccountActivity {
     id: String,
@@ -702,6 +714,7 @@ pub struct AccountActivity {
     side: Option<String>,
     shares: Option<Decimal>,
     price: Option<Decimal>,
+    net_amount: Option<Decimal>,
     order_id: Option<String>,
 }
 
@@ -715,6 +728,7 @@ impl AccountActivity {
         side: Option<String>,
         shares: Option<Decimal>,
         price: Option<Decimal>,
+        net_amount: Option<Decimal>,
         order_id: Option<String>,
     ) -> Self {
         Self {
@@ -725,6 +739,7 @@ impl AccountActivity {
             side,
             shares,
             price,
+            net_amount,
             order_id,
         }
     }
@@ -756,6 +771,14 @@ impl AccountActivity {
 
     pub fn price(&self) -> Option<Decimal> {
         self.price
+    }
+
+    /// The signed cash effect of a non-trade activity, as Alpaca reports it.
+    ///
+    /// Transfers carry this instead of quantity and price, so it is the only field that says how
+    /// much a deposit moved. Negative for withdrawals and fees.
+    pub fn net_amount(&self) -> Option<Decimal> {
+        self.net_amount
     }
 
     pub fn order_id(&self) -> Option<&str> {
@@ -1025,12 +1048,10 @@ impl TradingClient {
             let last_id = payloads.last().map(|payload| payload.id.clone());
 
             for payload in payloads {
-                let Some(transaction_time) = payload.transaction_time.or_else(|| {
-                    payload
-                        .date
-                        .and_then(|day| day.and_hms_opt(0, 0, 0))
-                        .map(|naive| naive.and_utc())
-                }) else {
+                let Some(transaction_time) = payload
+                    .transaction_time
+                    .or_else(|| payload.date.map(eastern_midnight))
+                else {
                     undated += 1;
                     continue;
                 };
@@ -1047,6 +1068,11 @@ impl TradingClient {
                         .and_then(decimal_or_none),
                     payload
                         .price
+                        .as_deref()
+                        .map(str::trim)
+                        .and_then(decimal_or_none),
+                    payload
+                        .net_amount
                         .as_deref()
                         .map(str::trim)
                         .and_then(decimal_or_none),
@@ -1079,6 +1105,27 @@ impl TradingClient {
         debug!(activity_type, %date, activities = activities.len(), "Account activities fetched");
         Ok(activities)
     }
+}
+
+/// Midnight Eastern on a settlement date, as the equivalent UTC instant.
+///
+/// Non-trade activities carry a `date` and no time, but `account_activities.transaction_time` is
+/// `NOT NULL`, so an instant has to be chosen. Eastern midnight is the only choice that round-trips:
+/// consumers recover the session with `SessionDate::at`, which reads the Eastern calendar day, so
+/// midnight UTC would resolve to the *previous* session for the whole Eastern evening and file a
+/// transfer against the wrong day's capital flows.
+///
+/// Duplicates `SessionDate::midnight`, which cannot be called from here: it lives in
+/// `data::calendar`, and that module already depends on this one.
+fn eastern_midnight(date: NaiveDate) -> DateTime<Utc> {
+    let local_midnight = date
+        .and_hms_opt(0, 0, 0)
+        .expect("midnight is a valid wall-clock time");
+    New_York
+        .from_local_datetime(&local_midnight)
+        .earliest()
+        .map(|zoned| zoned.with_timezone(&Utc))
+        .unwrap_or_else(|| local_midnight.and_utc())
 }
 
 /// Collapses Alpaca's order status vocabulary into [`OrderState`].
@@ -1201,6 +1248,9 @@ struct ActivityResponse {
     side: Option<String>,
     qty: Option<String>,
     price: Option<String>,
+    /// Present on non-trade activities, which carry a net cash amount rather than a quantity and a
+    /// price.
+    net_amount: Option<String>,
     order_id: Option<String>,
 }
 
@@ -2231,6 +2281,7 @@ mod tests {
                 Some(Decimal::new(10, 0)),
                 Some(Decimal::new(15050, 2)),
                 None,
+                None,
             )
         };
         assert_eq!(
@@ -2259,9 +2310,11 @@ mod tests {
             None,
             None,
             None,
+            Some(Decimal::new(-2, 2)),
             None,
         );
         assert_eq!(fee.signed_cash_flow(), None);
+        assert_eq!(fee.net_amount(), Some(Decimal::new(-2, 2)));
     }
 
     /// `account_activities.transaction_time` is NOT NULL, so an activity with neither a time nor a
@@ -2288,6 +2341,116 @@ mod tests {
 
         assert_eq!(activities.len(), 1);
         assert_eq!(activities[0].id(), "dated");
+        mock.assert_async().await;
+    }
+
+    /// A settlement date carries no time, and the instant synthesized for it decides which session
+    /// the activity lands in. Midnight UTC is still the *previous* Eastern day for the whole
+    /// evening, so a transfer dated the 15th would reconcile against the 14th's capital flows.
+    #[tokio::test]
+    async fn test_dated_activity_resolves_to_its_eastern_session() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"[{"id":"20260515000000000::journal","activity_type":"JNLC",
+                     "date":"2026-05-15","net_amount":"20000","status":"executed"}]"#,
+            )
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(credentials(), server.url());
+        let activities = client
+            .fetch_activities("JNLC", date(2026, 5, 15))
+            .await
+            .expect("activities must parse");
+
+        assert_eq!(
+            activities[0]
+                .transaction_time()
+                .with_timezone(&New_York)
+                .date_naive(),
+            date(2026, 5, 15),
+            "a dated activity must land in the session Alpaca dated it"
+        );
+        mock.assert_async().await;
+    }
+
+    /// A transfer carries neither quantity nor price, so `net_amount` is the only field saying how
+    /// much moved. Dropping it would store the deposit with no amount at all.
+    ///
+    /// The `JNLC` fixture is the shape a real paper account returns; `CSD` is what a bank deposit
+    /// into a live account books as, and has no live coverage until real money moves.
+    #[tokio::test]
+    async fn test_transfer_activities_retain_their_net_amount() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"[{"id":"20260515000000000::journal","activity_type":"JNLC",
+                     "date":"2026-05-15","net_amount":"20000","description":"",
+                     "status":"executed","currency":"USD"},
+                    {"id":"20260515000000001::deposit","activity_type":"CSD",
+                     "date":"2026-05-15","net_amount":"10000.50","status":"executed"},
+                    {"id":"20260515000000002::withdrawal","activity_type":"CSW",
+                     "date":"2026-05-15","net_amount":"-2500.25","status":"executed"}]"#,
+            )
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(credentials(), server.url());
+        let activities = client
+            .fetch_activities("JNLC", date(2026, 5, 15))
+            .await
+            .expect("activities must parse");
+
+        assert_eq!(activities.len(), 3);
+        assert_eq!(activities[0].net_amount(), Some(Decimal::new(20000, 0)));
+        assert_eq!(activities[1].net_amount(), Some(Decimal::new(1000050, 2)));
+        assert_eq!(
+            activities[2].net_amount(),
+            Some(Decimal::new(-250025, 2)),
+            "a withdrawal must keep its sign"
+        );
+        for activity in &activities {
+            assert_eq!(
+                activity.signed_cash_flow(),
+                None,
+                "a transfer is not a two-sided trade and must never be attributed to a pair"
+            );
+        }
+        mock.assert_async().await;
+    }
+
+    /// The fallback must not disturb activities that carry a real time of their own.
+    #[tokio::test]
+    async fn test_timed_activity_keeps_its_transaction_time() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"[{"id":"fill","activity_type":"FILL","transaction_time":"2026-05-15T13:45:00Z",
+                     "symbol":"AAPL","side":"buy","qty":"1","price":"150.00"}]"#,
+            )
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(credentials(), server.url());
+        let activities = client
+            .fetch_activities("FILL", date(2026, 5, 15))
+            .await
+            .expect("activities must parse");
+
+        assert_eq!(
+            activities[0].transaction_time(),
+            "2026-05-15T13:45:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
         mock.assert_async().await;
     }
 

--- a/src/dashboard/database.rs
+++ b/src/dashboard/database.rs
@@ -52,7 +52,13 @@ pub struct DashboardData {
 /// the previous state.
 pub async fn fetch_dashboard_data(pool: &PgPool) -> Result<DashboardData, sqlx::Error> {
     let equity_history = fetch_equity_history(pool).await?;
-    let transfer_sessions = fetch_transfer_sessions(pool).await?;
+    let transfer_sessions = match (equity_history.first(), equity_history.last()) {
+        (Some(first), Some(last)) => {
+            fetch_transfer_sessions(pool, first.session_date, last.session_date).await?
+        }
+        // No history means no baseline to measure from, so there is nothing a transfer could spoil.
+        _ => Vec::new(),
+    };
     let period_returns = compute_period_returns(&equity_history, &transfer_sessions);
     let open_pairs = fetch_open_pairs(pool).await?;
     let closed_pairs = fetch_closed_pairs(pool).await?;
@@ -102,18 +108,36 @@ async fn fetch_equity_history(pool: &PgPool) -> Result<Vec<AccountSnapshot>, sql
         .collect()
 }
 
-/// Fetches the sessions in which capital moved into or out of the account.
+/// Fetches the sessions in which capital moved into or out of the account, within a session range.
+///
+/// Bounded to the equity history the dashboard displays, because a transfer outside it cannot change
+/// any published figure: every baseline [`compute_period_returns`] measures from comes out of that
+/// same history. Bounding also keeps the scan off the whole table —
+/// `idx_account_activities_transaction_time` covers this predicate, and there is no index on
+/// `activity_type`.
 ///
 /// Timestamps come back raw and become sessions through [`SessionDate::at`], rather than being
-/// converted in SQL: `(transaction_time AT TIME ZONE 'America/New_York')::date` hides the column
-/// behind an expression, and one place owning the Eastern rollover is worth more than the alternative.
-async fn fetch_transfer_sessions(pool: &PgPool) -> Result<Vec<SessionDate>, sqlx::Error> {
+/// converted in SQL: `(transaction_time AT TIME ZONE 'America/New_York')::date` would hide the column
+/// behind an expression and defeat that index, which is the same reasoning
+/// [`SessionDate::bounds`] documents for itself.
+async fn fetch_transfer_sessions(
+    pool: &PgPool,
+    first: SessionDate,
+    last: SessionDate,
+) -> Result<Vec<SessionDate>, sqlx::Error> {
+    let (start, _) = first.bounds();
+    let (_, end) = last.bounds();
+
     let rows = sqlx::query(
         "SELECT transaction_time
          FROM account_activities
-         WHERE activity_type = ANY($1)",
+         WHERE activity_type = ANY($1)
+           AND transaction_time >= $2
+           AND transaction_time < $3",
     )
     .bind(TRANSFER_ACTIVITY_TYPES)
+    .bind(start)
+    .bind(end)
     .fetch_all(pool)
     .await?;
 

--- a/src/dashboard/database.rs
+++ b/src/dashboard/database.rs
@@ -14,6 +14,7 @@ use rust_decimal::Decimal;
 use sqlx::{PgPool, Row};
 use tracing::warn;
 
+use crate::common::alpaca::TRANSFER_ACTIVITY_TYPES;
 use crate::common::types::{PairID, Ticker};
 use crate::dashboard::cache::{
     AccountSnapshot, ClosedPair, ClosedSummary, EventEntry, OpenPair, PeriodReturns, Prediction,
@@ -51,7 +52,8 @@ pub struct DashboardData {
 /// the previous state.
 pub async fn fetch_dashboard_data(pool: &PgPool) -> Result<DashboardData, sqlx::Error> {
     let equity_history = fetch_equity_history(pool).await?;
-    let period_returns = compute_period_returns(&equity_history);
+    let transfer_sessions = fetch_transfer_sessions(pool).await?;
+    let period_returns = compute_period_returns(&equity_history, &transfer_sessions);
     let open_pairs = fetch_open_pairs(pool).await?;
     let closed_pairs = fetch_closed_pairs(pool).await?;
     let closed_summary = compute_closed_summary(&closed_pairs);
@@ -96,6 +98,30 @@ async fn fetch_equity_history(pool: &PgPool) -> Result<Vec<AccountSnapshot>, sql
                 long_market_value: row.try_get("long_market_value")?,
                 short_market_value: row.try_get("short_market_value")?,
             })
+        })
+        .collect()
+}
+
+/// Fetches the sessions in which capital moved into or out of the account.
+///
+/// Timestamps come back raw and become sessions through [`SessionDate::at`], rather than being
+/// converted in SQL: `(transaction_time AT TIME ZONE 'America/New_York')::date` hides the column
+/// behind an expression, and one place owning the Eastern rollover is worth more than the alternative.
+async fn fetch_transfer_sessions(pool: &PgPool) -> Result<Vec<SessionDate>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT transaction_time
+         FROM account_activities
+         WHERE activity_type = ANY($1)",
+    )
+    .bind(TRANSFER_ACTIVITY_TYPES)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(SessionDate::at(
+                row.try_get::<DateTime<Utc>, _>("transaction_time")?,
+            ))
         })
         .collect()
 }
@@ -311,14 +337,36 @@ fn baseline_at_or_before(
 }
 
 /// Computes the return over each horizon from an ascending-ordered account history.
-pub fn compute_period_returns(history: &[AccountSnapshot]) -> PeriodReturns {
+///
+/// **Flow-blind by construction.** Every figure here is a raw equity-to-equity change, so a deposit
+/// inside a horizon reads as performance — a $10,000 contribution into a flat $20,000 book publishes
+/// as +50%. Any horizon spanning a capital flow therefore returns `None` rather than a plausible
+/// wrong number. `nav_per_unit` replaces this calculation outright when the unit ledger lands, at
+/// which point the guard has nothing left to protect; see `.scratchpad/unit_accounting.md`.
+pub fn compute_period_returns(
+    history: &[AccountSnapshot],
+    transfer_sessions: &[SessionDate],
+) -> PeriodReturns {
     let Some(latest) = history.last() else {
         return PeriodReturns::default();
     };
 
+    // Flows are treated as arriving at the end of their session, so a transfer *on* the baseline
+    // session is already inside the baseline equity and does not distort the comparison. Anything
+    // strictly after it does.
+    let change_from = |baseline: &AccountSnapshot| {
+        let spans_a_flow = transfer_sessions
+            .iter()
+            .any(|session| *session > baseline.session_date && *session <= latest.session_date);
+        if spans_a_flow {
+            return None;
+        }
+        percentage_change(baseline.equity, latest.equity)
+    };
+
     let horizon = |days: i64| {
         baseline_at_or_before(history, latest.session_date.plus_calendar_days(-days))
-            .and_then(|baseline| percentage_change(baseline.equity, latest.equity))
+            .and_then(change_from)
     };
 
     // Year to date measures from the last session of the previous year, so the first session of
@@ -327,16 +375,14 @@ pub fn compute_period_returns(history: &[AccountSnapshot]) -> PeriodReturns {
     let year_to_date = year_start
         .and_then(|start| baseline_at_or_before(history, SessionDate::from_date(start.pred_opt()?)))
         .or_else(|| history.first())
-        .and_then(|baseline| percentage_change(baseline.equity, latest.equity));
+        .and_then(change_from);
 
     PeriodReturns {
         one_day: horizon(1),
         one_week: horizon(7),
         one_month: horizon(30),
         year_to_date,
-        since_inception: history
-            .first()
-            .and_then(|baseline| percentage_change(baseline.equity, latest.equity)),
+        since_inception: history.first().and_then(change_from),
     }
 }
 
@@ -471,7 +517,7 @@ mod tests {
 
     #[test]
     fn test_period_returns_are_empty_without_history() {
-        assert_eq!(compute_period_returns(&[]), PeriodReturns::default());
+        assert_eq!(compute_period_returns(&[], &[]), PeriodReturns::default());
     }
 
     #[test]
@@ -480,7 +526,7 @@ mod tests {
             snapshot("2026-07-30", "100000"),
             snapshot("2026-07-31", "101000"),
         ];
-        let returns = compute_period_returns(&history);
+        let returns = compute_period_returns(&history, &[]);
         assert_eq!(returns.one_day, Some(1.0));
         // Nothing sits at or before 2026-07-24, so a weekly return cannot be computed.
         assert_eq!(returns.one_week, None);
@@ -497,7 +543,7 @@ mod tests {
             snapshot("2026-07-31", "110000"),
         ];
         // 2026-07-31 minus seven days is 2026-07-24, a Friday, and it is in the series.
-        assert_eq!(compute_period_returns(&history).one_week, Some(10.0));
+        assert_eq!(compute_period_returns(&history, &[]).one_week, Some(10.0));
 
         let shifted = vec![
             snapshot("2026-07-23", "100000"),
@@ -505,7 +551,7 @@ mod tests {
             snapshot("2026-07-31", "110000"),
         ];
         // The cutoff now falls on a day with no session, so the prior one is used.
-        assert_eq!(compute_period_returns(&shifted).one_week, Some(10.0));
+        assert_eq!(compute_period_returns(&shifted, &[]).one_week, Some(10.0));
     }
 
     #[test]
@@ -515,7 +561,10 @@ mod tests {
             snapshot("2026-01-02", "102000"),
             snapshot("2026-07-31", "120000"),
         ];
-        assert_eq!(compute_period_returns(&history).year_to_date, Some(20.0));
+        assert_eq!(
+            compute_period_returns(&history, &[]).year_to_date,
+            Some(20.0)
+        );
     }
 
     #[test]
@@ -524,7 +573,10 @@ mod tests {
             snapshot("2026-01-02", "100000"),
             snapshot("2026-07-31", "125000"),
         ];
-        assert_eq!(compute_period_returns(&history).year_to_date, Some(25.0));
+        assert_eq!(
+            compute_period_returns(&history, &[]).year_to_date,
+            Some(25.0)
+        );
     }
 
     /// A zero baseline is a division by zero, and it is reachable: the first snapshot of an account
@@ -535,9 +587,72 @@ mod tests {
             snapshot("2026-07-30", "0"),
             snapshot("2026-07-31", "100000"),
         ];
-        let returns = compute_period_returns(&history);
+        let returns = compute_period_returns(&history, &[]);
         assert_eq!(returns.one_day, None);
         assert_eq!(returns.since_inception, None);
+    }
+
+    fn session(date: &str) -> SessionDate {
+        SessionDate::from_date(
+            NaiveDate::parse_from_str(date, "%Y-%m-%d").expect("a valid test date"),
+        )
+    }
+
+    /// The bug this guard exists for: a flat book that receives a deposit publishes the deposit as
+    /// performance. $10,000 into a flat $20,000 book reads as +50%, and the error never washes out
+    /// of a cumulative series. Withholding the figure is the only correct answer until the return
+    /// series comes from `nav_per_unit`.
+    #[test]
+    fn test_a_horizon_spanning_a_capital_flow_publishes_no_return() {
+        let history = vec![
+            snapshot("2026-07-30", "20000"),
+            snapshot("2026-07-31", "30000"),
+        ];
+
+        let unguarded = compute_period_returns(&history, &[]);
+        assert_eq!(
+            unguarded.one_day,
+            Some(50.0),
+            "without the flow this really is a 50% gain"
+        );
+
+        let guarded = compute_period_returns(&history, &[session("2026-07-31")]);
+        assert_eq!(guarded.one_day, None);
+        assert_eq!(guarded.since_inception, None);
+    }
+
+    /// Flows land at the end of their session, so a transfer *on* the baseline session is already
+    /// inside the baseline equity. Refusing there would blank the dashboard for a year after a
+    /// contribution that does not affect the comparison at all.
+    #[test]
+    fn test_a_flow_on_the_baseline_session_does_not_withhold_the_return() {
+        let history = vec![
+            snapshot("2026-07-30", "20000"),
+            snapshot("2026-07-31", "22000"),
+        ];
+        let returns = compute_period_returns(&history, &[session("2026-07-30")]);
+        assert_eq!(returns.one_day, Some(10.0));
+    }
+
+    /// A flow outside the window says nothing about the window. Only horizons reaching back across
+    /// it are withheld, so a deposit does not blank every figure on the page forever.
+    #[test]
+    fn test_a_flow_outside_the_window_leaves_shorter_horizons_intact() {
+        let history = vec![
+            snapshot("2026-07-24", "100000"),
+            snapshot("2026-07-27", "100000"),
+            snapshot("2026-07-31", "110000"),
+        ];
+        let returns = compute_period_returns(&history, &[session("2026-07-27")]);
+        assert_eq!(
+            returns.one_week, None,
+            "the weekly baseline is 2026-07-24, so its window spans the flow"
+        );
+        assert_eq!(
+            returns.one_day,
+            Some(10.0),
+            "the daily baseline is 2026-07-27 itself, so the flow is already inside it"
+        );
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -424,7 +424,7 @@ async fn handle_account_sync(state: &ServiceState) -> Result<Value, HandlerError
         return Ok(json!({ "skipped": "not_a_trading_day", "session_date": today }));
     }
 
-    let summary = account::sync_account(&state.pool, &state.trading, today).await?;
+    let summary = account::sync_account(&state.pool, &state.trading, &calendar, today).await?;
     Ok(serde_json::to_value(summary).unwrap_or_else(|_| json!({})))
 }
 

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -1,12 +1,16 @@
 //! The post-close account sync: what Alpaca says actually happened.
 //!
 //! Three things, in order. Balances land in `account_snapshots`, whose `equity` is what the *next*
-//! session's drawdown gate measures against. Fills land in `account_activities`, keyed by Alpaca's
-//! activity identifier so a re-run conflicts on every row and changes nothing. Then the fills are
-//! attributed back to their pairs.
+//! session's drawdown gate measures against. Fills and transfers land in `account_activities`,
+//! keyed by Alpaca's activity identifier so a re-run conflicts on every row and changes nothing.
+//! Then the fills — and only the fills — are attributed back to their pairs.
 //!
 //! Attribution is a materialization, not a source: `realized_profit_and_loss` exists so the
 //! dashboard need not re-join activities to pairs on every page load.
+//!
+//! Transfers are stored because they are read, not because they are attributed: a capital flow
+//! makes every equity-derived return wrong, and the dashboard withholds those figures rather than
+//! publishing them. Nothing here decides *whose* capital moved — Alpaca does not know.
 
 use std::collections::HashMap;
 
@@ -16,16 +20,26 @@ use sqlx::PgPool;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::common::alpaca::{AccountActivity, AccountSnapshot, ClientError, TradingClient};
-use crate::data::calendar::SessionDate;
+use crate::common::alpaca::{
+    AccountActivity, AccountSnapshot, ClientError, TradingClient, FILL_ACTIVITY_TYPE,
+    TRANSFER_ACTIVITY_TYPES,
+};
+use crate::data::calendar::{SessionDate, TradingCalendar};
 use crate::portfolio::pairs::{self, ClosedPair, PairsError};
 
-/// The activity type carrying trade fills.
+/// The activity types this sync fetches and stores.
 ///
-/// Only fills are synced today. Fees, dividends, and interest are real and the table can hold them,
-/// but nothing reads them until the dashboard is rewritten, and syncing a type nothing consumes is
-/// how a column full of untested parsing gets discovered in production.
-pub const FILL_ACTIVITY_TYPE: &str = "FILL";
+/// Fills, because they are attributed to pairs, plus transfers, because a capital flow invalidates
+/// every equity-derived return the dashboard publishes and something has to see it arrive.
+///
+/// `INT`, `DIV`, and `FEE` are deliberately absent. They are return rather than external flow, so
+/// nothing consumes them yet, and syncing a type nothing reads is how a column full of untested
+/// parsing gets discovered in production. They join when the unit ledger needs them.
+pub fn synced_activity_types() -> Vec<&'static str> {
+    std::iter::once(FILL_ACTIVITY_TYPE)
+        .chain(TRANSFER_ACTIVITY_TYPES)
+        .collect()
+}
 
 /// Errors syncing the account.
 #[derive(Debug, thiserror::Error)]
@@ -46,31 +60,58 @@ pub struct AccountSyncSummary {
     pub activities_stored: u64,
     pub pairs_attributed: usize,
     pub activities_unattributed: usize,
+    /// The previous trading session, when it has no snapshot — a hole in the equity series that a
+    /// future time-weighted return cannot chain across.
+    pub previous_session_gap: Option<SessionDate>,
 }
 
 /// Runs the whole post-close sync for one session date.
 pub async fn sync_account(
     pool: &PgPool,
     client: &TradingClient,
+    calendar: &TradingCalendar,
     session_date: SessionDate,
 ) -> Result<AccountSyncSummary, AccountError> {
     let account = client.fetch_account().await?;
     store_snapshot(pool, session_date, &account).await?;
+    let previous_session_gap = missing_previous_snapshot(pool, calendar, session_date).await;
 
-    let activities = client
-        .fetch_activities(FILL_ACTIVITY_TYPE, session_date.date())
-        .await?;
+    // One request per type: Alpaca puts the activity type in the URL path, and the sync already
+    // tolerates several round trips.
+    let mut activities = Vec::new();
+    for activity_type in synced_activity_types() {
+        activities.extend(
+            client
+                .fetch_activities(activity_type, session_date.date())
+                .await?,
+        );
+    }
     let activities_stored = store_activities(pool, &activities).await?;
 
     let (start, end) = session_date.bounds();
     let closed = pairs::load_closed_between(pool, start, end).await?;
-    let attribution = attribute(&closed, &activities);
+    // Only fills reach `attribute`. A transfer has no ticker and no signed cash flow, so passing
+    // one in would count it as unattributed and warn on every session that received capital.
+    let fills: Vec<AccountActivity> = activities
+        .iter()
+        .filter(|activity| activity.activity_type() == FILL_ACTIVITY_TYPE)
+        .cloned()
+        .collect();
+    let attribution = attribute(&closed, &fills);
 
     let mut pairs_attributed = 0;
     for (id, amount) in &attribution.realized {
         if pairs::record_realized_profit_and_loss(pool, *id, *amount).await? {
             pairs_attributed += 1;
         }
+    }
+
+    if let Some(previous) = previous_session_gap {
+        warn!(
+            %previous,
+            %session_date,
+            "Previous trading session has no account snapshot; the equity series has a gap"
+        );
     }
 
     info!(
@@ -87,6 +128,7 @@ pub async fn sync_account(
         equity: account.equity(),
         activities_stored,
         pairs_attributed,
+        previous_session_gap,
         activities_unattributed: attribution.unattributed,
     })
 }
@@ -140,7 +182,8 @@ pub async fn store_activities(
     for chunk in activities.chunks(1_000) {
         let mut query_builder = sqlx::QueryBuilder::new(
             "INSERT INTO account_activities \
-             (id, activity_type, transaction_time, ticker, side, quantity, price, order_id) ",
+             (id, activity_type, transaction_time, ticker, side, quantity, price, net_amount, \
+              order_id) ",
         );
         query_builder.push_values(chunk, |mut builder, activity| {
             builder
@@ -151,6 +194,7 @@ pub async fn store_activities(
                 .push_bind(activity.side().map(str::to_string))
                 .push_bind(activity.shares())
                 .push_bind(activity.price())
+                .push_bind(activity.net_amount())
                 .push_bind(activity.order_id().map(str::to_string));
         });
         query_builder.push(" ON CONFLICT (id) DO NOTHING");
@@ -169,6 +213,35 @@ pub async fn store_activities(
         "Account activities stored"
     );
     Ok(rows_affected)
+}
+
+/// The previous trading session, when it has no snapshot of its own.
+///
+/// A sync that failed at 16:15 leaves a hole nothing else notices, and the equity series is what a
+/// time-weighted return will eventually be folded from — a fold cannot chain across a missing
+/// session, and by the time one is discovered it may be months old.
+/// `/v2/account/portfolio/history` can refill it.
+///
+/// Asking the calendar for the previous session, rather than testing a date against
+/// [`TradingCalendar::is_trading_day`], is deliberate: it only ever returns days it actually holds,
+/// so a date beyond the fetched horizon cannot pass for a holiday. `None` means either no gap or no
+/// calendar reaching back that far, and neither is worth failing the sync over.
+async fn missing_previous_snapshot(
+    pool: &PgPool,
+    calendar: &TradingCalendar,
+    session_date: SessionDate,
+) -> Option<SessionDate> {
+    let previous = calendar.previous_trading_day(session_date)?;
+    match load_equity_for(pool, previous).await {
+        Ok(None) => Some(previous),
+        Ok(Some(_)) => None,
+        // A read failure says nothing about whether a gap exists, and the sync's real work is
+        // already done. Reporting it and continuing beats failing the session over a diagnostic.
+        Err(error) => {
+            warn!(%error, %previous, "Could not check the previous session for a gap");
+            None
+        }
+    }
 }
 
 /// Reads the equity recorded for a session, if one was.
@@ -298,6 +371,7 @@ mod tests {
             Some(Decimal::from(shares)),
             Some(Decimal::from(price)),
             None,
+            None,
         )
     }
 
@@ -371,6 +445,7 @@ mod tests {
             "FEE".to_string(),
             instant(16, 0),
             Some(ticker("AAAA")),
+            None,
             None,
             None,
             None,

--- a/tests/test_dashboard.rs
+++ b/tests/test_dashboard.rs
@@ -278,3 +278,70 @@ async fn test_open_and_closed_pairs_do_not_appear_in_each_others_sections() {
     assert_eq!(open_identifiers, vec!["AAPL-MSFT"]);
     assert_eq!(closed_identifiers, vec!["GOOG-AMZN"]);
 }
+
+/// The whole flow guard, end to end against PostgreSQL.
+///
+/// The unit tests hand `compute_period_returns` a list of sessions directly, which proves the
+/// arithmetic and nothing about how that list is obtained. This exercises the parts only a real
+/// database can: the `activity_type = ANY($1)` array bind, the range predicate, and the Eastern
+/// mapping from a stored `transaction_time` back to the session the guard compares against.
+#[tokio::test]
+#[serial]
+async fn test_a_recorded_transfer_withholds_the_returns_it_invalidates() {
+    use fund::common::alpaca::AccountActivity;
+
+    let pool = fresh_pool().await;
+    let today = SessionDate::at(Utc::now());
+    let yesterday = today.plus_calendar_days(-1);
+
+    // A flat book that doubles only because capital arrived: the exact shape the guard exists for.
+    store_equity(&pool, yesterday, "20000").await;
+    store_equity(&pool, today, "30000").await;
+
+    let baseline = fetch_dashboard_data(&pool)
+        .await
+        .expect("the dashboard must read a database with no transfers");
+    assert_eq!(
+        baseline.period_returns.one_day,
+        Some(50.0),
+        "with no transfer recorded this reads as a 50% gain, which is the bug"
+    );
+
+    // Stamped at Eastern midnight, the way a dated transfer arrives from Alpaca.
+    let transfer = |id: &str, session: SessionDate| {
+        AccountActivity::new(
+            id.to_string(),
+            "CSD".to_string(),
+            session.midnight(),
+            None,
+            None,
+            None,
+            None,
+            Some(decimal("10000")),
+            None,
+        )
+    };
+
+    // A transfer far outside the displayed history must not blank the page. It is excluded by the
+    // query's range bound and would be ignored by the guard regardless, so this pins the pair of
+    // them together: an old contribution cannot withhold today's return forever.
+    let ancient = transfer("deposit-ancient", today.plus_calendar_days(-400));
+    account::store_activities(&pool, std::slice::from_ref(&ancient))
+        .await
+        .expect("Failed to store the out-of-range transfer");
+    let unaffected = fetch_dashboard_data(&pool)
+        .await
+        .expect("the dashboard must read a database with an out-of-range transfer");
+    assert_eq!(unaffected.period_returns.one_day, Some(50.0));
+
+    let deposit = transfer("deposit-1", today);
+    account::store_activities(&pool, std::slice::from_ref(&deposit))
+        .await
+        .expect("Failed to store the transfer");
+
+    let guarded = fetch_dashboard_data(&pool)
+        .await
+        .expect("the dashboard must read a database containing a transfer");
+    assert_eq!(guarded.period_returns.one_day, None);
+    assert_eq!(guarded.period_returns.since_inception, None);
+}

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -202,6 +202,7 @@ async fn test_activities_are_idempotent_on_alpacas_identifier() {
         Some("buy".to_string()),
         Some(Decimal::from(10)),
         Some(Decimal::from(150)),
+        None,
         Some("order-1".to_string()),
     );
 

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use chrono::{Duration, NaiveTime, Utc};
 use fund::common::alpaca::{
     AlpacaCredentials, CalendarDay, DataFeed, MarketDataClient, TradingClient,
+    TRANSFER_ACTIVITY_TYPES,
 };
 use fund::common::types::{BarInterval, Ticker};
 use fund::data::bars;
@@ -64,12 +65,24 @@ fn calendar_for_today() -> TradingCalendar {
     TradingCalendar::from_days(days)
 }
 
-/// Consecutive sessions ending at `session_date`, for tests that pin a fixed date.
+/// The five most recent weekday sessions ending at `session_date`.
+///
+/// Weekends are filtered rather than taken as consecutive calendar days, so
+/// `previous_trading_day` answers what it would in production: Friday for a Monday session, not
+/// Sunday. Without the filter a Monday would silently exercise a calendar that cannot exist, and the
+/// gap test would pass while checking nothing real.
+///
+/// `is_weekend` rather than `is_trading_day` because this *builds* the calendar the latter consults;
+/// it is the case that method's own documentation names, "bounding a fetch range before the calendar
+/// is available". Holidays are not modelled — no test here turns on one.
 fn calendar_ending_at(session_date: SessionDate) -> TradingCalendar {
-    let days = (0..5)
-        .filter_map(|offset| {
+    let days = (0..10)
+        .map(|offset| session_date.plus_calendar_days(-offset))
+        .filter(|date| !date.is_weekend())
+        .take(5)
+        .filter_map(|date| {
             CalendarDay::new(
-                session_date.plus_calendar_days(-offset).date(),
+                date.date(),
                 NaiveTime::from_hms_opt(9, 30, 0).unwrap(),
                 NaiveTime::from_hms_opt(16, 0, 0).unwrap(),
             )
@@ -81,9 +94,10 @@ fn calendar_ending_at(session_date: SessionDate) -> TradingCalendar {
 /// Answers every transfer activity endpoint with an empty list.
 ///
 /// The sync asks for each synced type in turn, so a test mocking only `FILL` would have its
-/// remaining requests go unmatched.
+/// remaining requests go unmatched. Driven by the production constant so a new transfer type cannot
+/// leave these tests quietly mocking the wrong set.
 async fn mock_no_transfers(server: &mut mockito::ServerGuard) {
-    for activity_type in ["CSD", "CSW", "JNLC"] {
+    for activity_type in TRANSFER_ACTIVITY_TYPES {
         server
             .mock(
                 "GET",
@@ -762,10 +776,15 @@ async fn test_the_account_sync_is_idempotent() {
 /// of how much arrived — and it must not be mistaken for a fill along the way. `attribute` counts
 /// anything without a ticker as unattributed, so a transfer reaching it would raise a false alarm
 /// on every session that received capital.
+///
+/// `CSD` is the type a live bank deposit books as, and the one branch the paper account cannot
+/// exercise: paper funds by journal, so `CSD` has no coverage anywhere but here.
 #[tokio::test]
 #[serial]
 async fn test_the_account_sync_stores_transfers_without_attributing_them() {
     use fund::portfolio::account;
+
+    const DEPOSIT_ACTIVITY_TYPE: &str = "CSD";
 
     let pool = fresh_pool().await;
     let mut server = mockito::Server::new_async().await;
@@ -777,7 +796,12 @@ async fn test_the_account_sync_stores_transfers_without_attributing_them() {
         .with_body(account_body(30_000))
         .create_async()
         .await;
-    for activity_type in ["FILL", "CSW"] {
+    // Every type the sync actually asks for answers empty, except the deposit under test. Driven by
+    // the production list so an added type cannot leave a request unmatched here.
+    for activity_type in account::synced_activity_types()
+        .into_iter()
+        .filter(|activity_type| *activity_type != DEPOSIT_ACTIVITY_TYPE)
+    {
         server
             .mock(
                 "GET",
@@ -793,23 +817,14 @@ async fn test_the_account_sync_stores_transfers_without_attributing_them() {
     let _deposit = server
         .mock(
             "GET",
-            mockito::Matcher::Regex(r"^/v2/account/activities/CSD".into()),
+            mockito::Matcher::Regex(format!("^/v2/account/activities/{DEPOSIT_ACTIVITY_TYPE}")),
         )
         .with_status(200)
         .with_body(format!(
-            r#"[{{"id":"deposit-1","activity_type":"CSD","date":"{}",
+            r#"[{{"id":"deposit-1","activity_type":"{DEPOSIT_ACTIVITY_TYPE}","date":"{}",
                   "net_amount":"10000.00","status":"executed"}}]"#,
             session_date.date()
         ))
-        .create_async()
-        .await;
-    let _journal = server
-        .mock(
-            "GET",
-            mockito::Matcher::Regex(r"^/v2/account/activities/JNLC".into()),
-        )
-        .with_status(200)
-        .with_body("[]")
         .create_async()
         .await;
 
@@ -871,7 +886,7 @@ async fn test_the_account_sync_reports_a_missing_previous_session() {
         .with_body(account_body(100_000))
         .create_async()
         .await;
-    for activity_type in ["FILL", "CSD", "CSW", "JNLC"] {
+    for activity_type in account::synced_activity_types() {
         server
             .mock(
                 "GET",

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -64,6 +64,39 @@ fn calendar_for_today() -> TradingCalendar {
     TradingCalendar::from_days(days)
 }
 
+/// Consecutive sessions ending at `session_date`, for tests that pin a fixed date.
+fn calendar_ending_at(session_date: SessionDate) -> TradingCalendar {
+    let days = (0..5)
+        .filter_map(|offset| {
+            CalendarDay::new(
+                session_date.plus_calendar_days(-offset).date(),
+                NaiveTime::from_hms_opt(9, 30, 0).unwrap(),
+                NaiveTime::from_hms_opt(16, 0, 0).unwrap(),
+            )
+        })
+        .collect();
+    TradingCalendar::from_days(days)
+}
+
+/// Answers every transfer activity endpoint with an empty list.
+///
+/// The sync asks for each synced type in turn, so a test mocking only `FILL` would have its
+/// remaining requests go unmatched.
+async fn mock_no_transfers(server: &mut mockito::ServerGuard) {
+    for activity_type in ["CSD", "CSW", "JNLC"] {
+        server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(format!("^/v2/account/activities/{activity_type}")),
+            )
+            .with_status(200)
+            .with_body("[]")
+            .expect_at_least(1)
+            .create_async()
+            .await;
+    }
+}
+
 /// A universe holding exactly the named tickers, every one of them shortable.
 fn universe_of(tickers: &[&str]) -> Universe {
     use fund::common::alpaca::TradableAssets;
@@ -636,10 +669,17 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
         .create_async()
         .await;
 
+    mock_no_transfers(&mut server).await;
+
     let trading = TradingClient::with_base_url(credentials(), server.url());
-    let summary = account::sync_account(&pool, &trading, session_date)
-        .await
-        .expect("the sync must run");
+    let summary = account::sync_account(
+        &pool,
+        &trading,
+        &calendar_ending_at(session_date),
+        session_date,
+    )
+    .await
+    .expect("the sync must run");
 
     assert_eq!(summary.activities_stored, 2);
     assert_eq!(summary.activities_unattributed, 0);
@@ -691,11 +731,14 @@ async fn test_the_account_sync_is_idempotent() {
         .create_async()
         .await;
 
+    mock_no_transfers(&mut server).await;
+
     let trading = TradingClient::with_base_url(credentials(), server.url());
-    let first = account::sync_account(&pool, &trading, session_date)
+    let calendar = calendar_ending_at(session_date);
+    let first = account::sync_account(&pool, &trading, &calendar, session_date)
         .await
         .unwrap();
-    let second = account::sync_account(&pool, &trading, session_date)
+    let second = account::sync_account(&pool, &trading, &calendar, session_date)
         .await
         .unwrap();
 
@@ -713,6 +756,151 @@ async fn test_the_account_sync_is_idempotent() {
         .await
         .unwrap();
     assert_eq!(snapshots, 1, "the same session must not stack rows");
+}
+
+/// A deposit has to survive the round trip with its amount, because that amount is the only record
+/// of how much arrived — and it must not be mistaken for a fill along the way. `attribute` counts
+/// anything without a ticker as unattributed, so a transfer reaching it would raise a false alarm
+/// on every session that received capital.
+#[tokio::test]
+#[serial]
+async fn test_the_account_sync_stores_transfers_without_attributing_them() {
+    use fund::portfolio::account;
+
+    let pool = fresh_pool().await;
+    let mut server = mockito::Server::new_async().await;
+    let session_date = SessionDate::at(session_instant());
+
+    let _account = server
+        .mock("GET", "/v2/account")
+        .with_status(200)
+        .with_body(account_body(30_000))
+        .create_async()
+        .await;
+    for activity_type in ["FILL", "CSW"] {
+        server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(format!("^/v2/account/activities/{activity_type}")),
+            )
+            .with_status(200)
+            .with_body("[]")
+            .create_async()
+            .await;
+    }
+    // The shape a real account returns: a settlement date, no transaction time, and the amount
+    // carried by `net_amount` rather than a quantity and a price.
+    let _deposit = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"^/v2/account/activities/CSD".into()),
+        )
+        .with_status(200)
+        .with_body(format!(
+            r#"[{{"id":"deposit-1","activity_type":"CSD","date":"{}",
+                  "net_amount":"10000.00","status":"executed"}}]"#,
+            session_date.date()
+        ))
+        .create_async()
+        .await;
+    let _journal = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"^/v2/account/activities/JNLC".into()),
+        )
+        .with_status(200)
+        .with_body("[]")
+        .create_async()
+        .await;
+
+    let trading = TradingClient::with_base_url(credentials(), server.url());
+    let summary = account::sync_account(
+        &pool,
+        &trading,
+        &calendar_ending_at(session_date),
+        session_date,
+    )
+    .await
+    .expect("the sync must run");
+
+    assert_eq!(summary.activities_stored, 1);
+    assert_eq!(
+        summary.activities_unattributed, 0,
+        "a transfer is not a fill and must never reach attribution"
+    );
+
+    let (activity_type, net_amount, stored_time): (
+        String,
+        rust_decimal::Decimal,
+        chrono::DateTime<Utc>,
+    ) = sqlx::query_as(
+        "SELECT activity_type, net_amount, transaction_time
+             FROM account_activities WHERE id = 'deposit-1'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(activity_type, "CSD");
+    assert_eq!(net_amount, rust_decimal::Decimal::new(1000000, 2));
+    assert_eq!(
+        SessionDate::at(stored_time),
+        session_date,
+        "a dated transfer must land in the session Alpaca dated it, not the one before"
+    );
+}
+
+/// Nothing else notices a failed sync: the hole it leaves is silent until a return spanning it is
+/// asked for, which may be months later.
+#[tokio::test]
+#[serial]
+async fn test_the_account_sync_reports_a_missing_previous_session() {
+    use fund::portfolio::account;
+
+    let pool = fresh_pool().await;
+    let mut server = mockito::Server::new_async().await;
+    let session_date = SessionDate::at(session_instant());
+    let calendar = calendar_ending_at(session_date);
+    let previous = calendar
+        .previous_trading_day(session_date)
+        .expect("the fixture calendar reaches back");
+
+    let _account = server
+        .mock("GET", "/v2/account")
+        .with_status(200)
+        .with_body(account_body(100_000))
+        .create_async()
+        .await;
+    for activity_type in ["FILL", "CSD", "CSW", "JNLC"] {
+        server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(format!("^/v2/account/activities/{activity_type}")),
+            )
+            .with_status(200)
+            .with_body("[]")
+            .create_async()
+            .await;
+    }
+
+    let trading = TradingClient::with_base_url(credentials(), server.url());
+    let with_gap = account::sync_account(&pool, &trading, &calendar, session_date)
+        .await
+        .expect("the sync must run");
+    assert_eq!(
+        with_gap.previous_session_gap,
+        Some(previous),
+        "the previous session has no snapshot and the sync must say so"
+    );
+
+    // Fill the hole and the same sync stops reporting it.
+    account::sync_account(&pool, &trading, &calendar, previous)
+        .await
+        .expect("the sync must run");
+    let repaired = account::sync_account(&pool, &trading, &calendar, session_date)
+        .await
+        .expect("the sync must run");
+    assert_eq!(repaired.previous_session_gap, None);
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/dashboard_reader_setup.sql
+++ b/tools/dashboard_reader_setup.sql
@@ -19,15 +19,16 @@ $$;
 GRANT CONNECT ON DATABASE fund TO dashboard_reader;
 GRANT USAGE ON SCHEMA public TO dashboard_reader;
 
--- Five tables, one per section of the page. equity_bars, equity_predictions, and events are
--- TimescaleDB hypertables; granting on the hypertable covers its existing chunks and the ones
--- created later, so there is nothing to re-run when a chunk rolls over.
+-- equity_bars, equity_predictions, and events are TimescaleDB hypertables; granting on the
+-- hypertable covers its existing chunks and the ones created later, so there is nothing to re-run
+-- when a chunk rolls over.
 --
--- account_activities is deliberately absent. Realized profit and loss is materialized onto
--- equity_pairs by the post-close sync precisely so the dashboard does not re-join activities to
--- legs on every page load, and a grant for a table nothing reads is a grant nobody will remember to
--- remove.
+-- account_activities is read only for its transfer rows. Period returns are raw equity changes and
+-- are wrong across a capital flow, so the page must be able to see that one arrived and withhold
+-- the number. Realized profit and loss is still materialized onto equity_pairs by the post-close
+-- sync, so nothing here re-joins activities to legs on a page load.
 GRANT SELECT ON account_snapshots   TO dashboard_reader;
+GRANT SELECT ON account_activities  TO dashboard_reader;
 GRANT SELECT ON equity_pairs        TO dashboard_reader;
 GRANT SELECT ON equity_predictions  TO dashboard_reader;
 GRANT SELECT ON equity_bars         TO dashboard_reader;


### PR DESCRIPTION
# Overview

Dashboard period returns are raw equity-to-equity changes, so a capital flow inside a window reads as performance: a $10,000 contribution into a flat $20,000 book publishes as +50%, and the error never washes out of a cumulative series. It is currently harmless only because no capital has moved.

Rather than fix that by building the full unit ledger now, this makes the two conditions that keep it harmless into checked assertions: nothing could see a capital flow arrive, and nothing noticed a missing session. Both are now visible. The ledger itself is deferred until external capital arrives.

## Changes

- **Fixes a latent timestamp bug.** `fetch_activities` synthesized a `transaction_time` for date-only activities as `date.and_hms_opt(0, 0, 0).and_utc()` — midnight **UTC**. Non-trade activities carry a settlement date and no time, so a transfer dated `2026-05-15` resolved to session `2026-05-14`, since `SessionDate::at` reads the Eastern calendar day and 00:00Z is still the previous day there for the whole evening. Latent because only `FILL` was synced and fills carry a real time of their own. The reproducing test failed with `left: 2026-05-14, right: 2026-05-15` before the fix.
- **Syncs transfers.** `FILL_ACTIVITY_TYPE` and `TRANSFER_ACTIVITY_TYPES` (`CSD`, `CSW`, `JNLC`) now sit together in `common::alpaca`, which owns Alpaca's wire vocabulary; `account.rs` keeps `synced_activity_types`, the policy decision about which of them this sync fetches. `INT`, `DIV`, and `FEE` stay out — they are return rather than external flow.
- **Adds `net_amount`** to `AccountActivity` and `account_activities`. Transfers carry no quantity or price, so it is the only field saying how much moved.
- **Filters to fills before attribution.** `attribute` counts any activity without a ticker as unattributed, so syncing transfers would otherwise have raised a false warning on every session that received capital.
- **Guards `compute_period_returns`.** It now takes the transfer sessions and withholds any horizon spanning one. Flows land at the end of their session, so a transfer *on* the baseline session is already inside the baseline equity and does not withhold — otherwise a single contribution would blank the dashboard for a year.
- **Grants `dashboard_reader` SELECT on `account_activities`.** The grant was deliberately absent because nothing read the table; the guard now does, which is the condition its own comment named.
- **Reports `previous_session_gap`** on `AccountSyncSummary`, so a missing snapshot reaches the completion event rather than only a log line.

## Context

Design and rationale live in `.scratchpad/flow_visibility_and_backfill.md`, with the deferred ledger design in `.scratchpad/unit_accounting.md`.

Two things worth a reviewer's attention:

**`eastern_midnight` duplicates `SessionDate::midnight` rather than calling it.** `data::calendar` already imports from `common::alpaca`, so reaching the other way is a module cycle, and `CLAUDE.md` independently says transport modules keep `NaiveDate`. The alternative was having `calendar.rs` delegate its core timezone primitive to the Alpaca transport module, which seemed worse. Open to being talked out of it.

**Deferring the NAV fold removed the only thing that would ever have caught a snapshot gap**, which is why the staleness check is in this change rather than waiting. A backfill tool that can repair a gap from `/v2/account/portfolio/history` is the follow-up pull request; until it lands, a missing session is visible but not yet repairable.

Note that `net_amount` is a new column and `CREATE TABLE IF NOT EXISTS` does not add columns to an existing table, so this requires `database:reset` followed by `database:create`. That is currently free — the application is not running and the VM is torn down.

Unrelated preexisting issue found along the way: `DATABASE_URL` in `devenv.nix` carries no user, and sqlx-cli does not fall back to the OS user the way libpq does, so `check-sqlx` fails with `role "anonymous" does not exist`. Reproducible on `master`. Worth its own fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account activity records now support transfer, withdrawal, deposit, and fee amounts.
  * Account synchronization includes transfer activity and identifies missing prior-session snapshots.
  * Dashboard returns account for capital flows by withholding period returns across transfer dates.
  * Date-only activities preserve their correct trading session dates across time zones.

* **Bug Fixes**
  * Transfers are excluded from trade cash-flow attribution while remaining available for account tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->