### PR TITLE
Give the documentation rule a budget rather than a principle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is a collection of guidelines and references.
 - Use `devenv tasks run checks:rust` for comprehensive Rust checks
 - Docstrings are one sentence on what the item is for, plus at most two more for a caveat, invariant, or
   assumption a caller cannot read off the signature; never multi-paragraph, and never longer than the
-  function being documented
+  item it documents
 - Module documentation is three lines maximum
 - In-line comments are one line and appear only where a step is genuinely surprising, with two lines the
   hard ceiling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,15 @@ This is a collection of guidelines and references.
 - AWS S3 is used for blob storage
 - AWS Secrets Manager stores secrets in secretspec format (`secretspec/{project}/{profile}/{key}`)
 - Use `devenv tasks run checks:rust` for comprehensive Rust checks
-- Document sparingly and durably - write language-appropriate docstrings for functions, types, and modules, and add
-  in-line comments only where a step is genuinely surprising; a docstring says what something is for, plus any
-  caveat, invariant, or assumption a caller cannot read off the signature — it never restates the implementation,
-  because prose duplicating the code silently falls out of sync and module documentation is a few lines of high-level
-  orientation, not an inventory of its contents
+- Docstrings are one sentence on what the item is for, plus at most two more for a caveat, invariant, or
+  assumption a caller cannot read off the signature; never multi-paragraph, and never longer than the
+  function being documented
+- Module documentation is three lines maximum
+- In-line comments are one line and appear only where a step is genuinely surprising, with two lines the
+  hard ceiling
+- Rationale belongs in the commit message rather than the source — why this approach and not the obvious
+  one, what broke before, what the alternative would cost; the source states the constraint and the commit
+  argues it
 - Spell identifiers out fully in code (variables, functions, fields, modules): prefer `dataframe` over
   `df`, `message` over `msg`, `error_message` over `err_msg`, `quantity` over `qty`, `index` over `idx`,
   `column` over `col`, `value` over `val`, `volatility` over `vol`, `profit_and_loss` over `pnl`,


### PR DESCRIPTION
# Overview

## Changes

- Replace the single `Document sparingly and durably` bullet with four bounded rules: one sentence plus at most two for docstrings, three lines for module documentation, one line for an inline comment with a two-line ceiling, and rationale in the commit message
- Match the surrounding bullet style, which carries no terminal punctuation

## Context

The previous rule asked for sparing documentation and then licensed a docstring to carry "any caveat, invariant, or assumption a caller cannot read off the signature". That clause is unbounded. Every additional paragraph is individually defensible under it, since one more caveat can always be found, and the only thing actually prohibited was restating the implementation — a different failure mode than the one the rule was written to prevent.

The effect shows in the most recent commit to land on `master`. `fit_scaler` in `src/models/tide/fit.rs` carries a ten-line docstring, `training_cutoff` in `data.rs` a four-line one, and the tests added alongside them four-line inline comments explaining arithmetic the assertions already state. None of it restates the implementation, and all of it is longer than what it documents.

The replacement states countable limits, because a qualitative instruction cannot be checked against a diff and a numeric one can.

The last bullet is the load-bearing one. Suppressing the prose without giving it a destination invites smuggling it back in, and the rationale is worth keeping — commit d94bbe3f argues the scaler leak well. That argument belongs in exactly one place. Duplicating it into the source is what leaves the source copy to rot, since a commit message is immutable and a docstring is not.

No code changes, so nothing to verify beyond the markdown pre-commit check, which passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified maximum lengths and content limits for docstrings, module documentation, and inline comments.
  * Directed explanations of implementation rationale to commit messages instead of source comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
