### PR TITLE
Resolve the sync owner at run time so the application sync can run under cron

### DIFF
--- a/tools/sync-application
+++ b/tools/sync-application
@@ -45,19 +45,15 @@ log "New commits detected (local=$local_head remote=$remote_head)"
 # Stop devenv by terminating process-compose (the process manager spawned by
 # devenv) which in turn terminates all managed services.
 #
-# `id -un` rather than $USER, which cron does not set. With `set -u` above, reading it aborted this
-# script at this line on every run: the fetch had already happened, so the log recorded "New commits
-# detected" once a minute and the reset below was never reached.
+# $USER is unset under cron, and `set -u` above makes reading it fatal.
 owner="$(id -un)"
 if pkill -TERM -u "$owner" -f "process-compose" 2>/dev/null; then
   log "Sent SIGTERM to process-compose"
 else
   log "WARNING: process-compose not found"
 fi
-# Anchored on the trailing `up`, which is what separates devenv itself from the tmux shell
-# supervising it. `start-application` runs `while true; do devenv --profile application up; sleep 5;
-# done`, and that whole string is the shell's command line, so the unanchored pattern matched the
-# supervisor too and killed the restart loop this script depends on to bring the service back.
+# Anchored: the tmux shell supervising devenv carries the same string and would otherwise match,
+# killing the restart loop.
 if pkill -TERM -u "$owner" -f "devenv --profile application up\$" 2>/dev/null; then
   log "Sent SIGTERM to devenv"
 else

--- a/tools/sync-application
+++ b/tools/sync-application
@@ -44,12 +44,17 @@ log "New commits detected (local=$local_head remote=$remote_head)"
 
 # Stop devenv by terminating process-compose (the process manager spawned by
 # devenv) which in turn terminates all managed services.
-if pkill -TERM -u "$USER" -f "process-compose" 2>/dev/null; then
+#
+# `id -un` rather than $USER, which cron does not set. With `set -u` above, reading it aborted this
+# script at this line on every run: the fetch had already happened, so the log recorded "New commits
+# detected" once a minute and the reset below was never reached.
+owner="$(id -un)"
+if pkill -TERM -u "$owner" -f "process-compose" 2>/dev/null; then
   log "Sent SIGTERM to process-compose"
 else
   log "WARNING: process-compose not found"
 fi
-if pkill -TERM -u "$USER" -f "devenv.*--profile application" 2>/dev/null; then
+if pkill -TERM -u "$owner" -f "devenv.*--profile application" 2>/dev/null; then
   log "Sent SIGTERM to devenv"
 else
   log "WARNING: devenv process not found"

--- a/tools/sync-application
+++ b/tools/sync-application
@@ -54,7 +54,11 @@ if pkill -TERM -u "$owner" -f "process-compose" 2>/dev/null; then
 else
   log "WARNING: process-compose not found"
 fi
-if pkill -TERM -u "$owner" -f "devenv.*--profile application" 2>/dev/null; then
+# Anchored on the trailing `up`, which is what separates devenv itself from the tmux shell
+# supervising it. `start-application` runs `while true; do devenv --profile application up; sleep 5;
+# done`, and that whole string is the shell's command line, so the unanchored pattern matched the
+# supervisor too and killed the restart loop this script depends on to bring the service back.
+if pkill -TERM -u "$owner" -f "devenv --profile application up\$" 2>/dev/null; then
   log "Sent SIGTERM to devenv"
 else
   log "WARNING: devenv process not found"


### PR DESCRIPTION
body updated
tools/sync-application` has never been able to run under cron. It aborts on an unbound `$USER`
before it reaches the reset, so a VM running it stays on whatever commit it was last set to by hand
while the log reports the gap every minute.

## Changes

- Resolve the process owner with `id -un` instead of `$USER` in `tools/sync-application`
- Anchor the devenv pkill pattern so it stops matching the tmux shell that supervises devenv

## Context

The script is `set -euo pipefail` and cron sets no `USER`, so line 47 aborts every run. The position
of the failure is what makes it quiet: the fetch has already happened and the `git reset --hard
origin/master` has not, so `sync-application.log` fills with

```
New commits detected (local=4d59a035 remote=e79fe584)
tools/sync-application: line 47: USER: unbound variable
```

once a minute, and the checkout never moves. Nothing else surfaces it — the log line that would
report the failure is one of the lines that never runs.

Found on the development application VM after merging #1056: the trainer VM had picked the merge up
within a minute while the application VM sat three commits behind. `tools/sync-trainer` does not
reference `$USER` at all, which is exactly why one worked and the other did not; the two scripts had
drifted.

**Worth checking on production before assuming that machine is current.** `start-application`
installs this same script under the same crontab entry on the production application VM, so it has
very likely not been self-syncing either. `tail /var/log/fund/sync-application.log` there will say
so immediately.

`id -un` reads the process's own identity rather than an inherited login-shell variable, which is
the same fix and the same reasoning applied to `PGUSER` in `devenv.nix` in #1056.


## Second defect, found while verifying the first

With the unbound variable fixed, the sync still would not have worked. The second `pkill` used
`devenv.*--profile application`, and `start-application` supervises the service with
`while true; do devenv --profile application up; sleep 5; done` inside tmux — that whole string is
the supervising shell's command line. One pattern matched three processes on the VM:

```
27958 tmux new-session -d -s fund cd ~/fund && while true; do devenv ... done
27959 bash -c cd ~/fund && while true; do devenv ... done
27961 devenv --profile application up
```

Killing 27959 destroys the restart loop that this script's own header comment relies on to bring
devenv back. A sync that got past the abort would therefore have stopped the application and left it
stopped — worse than not syncing, and visible only as a service that went quiet after a merge.

Anchoring on the trailing `up` separates them, since the supervising shell ends in `done`. Verified
on the VM that the anchored pattern matches only 27961 and leaves the loop shell running.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application process cleanup in scheduled environments.
  * Prevented the restart supervisor from being stopped unintentionally.
  * Ensured cleanup targets the correct active application process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->