### PR TITLE
Fit the TiDE scaler on the training window rather than every row

### DIFF
--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -158,9 +158,13 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     // --- stage three: train and evaluate ---
 
-    let fit_result = fit(filtered)?;
-
+    // The same fraction reaches preprocessing and windowing, because the scaler is fitted on the
+    // rows at or before its cutoff. Passing one value here and another below would fit statistics
+    // over a window other than the one the model trains on.
     let training_fraction = TrainingFraction::new(TRAINING_FRACTION)?;
+
+    let fit_result = fit(filtered, training_fraction)?;
+
     let train_dataset = fit_result.data.get_dataset(
         DatasetKind::Train(training_fraction),
         INPUT_LENGTH,

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -381,6 +381,11 @@ impl Data {
 ///
 /// A `TrainingFraction` is strictly between 0 and 1, so the cutoff never falls below the minimum
 /// timestamp: the training side is non-empty for any non-empty frame.
+///
+/// The span is measured with `checked_sub` because a column carrying timestamps at both ends of
+/// `i64` wraps it negative in a release build, which puts the cutoff below every row and empties the
+/// training side — surfacing as `fit_scaler` reporting no rows to fit on, which blames the cutoff
+/// for a corrupt column.
 pub(crate) fn training_cutoff(
     data: &DataFrame,
     training_fraction: TrainingFraction,
@@ -391,8 +396,14 @@ pub(crate) fn training_cutoff(
     let timestamps = timestamps.i64().map_err(|error| error.to_string())?;
     let minimum_timestamp = timestamps.min().unwrap_or(0);
     let maximum_timestamp = timestamps.max().unwrap_or(0);
-    Ok(minimum_timestamp
-        + (((maximum_timestamp - minimum_timestamp) as f64) * training_fraction.fraction()) as i64)
+
+    let span = maximum_timestamp
+        .checked_sub(minimum_timestamp)
+        .ok_or("The timestamp range is wider than i64, so no training cutoff exists")?;
+    // Only the span needs checking. The fraction is strictly between 0 and 1 and the `as` cast
+    // saturates, so the offset lands in `[0, span]` and the sum in `[minimum, maximum]`.
+    let training_span = ((span as f64) * training_fraction.fraction()) as i64;
+    Ok(minimum_timestamp + training_span)
 }
 
 /// Partition a frame at `cutoff` into (at or before, after).
@@ -1427,6 +1438,26 @@ mod tests {
         assert_eq!(train.height() + valid.height(), 10);
         assert!(train.height() > 0);
         assert!(valid.height() > 0);
+    }
+
+    /// A range wider than `i64` panics on the subtraction in a debug build and wraps in a release
+    /// one — and a wrapped range is negative, which puts the cutoff below every timestamp, empties
+    /// the training side, and surfaces as `fit_scaler` complaining that there are no rows to fit on.
+    /// Naming the range is the point: the message otherwise blames the cutoff for a corrupt column.
+    #[test]
+    fn test_training_cutoff_refuses_an_unrepresentable_timestamp_range() {
+        let data = DataFrame::new(vec![Column::new(
+            "timestamp".into(),
+            vec![i64::MIN, i64::MAX],
+        )])
+        .unwrap();
+
+        let error = training_cutoff(&data, fraction_of(0.8))
+            .expect_err("a timestamp range wider than i64 must be refused");
+        assert!(
+            error.to_string().contains("range"),
+            "the message must name the timestamp range: {error}"
+        );
     }
 
     /// Two tickers, two days each, unsorted on input; close prices chosen so

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -343,28 +343,8 @@ impl Data {
         &self,
         training_fraction: TrainingFraction,
     ) -> Result<(DataFrame, DataFrame), Box<dyn std::error::Error>> {
-        let training_fraction = training_fraction.fraction();
-        let timestamps = self
-            .data
-            .column("timestamp")
-            .map_err(|error| error.to_string())?;
-        let timestamps = timestamps.i64().map_err(|error| error.to_string())?;
-        let minimum_timestamp = timestamps.min().unwrap_or(0);
-        let maximum_timestamp = timestamps.max().unwrap_or(0);
-        let cutoff = minimum_timestamp
-            + (((maximum_timestamp - minimum_timestamp) as f64) * training_fraction) as i64;
-
-        let train_mask = timestamps.lt_eq(cutoff);
-        let validation_mask = timestamps.gt(cutoff);
-        let train = self
-            .data
-            .filter(&train_mask)
-            .map_err(|error| error.to_string())?;
-        let validation = self
-            .data
-            .filter(&validation_mask)
-            .map_err(|error| error.to_string())?;
-        Ok((train, validation))
+        let cutoff = training_cutoff(&self.data, training_fraction)?;
+        split_at_cutoff(&self.data, cutoff)
     }
 
     /// Build a windowed dataset.
@@ -388,6 +368,49 @@ impl Data {
             }
         }
     }
+}
+
+/// The timestamp at or before which a row belongs to the training side of the split:
+/// `min + (max - min) * training_fraction`.
+///
+/// Shared with [`crate::models::tide::fit::fit`], which fits the scaler on the rows this selects
+/// while [`Data::split_by_timestamp`] later selects the rows the model trains on. The two must name
+/// the same instant — statistics fitted over a window other than the one they scale are the
+/// look-ahead this function exists to prevent — so the arithmetic lives here once rather than at
+/// both call sites.
+///
+/// A `TrainingFraction` is strictly between 0 and 1, so the cutoff never falls below the minimum
+/// timestamp: the training side is non-empty for any non-empty frame.
+pub(crate) fn training_cutoff(
+    data: &DataFrame,
+    training_fraction: TrainingFraction,
+) -> Result<i64, Box<dyn std::error::Error>> {
+    let timestamps = data
+        .column("timestamp")
+        .map_err(|error| error.to_string())?;
+    let timestamps = timestamps.i64().map_err(|error| error.to_string())?;
+    let minimum_timestamp = timestamps.min().unwrap_or(0);
+    let maximum_timestamp = timestamps.max().unwrap_or(0);
+    Ok(minimum_timestamp
+        + (((maximum_timestamp - minimum_timestamp) as f64) * training_fraction.fraction()) as i64)
+}
+
+/// Partition a frame at `cutoff` into (at or before, after).
+pub(crate) fn split_at_cutoff(
+    data: &DataFrame,
+    cutoff: i64,
+) -> Result<(DataFrame, DataFrame), Box<dyn std::error::Error>> {
+    let timestamps = data
+        .column("timestamp")
+        .map_err(|error| error.to_string())?;
+    let timestamps = timestamps.i64().map_err(|error| error.to_string())?;
+    let train = data
+        .filter(&timestamps.lt_eq(cutoff))
+        .map_err(|error| error.to_string())?;
+    let validation = data
+        .filter(&timestamps.gt(cutoff))
+        .map_err(|error| error.to_string())?;
+    Ok((train, validation))
 }
 
 /// Core windowing over a single (already preprocessed) frame.

--- a/src/models/tide/fit.rs
+++ b/src/models/tide/fit.rs
@@ -2,6 +2,8 @@
 //! files the inference path loads.
 //!
 //! Categoricals are encoded over sorted-unique values so the mapping is deterministic across runs.
+//!
+//! The scaler and the mappings are deliberately fitted over different row sets; see [`fit`].
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -10,8 +12,9 @@ use polars::prelude::*;
 
 use crate::models::tide::configuration::ModelParameters;
 use crate::models::tide::data::{
-    apply_scaling, clean_data, encode_categoricals, engineer_features, CategoryMapping, Data,
-    FeatureMappings, Scaler, CATEGORICAL_COLUMNS, CONTINUOUS_COLUMNS, STATIC_CATEGORICAL_COLUMNS,
+    apply_scaling, clean_data, encode_categoricals, engineer_features, split_at_cutoff,
+    training_cutoff, CategoryMapping, Data, FeatureMappings, Scaler, TrainingFraction,
+    CATEGORICAL_COLUMNS, CONTINUOUS_COLUMNS, STATIC_CATEGORICAL_COLUMNS,
 };
 
 /// Result of fitting: the preprocessed (scaled + encoded) data ready for
@@ -23,11 +26,30 @@ pub struct FitResult {
 }
 
 /// Fit preprocessing on a raw consolidated frame (bars joined with categories).
-pub fn fit(raw: DataFrame) -> Result<FitResult, Box<dyn std::error::Error>> {
+///
+/// The scaler is fitted on the rows at or before `training_fraction`'s cutoff and then applied to
+/// the whole frame, so the validation rows are standardized by statistics that never saw them.
+/// Fitting over every row instead put the validation period's own volatility in the divisor of the
+/// `daily_return` target — and [`crate::models::tide::evaluate`] scores in scaled units, so the
+/// reported CRPS was denominated in a scale the held-out data had helped set.
+///
+/// The **mappings are fitted over the whole frame**, and that asymmetry is deliberate. A mapping is
+/// a vocabulary, not a statistic: it carries which symbols, sectors, and industries exist, and
+/// nothing about their returns. Restricting it to the training rows would instead be actively
+/// harmful, because [`encode_categoricals`] drops rows whose static value it cannot map — every
+/// instrument first listed (or first clearing the liquidity floors) after the cutoff would vanish
+/// from the validation split, and, since these mappings ship in the artifact as the inference
+/// vocabulary, could not be predicted at all until it had traded the full pre-cutoff window.
+pub fn fit(
+    raw: DataFrame,
+    training_fraction: TrainingFraction,
+) -> Result<FitResult, Box<dyn std::error::Error>> {
     let engineered = engineer_features(raw)?;
     let cleaned = clean_data(engineered)?;
 
-    let scaler = fit_scaler(&cleaned)?;
+    let cutoff = training_cutoff(&cleaned, training_fraction)?;
+    let (training_rows, _) = split_at_cutoff(&cleaned, cutoff)?;
+    let scaler = fit_scaler(&training_rows)?;
     let scaled = apply_scaling(cleaned, &scaler)?;
 
     let mappings = fit_mappings(&scaled)?;
@@ -44,7 +66,16 @@ pub fn fit(raw: DataFrame) -> Result<FitResult, Box<dyn std::error::Error>> {
 /// Compute per-column mean and (sample) standard deviation for the continuous
 /// columns. A zero std is replaced with a tiny value so scaling and inverse
 /// scaling stay finite.
+///
+/// `data` is the training side of the split, not the whole frame. An empty one is refused rather
+/// than fitted: `mean()` and `std()` both return `None` over no rows, every mean would fall back to
+/// `0.0` and every deviation to the `1e-8` floor, and the result passes [`Scaler::new`] while
+/// scaling by a hundred million.
 fn fit_scaler(data: &DataFrame) -> Result<Scaler, Box<dyn std::error::Error>> {
+    if data.height() == 0 {
+        return Err("No rows at or before the training cutoff to fit the scaler on".into());
+    }
+
     let mut means = std::collections::HashMap::new();
     let mut standard_deviations = std::collections::HashMap::new();
 
@@ -216,6 +247,54 @@ pub fn write_artifact_json(
 mod tests {
     use super::*;
 
+    /// The fraction the trainer runs with, so the tests exercise the split production uses.
+    fn training_fraction() -> TrainingFraction {
+        TrainingFraction::new(0.8).expect("0.8 is a valid training fraction")
+    }
+
+    /// Build a raw frame from `(ticker, sector, industry, day, close_price)` rows. The remaining
+    /// price columns track the close, and `day` is a session index turned into a midnight stamp.
+    fn frame_from_rows(rows: &[(&str, &str, &str, i64, f64)]) -> DataFrame {
+        let tickers: Vec<&str> = rows.iter().map(|row| row.0).collect();
+        let sectors: Vec<&str> = rows.iter().map(|row| row.1).collect();
+        let industries: Vec<&str> = rows.iter().map(|row| row.2).collect();
+        let timestamps: Vec<i64> = rows.iter().map(|row| row.3 * 86_400_000).collect();
+        let close_prices: Vec<f64> = rows.iter().map(|row| row.4).collect();
+        let volumes: Vec<f64> = close_prices.iter().map(|price| price * 1_000.0).collect();
+
+        DataFrame::new(vec![
+            Column::new("ticker".into(), tickers),
+            Column::new("timestamp".into(), timestamps),
+            Column::new("open_price".into(), close_prices.clone()),
+            Column::new("high_price".into(), close_prices.clone()),
+            Column::new("low_price".into(), close_prices.clone()),
+            Column::new("close_price".into(), close_prices.clone()),
+            Column::new("volume".into(), volumes),
+            Column::new("volume_weighted_average_price".into(), close_prices),
+            Column::new("sector".into(), sectors),
+            Column::new("industry".into(), industries),
+        ])
+        .unwrap()
+    }
+
+    /// One ticker over eleven sessions whose last two sit on a wholly different scale.
+    ///
+    /// `clean_data` drops each ticker's first row for its null return, so the fitted frame spans
+    /// days 1 through 10 and the 0.8 cutoff lands at day 8.2: days 1 through 8 train, days 9 and 10
+    /// validate. Close prices run 101 through 108 over the training days and jump to 5,000 over the
+    /// validation days, which is what makes a leaked statistic impossible to mistake for noise.
+    fn scale_shifted_frame() -> DataFrame {
+        let close_prices = [
+            100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0, 5_000.0, 5_100.0,
+        ];
+        let rows: Vec<(&str, &str, &str, i64, f64)> = close_prices
+            .iter()
+            .enumerate()
+            .map(|(day, close_price)| ("AAAA", "TECH", "SOFTWARE", day as i64, *close_price))
+            .collect();
+        frame_from_rows(&rows)
+    }
+
     fn raw_frame() -> DataFrame {
         // Two tickers, two days each; unsorted on input.
         DataFrame::new(vec![
@@ -238,7 +317,7 @@ mod tests {
 
     #[test]
     fn test_fit_mappings_are_sorted_and_deterministic() {
-        let result = fit(raw_frame()).unwrap();
+        let result = fit(raw_frame(), training_fraction()).unwrap();
         let tickers = &result.mappings["ticker"];
         // Uppercased and sorted: AAPL -> 0, GOOG -> 1.
         assert_eq!(tickers["AAPL"], 0);
@@ -252,12 +331,112 @@ mod tests {
 
     #[test]
     fn test_fit_scaler_has_all_continuous_columns() {
-        let result = fit(raw_frame()).unwrap();
+        let result = fit(raw_frame(), training_fraction()).unwrap();
         for column in CONTINUOUS_COLUMNS {
             assert!(result.scaler.means().contains_key(*column));
             assert!(result.scaler.standard_deviations().contains_key(*column));
             assert!(*result.scaler.standard_deviations().get(*column).unwrap() != 0.0);
         }
+    }
+
+    /// The leak this module was changed to close: the scaler used to be fitted over every cleaned
+    /// row, so the held-out period set the scale its own predictions were later measured on.
+    #[test]
+    fn test_the_scaler_is_fitted_only_on_rows_at_or_before_the_training_cutoff() {
+        let result = fit(scale_shifted_frame(), training_fraction()).unwrap();
+
+        // Close prices 101 through 108 over the eight training days: mean 104.5, sample standard
+        // deviation sqrt(6). Fitted over every row the mean would be 1093.6 instead, dragged there
+        // by the two validation sessions.
+        let mean = result.scaler.means()["close_price"];
+        let standard_deviation = result.scaler.standard_deviations()["close_price"];
+        assert!(
+            (mean - 104.5).abs() < 1e-9,
+            "close_price mean is {mean}, not the training window's 104.5"
+        );
+        assert!(
+            (standard_deviation - 6.0_f64.sqrt()).abs() < 1e-9,
+            "close_price standard deviation is {standard_deviation}, not the training window's \
+             sqrt(6)"
+        );
+
+        // The one that matters most. `daily_return` is the model target and `evaluate` scores in
+        // scaled units, so this divisor sets what a good CRPS even means. The training days return
+        // about a percent each; day nine returns 4,529 percent. Over every row the deviation
+        // exceeds 10 — the leak is three orders of magnitude, not a rounding difference.
+        let return_deviation = result.scaler.standard_deviations()["daily_return"];
+        assert!(
+            return_deviation < 0.01,
+            "daily_return standard deviation is {return_deviation}, so the validation window's \
+             volatility reached the target scale"
+        );
+    }
+
+    /// `fit` and `Data::split_by_timestamp` derive the cutoff separately, and the scaler is only
+    /// honest if they land on the same instant. Standardizing a window by its own statistics leaves
+    /// mean 0 and sample deviation 1 exactly, so a disagreement of even one session shows up here.
+    #[test]
+    fn test_the_scaler_window_matches_the_rows_the_training_split_yields() {
+        let result = fit(scale_shifted_frame(), training_fraction()).unwrap();
+        let (train, validation) = result.data.split_by_timestamp(training_fraction()).unwrap();
+
+        assert_eq!(train.height(), 8, "days 1 through 8 train");
+        assert_eq!(validation.height(), 2, "days 9 and 10 validate");
+
+        let scaled = train.column("close_price").unwrap().f32().unwrap();
+        let mean = scaled.mean().unwrap();
+        let standard_deviation = scaled.std(1).unwrap();
+        assert!(
+            mean.abs() < 1e-5,
+            "the training split does not centre on zero under its own scaler: {mean}"
+        );
+        assert!(
+            (standard_deviation - 1.0).abs() < 1e-5,
+            "the training split is not unit-scaled under its own scaler: {standard_deviation}"
+        );
+
+        // The validation rows are scaled by the same statistics rather than their own, which is the
+        // whole point: 5,000 against a mean of 104.5 is enormously far from zero.
+        let held_out = validation.column("close_price").unwrap().f32().unwrap();
+        assert!(
+            held_out.into_no_null_iter().all(|value| value > 100.0),
+            "the validation rows were not scaled by the training statistics"
+        );
+    }
+
+    /// The deliberate asymmetry: the mappings stay fitted over the whole frame. A vocabulary
+    /// carries which instruments exist, not how they returned, and `encode_categoricals` deletes
+    /// rows whose static value it cannot map — so a training-only mapping would silently drop every
+    /// late listing out of the validation split and out of the shipped inference vocabulary.
+    #[test]
+    fn test_mappings_cover_categories_that_appear_only_after_the_cutoff() {
+        let mut rows: Vec<(&str, &str, &str, i64, f64)> = (0..=10)
+            .map(|day| ("AAAA", "TECH", "SOFTWARE", day, 100.0 + day as f64))
+            .collect();
+        // Listed on day nine, which the 0.8 cutoff at day 8.2 puts wholly in the validation window.
+        rows.push(("ZZZZ", "ENERGY", "SOLAR", 9, 50.0));
+        rows.push(("ZZZZ", "ENERGY", "SOLAR", 10, 51.0));
+
+        let result = fit(frame_from_rows(&rows), training_fraction()).unwrap();
+
+        assert!(
+            result.mappings["ticker"].contains_key("ZZZZ"),
+            "a ticker listed after the cutoff must still be in the vocabulary"
+        );
+        assert!(result.mappings["sector"].contains_key("ENERGY"));
+        assert!(result.mappings["industry"].contains_key("SOLAR"));
+
+        // `clean_data` spends ZZZZ's first session on its null return, leaving one encoded row.
+        let late_code = result.mappings["ticker"]["ZZZZ"];
+        let encoded = result.data.data.column("ticker").unwrap().i32().unwrap();
+        assert_eq!(
+            encoded
+                .into_no_null_iter()
+                .filter(|code| *code == late_code)
+                .count(),
+            1,
+            "the late listing's rows were dropped from the encoded frame"
+        );
     }
 
     #[test]
@@ -323,7 +502,7 @@ mod tests {
     /// exactly the mixed-artifact state the staging exists to prevent.
     #[test]
     fn test_write_artifact_json_leaves_no_staging_files_behind() {
-        let result = fit(raw_frame()).unwrap();
+        let result = fit(raw_frame(), training_fraction()).unwrap();
         let parameters = ModelParameters::new(448, 35, 5);
         let directory = tempfile::tempdir().unwrap();
 
@@ -353,7 +532,7 @@ mod tests {
 
     #[test]
     fn test_write_artifact_json_round_trips_via_loader() {
-        let result = fit(raw_frame()).unwrap();
+        let result = fit(raw_frame(), training_fraction()).unwrap();
         let parameters = ModelParameters::new(448, 35, 5);
         let directory = tempfile::tempdir().unwrap();
         write_artifact_json(


### PR DESCRIPTION
# Overview

The TiDE scaler was fitted before the train/validation split existed, so the held-out period helped set the scale its own predictions were later measured on.

## Changes

- Fit the scaler on the rows at or before the training cutoff, then apply those statistics to the whole frame, so validation rows are standardized by numbers that never saw them
- Move the cutoff arithmetic into `training_cutoff` and `split_at_cutoff` in `models::tide::data`, shared by `fit` and `Data::split_by_timestamp`
- Take a `TrainingFraction` in `fit`, and resolve it once in `tide_model_trainer` so preprocessing and windowing cannot receive different values
- Refuse an empty training side in `fit_scaler`
- Keep the categorical mappings fitted over the whole frame, and document why the two differ
- Add three tests covering the fitted window, the cutoff agreement, and the mapping asymmetry

## Context

`fit` ran `fit_scaler` over the whole cleaned frame while `Data::split_by_timestamp` only ran later, inside `get_dataset`. The last 20% of the lookback window therefore contributed to the mean and standard deviation that standardized the training rows.

That matters most for `daily_return`, which is both a feature and the model target. `evaluate` scores entirely in scaled units and never touches the scaler, so the reported CRPS was denominated in a scale the validation period had helped set — a volatile tail inflated the divisor and mechanically flattered the metric.

**The mappings deliberately stay on the whole frame.** A mapping is a vocabulary, not a statistic: it carries which symbols, sectors, and industries exist, and nothing about their returns. Restricting it to the training rows would be actively harmful, because `encode_categoricals` drops rows whose static value it cannot map. Every instrument first listed — or first clearing the liquidity floors — after the cutoff would vanish from the validation split, and, since these mappings ship in the artifact as the inference vocabulary, could not be predicted at all until it had traded the full pre-cutoff window.

The two cutoff helpers exist because `fit` and `split_by_timestamp` must name the same instant. Statistics fitted over a window other than the one they scale are the look-ahead this change removes, and a second copy of the formula is how the two would drift apart.

### Verification

Both leak tests were confirmed to fail against the old behavior before the fix was restored:

```
close_price mean is 1093.6, not the training window's 104.5
the training split does not centre on zero under its own scaler: -0.47431109473109245
```

The fixture's last two sessions jump from ~105 to 5,000, which puts the `daily_return` deviation three orders of magnitude apart between the two fittings. The cutoff-agreement test works off the fact that standardizing a window by its own statistics leaves mean 0 and sample deviation 1 exactly, so it fails if the two cutoffs differ by even one session.

`devenv tasks run checks:rust` passes; 478 library tests, 0 failures.

### Operational note

Expect the reported CRPS to move, likely upward, and to be incomparable with the runs already in the drift baseline. With `DRIFT_PRIOR_RUN_COUNT` at seven, the first several runs after this lands may report drift against a leak-flattered history. Nothing blocks an artifact on that signal, so this is a reporting artifact rather than a trading one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-based training and validation separation for Tide models.
  * Preprocessing now uses only the training portion of data, helping prevent validation data from influencing model scaling.
  * Updated handling ensures categories appearing later in the dataset remain supported.
  * Added safeguards for cases where the selected training portion contains no usable data.

* **Reliability**
  * Centralized timestamp splitting to keep dataset boundaries consistent across training workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->