### PR TITLE
Record what the application observed before it acted

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -17,6 +17,10 @@
       export FUND_LOG_DIR="''${FUND_LOG_DIR:-/var/log/fund}"
     fi
     mkdir -p "$FUND_LOG_DIR" 2>/dev/null || true
+    # The session log is data rather than logs, but it inherits FUND_LOG_DIR's writability
+    # fallback so it needs no provisioning of its own. Point it elsewhere to separate them.
+    export FUND_SESSION_LOG_DIR="''${FUND_SESSION_LOG_DIR:-$FUND_LOG_DIR/sessions}"
+    mkdir -p "$FUND_SESSION_LOG_DIR" 2>/dev/null || true
   '';
 
   applySchema = ''

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -841,6 +841,38 @@ impl AccountActivity {
     }
 }
 
+/// The order raised to close one position.
+///
+/// The price is deliberately absent: a close is submitted and not polled to a terminal state, so
+/// there is no fill to report yet. `alpaca_order_id` is what joins this to the fill when the
+/// post-close activity sync lands it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PositionClose {
+    ticker: Ticker,
+    /// Absent when Alpaca accepted the close but returned a body this client could not read.
+    alpaca_order_id: Option<String>,
+    side: Option<String>,
+    quantity: Option<f64>,
+}
+
+impl PositionClose {
+    pub fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    pub fn alpaca_order_id(&self) -> Option<&str> {
+        self.alpaca_order_id.as_deref()
+    }
+
+    pub fn side(&self) -> Option<&str> {
+        self.side.as_deref()
+    }
+
+    pub fn quantity(&self) -> Option<f64> {
+        self.quantity
+    }
+}
+
 /// The result of asking Alpaca to close one position during a bulk liquidation.
 ///
 /// Alpaca answers a bulk close with `207 Multi-Status` and a per-symbol status, so a single
@@ -850,11 +882,34 @@ impl AccountActivity {
 pub struct LiquidationOutcome {
     ticker: Ticker,
     status: u16,
+    /// The order Alpaca raised, absent when it refused the close.
+    alpaca_order_id: Option<String>,
+    quantity: Option<f64>,
 }
 
 impl LiquidationOutcome {
     pub fn new(ticker: Ticker, status: u16) -> Self {
-        Self { ticker, status }
+        Self {
+            ticker,
+            status,
+            alpaca_order_id: None,
+            quantity: None,
+        }
+    }
+
+    /// The outcome together with the order that carried it out.
+    pub fn with_order(
+        ticker: Ticker,
+        status: u16,
+        alpaca_order_id: Option<String>,
+        quantity: Option<f64>,
+    ) -> Self {
+        Self {
+            ticker,
+            status,
+            alpaca_order_id,
+            quantity,
+        }
     }
 
     pub fn ticker(&self) -> &Ticker {
@@ -863,6 +918,14 @@ impl LiquidationOutcome {
 
     pub fn status(&self) -> u16 {
         self.status
+    }
+
+    pub fn alpaca_order_id(&self) -> Option<&str> {
+        self.alpaca_order_id.as_deref()
+    }
+
+    pub fn quantity(&self) -> Option<f64> {
+        self.quantity
     }
 
     /// Whether Alpaca accepted the close for this symbol.
@@ -1008,7 +1071,16 @@ impl TradingClient {
     /// Returns `false` when there was no position to close (`404`). That is the expected answer
     /// when a pair is being closed for the second time — after a retry, or after Alpaca liquidated
     /// the leg itself — and treating it as an error would turn a no-op into an incident.
-    pub async fn close_position(&self, ticker: &Ticker) -> Result<bool, ClientError> {
+    /// Closes one position, returning the order Alpaca raised to do it.
+    ///
+    /// `None` means there was no position, which is the expected answer on a retry or after Alpaca
+    /// liquidated the leg itself. The order identifier is surfaced rather than discarded because it
+    /// is the only handle joining an exit to the fill that settles it: the close is not polled to a
+    /// terminal state, so the price arrives later through `account_activities`.
+    pub async fn close_position(
+        &self,
+        ticker: &Ticker,
+    ) -> Result<Option<PositionClose>, ClientError> {
         let url = format!("{}/v2/positions/{}", self.base_url, ticker.as_str());
         let response = self
             .delete(&url)
@@ -1018,11 +1090,29 @@ impl TradingClient {
 
         if response.status().as_u16() == 404 {
             info!(ticker = %ticker, "No position to close");
-            return Ok(false);
+            return Ok(None);
         }
-        error_for_status(response).await?;
-        info!(ticker = %ticker, "Position close submitted");
-        Ok(true)
+        let response = error_for_status(response).await?;
+
+        // A body that will not parse is not a failed close: Alpaca accepted it, and refusing here
+        // would make the caller unwind a position that is already on its way out. The identifier is
+        // lost and the close is not.
+        let order: Option<ClosedPositionOrder> = response.json().await.ok();
+        let alpaca_order_id = order.as_ref().and_then(|order| order.id.clone());
+        info!(
+            ticker = %ticker,
+            order_id = alpaca_order_id.as_deref().unwrap_or("unknown"),
+            "Position close submitted"
+        );
+        Ok(Some(PositionClose {
+            ticker: ticker.clone(),
+            alpaca_order_id,
+            side: order.as_ref().and_then(|order| order.side.clone()),
+            quantity: order
+                .as_ref()
+                .and_then(|order| order.qty.as_ref())
+                .and_then(|quantity| quantity.parse().ok()),
+        }))
     }
 
     /// Closes every open position and cancels every open order.
@@ -1057,7 +1147,16 @@ impl TradingClient {
             if !(200..300).contains(&payload.status) {
                 warn!(ticker = %ticker, status = payload.status, "Alpaca refused to close a position");
             }
-            outcomes.push(LiquidationOutcome::new(ticker, payload.status));
+            outcomes.push(LiquidationOutcome::with_order(
+                ticker,
+                payload.status,
+                payload.body.as_ref().and_then(|order| order.id.clone()),
+                payload
+                    .body
+                    .as_ref()
+                    .and_then(|order| order.qty.as_ref())
+                    .and_then(|quantity| quantity.parse().ok()),
+            ));
         }
 
         info!(
@@ -1372,6 +1471,23 @@ struct PositionResponse {
 struct ClosePositionResponse {
     symbol: String,
     status: u16,
+    /// The order Alpaca raised, present when it accepted the close.
+    body: Option<ClosedPositionOrder>,
+}
+
+/// The order returned by a position close, single or bulk.
+///
+/// Only the identity and the size: a close is submitted and not polled, so `filled_avg_price` is
+/// still null here and the fill arrives later through `account_activities`.
+///
+/// Every field is optional, `id` included. A bulk close answers per symbol, and a symbol Alpaca
+/// refused carries an error object in the same position an order would occupy — so requiring `id`
+/// would make one refused leg fail the parse for the whole liquidation.
+#[derive(Deserialize)]
+struct ClosedPositionOrder {
+    id: Option<String>,
+    qty: Option<String>,
+    side: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -2490,10 +2606,11 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        assert!(!client
+        assert!(client
             .close_position(&ticker("AAPL"))
             .await
-            .expect("a missing position is not an error"));
+            .expect("a missing position is not an error")
+            .is_none());
         mock.assert_async().await;
     }
 

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -843,9 +843,8 @@ impl AccountActivity {
 
 /// The order raised to close one position.
 ///
-/// The price is deliberately absent: a close is submitted and not polled to a terminal state, so
-/// there is no fill to report yet. `alpaca_order_id` is what joins this to the fill when the
-/// post-close activity sync lands it.
+/// The price is absent because a close is not polled to a terminal state; `alpaca_order_id` joins
+/// this to the fill when the post-close activity sync lands it.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PositionClose {
     ticker: Ticker,
@@ -1011,9 +1010,8 @@ impl TradingClient {
     /// Submits an order and returns Alpaca's order identifier.
     /// Sends an order under a caller-chosen `client_order_id`.
     ///
-    /// The identifier is the caller's because it has to exist before the request does: the session
-    /// log records the intent first, and a crash before Alpaca answers otherwise leaves an order
-    /// nothing can name.
+    /// The identifier is the caller's because it must exist before the request does, so a crash
+    /// before Alpaca answers still leaves an order something can name.
     pub async fn submit_order(
         &self,
         intent: &OrderIntent,
@@ -1073,10 +1071,8 @@ impl TradingClient {
     /// the leg itself — and treating it as an error would turn a no-op into an incident.
     /// Closes one position, returning the order Alpaca raised to do it.
     ///
-    /// `None` means there was no position, which is the expected answer on a retry or after Alpaca
-    /// liquidated the leg itself. The order identifier is surfaced rather than discarded because it
-    /// is the only handle joining an exit to the fill that settles it: the close is not polled to a
-    /// terminal state, so the price arrives later through `account_activities`.
+    /// `None` means there was no position, the expected answer on a retry. The order identifier is
+    /// the only handle joining an exit to the fill that settles it in `account_activities`.
     pub async fn close_position(
         &self,
         ticker: &Ticker,
@@ -1477,12 +1473,8 @@ struct ClosePositionResponse {
 
 /// The order returned by a position close, single or bulk.
 ///
-/// Only the identity and the size: a close is submitted and not polled, so `filled_avg_price` is
-/// still null here and the fill arrives later through `account_activities`.
-///
-/// Every field is optional, `id` included. A bulk close answers per symbol, and a symbol Alpaca
-/// refused carries an error object in the same position an order would occupy — so requiring `id`
-/// would make one refused leg fail the parse for the whole liquidation.
+/// Every field is optional, `id` included: a bulk close puts an error object where a refused
+/// symbol's order would be, so a required field would fail the parse for the whole liquidation.
 #[derive(Deserialize)]
 struct ClosedPositionOrder {
     id: Option<String>,
@@ -1612,9 +1604,8 @@ impl Snapshot {
 
     /// [`Snapshot::reference_price`] together with the field it came from.
     ///
-    /// The two branches are not interchangeable readings of one number — a midpoint moves with the
-    /// book while the last trade can be minutes stale — so a price recorded without its source
-    /// cannot be compared against the same symbol's price on the next pass.
+    /// A midpoint and a last trade are not interchangeable readings, so a price without its source
+    /// cannot be compared against the same symbol on the next pass.
     pub fn reference_price_with_source(&self) -> Option<(f64, PriceSource)> {
         self.latest_quote
             .as_ref()

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -487,12 +487,20 @@ impl OrderIntent {
         }
     }
 
+    /// Which side of the book this order takes, as Alpaca names it.
+    pub fn side(&self) -> &'static str {
+        match self {
+            OrderIntent::OpenLong { .. } => "buy",
+            OrderIntent::OpenShort { .. } => "sell",
+        }
+    }
+
     /// Builds the request body Alpaca expects.
     ///
     /// `position_intent` is sent explicitly rather than left to Alpaca's inference. Without it a
     /// sell against an existing long is read as a close rather than a short, which for a strategy
     /// that holds both sides of a pair is the difference between opening a hedge and unwinding one.
-    fn to_request(&self) -> OrderRequest {
+    fn to_request(&self, client_order_id: &str) -> OrderRequest {
         match self {
             OrderIntent::OpenLong { ticker, notional } => OrderRequest {
                 symbol: ticker.as_str().to_string(),
@@ -502,6 +510,7 @@ impl OrderIntent {
                 notional: Some(format!("{:.2}", notional.value())),
                 qty: None,
                 position_intent: "buy_to_open",
+                client_order_id: client_order_id.to_string(),
             },
             OrderIntent::OpenShort { ticker, shares } => OrderRequest {
                 symbol: ticker.as_str().to_string(),
@@ -511,6 +520,7 @@ impl OrderIntent {
                 notional: None,
                 qty: Some(shares.get()),
                 position_intent: "sell_to_open",
+                client_order_id: client_order_id.to_string(),
             },
         }
     }
@@ -936,10 +946,24 @@ impl TradingClient {
     }
 
     /// Submits an order and returns Alpaca's order identifier.
-    pub async fn submit_order(&self, intent: &OrderIntent) -> Result<String, ClientError> {
+    /// Sends an order under a caller-chosen `client_order_id`.
+    ///
+    /// The identifier is the caller's because it has to exist before the request does: the session
+    /// log records the intent first, and a crash before Alpaca answers otherwise leaves an order
+    /// nothing can name.
+    pub async fn submit_order(
+        &self,
+        intent: &OrderIntent,
+        client_order_id: &str,
+    ) -> Result<String, ClientError> {
         let url = format!("{}/v2/orders", self.base_url);
-        let response =
-            error_for_status(self.post(&url).json(&intent.to_request()).send().await?).await?;
+        let response = error_for_status(
+            self.post(&url)
+                .json(&intent.to_request(client_order_id))
+                .send()
+                .await?,
+        )
+        .await?;
         let order: OrderResponse = response.json().await.map_err(|error| {
             ClientError::Parse(format!("Failed to parse order response: {error}"))
         })?;
@@ -947,6 +971,7 @@ impl TradingClient {
         info!(
             ticker = %intent.ticker(),
             order_id = %order.id,
+            client_order_id,
             "Order submitted"
         );
         Ok(order.id)
@@ -1318,6 +1343,12 @@ struct OrderRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     qty: Option<u32>,
     position_intent: &'static str,
+    /// The caller's own identifier, chosen before the order is sent.
+    ///
+    /// This is what makes an order recoverable after a crash between the session log write and
+    /// Alpaca's response: the broker's identifier does not exist yet at that point, and this one
+    /// does.
+    client_order_id: String,
 }
 
 #[derive(Deserialize)]
@@ -1460,10 +1491,46 @@ impl Snapshot {
     /// name. Callers needing to reject a wide or stale book should read [`Snapshot::latest_quote`]
     /// directly; this is the convenience path, not the careful one.
     pub fn reference_price(&self) -> Option<f64> {
+        self.reference_price_with_source().map(|(price, _)| price)
+    }
+
+    /// [`Snapshot::reference_price`] together with the field it came from.
+    ///
+    /// The two branches are not interchangeable readings of one number — a midpoint moves with the
+    /// book while the last trade can be minutes stale — so a price recorded without its source
+    /// cannot be compared against the same symbol's price on the next pass.
+    pub fn reference_price_with_source(&self) -> Option<(f64, PriceSource)> {
         self.latest_quote
             .as_ref()
-            .map(EquityQuote::mid_price)
-            .or(self.latest_trade_price)
+            .map(|quote| (quote.mid_price(), PriceSource::QuoteMidpoint))
+            .or_else(|| {
+                self.latest_trade_price
+                    .map(|price| (price, PriceSource::LastTrade))
+            })
+    }
+}
+
+/// Which field of a [`Snapshot`] a reference price was read from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PriceSource {
+    QuoteMidpoint,
+    LastTrade,
+}
+
+impl PriceSource {
+    /// A stable short name for the session log and the structured logs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PriceSource::QuoteMidpoint => "quote_midpoint",
+            PriceSource::LastTrade => "last_trade",
+        }
+    }
+}
+
+impl std::fmt::Display for PriceSource {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
     }
 }
 
@@ -2181,7 +2248,7 @@ mod tests {
             ticker: ticker("AAPL"),
             notional: Dollars::new(Decimal::new(123456, 2)).unwrap(),
         }
-        .to_request();
+        .to_request("client-long");
         assert_eq!(long.side, "buy");
         assert_eq!(long.notional.as_deref(), Some("1234.56"));
         assert_eq!(long.qty, None);
@@ -2191,7 +2258,7 @@ mod tests {
             ticker: ticker("MSFT"),
             shares: shares(40),
         }
-        .to_request();
+        .to_request("client-short");
         assert_eq!(short.side, "sell");
         assert_eq!(short.notional, None);
         assert_eq!(short.qty, Some(40));
@@ -2208,7 +2275,7 @@ mod tests {
                 ticker: ticker("MSFT"),
                 shares: shares(10),
             }
-            .to_request(),
+            .to_request("client-short"),
         )
         .unwrap();
         assert_eq!(body["position_intent"], "sell_to_open");
@@ -2395,10 +2462,13 @@ mod tests {
 
         let client = TradingClient::with_base_url(credentials(), server.url());
         let order_id = client
-            .submit_order(&OrderIntent::OpenLong {
-                ticker: ticker("AAPL"),
-                notional: Dollars::new(Decimal::new(5000, 0)).unwrap(),
-            })
+            .submit_order(
+                &OrderIntent::OpenLong {
+                    ticker: ticker("AAPL"),
+                    notional: Dollars::new(Decimal::new(5000, 0)).unwrap(),
+                },
+                "client-long",
+            )
             .await
             .expect("order must submit");
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,6 +8,9 @@
 //! Two S3 prefixes with one owner each. [`archive`] owns `data/`, the trainer's bars and the long-
 //! term record of them; [`export`] owns `exports/`, the application's own tables, which the purge
 //! deletes from PostgreSQL only once they are safely written. Neither writes the other's prefix.
+//!
+//! [`session_log`] is the exception to "tables first": it is written to local disk as it happens and
+//! is the original that PostgreSQL and S3 are both derived from.
 
 pub mod archive;
 pub mod bars;
@@ -15,4 +18,5 @@ pub mod calendar;
 pub mod details;
 pub mod export;
 pub mod purge;
+pub mod session_log;
 pub mod universe;

--- a/src/data/session_log.rs
+++ b/src/data/session_log.rs
@@ -154,7 +154,8 @@ pub struct ScreenInputReading {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ExcludedTickerReading {
     pub ticker: String,
-    /// `already_held`, `no_sector`, `no_close_history`, `outside_universe`, or `unpriced`.
+    /// `already_held`, `no_sector`, `no_close_history`, `outside_universe`, `unpriced`, or
+    /// `unusable_input`.
     pub reason: String,
 }
 
@@ -191,6 +192,11 @@ pub struct OpenPairReading {
 }
 
 /// A scored candidate and what became of it.
+///
+/// The sizing fields are set for every candidate that reached the sizer, including the ones the risk
+/// gate then refused. Recording them only on the orders that went out would leave a refusal
+/// unanswerable in the one dimension that caused it — a pair turned down for gross exposure is a
+/// statement about its size, and the size would be the part that was missing.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct CandidateReading {
     pub pair_id: String,
@@ -200,6 +206,11 @@ pub struct CandidateReading {
     pub entry_z_score: f64,
     pub signal_strength: f64,
     pub rank_score: f64,
+    /// Dollars the long leg was sized to, absent for a candidate that was never selected.
+    pub long_notional: Option<f64>,
+    /// Whole shares the short leg was sized to.
+    pub short_shares: Option<f64>,
+    pub gross_exposure: Option<f64>,
     /// `opened`, `not_selected`, `risk_refused`, `unfilled`, or `abandoned_at_shutdown`.
     pub decision: String,
     /// The risk gate's rendered reason, when `decision` is `risk_refused`.
@@ -713,8 +724,19 @@ mod tests {
         })
     }
 
+    /// A directory unique to this run.
+    ///
+    /// The name carries the process and a counter rather than the test's name alone: two `cargo
+    /// test` invocations overlapping on one machine would otherwise delete and recreate the same
+    /// path underneath each other, which is a flake that reproduces about once in fifteen runs.
     fn temporary_directory(name: &str) -> PathBuf {
-        let directory = std::env::temp_dir().join(format!("fund-session-log-{name}"));
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let directory = std::env::temp_dir().join(format!(
+            "fund-session-log-{name}-{}-{unique}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&directory);
         directory
     }

--- a/src/data/session_log.rs
+++ b/src/data/session_log.rs
@@ -20,20 +20,15 @@ use crate::data::calendar::SessionDate;
 
 /// Version stamped on every record written by this build.
 ///
-/// Readers map old versions forward rather than files being rewritten, so this only ever goes up.
-/// See the module note in [`Observation`] for what a change costs.
+/// Readers map old versions forward rather than rewriting files, so this only ever goes up.
 pub const SCHEMA_VERSION: u32 = 1;
 
 /// S3 prefix the sealed sessions are written under.
-///
-/// Inside `exports/`, which [`crate::data::export`] already owns, so the bucket keeps two prefixes
-/// with one writer each.
 pub const EXPORT_PREFIX: &str = "exports/session_log";
 
 /// Calendar days of sealed sessions kept on local disk after a clean export.
 ///
-/// The local file is the crash-exact original and Parquet is derived from it, so this is the window
-/// in which a bad conversion can still be repaired from the bytes that were actually written.
+/// The window in which a bad Parquet conversion can still be repaired from the original bytes.
 pub const RETENTION_DAYS: i64 = 7;
 
 /// Anything that stops a record reaching the disk.
@@ -57,13 +52,8 @@ pub enum SessionLogError {
 
 /// One observation, tagged with what kind it is.
 ///
-/// **Observations only.** No slippage, no realized profit and loss, no exposure totals — every one
-/// of those is a query over these rows, and storing a computed value creates a second thing that can
-/// disagree with the first.
-///
-/// Variants are additive. A field added to a payload is optional; a renamed field becomes a new
-/// variant while readers keep understanding the old one, and [`SCHEMA_VERSION`] goes up. Past files
-/// are never rewritten.
+/// Observations only — no slippage, profit and loss, or exposure totals, each of which is a query
+/// over these rows. Variants are additive and past files are never rewritten.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(tag = "event_type", content = "payload", rename_all = "snake_case")]
 pub enum Observation {
@@ -100,13 +90,8 @@ impl Observation {
 
 /// One evaluation pass, whole.
 ///
-/// `prices` carries every reading the pass used, once; the pair and candidate rows name tickers and
-/// do not repeat the number. That is what makes "did the price move or did the model refit" a join
-/// rather than a guess.
-///
-/// `candidates` holds the pairs the screen actually scored, not the full cross product — that is
-/// quadratic in the eligible universe and would be millions of rows a pass. `candidates_screened`
-/// and `eligible_tickers` are what bound the part that is not enumerated.
+/// `prices` holds every reading once; pair and candidate rows name tickers without repeating it.
+/// `candidates` holds only the pairs the screen scored, not the quadratic cross product.
 #[derive(Debug, Clone, PartialEq, Default, Serialize)]
 pub struct EvaluationPass {
     pub account_equity: Option<f64>,
@@ -135,9 +120,8 @@ pub struct EvaluationPass {
 
 /// One forecast as the screen consumed it.
 ///
-/// `expected_return` and `confidence` are derived from the stored quantiles and `is_shortable` from
-/// the session's universe, so neither is recoverable from `equity_predictions` alone — this is the
-/// only record of what the model actually offered the screen.
+/// Derived from the stored quantiles and the session's universe, so not recoverable from
+/// `equity_predictions` alone.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ScreenInputReading {
     pub ticker: String,
@@ -148,9 +132,7 @@ pub struct ScreenInputReading {
 
 /// One forecast the eligibility filter removed, and why.
 ///
-/// Written every pass rather than once a session. The tests are nearly static within a day, so most
-/// of this repeats — but `held` is not static, and a rule that says "record the funnel every pass"
-/// has no edge case where the one pass that mattered was the one that skipped it.
+/// Written every pass, because `held` changes within a session even though the other tests do not.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ExcludedTickerReading {
     pub ticker: String,
@@ -169,9 +151,8 @@ pub struct PriceReading {
 
 /// An open pair as this pass measured it, whether or not it closed.
 ///
-/// Every input to the z-score is here because a z-score on its own is unfalsifiable: a pair
-/// recorded at entry 6.09 and read at 1.25 five minutes later is indistinguishable from a price
-/// move, a refitted distribution, and a bug.
+/// Carries every input to the z-score, which on its own cannot distinguish a price move from a
+/// refit.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct OpenPairReading {
     pub pair_id: String,
@@ -184,7 +165,7 @@ pub struct OpenPairReading {
     pub z_score: Option<f64>,
     pub entry_z_score: f64,
     pub stop_at: f64,
-    pub entry_session: NaiveDate,
+    pub entry_session: SessionDate,
     pub minutes_held: i64,
     /// `held`, `convergence`, `stop_loss`, `end_of_day`, `position_missing`, `unpriced`,
     /// `no_spread_model`, `unreadable_spread`, or `close_failed`.
@@ -193,10 +174,7 @@ pub struct OpenPairReading {
 
 /// A scored candidate and what became of it.
 ///
-/// The sizing fields are set for every candidate that reached the sizer, including the ones the risk
-/// gate then refused. Recording them only on the orders that went out would leave a refusal
-/// unanswerable in the one dimension that caused it — a pair turned down for gross exposure is a
-/// statement about its size, and the size would be the part that was missing.
+/// The sizing fields are set for every candidate that reached the sizer, refused ones included.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct CandidateReading {
     pub pair_id: String,
@@ -219,9 +197,8 @@ pub struct CandidateReading {
 
 /// An order at the moment it was sent, before the broker has said anything about it.
 ///
-/// Written *before* the request leaves the process, which is why it is keyed by `client_order_id`
-/// rather than Alpaca's: the broker's identifier does not exist yet, and a crash in the gap would
-/// otherwise leave a live order that nothing on disk can name.
+/// Keyed by `client_order_id` because this is written before the request leaves the process, when
+/// the broker's identifier does not exist yet.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct OrderSubmitted {
     pub client_order_id: String,
@@ -235,31 +212,28 @@ pub struct OrderSubmitted {
 
 /// How the broker settled an order.
 ///
-/// One of these follows every [`OrderSubmitted`], filled or not, so a submission with no resolution
-/// means the process died between the two — which is the state worth alarming on.
-///
-/// Slippage is deliberately absent: it is this row joined to the pass that produced the order, and
-/// computing it here would freeze one definition of it into the archive.
+/// One follows every [`OrderSubmitted`], so an unresolved submission means the process died between
+/// the two. Slippage is absent: it is this row joined to the pass that produced the order.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct OrderResolved {
     pub client_order_id: String,
-    pub alpaca_order_id: String,
+    /// Absent when the order never reached the broker.
+    pub alpaca_order_id: Option<String>,
     pub ticker: String,
-    /// `filled`, or the broker's terminal status for an order that did not fill.
+    /// `filled`, `submit_failed`, `broker_unreachable`, or the broker's terminal status.
     pub outcome: String,
     pub filled_shares: Option<f64>,
     pub filled_average_price: Option<f64>,
     /// True when the fill was read after a cancel raced it.
     pub filled_after_cancel: bool,
+    /// The broker's error, when the order failed rather than settled.
+    pub error: Option<String>,
 }
 
 /// One position the application asked Alpaca to close.
 ///
-/// **Not symmetrical with [`OrderSubmitted`], and deliberately.** An entry is polled to a terminal
-/// state because the pass cannot proceed without knowing whether the leg filled; an exit is
-/// submitted and left, because blocking on a fill would delay every other exit behind it. So there
-/// is no resolution record and no fill price here — `alpaca_order_id` is the join to the fill when
-/// the post-close activity sync lands it.
+/// Unlike an entry, an exit is not polled to a terminal state, so there is no fill price here —
+/// `alpaca_order_id` is the join to the fill once the post-close activity sync lands it.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PositionCloseRequested {
     pub ticker: String,
@@ -276,6 +250,9 @@ pub struct PositionCloseRequested {
     pub accepted: bool,
     /// Alpaca's per-symbol status, on the bulk path that reports one.
     pub status: Option<u16>,
+    /// The broker's error, set only when the request itself failed. `accepted: false` with no
+    /// error means there was no position, which is the opposite state.
+    pub error: Option<String>,
 }
 
 /// The pre-close flattening.
@@ -288,8 +265,8 @@ pub struct LiquidationRun {
 
 /// The pre-open inference run.
 ///
-/// The forecasts themselves are not repeated here — they are rows in `equity_predictions` and reach
-/// S3 through the nightly export. What only this run knows is which artifact produced them.
+/// The forecasts live in `equity_predictions`; what only this run knows is which artifact made
+/// them.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PredictionsGenerated {
     pub model_run_id: String,
@@ -302,24 +279,25 @@ pub struct PredictionsGenerated {
 
 /// The post-close account state.
 ///
-/// Recorded in full because Alpaca cannot report most of it again: portfolio history backfills
-/// equity for a past date and nothing backfills cash, buying power, or the market values.
+/// Recorded in full because Alpaca backfills only equity for a past date, never the rest.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct AccountObserved {
     /// The session these balances describe, which is not always the one the record was written in:
     /// a post-close sync re-run after Eastern midnight observes yesterday from today.
-    pub session_date: NaiveDate,
-    pub equity: f64,
-    pub cash: f64,
-    pub buying_power: f64,
-    pub long_market_value: f64,
-    pub short_market_value: f64,
+    pub session_date: SessionDate,
+    /// `None` when the broker's decimal will not fit an `f64`. A fabricated zero would be a false
+    /// observation, which is the one thing this log must not contain.
+    pub equity: Option<f64>,
+    pub cash: Option<f64>,
+    pub buying_power: Option<f64>,
+    pub long_market_value: Option<f64>,
+    pub short_market_value: Option<f64>,
 }
 
 /// One line of the log: an observation with the envelope that makes it addressable.
 ///
-/// `session_date` is derived from `created_at` rather than supplied, so a record cannot be filed
-/// under a session it did not happen in.
+/// `session_date` is derived from `created_at`, so a record cannot be filed under a session it did
+/// not happen in.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Record {
     pub schema_version: u32,
@@ -358,8 +336,8 @@ struct OpenSession {
 
 /// Appends records to the current session's file.
 ///
-/// One handle for the life of the process. The file rolls when the Eastern date does, which is why
-/// the session is taken from the record rather than from a field set at construction.
+/// The file rolls when the Eastern date does, so the session comes from the record rather than from
+/// construction.
 pub struct SessionLog {
     directory: PathBuf,
     open_session: tokio::sync::Mutex<Option<OpenSession>>,
@@ -381,9 +359,7 @@ impl SessionLog {
 
     /// Opens a log at `FUND_SESSION_LOG_DIR`, or `sessions/` under the configured log directory.
     ///
-    /// Defaulting inside `FUND_LOG_DIR` is what lets this ship without a provisioning change: that
-    /// path is already created and already falls back to a writable location on a machine that was
-    /// never bootstrapped.
+    /// Defaulting inside `FUND_LOG_DIR` inherits that path's existing writability fallback.
     pub fn from_env() -> Result<Self, SessionLogError> {
         let directory = match std::env::var("FUND_SESSION_LOG_DIR") {
             Ok(directory) => PathBuf::from(directory),
@@ -399,10 +375,10 @@ impl SessionLog {
         &self.directory
     }
 
-    /// Appends one record and returns once it is on the disk.
+    /// Appends one record and returns once it is fsynced to the disk.
     ///
-    /// Flushed and fsynced before returning, so a caller that awaits this before acting knows the
-    /// observation survives the crash that the action might cause.
+    /// A caller that awaits this before acting knows the observation survives the crash the action
+    /// might cause.
     pub async fn append(&self, record: &Record) -> Result<(), SessionLogError> {
         let mut line = serde_json::to_vec(record)?;
         line.push(b'\n');
@@ -431,9 +407,8 @@ impl SessionLog {
 
     /// Appends a record, reporting a failure without propagating it.
     ///
-    /// A log write must not become a new way for the fund to stop trading: refusing to act because
-    /// the observation could not be stored is strictly worse than acting unobserved, and the error
-    /// is loud enough to notice the next morning.
+    /// A log write must not become a new way for the fund to stop trading, so acting unobserved
+    /// beats refusing to act.
     pub async fn record(
         &self,
         correlation_id: Uuid,
@@ -454,6 +429,18 @@ impl SessionLog {
     }
 }
 
+impl SessionLog {
+    /// Blocks appends for as long as the returned guard is held.
+    ///
+    /// The export takes this before reading, so no reader sees a half-written line. The open handle
+    /// is dropped, so the next append reopens the file.
+    async fn seal(&self) -> tokio::sync::MutexGuard<'_, Option<OpenSession>> {
+        let mut open_session = self.open_session.lock().await;
+        *open_session = None;
+        open_session
+    }
+}
+
 /// The file one session's records live in.
 fn file_name(session_date: SessionDate) -> String {
     format!("session-{}.jsonl", session_date.date())
@@ -461,8 +448,8 @@ fn file_name(session_date: SessionDate) -> String {
 
 /// Recovers the session from a name built by [`file_name`], or `None` for anything else.
 ///
-/// `None` rather than an error: the directory may hold files this layout knows nothing about, and a
-/// stray one is something to skip rather than to fail a run over.
+/// `None` rather than an error, because a stray file is something to skip, not to fail a run
+/// over.
 fn session_from_file_name(name: &str) -> Option<SessionDate> {
     let date = name.strip_prefix("session-")?.strip_suffix(".jsonl")?;
     let session_date = SessionDate::from_date(NaiveDate::parse_from_str(date, "%Y-%m-%d").ok()?);
@@ -485,10 +472,10 @@ pub struct SessionLogExportSummary {
     pub failed: Vec<(NaiveDate, String)>,
     /// Sessions whose local file was deleted after the retention window.
     pub deleted: Vec<NaiveDate>,
-    /// Lines that could not be parsed and were skipped, across every session.
+    /// Lines skipped as unreadable, across every session.
     ///
-    /// A torn final line is what a crash mid-append leaves behind, and is the expected non-zero
-    /// case. A number larger than the number of sessions means something else is wrong.
+    /// A torn final line per crashed session is expected; more than that means something else is
+    /// wrong.
     pub unparsable_lines: usize,
 }
 
@@ -504,14 +491,9 @@ impl SessionLogExportSummary {
 
 /// Converts every sealed session on disk to Parquet in S3, then deletes what has aged out.
 ///
-/// **Every file present is exported, not just the retention window.** The unit is the whole sealed
-/// file at a deterministic key, so a repeat is a byte-identical overwrite rather than a duplicate —
-/// which means there is no cursor to track, a failed run repairs itself on the next one, and a
-/// straggler that landed after the last export is picked up. A process that was down for a fortnight
-/// still ships everything it held.
-///
-/// Local files are deleted only when the whole run was clean, so a session cannot age out of a
-/// window it never left the machine in.
+/// Every file present is exported, not just the retention window: one whole file at a deterministic
+/// key makes a repeat a byte-identical overwrite, so a failed run repairs itself. Local files are
+/// deleted only after a clean run.
 pub async fn export_session_logs(
     log: &SessionLog,
     s3_client: &S3Client,
@@ -529,6 +511,10 @@ pub async fn export_session_logs(
     };
     sessions.sort();
 
+    // Held across the reads so no append can interleave with one. Today's file is sealed by the
+    // clock rather than by anything structural, and a recovery replay can run a pass at any hour.
+    let sealed = log.seal().await;
+
     for session_date in &sessions {
         let path = log.directory().join(file_name(*session_date));
         match read_session_frame(&path) {
@@ -543,6 +529,8 @@ pub async fn export_session_logs(
             Err(error) => summary.failed.push((session_date.date(), error)),
         }
     }
+
+    drop(sealed);
 
     if summary.is_clean() {
         summary.deleted = delete_aged_out(log.directory(), &sessions, today);
@@ -564,9 +552,8 @@ pub async fn export_session_logs(
 
 /// Sessions on disk whose trading day has finished.
 ///
-/// A file dated after `today` is not sealed and is left alone; one dated `today` is, because this
-/// runs after the close. A future-dated file means the clock moved, and exporting it would seal a
-/// session that is still being written.
+/// Today counts, because this runs after the close; a future-dated file does not, and exporting one
+/// would seal a session still being written.
 fn sealed_sessions(
     directory: &Path,
     today: SessionDate,
@@ -591,9 +578,8 @@ fn sealed_sessions(
 
 /// Removes the local copies of sessions older than the retention window.
 ///
-/// Called only after a clean run, so a session cannot age out of a window it never left the machine
-/// in. A file that will not delete is a warning rather than a failure: the copy in S3 is what the
-/// archive rests on, and a stale local file costs disk and nothing else.
+/// Called only after a clean run, so a session cannot age out without reaching S3. A file that will
+/// not delete is a warning: a stale local copy costs disk and nothing else.
 fn delete_aged_out(
     directory: &Path,
     sessions: &[SessionDate],
@@ -615,10 +601,9 @@ fn delete_aged_out(
     deleted
 }
 
-/// Reads one session file into a frame, skipping lines that will not parse.
+/// Reads one session file into a frame, returning it with the number of lines skipped.
 ///
-/// Returns the frame and the number of lines skipped. A torn final line is what a crash mid-append
-/// leaves, and discarding it is the whole reason the original is JSONL rather than Parquet.
+/// Discarding a torn final line is why the original is JSONL rather than Parquet.
 fn read_session_frame(path: &Path) -> Result<(DataFrame, usize), String> {
     let contents = std::fs::read_to_string(path)
         .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
@@ -638,16 +623,28 @@ fn read_session_frame(path: &Path) -> Result<(DataFrame, usize), String> {
             continue;
         };
         let text = |key: &str| record.get(key).and_then(Value::as_str).map(str::to_string);
+
+        // A record missing any of its envelope is discarded rather than written with nulls, so a
+        // query cannot mistake an unaddressable row for a good one.
+        let (Some(event_id), Some(event_type), Some(created_at)) = (
+            text("event_id"),
+            text("event_type"),
+            text("created_at").and_then(|stamp| {
+                DateTime::parse_from_rfc3339(&stamp)
+                    .ok()
+                    .map(|instant| instant.timestamp_millis())
+            }),
+        ) else {
+            unparsable += 1;
+            continue;
+        };
+
         schema_versions.push(record.get("schema_version").and_then(Value::as_i64));
-        event_ids.push(text("event_id"));
+        event_ids.push(Some(event_id));
         correlation_ids.push(text("correlation_id"));
-        event_types.push(text("event_type"));
+        event_types.push(Some(event_type));
         session_dates.push(text("session_date"));
-        created_ats.push(text("created_at").and_then(|stamp| {
-            DateTime::parse_from_rfc3339(&stamp)
-                .ok()
-                .map(|instant| instant.timestamp_millis())
-        }));
+        created_ats.push(Some(created_at));
         payloads.push(record.get("payload").map(Value::to_string));
     }
 
@@ -715,20 +712,19 @@ mod tests {
 
     fn account_observation() -> Observation {
         Observation::AccountObserved(AccountObserved {
-            session_date: NaiveDate::from_ymd_opt(2026, 8, 11).expect("valid date"),
-            equity: 104_812.55,
-            cash: 12_000.0,
-            buying_power: 200_000.0,
-            long_market_value: 50_000.0,
-            short_market_value: -50_000.0,
+            session_date: session(2026, 8, 11),
+            equity: Some(104_812.55),
+            cash: Some(12_000.0),
+            buying_power: Some(200_000.0),
+            long_market_value: Some(50_000.0),
+            short_market_value: Some(-50_000.0),
         })
     }
 
     /// A directory unique to this run.
     ///
-    /// The name carries the process and a counter rather than the test's name alone: two `cargo
-    /// test` invocations overlapping on one machine would otherwise delete and recreate the same
-    /// path underneath each other, which is a flake that reproduces about once in fifteen runs.
+    /// The process and counter suffix stop two overlapping `cargo test` invocations deleting and
+    /// recreating one path underneath each other.
     fn temporary_directory(name: &str) -> PathBuf {
         use std::sync::atomic::{AtomicUsize, Ordering};
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -808,12 +804,13 @@ mod tests {
     fn test_a_fill_records_the_observation_and_not_the_slippage() {
         let filled = OrderResolved {
             client_order_id: "kopep-long".to_string(),
-            alpaca_order_id: "order-1".to_string(),
+            alpaca_order_id: Some("order-1".to_string()),
             ticker: "KO".to_string(),
             outcome: "filled".to_string(),
             filled_shares: Some(412.0),
             filled_average_price: Some(62.44),
             filled_after_cancel: false,
+            error: None,
         };
         let value = serde_json::to_value(&filled).expect("fill must serialize");
         let object = value.as_object().expect("a fill is an object");
@@ -893,6 +890,39 @@ mod tests {
         assert_eq!(frame.height(), 1);
         assert_eq!(unparsable, 1);
         let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// Valid JSON is not enough: a row without an addressable envelope would reach Parquet with
+    /// nulls no query could tell apart from a good record.
+    #[test]
+    fn test_a_record_missing_its_envelope_is_counted_unparsable() {
+        let directory = temporary_directory("envelope");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("session-2026-08-11.jsonl");
+        let complete = serde_json::to_string(&Record::new(
+            Uuid::nil(),
+            instant("2026-08-11T20:15:00Z"),
+            account_observation(),
+        ))
+        .expect("the record must serialize");
+        let lines = [
+            complete.as_str(),
+            r#"{"schema_version":1,"event_type":"account_observed","created_at":"2026-08-11T20:15:00Z"}"#,
+            r#"{"schema_version":1,"event_id":"a","event_type":"account_observed","created_at":"not a time"}"#,
+        ]
+        .join("\n");
+        std::fs::write(&path, lines).expect("the file must be writable");
+
+        let (frame, unparsable) = read_session_frame(&path).expect("the session must read");
+        assert_eq!(
+            frame.height(),
+            1,
+            "only the complete record reaches the frame"
+        );
+        assert_eq!(
+            unparsable, 2,
+            "a missing event_id and an unparseable instant"
+        );
     }
 
     #[test]
@@ -1044,12 +1074,12 @@ mod tests {
                 Uuid::new_v4(),
                 instant("2026-08-11T20:15:00Z"),
                 Observation::AccountObserved(AccountObserved {
-                    session_date: NaiveDate::from_ymd_opt(2026, 8, 11).expect("valid date"),
-                    equity,
-                    cash: 12_000.0,
-                    buying_power: 200_000.0,
-                    long_market_value: 50_000.0,
-                    short_market_value: -50_000.0,
+                    session_date: session(2026, 8, 11),
+                    equity: Some(equity),
+                    cash: Some(12_000.0),
+                    buying_power: Some(200_000.0),
+                    long_market_value: Some(50_000.0),
+                    short_market_value: Some(-50_000.0),
                 }),
             );
             lines.push_str(&serde_json::to_string(&record).expect("the record must serialize"));

--- a/src/data/session_log.rs
+++ b/src/data/session_log.rs
@@ -73,6 +73,8 @@ pub enum Observation {
     OrderSubmitted(OrderSubmitted),
     /// How the broker settled that order, filled or not.
     OrderResolved(OrderResolved),
+    /// A position the application asked Alpaca to close.
+    PositionCloseRequested(PositionCloseRequested),
     /// The pre-close flattening.
     LiquidationRun(LiquidationRun),
     /// The pre-open inference run and the artifact it resolved.
@@ -88,6 +90,7 @@ impl Observation {
             Observation::EvaluationPass(_) => "evaluation_pass",
             Observation::OrderSubmitted(_) => "order_submitted",
             Observation::OrderResolved(_) => "order_resolved",
+            Observation::PositionCloseRequested(_) => "position_close_requested",
             Observation::LiquidationRun(_) => "liquidation_run",
             Observation::PredictionsGenerated(_) => "predictions_generated",
             Observation::AccountObserved(_) => "account_observed",
@@ -123,7 +126,36 @@ pub struct EvaluationPass {
     pub session_block: Option<String>,
     pub prices: Vec<PriceReading>,
     pub open_pairs: Vec<OpenPairReading>,
+    /// Every forecast that reached the screen, as the screen received it.
+    pub screen_inputs: Vec<ScreenInputReading>,
+    /// Every forecast that did not, and the first test it failed.
+    pub excluded: Vec<ExcludedTickerReading>,
     pub candidates: Vec<CandidateReading>,
+}
+
+/// One forecast as the screen consumed it.
+///
+/// `expected_return` and `confidence` are derived from the stored quantiles and `is_shortable` from
+/// the session's universe, so neither is recoverable from `equity_predictions` alone — this is the
+/// only record of what the model actually offered the screen.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ScreenInputReading {
+    pub ticker: String,
+    pub expected_return: f64,
+    pub confidence: f64,
+    pub is_shortable: bool,
+}
+
+/// One forecast the eligibility filter removed, and why.
+///
+/// Written every pass rather than once a session. The tests are nearly static within a day, so most
+/// of this repeats — but `held` is not static, and a rule that says "record the funnel every pass"
+/// has no edge case where the one pass that mattered was the one that skipped it.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ExcludedTickerReading {
+    pub ticker: String,
+    /// `already_held`, `no_sector`, `no_close_history`, `outside_universe`, or `unpriced`.
+    pub reason: String,
 }
 
 /// One symbol's reference price, and which snapshot field it came from.
@@ -208,6 +240,31 @@ pub struct OrderResolved {
     pub filled_average_price: Option<f64>,
     /// True when the fill was read after a cancel raced it.
     pub filled_after_cancel: bool,
+}
+
+/// One position the application asked Alpaca to close.
+///
+/// **Not symmetrical with [`OrderSubmitted`], and deliberately.** An entry is polled to a terminal
+/// state because the pass cannot proceed without knowing whether the leg filled; an exit is
+/// submitted and left, because blocking on a fill would delay every other exit behind it. So there
+/// is no resolution record and no fill price here — `alpaca_order_id` is the join to the fill when
+/// the post-close activity sync lands it.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PositionCloseRequested {
+    pub ticker: String,
+    /// The pair this leg belonged to, absent when the account is flattened without consulting them.
+    pub pair_id: Option<String>,
+    /// Absent when there was no position, or when Alpaca accepted the close and returned a body
+    /// this client could not read.
+    pub alpaca_order_id: Option<String>,
+    pub side: Option<String>,
+    pub quantity: Option<f64>,
+    /// `pair_exit`, `entry_unwind`, or `liquidation`.
+    pub reason: String,
+    /// False when Alpaca refused the close, or when there was no position to close.
+    pub accepted: bool,
+    /// Alpaca's per-symbol status, on the bulk path that reports one.
+    pub status: Option<u16>,
 }
 
 /// The pre-close flattening.

--- a/src/data/session_log.rs
+++ b/src/data/session_log.rs
@@ -1,0 +1,1061 @@
+//! Append-only record of what the application observed before it acted.
+//!
+//! One JSONL file per session on local disk, sealed at the close and written to S3 as Parquet.
+//! This is the only original the application owns: every other store is a fold or a query over it.
+
+use std::path::{Path, PathBuf};
+
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::Client as S3Client;
+use chrono::{DateTime, NaiveDate, Utc};
+use polars::prelude::*;
+use serde::Serialize;
+use serde_json::Value;
+use tokio::io::AsyncWriteExt;
+use tracing::{debug, error, info, warn};
+use uuid::Uuid;
+
+use crate::common::aws::date_partitioned_key;
+use crate::data::calendar::SessionDate;
+
+/// Version stamped on every record written by this build.
+///
+/// Readers map old versions forward rather than files being rewritten, so this only ever goes up.
+/// See the module note in [`Observation`] for what a change costs.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// S3 prefix the sealed sessions are written under.
+///
+/// Inside `exports/`, which [`crate::data::export`] already owns, so the bucket keeps two prefixes
+/// with one writer each.
+pub const EXPORT_PREFIX: &str = "exports/session_log";
+
+/// Calendar days of sealed sessions kept on local disk after a clean export.
+///
+/// The local file is the crash-exact original and Parquet is derived from it, so this is the window
+/// in which a bad conversion can still be repaired from the bytes that were actually written.
+pub const RETENTION_DAYS: i64 = 7;
+
+/// Anything that stops a record reaching the disk.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionLogError {
+    #[error("session log directory {directory} is unusable: {source}")]
+    Directory {
+        directory: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("session log write failed: {0}")]
+    Write(#[from] std::io::Error),
+    #[error("observation could not be serialized: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+/// One observation, tagged with what kind it is.
+///
+/// **Observations only.** No slippage, no realized profit and loss, no exposure totals — every one
+/// of those is a query over these rows, and storing a computed value creates a second thing that can
+/// disagree with the first.
+///
+/// Variants are additive. A field added to a payload is optional; a renamed field becomes a new
+/// variant while readers keep understanding the old one, and [`SCHEMA_VERSION`] goes up. Past files
+/// are never rewritten.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "event_type", content = "payload", rename_all = "snake_case")]
+pub enum Observation {
+    /// One five-minute pass: what it saw, what it decided, and what stopped it doing more.
+    EvaluationPass(Box<EvaluationPass>),
+    /// An order as it was sent, written before the request leaves the process.
+    OrderSubmitted(OrderSubmitted),
+    /// How the broker settled that order, filled or not.
+    OrderResolved(OrderResolved),
+    /// The pre-close flattening.
+    LiquidationRun(LiquidationRun),
+    /// The pre-open inference run and the artifact it resolved.
+    PredictionsGenerated(PredictionsGenerated),
+    /// The post-close account state, which Alpaca cannot fully report again for a past date.
+    AccountObserved(AccountObserved),
+}
+
+impl Observation {
+    /// The stable name this observation serializes under.
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Observation::EvaluationPass(_) => "evaluation_pass",
+            Observation::OrderSubmitted(_) => "order_submitted",
+            Observation::OrderResolved(_) => "order_resolved",
+            Observation::LiquidationRun(_) => "liquidation_run",
+            Observation::PredictionsGenerated(_) => "predictions_generated",
+            Observation::AccountObserved(_) => "account_observed",
+        }
+    }
+}
+
+/// One evaluation pass, whole.
+///
+/// `prices` carries every reading the pass used, once; the pair and candidate rows name tickers and
+/// do not repeat the number. That is what makes "did the price move or did the model refit" a join
+/// rather than a guess.
+///
+/// `candidates` holds the pairs the screen actually scored, not the full cross product — that is
+/// quadratic in the eligible universe and would be millions of rows a pass. `candidates_screened`
+/// and `eligible_tickers` are what bound the part that is not enumerated.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct EvaluationPass {
+    pub account_equity: Option<f64>,
+    pub previous_session_equity: Option<f64>,
+    pub gross_exposure_used: Option<f64>,
+    pub gross_exposure_cap: Option<f64>,
+    pub drawdown: Option<f64>,
+    pub minutes_until_close: Option<i64>,
+    pub open_pairs_at_start: usize,
+    pub vacant_slots: Option<usize>,
+    pub universe_size: usize,
+    pub predictions_available: usize,
+    pub eligible_tickers: usize,
+    pub candidates_screened: usize,
+    pub model_run_id: Option<String>,
+    /// Why the entry half did not run at all, if it did not.
+    pub session_block: Option<String>,
+    pub prices: Vec<PriceReading>,
+    pub open_pairs: Vec<OpenPairReading>,
+    pub candidates: Vec<CandidateReading>,
+}
+
+/// One symbol's reference price, and which snapshot field it came from.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PriceReading {
+    pub ticker: String,
+    pub price: f64,
+    pub price_source: String,
+}
+
+/// An open pair as this pass measured it, whether or not it closed.
+///
+/// Every input to the z-score is here because a z-score on its own is unfalsifiable: a pair
+/// recorded at entry 6.09 and read at 1.25 five minutes later is indistinguishable from a price
+/// move, a refitted distribution, and a bug.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct OpenPairReading {
+    pub pair_id: String,
+    pub long_ticker: String,
+    pub short_ticker: String,
+    pub stored_hedge_ratio: f64,
+    pub model_hedge_ratio: Option<f64>,
+    pub spread_mean: Option<f64>,
+    pub spread_standard_deviation: Option<f64>,
+    pub z_score: Option<f64>,
+    pub entry_z_score: f64,
+    pub stop_at: f64,
+    pub entry_session: NaiveDate,
+    pub minutes_held: i64,
+    /// `held`, `convergence`, `stop_loss`, `end_of_day`, `position_missing`, `unpriced`,
+    /// `no_spread_model`, `unreadable_spread`, or `close_failed`.
+    pub decision: String,
+}
+
+/// A scored candidate and what became of it.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CandidateReading {
+    pub pair_id: String,
+    pub long_ticker: String,
+    pub short_ticker: String,
+    pub hedge_ratio: f64,
+    pub entry_z_score: f64,
+    pub signal_strength: f64,
+    pub rank_score: f64,
+    /// `opened`, `not_selected`, `risk_refused`, `unfilled`, or `abandoned_at_shutdown`.
+    pub decision: String,
+    /// The risk gate's rendered reason, when `decision` is `risk_refused`.
+    pub refusal: Option<String>,
+}
+
+/// An order at the moment it was sent, before the broker has said anything about it.
+///
+/// Written *before* the request leaves the process, which is why it is keyed by `client_order_id`
+/// rather than Alpaca's: the broker's identifier does not exist yet, and a crash in the gap would
+/// otherwise leave a live order that nothing on disk can name.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct OrderSubmitted {
+    pub client_order_id: String,
+    pub ticker: String,
+    pub side: String,
+    /// Set for the short leg, which is sized in shares.
+    pub shares: Option<f64>,
+    /// Set for the long leg, which is sized in dollars.
+    pub notional: Option<f64>,
+}
+
+/// How the broker settled an order.
+///
+/// One of these follows every [`OrderSubmitted`], filled or not, so a submission with no resolution
+/// means the process died between the two — which is the state worth alarming on.
+///
+/// Slippage is deliberately absent: it is this row joined to the pass that produced the order, and
+/// computing it here would freeze one definition of it into the archive.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct OrderResolved {
+    pub client_order_id: String,
+    pub alpaca_order_id: String,
+    pub ticker: String,
+    /// `filled`, or the broker's terminal status for an order that did not fill.
+    pub outcome: String,
+    pub filled_shares: Option<f64>,
+    pub filled_average_price: Option<f64>,
+    /// True when the fill was read after a cancel raced it.
+    pub filled_after_cancel: bool,
+}
+
+/// The pre-close flattening.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LiquidationRun {
+    pub pairs_closed: usize,
+    pub positions_refused: usize,
+    pub pairs_still_open: Vec<String>,
+}
+
+/// The pre-open inference run.
+///
+/// The forecasts themselves are not repeated here — they are rows in `equity_predictions` and reach
+/// S3 through the nightly export. What only this run knows is which artifact produced them.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PredictionsGenerated {
+    pub model_run_id: String,
+    pub artifact_key: String,
+    pub artifact_staleness_sessions: Option<i64>,
+    pub predictions: usize,
+    pub rows_written: u64,
+    pub universe_size: usize,
+}
+
+/// The post-close account state.
+///
+/// Recorded in full because Alpaca cannot report most of it again: portfolio history backfills
+/// equity for a past date and nothing backfills cash, buying power, or the market values.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct AccountObserved {
+    /// The session these balances describe, which is not always the one the record was written in:
+    /// a post-close sync re-run after Eastern midnight observes yesterday from today.
+    pub session_date: NaiveDate,
+    pub equity: f64,
+    pub cash: f64,
+    pub buying_power: f64,
+    pub long_market_value: f64,
+    pub short_market_value: f64,
+}
+
+/// One line of the log: an observation with the envelope that makes it addressable.
+///
+/// `session_date` is derived from `created_at` rather than supplied, so a record cannot be filed
+/// under a session it did not happen in.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Record {
+    pub schema_version: u32,
+    pub event_id: Uuid,
+    /// Threads a pass to the orders it caused to the fills they produced.
+    pub correlation_id: Uuid,
+    pub session_date: SessionDate,
+    pub created_at: DateTime<Utc>,
+    #[serde(flatten)]
+    pub observation: Observation,
+}
+
+impl Record {
+    /// Stamps an observation with a fresh identity at `created_at`.
+    pub fn new(correlation_id: Uuid, created_at: DateTime<Utc>, observation: Observation) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            event_id: Uuid::new_v4(),
+            correlation_id,
+            session_date: SessionDate::at(created_at),
+            created_at,
+            observation,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Writer
+// ---------------------------------------------------------------------------
+
+/// The file the writer currently holds open, and the session it belongs to.
+struct OpenSession {
+    session_date: SessionDate,
+    file: tokio::fs::File,
+}
+
+/// Appends records to the current session's file.
+///
+/// One handle for the life of the process. The file rolls when the Eastern date does, which is why
+/// the session is taken from the record rather than from a field set at construction.
+pub struct SessionLog {
+    directory: PathBuf,
+    open_session: tokio::sync::Mutex<Option<OpenSession>>,
+}
+
+impl SessionLog {
+    /// Opens a log against `directory`, creating it if needed.
+    pub fn new(directory: impl Into<PathBuf>) -> Result<Self, SessionLogError> {
+        let directory = directory.into();
+        std::fs::create_dir_all(&directory).map_err(|source| SessionLogError::Directory {
+            directory: directory.display().to_string(),
+            source,
+        })?;
+        Ok(Self {
+            directory,
+            open_session: tokio::sync::Mutex::new(None),
+        })
+    }
+
+    /// Opens a log at `FUND_SESSION_LOG_DIR`, or `sessions/` under the configured log directory.
+    ///
+    /// Defaulting inside `FUND_LOG_DIR` is what lets this ship without a provisioning change: that
+    /// path is already created and already falls back to a writable location on a machine that was
+    /// never bootstrapped.
+    pub fn from_env() -> Result<Self, SessionLogError> {
+        let directory = match std::env::var("FUND_SESSION_LOG_DIR") {
+            Ok(directory) => PathBuf::from(directory),
+            Err(_) => Path::new(
+                &std::env::var("FUND_LOG_DIR").unwrap_or_else(|_| "/var/log/fund".to_string()),
+            )
+            .join("sessions"),
+        };
+        Self::new(directory)
+    }
+
+    pub fn directory(&self) -> &Path {
+        &self.directory
+    }
+
+    /// Appends one record and returns once it is on the disk.
+    ///
+    /// Flushed and fsynced before returning, so a caller that awaits this before acting knows the
+    /// observation survives the crash that the action might cause.
+    pub async fn append(&self, record: &Record) -> Result<(), SessionLogError> {
+        let mut line = serde_json::to_vec(record)?;
+        line.push(b'\n');
+
+        let mut open_session = self.open_session.lock().await;
+        let session = match open_session.as_mut() {
+            Some(session) if session.session_date == record.session_date => session,
+            _ => {
+                let file = tokio::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(self.directory.join(file_name(record.session_date)))
+                    .await?;
+                open_session.insert(OpenSession {
+                    session_date: record.session_date,
+                    file,
+                })
+            }
+        };
+
+        session.file.write_all(&line).await?;
+        session.file.flush().await?;
+        session.file.sync_all().await?;
+        Ok(())
+    }
+
+    /// Appends a record, reporting a failure without propagating it.
+    ///
+    /// A log write must not become a new way for the fund to stop trading: refusing to act because
+    /// the observation could not be stored is strictly worse than acting unobserved, and the error
+    /// is loud enough to notice the next morning.
+    pub async fn record(
+        &self,
+        correlation_id: Uuid,
+        created_at: DateTime<Utc>,
+        observation: Observation,
+    ) {
+        let record = Record::new(correlation_id, created_at, observation);
+        let event_type = record.observation.event_type();
+        match self.append(&record).await {
+            Ok(()) => debug!(event_type, %correlation_id, "Session log record written"),
+            Err(error) => error!(
+                event_type,
+                %correlation_id,
+                %error,
+                "Session log record could not be written; the action proceeds unobserved"
+            ),
+        }
+    }
+}
+
+/// The file one session's records live in.
+fn file_name(session_date: SessionDate) -> String {
+    format!("session-{}.jsonl", session_date.date())
+}
+
+/// Recovers the session from a name built by [`file_name`], or `None` for anything else.
+///
+/// `None` rather than an error: the directory may hold files this layout knows nothing about, and a
+/// stray one is something to skip rather than to fail a run over.
+fn session_from_file_name(name: &str) -> Option<SessionDate> {
+    let date = name.strip_prefix("session-")?.strip_suffix(".jsonl")?;
+    let session_date = SessionDate::from_date(NaiveDate::parse_from_str(date, "%Y-%m-%d").ok()?);
+    // Accepted only if it is exactly what the writer would have produced. `%Y-%m-%d` also parses
+    // `2026-8-11`, and admitting both spellings would let one session reach the export twice under
+    // a single key, where whichever was read last silently wins.
+    (file_name(session_date) == name).then_some(session_date)
+}
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+/// What one export run accomplished.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SessionLogExportSummary {
+    /// `(session_date, records)` for each session written to S3.
+    pub exported: Vec<(NaiveDate, usize)>,
+    /// `(session_date, error)` for each session that failed.
+    pub failed: Vec<(NaiveDate, String)>,
+    /// Sessions whose local file was deleted after the retention window.
+    pub deleted: Vec<NaiveDate>,
+    /// Lines that could not be parsed and were skipped, across every session.
+    ///
+    /// A torn final line is what a crash mid-append leaves behind, and is the expected non-zero
+    /// case. A number larger than the number of sessions means something else is wrong.
+    pub unparsable_lines: usize,
+}
+
+impl SessionLogExportSummary {
+    pub fn total_records(&self) -> usize {
+        self.exported.iter().map(|(_, records)| records).sum()
+    }
+
+    pub fn is_clean(&self) -> bool {
+        self.failed.is_empty()
+    }
+}
+
+/// Converts every sealed session on disk to Parquet in S3, then deletes what has aged out.
+///
+/// **Every file present is exported, not just the retention window.** The unit is the whole sealed
+/// file at a deterministic key, so a repeat is a byte-identical overwrite rather than a duplicate —
+/// which means there is no cursor to track, a failed run repairs itself on the next one, and a
+/// straggler that landed after the last export is picked up. A process that was down for a fortnight
+/// still ships everything it held.
+///
+/// Local files are deleted only when the whole run was clean, so a session cannot age out of a
+/// window it never left the machine in.
+pub async fn export_session_logs(
+    log: &SessionLog,
+    s3_client: &S3Client,
+    bucket: &str,
+    today: SessionDate,
+) -> SessionLogExportSummary {
+    let mut summary = SessionLogExportSummary::default();
+
+    let mut sessions = match sealed_sessions(log.directory(), today) {
+        Ok(sessions) => sessions,
+        Err(error) => {
+            warn!(%error, "Session log directory could not be read; nothing exported");
+            return summary;
+        }
+    };
+    sessions.sort();
+
+    for session_date in &sessions {
+        let path = log.directory().join(file_name(*session_date));
+        match read_session_frame(&path) {
+            Ok((mut frame, unparsable)) => {
+                summary.unparsable_lines += unparsable;
+                let key = date_partitioned_key(EXPORT_PREFIX, session_date.date());
+                match write_frame(s3_client, bucket, &key, &mut frame).await {
+                    Ok(()) => summary.exported.push((session_date.date(), frame.height())),
+                    Err(error) => summary.failed.push((session_date.date(), error)),
+                }
+            }
+            Err(error) => summary.failed.push((session_date.date(), error)),
+        }
+    }
+
+    if summary.is_clean() {
+        summary.deleted = delete_aged_out(log.directory(), &sessions, today);
+    }
+
+    info!(
+        sessions = summary.exported.len(),
+        records = summary.total_records(),
+        failed = summary.failed.len(),
+        deleted = summary.deleted.len(),
+        unparsable_lines = summary.unparsable_lines,
+        "Session log export finished"
+    );
+    for (session_date, error) in &summary.failed {
+        warn!(%session_date, error, "Session log failed to export");
+    }
+    summary
+}
+
+/// Sessions on disk whose trading day has finished.
+///
+/// A file dated after `today` is not sealed and is left alone; one dated `today` is, because this
+/// runs after the close. A future-dated file means the clock moved, and exporting it would seal a
+/// session that is still being written.
+fn sealed_sessions(
+    directory: &Path,
+    today: SessionDate,
+) -> Result<Vec<SessionDate>, std::io::Error> {
+    let mut sessions = Vec::new();
+    for entry in std::fs::read_dir(directory)? {
+        let entry = entry?;
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let Some(session_date) = session_from_file_name(&name) else {
+            continue;
+        };
+        if session_date > today {
+            warn!(%session_date, %today, "Session log is dated ahead of today; not sealed");
+            continue;
+        }
+        sessions.push(session_date);
+    }
+    Ok(sessions)
+}
+
+/// Removes the local copies of sessions older than the retention window.
+///
+/// Called only after a clean run, so a session cannot age out of a window it never left the machine
+/// in. A file that will not delete is a warning rather than a failure: the copy in S3 is what the
+/// archive rests on, and a stale local file costs disk and nothing else.
+fn delete_aged_out(
+    directory: &Path,
+    sessions: &[SessionDate],
+    today: SessionDate,
+) -> Vec<NaiveDate> {
+    let oldest_kept = today.plus_calendar_days(-RETENTION_DAYS);
+    let mut deleted = Vec::new();
+    for session_date in sessions.iter().filter(|session| **session < oldest_kept) {
+        let path = directory.join(file_name(*session_date));
+        match std::fs::remove_file(&path) {
+            Ok(()) => deleted.push(session_date.date()),
+            Err(error) => warn!(
+                path = %path.display(),
+                %error,
+                "Aged-out session log could not be deleted"
+            ),
+        }
+    }
+    deleted
+}
+
+/// Reads one session file into a frame, skipping lines that will not parse.
+///
+/// Returns the frame and the number of lines skipped. A torn final line is what a crash mid-append
+/// leaves, and discarding it is the whole reason the original is JSONL rather than Parquet.
+fn read_session_frame(path: &Path) -> Result<(DataFrame, usize), String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+
+    let mut schema_versions: Vec<Option<i64>> = Vec::new();
+    let mut event_ids: Vec<Option<String>> = Vec::new();
+    let mut correlation_ids: Vec<Option<String>> = Vec::new();
+    let mut event_types: Vec<Option<String>> = Vec::new();
+    let mut session_dates: Vec<Option<String>> = Vec::new();
+    let mut created_ats: Vec<Option<i64>> = Vec::new();
+    let mut payloads: Vec<Option<String>> = Vec::new();
+    let mut unparsable = 0usize;
+
+    for line in contents.lines().filter(|line| !line.trim().is_empty()) {
+        let Ok(Value::Object(record)) = serde_json::from_str::<Value>(line) else {
+            unparsable += 1;
+            continue;
+        };
+        let text = |key: &str| record.get(key).and_then(Value::as_str).map(str::to_string);
+        schema_versions.push(record.get("schema_version").and_then(Value::as_i64));
+        event_ids.push(text("event_id"));
+        correlation_ids.push(text("correlation_id"));
+        event_types.push(text("event_type"));
+        session_dates.push(text("session_date"));
+        created_ats.push(text("created_at").and_then(|stamp| {
+            DateTime::parse_from_rfc3339(&stamp)
+                .ok()
+                .map(|instant| instant.timestamp_millis())
+        }));
+        payloads.push(record.get("payload").map(Value::to_string));
+    }
+
+    if unparsable > 0 {
+        warn!(
+            path = %path.display(),
+            unparsable,
+            "Skipped session log lines that would not parse"
+        );
+    }
+
+    let frame = DataFrame::new(vec![
+        Column::new("schema_version".into(), schema_versions),
+        Column::new("event_id".into(), event_ids),
+        Column::new("correlation_id".into(), correlation_ids),
+        Column::new("event_type".into(), event_types),
+        Column::new("session_date".into(), session_dates),
+        Column::new("created_at".into(), created_ats),
+        Column::new("payload".into(), payloads),
+    ])
+    .map_err(|error| format!("failed to build frame for {}: {error}", path.display()))?;
+
+    Ok((frame, unparsable))
+}
+
+/// Serializes a frame to Parquet and puts it at `key`.
+async fn write_frame(
+    s3_client: &S3Client,
+    bucket: &str,
+    key: &str,
+    frame: &mut DataFrame,
+) -> Result<(), String> {
+    let mut buffer: Vec<u8> = Vec::new();
+    ParquetWriter::new(&mut buffer)
+        .finish(frame)
+        .map_err(|error| format!("failed to serialize Parquet: {error}"))?;
+
+    s3_client
+        .put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(ByteStream::from(buffer))
+        .content_type("application/vnd.apache.parquet")
+        .send()
+        .await
+        .map_err(|error| format!("failed to write s3://{bucket}/{key}: {error}"))?;
+
+    info!(key, records = frame.height(), "Session log exported");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(year: i32, month: u32, day: u32) -> SessionDate {
+        SessionDate::from_date(NaiveDate::from_ymd_opt(year, month, day).expect("valid date"))
+    }
+
+    fn instant(raw: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(raw)
+            .expect("valid instant")
+            .with_timezone(&Utc)
+    }
+
+    fn account_observation() -> Observation {
+        Observation::AccountObserved(AccountObserved {
+            session_date: NaiveDate::from_ymd_opt(2026, 8, 11).expect("valid date"),
+            equity: 104_812.55,
+            cash: 12_000.0,
+            buying_power: 200_000.0,
+            long_market_value: 50_000.0,
+            short_market_value: -50_000.0,
+        })
+    }
+
+    fn temporary_directory(name: &str) -> PathBuf {
+        let directory = std::env::temp_dir().join(format!("fund-session-log-{name}"));
+        let _ = std::fs::remove_dir_all(&directory);
+        directory
+    }
+
+    #[test]
+    fn test_a_file_name_round_trips_through_its_session() {
+        for date in [
+            session(2026, 8, 11),
+            session(2025, 12, 31),
+            session(2024, 2, 29),
+        ] {
+            assert_eq!(session_from_file_name(&file_name(date)), Some(date));
+        }
+    }
+
+    #[test]
+    fn test_unrecognized_file_names_are_skipped() {
+        for name in [
+            "",
+            "session-2026-08-11.parquet",
+            "session-2026-8-11.jsonl",
+            "2026-08-11.jsonl",
+            "session-not-a-date.jsonl",
+            "session-2026-02-30.jsonl",
+        ] {
+            assert_eq!(session_from_file_name(name), None, "name: {name}");
+        }
+    }
+
+    /// The envelope files a record under the session its instant falls in, not the UTC date. 01:00
+    /// UTC is still the previous evening in New York, and getting this wrong splits one session
+    /// across two files for part of the year.
+    #[test]
+    fn test_the_session_is_derived_from_the_instant_in_eastern_terms() {
+        let record = Record::new(
+            Uuid::new_v4(),
+            instant("2026-08-12T01:00:00Z"),
+            account_observation(),
+        );
+        assert_eq!(record.session_date, session(2026, 8, 11));
+    }
+
+    #[test]
+    fn test_a_record_serializes_with_its_type_and_payload() {
+        let record = Record::new(
+            Uuid::nil(),
+            instant("2026-08-11T20:15:00Z"),
+            account_observation(),
+        );
+        let value: Value = serde_json::to_value(&record).expect("record must serialize");
+
+        assert_eq!(value["schema_version"], json_number(SCHEMA_VERSION as i64));
+        assert_eq!(value["event_type"], "account_observed");
+        assert_eq!(value["session_date"], "2026-08-11");
+        assert_eq!(value["payload"]["equity"], 104_812.55);
+        assert!(
+            value.get("event_id").and_then(Value::as_str).is_some(),
+            "every record is addressable by its own identifier"
+        );
+    }
+
+    fn json_number(value: i64) -> Value {
+        Value::Number(value.into())
+    }
+
+    /// No conclusions in the log. Storing a computed value would create a second thing that can
+    /// disagree with the observations it was derived from.
+    #[test]
+    fn test_a_fill_records_the_observation_and_not_the_slippage() {
+        let filled = OrderResolved {
+            client_order_id: "kopep-long".to_string(),
+            alpaca_order_id: "order-1".to_string(),
+            ticker: "KO".to_string(),
+            outcome: "filled".to_string(),
+            filled_shares: Some(412.0),
+            filled_average_price: Some(62.44),
+            filled_after_cancel: false,
+        };
+        let value = serde_json::to_value(&filled).expect("fill must serialize");
+        let object = value.as_object().expect("a fill is an object");
+        assert!(!object.contains_key("slippage"));
+        assert!(!object.contains_key("realized_profit_and_loss"));
+    }
+
+    #[tokio::test]
+    async fn test_records_append_to_one_file_per_session() {
+        let directory = temporary_directory("append");
+        let log = SessionLog::new(&directory).expect("the directory must be creatable");
+
+        log.record(
+            Uuid::new_v4(),
+            instant("2026-08-11T14:35:00Z"),
+            account_observation(),
+        )
+        .await;
+        log.record(
+            Uuid::new_v4(),
+            instant("2026-08-11T18:00:00Z"),
+            account_observation(),
+        )
+        .await;
+
+        let contents = std::fs::read_to_string(directory.join("session-2026-08-11.jsonl"))
+            .expect("the session file must exist");
+        assert_eq!(contents.lines().count(), 2);
+        for line in contents.lines() {
+            serde_json::from_str::<Value>(line).expect("every line must be a complete object");
+        }
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// The file rolls when the Eastern date does. A writer that held one file for the life of the
+    /// process would put two sessions in one archive object.
+    #[tokio::test]
+    async fn test_a_new_session_opens_a_new_file() {
+        let directory = temporary_directory("rollover");
+        let log = SessionLog::new(&directory).expect("the directory must be creatable");
+
+        log.record(
+            Uuid::new_v4(),
+            instant("2026-08-11T20:00:00Z"),
+            account_observation(),
+        )
+        .await;
+        log.record(
+            Uuid::new_v4(),
+            instant("2026-08-12T20:00:00Z"),
+            account_observation(),
+        )
+        .await;
+
+        assert!(directory.join("session-2026-08-11.jsonl").is_file());
+        assert!(directory.join("session-2026-08-12.jsonl").is_file());
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// A crash mid-append leaves a partial final line. Discarding it is the whole reason the
+    /// original is JSONL: the same truncation in a Parquet file loses the entire session.
+    #[test]
+    fn test_a_torn_final_line_is_skipped_rather_than_failing_the_session() {
+        let directory = temporary_directory("torn");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("session-2026-08-11.jsonl");
+        let complete = serde_json::to_string(&Record::new(
+            Uuid::nil(),
+            instant("2026-08-11T14:35:00Z"),
+            account_observation(),
+        ))
+        .expect("the record must serialize");
+        std::fs::write(&path, format!("{complete}\n{{\"schema_version\":1,\"eve"))
+            .expect("the file must be writable");
+
+        let (frame, unparsable) = read_session_frame(&path).expect("the session must still read");
+        assert_eq!(frame.height(), 1);
+        assert_eq!(unparsable, 1);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    #[test]
+    fn test_a_frame_carries_the_envelope_as_columns_and_the_payload_as_json() {
+        let directory = temporary_directory("frame");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("session-2026-08-11.jsonl");
+        let record = Record::new(
+            Uuid::nil(),
+            instant("2026-08-11T20:15:00Z"),
+            account_observation(),
+        );
+        std::fs::write(
+            &path,
+            format!(
+                "{}\n",
+                serde_json::to_string(&record).expect("the record must serialize")
+            ),
+        )
+        .expect("the file must be writable");
+
+        let (frame, _) = read_session_frame(&path).expect("the session must read");
+        assert_eq!(
+            frame.get_column_names(),
+            [
+                "schema_version",
+                "event_id",
+                "correlation_id",
+                "event_type",
+                "session_date",
+                "created_at",
+                "payload"
+            ]
+        );
+        let payload = frame
+            .column("payload")
+            .expect("payload column")
+            .str()
+            .expect("payload is text")
+            .get(0)
+            .expect("one row");
+        let parsed: Value = serde_json::from_str(payload).expect("the payload stays valid JSON");
+        assert_eq!(parsed["equity"], 104_812.55);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// Today's file is sealed because the export runs after the close; a future-dated one is not,
+    /// and exporting it would seal a session still being written.
+    #[test]
+    fn test_only_sessions_up_to_today_are_sealed() {
+        let directory = temporary_directory("sealed");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        for name in [
+            "session-2026-08-09.jsonl",
+            "session-2026-08-11.jsonl",
+            "session-2026-08-12.jsonl",
+            "notes.txt",
+        ] {
+            std::fs::write(directory.join(name), "").expect("the file must be writable");
+        }
+
+        let mut sealed = sealed_sessions(&directory, session(2026, 8, 11)).expect("readable");
+        sealed.sort();
+        assert_eq!(sealed, vec![session(2026, 8, 9), session(2026, 8, 11)]);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// RAII guard that restores an environment variable on drop, panic-safe.
+    ///
+    /// Tests using this must be marked `#[serial]` to prevent concurrent env access.
+    struct EnvVarRestoreGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarRestoreGuard {
+        fn save(key: &'static str) -> Self {
+            Self {
+                key,
+                previous: std::env::var(key).ok(),
+            }
+        }
+    }
+
+    impl Drop for EnvVarRestoreGuard {
+        fn drop(&mut self) {
+            // SAFETY: Protected by #[serial_test::serial] — no concurrent env access.
+            unsafe {
+                match self.previous.as_ref() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    /// The explicit override wins, and the directory is created rather than assumed.
+    ///
+    /// This is what runs at startup: a service that cannot resolve a writable directory here fails
+    /// to construct at all, which is the loud failure rather than a session silently unrecorded.
+    #[test]
+    #[serial_test::serial]
+    fn test_from_env_prefers_the_explicit_directory() {
+        let directory = temporary_directory("from-env-explicit");
+        let _restore_session = EnvVarRestoreGuard::save("FUND_SESSION_LOG_DIR");
+        // SAFETY: Protected by #[serial_test::serial] — no concurrent env access.
+        unsafe { std::env::set_var("FUND_SESSION_LOG_DIR", &directory) };
+
+        let log = SessionLog::from_env().expect("the log must resolve");
+
+        assert_eq!(log.directory(), directory);
+        assert!(directory.is_dir());
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// Falling back inside `FUND_LOG_DIR` is what lets this ship without provisioning: that path is
+    /// already created and already falls back to a writable location on an un-bootstrapped machine.
+    #[test]
+    #[serial_test::serial]
+    fn test_from_env_falls_back_beneath_the_log_directory() {
+        let log_directory = temporary_directory("from-env-fallback");
+        let _restore_session = EnvVarRestoreGuard::save("FUND_SESSION_LOG_DIR");
+        let _restore_log = EnvVarRestoreGuard::save("FUND_LOG_DIR");
+        // SAFETY: Protected by #[serial_test::serial] — no concurrent env access.
+        unsafe {
+            std::env::remove_var("FUND_SESSION_LOG_DIR");
+            std::env::set_var("FUND_LOG_DIR", &log_directory);
+        }
+
+        let log = SessionLog::from_env().expect("the log must resolve");
+
+        assert_eq!(log.directory(), log_directory.join("sessions"));
+        assert!(log.directory().is_dir());
+        let _ = std::fs::remove_dir_all(&log_directory);
+    }
+
+    /// The frame survives a Parquet round trip with its envelope typed and its payload intact.
+    ///
+    /// This is the artifact DuckDB reads, so a serialization that silently dropped a column or
+    /// widened the payload out of shape would take the whole archive with it.
+    #[test]
+    fn test_a_session_frame_round_trips_through_parquet() {
+        let directory = temporary_directory("parquet");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("session-2026-08-11.jsonl");
+        let mut lines = String::new();
+        for equity in [104_812.55_f64, 105_000.0] {
+            let record = Record::new(
+                Uuid::new_v4(),
+                instant("2026-08-11T20:15:00Z"),
+                Observation::AccountObserved(AccountObserved {
+                    session_date: NaiveDate::from_ymd_opt(2026, 8, 11).expect("valid date"),
+                    equity,
+                    cash: 12_000.0,
+                    buying_power: 200_000.0,
+                    long_market_value: 50_000.0,
+                    short_market_value: -50_000.0,
+                }),
+            );
+            lines.push_str(&serde_json::to_string(&record).expect("the record must serialize"));
+            lines.push('\n');
+        }
+        std::fs::write(&path, lines).expect("the file must be writable");
+
+        let (mut frame, _) = read_session_frame(&path).expect("the session must read");
+        let mut buffer: Vec<u8> = Vec::new();
+        ParquetWriter::new(&mut buffer)
+            .finish(&mut frame)
+            .expect("the frame must serialize to Parquet");
+
+        let restored = ParquetReader::new(std::io::Cursor::new(buffer))
+            .finish()
+            .expect("the Parquet must read back");
+        assert_eq!(restored.height(), 2);
+        assert_eq!(restored.get_column_names(), frame.get_column_names());
+        // The instant survives as milliseconds, which is what lets a reader recover 16:15 Eastern.
+        assert_eq!(
+            restored
+                .column("created_at")
+                .expect("created_at column")
+                .i64()
+                .expect("created_at is an integer")
+                .get(0),
+            Some(instant("2026-08-11T20:15:00Z").timestamp_millis())
+        );
+        let payload = restored
+            .column("payload")
+            .expect("payload column")
+            .str()
+            .expect("payload is text")
+            .get(0)
+            .expect("one row");
+        let parsed: Value = serde_json::from_str(payload).expect("the payload stays valid JSON");
+        assert_eq!(parsed["equity"], 104_812.55);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// Only what has aged out goes, and the window's own edge stays. The local file is the
+    /// crash-exact original, so deleting one still inside the window would remove the only thing a
+    /// bad Parquet conversion could be repaired from.
+    #[test]
+    fn test_only_sessions_past_the_retention_window_are_deleted() {
+        let directory = temporary_directory("retention");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+
+        let today = session(2026, 8, 11);
+        let sessions = [
+            today.plus_calendar_days(-RETENTION_DAYS - 1),
+            today.plus_calendar_days(-RETENTION_DAYS),
+            today.plus_calendar_days(-1),
+            today,
+        ];
+        for session_date in sessions {
+            std::fs::write(directory.join(file_name(session_date)), "")
+                .expect("the file must be writable");
+        }
+
+        let deleted = delete_aged_out(&directory, &sessions, today);
+
+        assert_eq!(deleted, vec![sessions[0].date()]);
+        assert!(!directory.join(file_name(sessions[0])).exists());
+        for session_date in &sessions[1..] {
+            assert!(
+                directory.join(file_name(*session_date)).exists(),
+                "{session_date} is still inside the window"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// The key is a pure function of the session, which is what makes a repeat export an overwrite
+    /// rather than a duplicate — and why there is no cursor to keep in sync.
+    #[test]
+    fn test_the_export_key_is_determined_by_the_session_alone() {
+        let key = date_partitioned_key(EXPORT_PREFIX, session(2026, 8, 11).date());
+        assert_eq!(
+            key,
+            "exports/session_log/year=2026/month=08/day=11/data.parquet"
+        );
+        assert_eq!(
+            key,
+            date_partitioned_key(EXPORT_PREFIX, session(2026, 8, 11).date())
+        );
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -25,6 +25,9 @@ use crate::data::calendar::{CalendarCache, SessionDate, TradingCalendar};
 use crate::data::details;
 use crate::data::export;
 use crate::data::purge;
+use crate::data::session_log::{
+    self, Observation, PredictionsGenerated, SessionLog, SessionLogError,
+};
 use crate::data::universe::{UniverseCache, UniverseError};
 use crate::models::tide::{artifact, predict};
 use crate::portfolio::account;
@@ -67,6 +70,8 @@ pub enum HandlerError {
         stage: &'static str,
         message: String,
     },
+    #[error("session log is unusable: {0}")]
+    SessionLog(#[from] SessionLogError),
     #[error("configuration is missing or unusable: {0}")]
     Configuration(String),
 }
@@ -92,6 +97,8 @@ pub struct ServiceState {
     close_history_cache: CloseHistoryCache,
     sizing: SizingParameters,
     execution: ExecutionSettings,
+    /// The append-only record of what this process observed before it acted.
+    session_log: SessionLog,
     /// Cancelled when the process is asked to stop.
     ///
     /// Held here so a handler can decline to *start* more work it would not be able to finish. The
@@ -133,6 +140,7 @@ impl ServiceState {
             close_history_cache: CloseHistoryCache::new(),
             sizing: SizingParameters::from_env(),
             execution: ExecutionSettings::default(),
+            session_log: SessionLog::from_env()?,
             shutdown,
             in_flight: std::sync::Mutex::new(HashSet::new()),
         })
@@ -140,6 +148,10 @@ impl ServiceState {
 
     pub fn pool(&self) -> &PgPool {
         &self.pool
+    }
+
+    pub fn session_log(&self) -> &SessionLog {
+        &self.session_log
     }
 
     /// Claims a command, or reports that one is already running.
@@ -298,6 +310,25 @@ async fn handle_predictions(state: &ServiceState) -> Result<Value, HandlerError>
     let correlation_id = Uuid::new_v4();
     let (predictions, rows) = run_inference(state, &model_state, correlation_id).await?;
 
+    // The forecasts themselves are not repeated into the log — they are rows in
+    // `equity_predictions` and reach S3 through the nightly export. What only this run knows is
+    // which artifact produced them.
+    state
+        .session_log
+        .record(
+            correlation_id,
+            now,
+            Observation::PredictionsGenerated(PredictionsGenerated {
+                model_run_id: model_state.run_id().to_string(),
+                artifact_key: artifact_key.clone(),
+                artifact_staleness_sessions,
+                predictions,
+                rows_written: rows,
+                universe_size: universe.len(),
+            }),
+        )
+        .await;
+
     Ok(json!({
         "session_date": today,
         "correlation_id": correlation_id,
@@ -396,6 +427,7 @@ async fn handle_portfolio_evaluation(state: &ServiceState) -> Result<Value, Hand
         close_history: &close_history,
         sizing: state.sizing,
         execution: state.execution,
+        session_log: &state.session_log,
         shutdown: &state.shutdown,
         now,
     };
@@ -410,7 +442,9 @@ async fn handle_portfolio_evaluation(state: &ServiceState) -> Result<Value, Hand
 /// nothing and costs one API call; a liquidation skipped because the calendar was wrong or
 /// unreachable carries positions overnight. The asymmetry is the whole argument.
 async fn handle_portfolio_liquidation(state: &ServiceState) -> Result<Value, HandlerError> {
-    let summary = evaluate::run_liquidation(&state.pool, &state.trading, Utc::now()).await?;
+    let summary =
+        evaluate::run_liquidation(&state.pool, &state.trading, &state.session_log, Utc::now())
+            .await?;
     Ok(serde_json::to_value(summary).unwrap_or_else(|_| json!({})))
 }
 
@@ -424,7 +458,14 @@ async fn handle_account_sync(state: &ServiceState) -> Result<Value, HandlerError
         return Ok(json!({ "skipped": "not_a_trading_day", "session_date": today }));
     }
 
-    let summary = account::sync_account(&state.pool, &state.trading, &calendar, today).await?;
+    let summary = account::sync_account(
+        &state.pool,
+        &state.trading,
+        &state.session_log,
+        &calendar,
+        today,
+    )
+    .await?;
     Ok(serde_json::to_value(summary).unwrap_or_else(|_| json!({})))
 }
 
@@ -504,13 +545,35 @@ async fn handle_market_data_sync(state: &ServiceState) -> Result<Value, HandlerE
     }))
 }
 
-/// Chained from a completed market data sync: export to S3, then purge.
+/// Chained from a completed market data sync: seal the session log, export to S3, then purge.
 ///
-/// The order is fixed and the purge is conditional on the export being clean. Purging after a
-/// partial export deletes rows that never reached S3, and nothing afterwards can tell that it
-/// happened.
+/// The order is fixed and the purge is conditional on the *database* export being clean. Purging
+/// after a partial export deletes rows that never reached S3, and nothing afterwards can tell that
+/// it happened.
+///
+/// The session log seals independently and does not gate the purge. It holds different data written
+/// by a different path, and letting a failure there hold PostgreSQL rows would couple two things
+/// whose only relationship is that they run on the same schedule.
 async fn handle_database_export(state: &ServiceState) -> Result<Value, HandlerError> {
     let today = SessionDate::at(Utc::now());
+
+    let sessions = session_log::export_session_logs(
+        &state.session_log,
+        &state.s3_client,
+        &state.bucket,
+        today,
+    )
+    .await;
+    let session_log_summary = json!({
+        "sessions_exported": sessions.exported.len(),
+        "records_exported": sessions.total_records(),
+        "sessions_failed": sessions.failed.iter().map(|(session_date, error)| json!({
+            "session_date": session_date, "error": error
+        })).collect::<Vec<_>>(),
+        "sessions_deleted": sessions.deleted.len(),
+        "unparsable_lines": sessions.unparsable_lines,
+    });
+
     let export = export::export_database(&state.pool, &state.s3_client, &state.bucket, today).await;
 
     if !export.is_clean() {
@@ -525,6 +588,7 @@ async fn handle_database_export(state: &ServiceState) -> Result<Value, HandlerEr
                 "dataset": dataset, "error": error.to_string()
             })).collect::<Vec<_>>(),
             "purged": Value::Null,
+            "session_log": session_log_summary,
         }));
     }
 
@@ -535,6 +599,7 @@ async fn handle_database_export(state: &ServiceState) -> Result<Value, HandlerEr
         "total_rows_exported": export.total_rows(),
         "purged_rows": purged.total_rows(),
         "purge_clean": purged.is_clean(),
+        "session_log": session_log_summary,
     }))
 }
 

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -88,12 +88,12 @@ pub async fn sync_account(
             Observation::AccountObserved(AccountObserved {
                 // The session this describes, which a sync re-run after Eastern midnight would
                 // otherwise lose: the envelope files a record under the session it *happened* in.
-                session_date: session_date.date(),
-                equity: account.equity().to_f64().unwrap_or_default(),
-                cash: account.cash().to_f64().unwrap_or_default(),
-                buying_power: account.buying_power().to_f64().unwrap_or_default(),
-                long_market_value: account.long_market_value().to_f64().unwrap_or_default(),
-                short_market_value: account.short_market_value().to_f64().unwrap_or_default(),
+                session_date,
+                equity: account.equity().to_f64(),
+                cash: account.cash().to_f64(),
+                buying_power: account.buying_power().to_f64(),
+                long_market_value: account.long_market_value().to_f64(),
+                short_market_value: account.short_market_value().to_f64(),
             }),
         )
         .await;

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 use tracing::{info, warn};
@@ -25,6 +26,7 @@ use crate::common::alpaca::{
     TRANSFER_ACTIVITY_TYPES,
 };
 use crate::data::calendar::{SessionDate, TradingCalendar};
+use crate::data::session_log::{AccountObserved, Observation, SessionLog};
 use crate::portfolio::pairs::{self, ClosedPair, PairsError};
 
 /// The activity types this sync fetches and stores.
@@ -69,11 +71,32 @@ pub struct AccountSyncSummary {
 pub async fn sync_account(
     pool: &PgPool,
     client: &TradingClient,
+    session_log: &SessionLog,
     calendar: &TradingCalendar,
     session_date: SessionDate,
 ) -> Result<AccountSyncSummary, AccountError> {
     let account = client.fetch_account().await?;
     store_snapshot(pool, session_date, &account).await?;
+
+    // Recorded in full, not just the equity. Alpaca's portfolio history can report equity for a
+    // past date and nothing can report cash, buying power, or the market values, so this is the
+    // only moment they are observable at all.
+    session_log
+        .record(
+            uuid::Uuid::new_v4(),
+            Utc::now(),
+            Observation::AccountObserved(AccountObserved {
+                // The session this describes, which a sync re-run after Eastern midnight would
+                // otherwise lose: the envelope files a record under the session it *happened* in.
+                session_date: session_date.date(),
+                equity: account.equity().to_f64().unwrap_or_default(),
+                cash: account.cash().to_f64().unwrap_or_default(),
+                buying_power: account.buying_power().to_f64().unwrap_or_default(),
+                long_market_value: account.long_market_value().to_f64().unwrap_or_default(),
+                short_market_value: account.short_market_value().to_f64().unwrap_or_default(),
+            }),
+        )
+        .await;
     let previous_session_gap = missing_previous_snapshot(pool, calendar, session_date).await;
 
     // One request per type: Alpaca puts the activity type in the URL path, and the sync already

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -307,12 +307,23 @@ pub async fn run_pass(
                     entry_z_score: candidate.entry_z_score(),
                     signal_strength: candidate.signal_strength(),
                     rank_score: candidate.rank_score(),
+                    long_notional: None,
+                    short_shares: None,
+                    gross_exposure: None,
                     decision: "not_selected".to_string(),
                     refusal: None,
                 },
             )
         })
         .collect();
+    // Every candidate that reached the sizer carries what it was sized to, refused or not.
+    for pair in &sized {
+        if let Some(reading) = candidate_decisions.get_mut(pair.candidate().pair_id().as_str()) {
+            reading.long_notional = pair.long_notional().value().to_f64();
+            reading.short_shares = Some(f64::from(pair.short_shares().get()));
+            reading.gross_exposure = pair.gross_exposure().to_f64();
+        }
+    }
     for refusal in &refusals {
         if let Some(reading) = candidate_decisions.get_mut(refusal.pair_id.as_str()) {
             reading.decision = "risk_refused".to_string();

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -83,9 +83,8 @@ pub struct EvaluationContext<'a> {
 
 /// A price as one pass read it, with the snapshot field it came from.
 ///
-/// The source travels with the number because the two branches are not interchangeable: a midpoint
-/// moves with the book while a last trade can be minutes stale, so the same symbol read from
-/// different fields on consecutive passes is not one series.
+/// A midpoint moves with the book while a last trade can be minutes stale, so the same symbol read
+/// from different fields on consecutive passes is not one series.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ReferencePrice {
     price: f64,
@@ -274,7 +273,7 @@ pub async fn run_pass(
 
     let screened = build_screen_inputs(context, &held, &mut prices).await?;
     observation.predictions_available = screened.predictions_available;
-    observation.eligible_tickers = screened.inputs.len();
+    observation.eligible_tickers = screened.eligible;
     observation.screen_inputs = screened.readings.clone();
     observation.excluded = screened.excluded.clone();
 
@@ -416,9 +415,8 @@ pub async fn run_pass(
 
 /// Writes the pass observation, attaching every price it read.
 ///
-/// Called on both paths out of a pass, including the one the risk gate blocks — a pass that opened
-/// nothing because the drawdown gate fired and one that opened nothing because no pair cleared the
-/// screen look identical in a count and are very different days.
+/// Called on both paths out of a pass, including the one the risk gate blocks: those two look
+/// identical in a count and are very different days.
 async fn record_pass(
     context: &EvaluationContext<'_>,
     correlation_id: uuid::Uuid,
@@ -478,6 +476,9 @@ pub async fn run_liquidation(
                     reason: "liquidation".to_string(),
                     accepted: outcome.succeeded(),
                     status: Some(outcome.status()),
+                    // The bulk path reports a per-symbol status rather than an error body, so a
+                    // refusal is legible from `status` alone.
+                    error: None,
                 }),
             )
             .await;
@@ -568,8 +569,7 @@ async fn fetch_prices(
 
 /// Every price the pass used, as rows for the session log.
 ///
-/// Recorded once at pass level rather than repeated onto each pair, so a candidate row and an open
-/// pair row that share a leg are provably reading the same number.
+/// Recorded once at pass level, so rows sharing a leg are provably reading the same number.
 fn price_readings(prices: &HashMap<Ticker, ReferencePrice>) -> Vec<PriceReading> {
     let mut readings: Vec<PriceReading> = prices
         .iter()
@@ -618,7 +618,7 @@ async fn close_what_should_close(
             z_score: None,
             entry_z_score: pair.entry_z_score(),
             stop_at: pair.entry_z_score() + screen::STOP_LOSS_WIDENING,
-            entry_session: SessionDate::at(pair.opened_at()).date(),
+            entry_session: SessionDate::at(pair.opened_at()),
             minutes_held: pair.minutes_held(context.now),
             decision: "held".to_string(),
         };
@@ -779,6 +779,8 @@ async fn previous_session_equity(
 /// The screen's inputs, and the model run they came from.
 struct ScreenedUniverse {
     inputs: Vec<ScreenInput>,
+    /// Forecasts that passed the eligibility filter, before pricing removed any.
+    eligible: usize,
     /// The same inputs as session-log rows: what the model offered, as the screen received it.
     readings: Vec<ScreenInputReading>,
     /// Every forecast the funnel removed, with the first test it failed.
@@ -804,6 +806,7 @@ async fn build_screen_inputs(
         info!("No predictions for the current session; no entries will be screened");
         return Ok(ScreenedUniverse {
             inputs: Vec::new(),
+            eligible: 0,
             readings: Vec::new(),
             excluded: Vec::new(),
             model_run_id: None,
@@ -912,6 +915,7 @@ async fn build_screen_inputs(
     );
     Ok(ScreenedUniverse {
         inputs,
+        eligible: eligible.len(),
         readings,
         excluded,
         model_run_id,

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -10,19 +10,26 @@
 use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Utc};
+use rust_decimal::prelude::ToPrimitive;
 use serde::Serialize;
 use sqlx::PgPool;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-use crate::common::alpaca::{ClientError, MarketDataClient, TradingClient};
+use crate::common::alpaca::{ClientError, MarketDataClient, PriceSource, TradingClient};
 use crate::common::types::{EquityPrediction, Ticker};
 use crate::data::calendar::{SessionDate, TradingCalendar};
 use crate::data::details::{self, DetailsError};
+use crate::data::session_log::{
+    CandidateReading, EvaluationPass, LiquidationRun, Observation, OpenPairReading, PriceReading,
+    SessionLog,
+};
 use crate::data::universe::Universe;
 use crate::models::tide::predict;
 use crate::portfolio::account::{self, AccountError};
-use crate::portfolio::execute::{self, ExecutionError, ExecutionSettings, OpenOutcome};
+use crate::portfolio::execute::{
+    self, ExecutionContext, ExecutionError, ExecutionSettings, OpenOutcome,
+};
 use crate::portfolio::pairs::{self, CloseReason, OpenPair, PairsError};
 use crate::portfolio::risk::RiskGate;
 use crate::portfolio::screen::{
@@ -63,6 +70,8 @@ pub struct EvaluationContext<'a> {
     pub close_history: &'a HashMap<Ticker, Vec<f64>>,
     pub sizing: SizingParameters,
     pub execution: ExecutionSettings,
+    /// Where the pass records what it observed before acting on it.
+    pub session_log: &'a SessionLog,
     /// Cancelled when the process is asked to stop.
     ///
     /// Checked between pairs in the entry half so the pass stops *starting* positions it could not
@@ -70,6 +79,27 @@ pub struct EvaluationContext<'a> {
     /// this is what keeps the drain's bound honest.
     pub shutdown: &'a CancellationToken,
     pub now: DateTime<Utc>,
+}
+
+/// A price as one pass read it, with the snapshot field it came from.
+///
+/// The source travels with the number because the two branches are not interchangeable: a midpoint
+/// moves with the book while a last trade can be minutes stale, so the same symbol read from
+/// different fields on consecutive passes is not one series.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ReferencePrice {
+    price: f64,
+    source: PriceSource,
+}
+
+impl ReferencePrice {
+    pub fn price(self) -> f64 {
+        self.price
+    }
+
+    pub fn source(self) -> PriceSource {
+        self.source
+    }
 }
 
 /// One pair the pass closed.
@@ -164,15 +194,38 @@ pub fn convergence_only(z_score: f64) -> Option<CloseReason> {
 pub async fn run_pass(
     context: &EvaluationContext<'_>,
 ) -> Result<EvaluationSummary, EvaluationError> {
+    // One identifier for the pass, carried onto every order it sends and every fill they produce.
+    // That thread is what turns "the session lost money" into "it was lost at sizing" or "it was
+    // lost at execution".
+    let correlation_id = uuid::Uuid::new_v4();
     let mut summary = EvaluationSummary::default();
+    let mut observation = EvaluationPass {
+        universe_size: context.universe.len(),
+        ..EvaluationPass::default()
+    };
+    let execution = ExecutionContext {
+        client: context.trading,
+        settings: context.execution,
+        session_log: context.session_log,
+        correlation_id,
+    };
 
     let open_pairs = pairs::load_open_pairs(context.pool).await?;
     summary.open_pairs_at_start = open_pairs.len();
+    observation.open_pairs_at_start = open_pairs.len();
 
     // --- exits, unconditionally ---
 
     let mut prices = fetch_prices(context.market_data, &leg_symbols(&open_pairs)).await?;
-    let closed = close_what_should_close(context, &open_pairs, &prices, &mut summary).await?;
+    let closed = close_what_should_close(
+        context,
+        &execution,
+        &open_pairs,
+        &prices,
+        &mut summary,
+        &mut observation,
+    )
+    .await?;
 
     let held: HashSet<Ticker> = open_pairs
         .iter()
@@ -195,22 +248,37 @@ pub async fn run_pass(
         context.sizing,
     );
 
+    observation.account_equity = account.equity().to_f64();
+    observation.previous_session_equity = previous_equity.and_then(|equity| equity.to_f64());
+    observation.gross_exposure_used = account.gross_exposure().to_f64();
+    observation.gross_exposure_cap = gate.gross_exposure_cap().to_f64();
+    observation.drawdown = gate.drawdown();
+    observation.minutes_until_close = minutes_until_close;
+    observation.vacant_slots = Some(gate.vacant_slots());
+
     // Before the gate, not after. A pass blocked by drawdown, capacity, or the hold window is the
     // most common way a session opens nothing, and those are exactly the rows where "which model
     // was deciding" matters — the difference between the model seeing no opportunity and the model
     // being three days old. Only the identifier is read here; the forecasts themselves stay behind
     // the gate, so a blocked pass still does not pay for the screen.
     summary.model_run_id = current_model_run_id(context).await?;
+    observation.model_run_id = summary.model_run_id.clone();
 
     if let Some(block) = gate.session_block() {
         info!(block = block.as_str(), reason = %block, "Entry half skipped");
         summary.entries_blocked = Some(format!("{}: {block}", block.as_str()));
+        observation.session_block = summary.entries_blocked.clone();
+        record_pass(context, correlation_id, &mut observation, &prices).await;
         return Ok(summary);
     }
 
     let screened = build_screen_inputs(context, &held, &mut prices).await?;
+    observation.predictions_available = screened.predictions_available;
+    observation.eligible_tickers = screened.inputs.len();
+
     let candidates = screen::score_candidates(&screened.inputs);
     summary.candidates_screened = candidates.len();
+    observation.candidates_screened = candidates.len();
 
     let selected =
         screen::select_disjoint(&candidates, gate.vacant_slots(), &held, &screened.sectors);
@@ -218,8 +286,37 @@ pub async fn run_pass(
     let (approved, refusals) = gate.admit_all(&sized);
     summary.entries_refused = refusals
         .iter()
-        .map(|block| format!("{}: {block}", block.as_str()))
+        .map(|refusal| format!("{}: {}", refusal.block.as_str(), refusal.block))
         .collect();
+
+    // Every scored candidate, with what became of it. Seeded as `not_selected` and overwritten as
+    // the pass gets further with each one, so a candidate that fell out at selection is recorded as
+    // precisely as one that opened.
+    let mut candidate_decisions: HashMap<String, CandidateReading> = candidates
+        .iter()
+        .map(|candidate| {
+            (
+                candidate.pair_id().as_str().to_string(),
+                CandidateReading {
+                    pair_id: candidate.pair_id().as_str().to_string(),
+                    long_ticker: candidate.long_ticker().to_string(),
+                    short_ticker: candidate.short_ticker().to_string(),
+                    hedge_ratio: candidate.hedge_ratio(),
+                    entry_z_score: candidate.entry_z_score(),
+                    signal_strength: candidate.signal_strength(),
+                    rank_score: candidate.rank_score(),
+                    decision: "not_selected".to_string(),
+                    refusal: None,
+                },
+            )
+        })
+        .collect();
+    for refusal in &refusals {
+        if let Some(reading) = candidate_decisions.get_mut(refusal.pair_id.as_str()) {
+            reading.decision = "risk_refused".to_string();
+            reading.refusal = Some(format!("{}: {}", refusal.block.as_str(), refusal.block));
+        }
+    }
 
     for (index, pair) in approved.iter().enumerate() {
         // Between pairs, never inside one: opening a pair is two broker legs and an insert, so the
@@ -235,17 +332,17 @@ pub async fn run_pass(
                 opened = summary.pairs_opened.len(),
                 "Shutdown requested mid-entry; opening no further pairs"
             );
+            for remaining in &approved[index..] {
+                if let Some(reading) =
+                    candidate_decisions.get_mut(remaining.candidate().pair_id().as_str())
+                {
+                    reading.decision = "abandoned_at_shutdown".to_string();
+                }
+            }
             break;
         }
 
-        match execute::open_pair(
-            context.trading,
-            pair,
-            screened.model_run_id.clone(),
-            context.execution,
-        )
-        .await?
-        {
+        match execute::open_pair(&execution, pair, screened.model_run_id.clone()).await? {
             OpenOutcome::Opened {
                 entry,
                 long_fill,
@@ -271,14 +368,29 @@ pub async fn run_pass(
                     );
                     return Err(error.into());
                 }
+                if let Some(reading) = candidate_decisions.get_mut(entry.pair_id().as_str()) {
+                    reading.decision = "opened".to_string();
+                }
                 summary.pairs_opened.push(entry.pair_id().to_string());
             }
             OpenOutcome::Abandoned { ticker, reason } => {
                 warn!(%ticker, reason, "Pair entry abandoned");
+                if let Some(reading) =
+                    candidate_decisions.get_mut(pair.candidate().pair_id().as_str())
+                {
+                    reading.decision = "unfilled".to_string();
+                    reading.refusal = Some(reason.clone());
+                }
                 summary.entries_refused.push(format!("unfilled:{ticker}"));
             }
         }
     }
+
+    observation.candidates = candidate_decisions.into_values().collect();
+    observation
+        .candidates
+        .sort_by(|left, right| left.pair_id.cmp(&right.pair_id));
+    record_pass(context, correlation_id, &mut observation, &prices).await;
 
     info!(
         closed = summary.pairs_closed.len(),
@@ -287,6 +399,28 @@ pub async fn run_pass(
         "Evaluation pass complete"
     );
     Ok(summary)
+}
+
+/// Writes the pass observation, attaching every price it read.
+///
+/// Called on both paths out of a pass, including the one the risk gate blocks — a pass that opened
+/// nothing because the drawdown gate fired and one that opened nothing because no pair cleared the
+/// screen look identical in a count and are very different days.
+async fn record_pass(
+    context: &EvaluationContext<'_>,
+    correlation_id: uuid::Uuid,
+    observation: &mut EvaluationPass,
+    prices: &HashMap<Ticker, ReferencePrice>,
+) {
+    observation.prices = price_readings(prices);
+    context
+        .session_log
+        .record(
+            correlation_id,
+            context.now,
+            Observation::EvaluationPass(Box::new(std::mem::take(observation))),
+        )
+        .await;
 }
 
 /// What the pre-close liquidation did.
@@ -308,8 +442,10 @@ pub struct LiquidationSummary {
 pub async fn run_liquidation(
     pool: &PgPool,
     client: &TradingClient,
+    session_log: &SessionLog,
     now: DateTime<Utc>,
 ) -> Result<LiquidationSummary, EvaluationError> {
+    let correlation_id = uuid::Uuid::new_v4();
     let outcomes = client.close_all_positions().await?;
     let refused: HashSet<Ticker> = outcomes
         .iter()
@@ -347,6 +483,18 @@ pub async fn run_liquidation(
             "Liquidation did not flatten the book"
         );
     }
+
+    session_log
+        .record(
+            correlation_id,
+            now,
+            Observation::LiquidationRun(LiquidationRun {
+                pairs_closed: summary.pairs_closed,
+                positions_refused: summary.positions_refused,
+                pairs_still_open: summary.pairs_still_open.clone(),
+            }),
+        )
+        .await;
     Ok(summary)
 }
 
@@ -369,7 +517,7 @@ fn leg_symbols(open_pairs: &[OpenPair]) -> Vec<String> {
 async fn fetch_prices(
     client: &MarketDataClient,
     symbols: &[String],
-) -> Result<HashMap<Ticker, f64>, EvaluationError> {
+) -> Result<HashMap<Ticker, ReferencePrice>, EvaluationError> {
     if symbols.is_empty() {
         return Ok(HashMap::new());
     }
@@ -377,10 +525,27 @@ async fn fetch_prices(
     Ok(snapshots
         .into_iter()
         .filter_map(|snapshot| {
-            let price = snapshot.reference_price()?;
-            Some((snapshot.ticker().clone(), price))
+            let (price, source) = snapshot.reference_price_with_source()?;
+            Some((snapshot.ticker().clone(), ReferencePrice { price, source }))
         })
         .collect())
+}
+
+/// Every price the pass used, as rows for the session log.
+///
+/// Recorded once at pass level rather than repeated onto each pair, so a candidate row and an open
+/// pair row that share a leg are provably reading the same number.
+fn price_readings(prices: &HashMap<Ticker, ReferencePrice>) -> Vec<PriceReading> {
+    let mut readings: Vec<PriceReading> = prices
+        .iter()
+        .map(|(ticker, reference)| PriceReading {
+            ticker: ticker.to_string(),
+            price: reference.price,
+            price_source: reference.source.as_str().to_string(),
+        })
+        .collect();
+    readings.sort_by(|left, right| left.ticker.cmp(&right.ticker));
+    readings
 }
 
 /// Prices the open book and closes whatever the spread says to close.
@@ -390,9 +555,11 @@ async fn fetch_prices(
 /// the worst case is holding it until 15:45 rather than exiting on a signal.
 async fn close_what_should_close(
     context: &EvaluationContext<'_>,
+    execution: &ExecutionContext<'_>,
     open_pairs: &[OpenPair],
-    prices: &HashMap<Ticker, f64>,
+    prices: &HashMap<Ticker, ReferencePrice>,
     summary: &mut EvaluationSummary,
+    observation: &mut EvaluationPass,
 ) -> Result<HashSet<uuid::Uuid>, EvaluationError> {
     let models = screen::exit_models(
         open_pairs
@@ -403,21 +570,51 @@ async fn close_what_should_close(
 
     let mut closed = HashSet::new();
     for pair in open_pairs {
+        // Filled in as the pair is measured and pushed on every path out of the iteration, so a
+        // pair that could not be priced is as visible in the log as one that closed.
+        let mut reading = OpenPairReading {
+            pair_id: pair.pair_id().to_string(),
+            long_ticker: pair.long_ticker().to_string(),
+            short_ticker: pair.short_ticker().to_string(),
+            stored_hedge_ratio: pair.hedge_ratio(),
+            model_hedge_ratio: None,
+            spread_mean: None,
+            spread_standard_deviation: None,
+            z_score: None,
+            entry_z_score: pair.entry_z_score(),
+            stop_at: pair.entry_z_score() + screen::STOP_LOSS_WIDENING,
+            entry_session: SessionDate::at(pair.opened_at()).date(),
+            minutes_held: pair.minutes_held(context.now),
+            decision: "held".to_string(),
+        };
+
         let (Some(long_price), Some(short_price)) = (
             prices.get(pair.long_ticker()),
             prices.get(pair.short_ticker()),
         ) else {
             summary.pairs_unpriced += 1;
             warn!(pair_id = %pair.pair_id(), "Open pair could not be priced this pass");
+            reading.decision = "unpriced".to_string();
+            observation.open_pairs.push(reading);
             continue;
         };
         let Some(model) = models.get(pair.pair_id()) else {
             warn!(pair_id = %pair.pair_id(), "Open pair has no rebuildable spread model");
+            reading.decision = "no_spread_model".to_string();
+            observation.open_pairs.push(reading);
             continue;
         };
-        let Some(z_score) = model.z_score(*long_price, *short_price) else {
+
+        reading.model_hedge_ratio = Some(model.hedge_ratio());
+        reading.spread_mean = Some(model.mean());
+        reading.spread_standard_deviation = Some(model.standard_deviation());
+
+        let Some(z_score) = model.z_score(long_price.price, short_price.price) else {
+            reading.decision = "unreadable_spread".to_string();
+            observation.open_pairs.push(reading);
             continue;
         };
+        reading.z_score = Some(z_score);
 
         // Every input to the z-score, on every pass, whether or not the pair closes.
         //
@@ -435,8 +632,10 @@ async fn close_what_should_close(
             spread_standard_deviation = model.standard_deviation(),
             hedge_ratio = model.hedge_ratio(),
             stored_hedge_ratio = pair.hedge_ratio(),
-            long_price = *long_price,
-            short_price = *short_price,
+            long_price = long_price.price,
+            long_price_source = %long_price.source,
+            short_price = short_price.price,
+            short_price_source = %short_price.source,
             "Priced an open pair"
         );
 
@@ -464,6 +663,7 @@ async fn close_what_should_close(
             convergence_only(z_score)
         };
         let Some(mut reason) = reason else {
+            observation.open_pairs.push(reading);
             continue;
         };
 
@@ -472,9 +672,7 @@ async fn close_what_should_close(
         // later pair open for another five minutes — turning one stuck position into all of them.
         // The pair stays open in the record, which is the honest state, and the next pass retries.
         let outcome =
-            match execute::close_pair(context.trading, pair.long_ticker(), pair.short_ticker())
-                .await
-            {
+            match execute::close_pair(execution, pair.long_ticker(), pair.short_ticker()).await {
                 Ok(outcome) => outcome,
                 Err(error) => {
                     error!(
@@ -483,6 +681,8 @@ async fn close_what_should_close(
                         "Closing a pair failed; it stays open and the next pass retries"
                     );
                     summary.exits_failed.push(pair.pair_id().to_string());
+                    reading.decision = "close_failed".to_string();
+                    observation.open_pairs.push(reading);
                     continue;
                 }
             };
@@ -492,6 +692,8 @@ async fn close_what_should_close(
         pairs::record_close(context.pool, pair.id(), reason, context.now).await?;
 
         closed.insert(pair.id());
+        reading.decision = reason.as_str().to_string();
+        observation.open_pairs.push(reading);
         summary.pairs_closed.push(ClosedRecord {
             pair_id: pair.pair_id().to_string(),
             reason: reason.as_str().to_string(),
@@ -537,6 +739,9 @@ async fn previous_session_equity(
 struct ScreenedUniverse {
     inputs: Vec<ScreenInput>,
     model_run_id: Option<String>,
+    /// Forecasts the session had before any eligibility test, for the session log. The gap between
+    /// this and `inputs.len()` is how much the filters removed.
+    predictions_available: usize,
     /// Every ticker's sector, not just the screened ones. `select_disjoint` needs the held legs
     /// too, and those are filtered out of `inputs` before it ever sees them.
     sectors: HashMap<Ticker, String>,
@@ -546,7 +751,7 @@ struct ScreenedUniverse {
 async fn build_screen_inputs(
     context: &EvaluationContext<'_>,
     held: &HashSet<Ticker>,
-    prices: &mut HashMap<Ticker, f64>,
+    prices: &mut HashMap<Ticker, ReferencePrice>,
 ) -> Result<ScreenedUniverse, EvaluationError> {
     let (start, end) = SessionDate::at(context.now).bounds();
     let predictions = predict::load_predictions_between(context.pool, start, end).await?;
@@ -555,6 +760,7 @@ async fn build_screen_inputs(
         return Ok(ScreenedUniverse {
             inputs: Vec::new(),
             model_run_id: None,
+            predictions_available: 0,
             sectors: HashMap::new(),
         });
     }
@@ -603,7 +809,7 @@ async fn build_screen_inputs(
             ScreenInput::new(
                 ticker.clone(),
                 context.close_history.get(ticker)?.clone(),
-                *prices.get(ticker)?,
+                prices.get(ticker)?.price,
                 prediction.expected_return(),
                 prediction.confidence(),
                 context.universe.is_shortable(ticker),
@@ -621,6 +827,7 @@ async fn build_screen_inputs(
     Ok(ScreenedUniverse {
         inputs,
         model_run_id,
+        predictions_available: predictions.len(),
         sectors,
     })
 }

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -21,8 +21,8 @@ use crate::common::types::{EquityPrediction, Ticker};
 use crate::data::calendar::{SessionDate, TradingCalendar};
 use crate::data::details::{self, DetailsError};
 use crate::data::session_log::{
-    CandidateReading, EvaluationPass, LiquidationRun, Observation, OpenPairReading, PriceReading,
-    SessionLog,
+    CandidateReading, EvaluationPass, ExcludedTickerReading, LiquidationRun, Observation,
+    OpenPairReading, PositionCloseRequested, PriceReading, ScreenInputReading, SessionLog,
 };
 use crate::data::universe::Universe;
 use crate::models::tide::predict;
@@ -275,6 +275,8 @@ pub async fn run_pass(
     let screened = build_screen_inputs(context, &held, &mut prices).await?;
     observation.predictions_available = screened.predictions_available;
     observation.eligible_tickers = screened.inputs.len();
+    observation.screen_inputs = screened.readings.clone();
+    observation.excluded = screened.excluded.clone();
 
     let candidates = screen::score_candidates(&screened.inputs);
     summary.candidates_screened = candidates.len();
@@ -447,6 +449,28 @@ pub async fn run_liquidation(
 ) -> Result<LiquidationSummary, EvaluationError> {
     let correlation_id = uuid::Uuid::new_v4();
     let outcomes = client.close_all_positions().await?;
+
+    // One record per position, not just the totals. The bulk close is the only path that touches
+    // positions the application does not know about — a leg from a pass that died before recording
+    // its pair — and a count cannot name those.
+    for outcome in &outcomes {
+        session_log
+            .record(
+                correlation_id,
+                now,
+                Observation::PositionCloseRequested(PositionCloseRequested {
+                    ticker: outcome.ticker().to_string(),
+                    pair_id: None,
+                    alpaca_order_id: outcome.alpaca_order_id().map(str::to_string),
+                    side: None,
+                    quantity: outcome.quantity(),
+                    reason: "liquidation".to_string(),
+                    accepted: outcome.succeeded(),
+                    status: Some(outcome.status()),
+                }),
+            )
+            .await;
+    }
     let refused: HashSet<Ticker> = outcomes
         .iter()
         .filter(|outcome| !outcome.succeeded())
@@ -671,21 +695,27 @@ async fn close_what_should_close(
         // here would abort the loop, so a single broker error on the first pair would leave every
         // later pair open for another five minutes — turning one stuck position into all of them.
         // The pair stays open in the record, which is the honest state, and the next pass retries.
-        let outcome =
-            match execute::close_pair(execution, pair.long_ticker(), pair.short_ticker()).await {
-                Ok(outcome) => outcome,
-                Err(error) => {
-                    error!(
-                        pair_id = %pair.pair_id(),
-                        %error,
-                        "Closing a pair failed; it stays open and the next pass retries"
-                    );
-                    summary.exits_failed.push(pair.pair_id().to_string());
-                    reading.decision = "close_failed".to_string();
-                    observation.open_pairs.push(reading);
-                    continue;
-                }
-            };
+        let outcome = match execute::close_pair(
+            execution,
+            pair.pair_id().as_str(),
+            pair.long_ticker(),
+            pair.short_ticker(),
+        )
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                error!(
+                    pair_id = %pair.pair_id(),
+                    %error,
+                    "Closing a pair failed; it stays open and the next pass retries"
+                );
+                summary.exits_failed.push(pair.pair_id().to_string());
+                reading.decision = "close_failed".to_string();
+                observation.open_pairs.push(reading);
+                continue;
+            }
+        };
         if outcome.was_already_gone() {
             reason = CloseReason::PositionMissing;
         }
@@ -738,6 +768,10 @@ async fn previous_session_equity(
 /// The screen's inputs, and the model run they came from.
 struct ScreenedUniverse {
     inputs: Vec<ScreenInput>,
+    /// The same inputs as session-log rows: what the model offered, as the screen received it.
+    readings: Vec<ScreenInputReading>,
+    /// Every forecast the funnel removed, with the first test it failed.
+    excluded: Vec<ExcludedTickerReading>,
     model_run_id: Option<String>,
     /// Forecasts the session had before any eligibility test, for the session log. The gap between
     /// this and `inputs.len()` is how much the filters removed.
@@ -759,6 +793,8 @@ async fn build_screen_inputs(
         info!("No predictions for the current session; no entries will be screened");
         return Ok(ScreenedUniverse {
             inputs: Vec::new(),
+            readings: Vec::new(),
+            excluded: Vec::new(),
             model_run_id: None,
             predictions_available: 0,
             sectors: HashMap::new(),
@@ -784,16 +820,32 @@ async fn build_screen_inputs(
     // cannot be measured is the conservative side of that trade; `select_disjoint` still tolerates
     // an unknown sector on a *held* leg, because a position already on the book cannot be
     // retroactively declined.
-    let eligible: Vec<&EquityPrediction> = predictions
-        .iter()
-        .filter(|prediction| {
-            let ticker = prediction.ticker();
-            !held.contains(ticker)
-                && sectors.contains_key(ticker)
-                && context.close_history.contains_key(ticker)
-                && context.universe.contains(ticker)
-        })
-        .collect();
+    // Partitioned rather than filtered, so the tickers that fall out are as recorded as the ones
+    // that stay. The first failing test is the one reported: the order below is the order the
+    // filter applies them in, and a ticker failing two is not two facts.
+    let mut eligible: Vec<&EquityPrediction> = Vec::new();
+    let mut excluded: Vec<ExcludedTickerReading> = Vec::new();
+    for prediction in &predictions {
+        let ticker = prediction.ticker();
+        let reason = if held.contains(ticker) {
+            Some("already_held")
+        } else if !sectors.contains_key(ticker) {
+            Some("no_sector")
+        } else if !context.close_history.contains_key(ticker) {
+            Some("no_close_history")
+        } else if !context.universe.contains(ticker) {
+            Some("outside_universe")
+        } else {
+            None
+        };
+        match reason {
+            Some(reason) => excluded.push(ExcludedTickerReading {
+                ticker: ticker.to_string(),
+                reason: reason.to_string(),
+            }),
+            None => eligible.push(prediction),
+        }
+    }
 
     let missing: Vec<String> = eligible
         .iter()
@@ -802,20 +854,43 @@ async fn build_screen_inputs(
         .collect();
     prices.extend(fetch_prices(context.market_data, &missing).await?);
 
-    let inputs: Vec<ScreenInput> = eligible
-        .iter()
-        .filter_map(|prediction| {
-            let ticker = prediction.ticker();
-            ScreenInput::new(
-                ticker.clone(),
-                context.close_history.get(ticker)?.clone(),
-                prices.get(ticker)?.price,
-                prediction.expected_return(),
-                prediction.confidence(),
-                context.universe.is_shortable(ticker),
-            )
-        })
-        .collect();
+    let mut inputs: Vec<ScreenInput> = Vec::with_capacity(eligible.len());
+    let mut readings: Vec<ScreenInputReading> = Vec::with_capacity(eligible.len());
+    for prediction in &eligible {
+        let ticker = prediction.ticker();
+        // Eligible and still unpriceable: Alpaca returned no usable quote or trade for it this
+        // pass. That is a fifth way out of the funnel and it belongs with the other four.
+        let (Some(window), Some(reference)) =
+            (context.close_history.get(ticker), prices.get(ticker))
+        else {
+            excluded.push(ExcludedTickerReading {
+                ticker: ticker.to_string(),
+                reason: "unpriced".to_string(),
+            });
+            continue;
+        };
+        let Some(input) = ScreenInput::new(
+            ticker.clone(),
+            window.clone(),
+            reference.price,
+            prediction.expected_return(),
+            prediction.confidence(),
+            context.universe.is_shortable(ticker),
+        ) else {
+            excluded.push(ExcludedTickerReading {
+                ticker: ticker.to_string(),
+                reason: "unusable_input".to_string(),
+            });
+            continue;
+        };
+        readings.push(ScreenInputReading {
+            ticker: ticker.to_string(),
+            expected_return: prediction.expected_return(),
+            confidence: prediction.confidence(),
+            is_shortable: context.universe.is_shortable(ticker),
+        });
+        inputs.push(input);
+    }
 
     info!(
         predictions = predictions.len(),
@@ -826,6 +901,8 @@ async fn build_screen_inputs(
     );
     Ok(ScreenedUniverse {
         inputs,
+        readings,
+        excluded,
         model_run_id,
         predictions_available: predictions.len(),
         sectors,

--- a/src/portfolio/execute.rs
+++ b/src/portfolio/execute.rs
@@ -68,8 +68,8 @@ impl Default for ExecutionSettings {
 
 /// Everything an order needs beyond the order itself.
 ///
-/// The log and the correlation identifier travel with the client rather than as further parameters
-/// so that no path can send an order without carrying the thread back to the pass that decided it.
+/// The log travels with the client so no path can send an order without the thread back to the pass
+/// that decided it.
 pub struct ExecutionContext<'a> {
     pub client: &'a TradingClient,
     pub settings: ExecutionSettings,
@@ -307,8 +307,8 @@ pub async fn close_pair(
 
 /// Records one close attempt, whatever came of it.
 ///
-/// Takes the `Result` rather than a success value so a refused close is as visible as an accepted
-/// one: a leg the broker would not let go of is the state the book is wrong about.
+/// Takes the `Result` so a refused close — the state the book is wrong about — is as visible as an
+/// accepted one.
 async fn record_close(
     context: &ExecutionContext<'_>,
     ticker: &Ticker,
@@ -317,6 +317,7 @@ async fn record_close(
     result: &Result<Option<PositionClose>, ClientError>,
 ) {
     let close = result.as_ref().ok().and_then(Option::as_ref);
+    let error = result.as_ref().err().map(ToString::to_string);
     context
         .session_log
         .record(
@@ -333,6 +334,7 @@ async fn record_close(
                 reason: reason.to_string(),
                 accepted: close.is_some(),
                 status: None,
+                error,
             }),
         )
         .await;
@@ -346,13 +348,8 @@ enum Filled {
 
 /// Submits one order and polls until it reaches a terminal state or the timeout expires.
 ///
-/// A timed-out order is cancelled before returning. Leaving it working would mean reporting the leg
-/// as unfilled while Alpaca still holds a live order that could fill afterwards, into a pair the
-/// application has already given up on.
-///
-/// The intent is written to the session log and fsynced *before* the request is sent. That ordering
-/// is the whole point: a crash between the two leaves a record of an order that may exist, which is
-/// recoverable, rather than an order that exists with no record, which is not.
+/// The intent reaches the disk before the request leaves the process, and every exit writes a
+/// resolution, so an unresolved submission means only that the process died.
 async fn submit_and_confirm(
     context: &ExecutionContext<'_>,
     intent: &OrderIntent,
@@ -377,37 +374,82 @@ async fn submit_and_confirm(
         )
         .await;
 
-    let order_id = context
-        .client
-        .submit_order(intent, &client_order_id)
-        .await?;
+    let order_id = match context.client.submit_order(intent, &client_order_id).await {
+        Ok(order_id) => order_id,
+        Err(error) => {
+            // The order never reached the broker, so there is no identifier to resolve it under.
+            // Recorded anyway: a rejection and a crash are otherwise the same absent row.
+            record_resolution(
+                context,
+                OrderResolved {
+                    client_order_id,
+                    alpaca_order_id: None,
+                    ticker: intent.ticker().to_string(),
+                    outcome: "submit_failed".to_string(),
+                    filled_shares: None,
+                    filled_average_price: None,
+                    filled_after_cancel: false,
+                    error: Some(error.to_string()),
+                },
+            )
+            .await;
+            return Err(error.into());
+        }
+    };
+
+    let confirmation = confirm_fill(context, intent, &client_order_id, &order_id).await;
+    if let Err(error) = &confirmation {
+        record_resolution(
+            context,
+            OrderResolved {
+                client_order_id,
+                alpaca_order_id: Some(order_id),
+                ticker: intent.ticker().to_string(),
+                outcome: "broker_unreachable".to_string(),
+                filled_shares: None,
+                filled_average_price: None,
+                filled_after_cancel: false,
+                error: Some(error.to_string()),
+            },
+        )
+        .await;
+    }
+    confirmation
+}
+
+/// Polls a submitted order to a terminal state, recording how it settled.
+///
+/// A timed-out order is cancelled first, so a pair the application gave up on cannot fill behind
+/// its back.
+async fn confirm_fill(
+    context: &ExecutionContext<'_>,
+    intent: &OrderIntent,
+    client_order_id: &str,
+    order_id: &str,
+) -> Result<Filled, ExecutionError> {
     let deadline = tokio::time::Instant::now() + context.settings.fill_timeout;
 
-    /// Records how the broker settled the order, then hands back what the caller returns.
     macro_rules! resolved {
         ($outcome:expr, $shares:expr, $price:expr, $after_cancel:expr) => {
-            context
-                .session_log
-                .record(
-                    context.correlation_id,
-                    Utc::now(),
-                    Observation::OrderResolved(OrderResolved {
-                        client_order_id: client_order_id.clone(),
-                        alpaca_order_id: order_id.clone(),
-                        ticker: intent.ticker().to_string(),
-                        outcome: $outcome,
-                        filled_shares: $shares,
-                        filled_average_price: $price,
-                        filled_after_cancel: $after_cancel,
-                    }),
-                )
-                .await
+            record_resolution(
+                context,
+                OrderResolved {
+                    client_order_id: client_order_id.to_string(),
+                    alpaca_order_id: Some(order_id.to_string()),
+                    ticker: intent.ticker().to_string(),
+                    outcome: $outcome,
+                    filled_shares: $shares,
+                    filled_average_price: $price,
+                    filled_after_cancel: $after_cancel,
+                    error: None,
+                },
+            )
+            .await
         };
     }
 
     loop {
-        let state = context.client.fetch_order(&order_id).await?;
-        match state {
+        match context.client.fetch_order(order_id).await? {
             OrderState::Filled {
                 filled_shares,
                 average_price,
@@ -420,7 +462,7 @@ async fn submit_and_confirm(
                 );
                 return Ok(Filled::Yes(LegFill {
                     ticker: intent.ticker().clone(),
-                    order_id,
+                    order_id: order_id.to_string(),
                     shares: filled_shares,
                     average_price,
                 }));
@@ -452,12 +494,12 @@ async fn submit_and_confirm(
                         order_id,
                         "Order did not reach a terminal state before the timeout; cancelling"
                     );
-                    context.client.cancel_order(&order_id).await?;
+                    context.client.cancel_order(order_id).await?;
                     // Read once more: the cancel may have raced a fill.
                     if let OrderState::Filled {
                         filled_shares,
                         average_price,
-                    } = context.client.fetch_order(&order_id).await?
+                    } = context.client.fetch_order(order_id).await?
                     {
                         resolved!(
                             "filled".to_string(),
@@ -467,7 +509,7 @@ async fn submit_and_confirm(
                         );
                         return Ok(Filled::Yes(LegFill {
                             ticker: intent.ticker().clone(),
-                            order_id,
+                            order_id: order_id.to_string(),
                             shares: filled_shares,
                             average_price,
                         }));
@@ -482,6 +524,18 @@ async fn submit_and_confirm(
             }
         }
     }
+}
+
+/// Writes how the broker settled one order.
+async fn record_resolution(context: &ExecutionContext<'_>, resolved: OrderResolved) {
+    context
+        .session_log
+        .record(
+            context.correlation_id,
+            Utc::now(),
+            Observation::OrderResolved(resolved),
+        )
+        .await;
 }
 
 #[cfg(test)]
@@ -856,11 +910,57 @@ mod tests {
         short.assert_async().await;
     }
 
+    /// The records of one type, preserving write order.
+    fn of_type<'a>(
+        records: &'a [serde_json::Value],
+        event_type: &str,
+    ) -> Vec<&'a serde_json::Value> {
+        records
+            .iter()
+            .filter(|record| record["event_type"] == event_type)
+            .collect()
+    }
+
+    /// A broker rejection resolves the submission rather than leaving it dangling.
+    ///
+    /// An unresolved submission is documented to mean the process died between the write and the
+    /// request; without this the same shape would also mean an ordinary rejection.
+    #[tokio::test]
+    async fn test_a_rejected_submission_still_writes_a_resolution() {
+        let mut server = mockito::Server::new_async().await;
+        let _submit = server
+            .mock("POST", "/v2/orders")
+            .with_status(422)
+            .with_body(r#"{"message":"insufficient buying power"}"#)
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(credentials(), server.url());
+        let log = session_log("rejected-submission");
+        let result = open_pair(&context(&client, &log), &pair(), None).await;
+
+        assert!(result.is_err(), "the broker failure must still be reported");
+        let records = recorded(&log);
+        let submitted = of_type(&records, "order_submitted");
+        let resolved = of_type(&records, "order_resolved");
+        assert_eq!(submitted.len(), 1);
+        assert_eq!(resolved.len(), 1, "every submission reaches a resolution");
+        assert_eq!(resolved[0]["payload"]["outcome"], "submit_failed");
+        assert!(resolved[0]["payload"]["alpaca_order_id"].is_null());
+        assert!(
+            resolved[0]["payload"]["error"].is_string(),
+            "the broker's reason is what separates a rejection from a crash"
+        );
+        assert_eq!(
+            submitted[0]["payload"]["client_order_id"],
+            resolved[0]["payload"]["client_order_id"]
+        );
+    }
+
     /// Both legs of every exit are recorded, including the leg that had nothing to close.
     ///
-    /// Exits were invisible for as long as entries were logged and closes were not, which made
-    /// realized profit and loss attributable in one direction only. A close that found no position
-    /// is recorded too: `accepted: false` with no order is a different fact from a filled exit.
+    /// A close that found no position is a different fact from a filled exit, and both matter to
+    /// attributing realized profit and loss.
     #[tokio::test]
     async fn test_closing_a_pair_records_both_legs() {
         let mut server = mockito::Server::new_async().await;
@@ -903,10 +1003,53 @@ mod tests {
         assert_eq!(filled["payload"]["alpaca_order_id"], "close-1");
         assert_eq!(filled["payload"]["quantity"], 50.0);
 
+        assert!(
+            filled["payload"]["error"].is_null(),
+            "an accepted close has no error"
+        );
+
         let missing = &records[1];
         assert_eq!(missing["payload"]["ticker"], "BBBB");
         assert_eq!(missing["payload"]["accepted"], false);
         assert!(missing["payload"]["alpaca_order_id"].is_null());
+        // No position and a refused close are opposite states, so the absent one carries no error.
+        assert!(missing["payload"]["error"].is_null());
+    }
+
+    /// A close the broker refused is not the same fact as a position that was not there.
+    #[tokio::test]
+    async fn test_a_refused_close_records_the_broker_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _long = server
+            .mock("DELETE", "/v2/positions/AAAA?percentage=100")
+            .with_status(500)
+            .with_body("internal error")
+            .create_async()
+            .await;
+        let _short = server
+            .mock("DELETE", "/v2/positions/BBBB?percentage=100")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(credentials(), server.url());
+        let log = session_log("refused-close");
+        let _ = close_pair(
+            &context(&client, &log),
+            "AAAA-BBBB",
+            &ticker("AAAA"),
+            &ticker("BBBB"),
+        )
+        .await;
+
+        let records = recorded(&log);
+        let refused = &records[0];
+        assert_eq!(refused["payload"]["ticker"], "AAAA");
+        assert_eq!(refused["payload"]["accepted"], false);
+        assert!(
+            refused["payload"]["error"].is_string(),
+            "a leg the broker would not release is still held, and the log has to say so"
+        );
     }
 
     #[tokio::test]

--- a/src/portfolio/execute.rs
+++ b/src/portfolio/execute.rs
@@ -508,7 +508,13 @@ mod tests {
     /// A log in a directory of this test's own. Every order path writes to one, so the tests
     /// exercise the record-before-submit ordering rather than mocking it away.
     fn session_log(name: &str) -> SessionLog {
-        let directory = std::env::temp_dir().join(format!("fund-execute-{name}"));
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let directory = std::env::temp_dir().join(format!(
+            "fund-execute-{name}-{}-{unique}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&directory);
         SessionLog::new(directory).expect("the log directory must be creatable")
     }

--- a/src/portfolio/execute.rs
+++ b/src/portfolio/execute.rs
@@ -9,10 +9,14 @@
 
 use std::time::Duration;
 
+use chrono::Utc;
+use rust_decimal::prelude::ToPrimitive;
 use tracing::{error, info, warn};
+use uuid::Uuid;
 
 use crate::common::alpaca::{ClientError, OrderIntent, OrderState, TradingClient};
 use crate::common::types::Ticker;
+use crate::data::session_log::{Observation, OrderResolved, OrderSubmitted, SessionLog};
 use crate::portfolio::pairs::PairEntry;
 use crate::portfolio::size::SizedPair;
 
@@ -58,6 +62,18 @@ impl Default for ExecutionSettings {
             poll_interval: FILL_POLL_INTERVAL,
         }
     }
+}
+
+/// Everything an order needs beyond the order itself.
+///
+/// The log and the correlation identifier travel with the client rather than as further parameters
+/// so that no path can send an order without carrying the thread back to the pass that decided it.
+pub struct ExecutionContext<'a> {
+    pub client: &'a TradingClient,
+    pub settings: ExecutionSettings,
+    pub session_log: &'a SessionLog,
+    /// The evaluation pass this order belongs to.
+    pub correlation_id: Uuid,
 }
 
 /// One leg that filled.
@@ -139,10 +155,9 @@ impl CloseOutcome {
 /// error only when the unwind itself failed — the case where something is held that nothing knows
 /// about, which the caller must surface rather than absorb.
 pub async fn open_pair(
-    client: &TradingClient,
+    context: &ExecutionContext<'_>,
     pair: &SizedPair,
     model_run_id: Option<String>,
-    settings: ExecutionSettings,
 ) -> Result<OpenOutcome, ExecutionError> {
     let candidate = pair.candidate();
     let short_ticker = candidate.short_ticker().clone();
@@ -151,12 +166,11 @@ pub async fn open_pair(
     // The short leg first, and confirmed, before the long is submitted. A borrow rejection then
     // costs nothing to recover from, because nothing is held yet.
     let short_fill = match submit_and_confirm(
-        client,
+        context,
         &OrderIntent::OpenShort {
             ticker: short_ticker.clone(),
             shares: pair.short_shares(),
         },
-        settings,
     )
     .await?
     {
@@ -176,12 +190,11 @@ pub async fn open_pair(
     };
 
     let long_fill = match submit_and_confirm(
-        client,
+        context,
         &OrderIntent::OpenLong {
             ticker: long_ticker.clone(),
             notional: pair.long_notional(),
         },
-        settings,
     )
     .await?
     {
@@ -197,7 +210,7 @@ pub async fn open_pair(
             // for it — `PairEntry` is not built until below. Name the held symbol and its size
             // before propagating, because the error carries only the broker's message and the
             // warning above names the leg that *failed*, not the one still on the book.
-            if let Err(error) = client.close_position(&short_ticker).await {
+            if let Err(error) = context.client.close_position(&short_ticker).await {
                 error!(
                     pair_id = %candidate.pair_id(),
                     held_ticker = %short_ticker,
@@ -242,12 +255,12 @@ pub async fn open_pair(
 /// short leg — the naked directional position the pair structure exists to avoid — in exactly the
 /// situation where it is most likely still held. The error is reported after both attempts.
 pub async fn close_pair(
-    client: &TradingClient,
+    context: &ExecutionContext<'_>,
     long_ticker: &Ticker,
     short_ticker: &Ticker,
 ) -> Result<CloseOutcome, ExecutionError> {
-    let long_result = client.close_position(long_ticker).await;
-    let short_result = client.close_position(short_ticker).await;
+    let long_result = context.client.close_position(long_ticker).await;
+    let short_result = context.client.close_position(short_ticker).await;
 
     if let Err(error) = &long_result {
         warn!(ticker = %long_ticker, %error, "Closing the long leg failed");
@@ -285,32 +298,87 @@ enum Filled {
 /// A timed-out order is cancelled before returning. Leaving it working would mean reporting the leg
 /// as unfilled while Alpaca still holds a live order that could fill afterwards, into a pair the
 /// application has already given up on.
+///
+/// The intent is written to the session log and fsynced *before* the request is sent. That ordering
+/// is the whole point: a crash between the two leaves a record of an order that may exist, which is
+/// recoverable, rather than an order that exists with no record, which is not.
 async fn submit_and_confirm(
-    client: &TradingClient,
+    context: &ExecutionContext<'_>,
     intent: &OrderIntent,
-    settings: ExecutionSettings,
 ) -> Result<Filled, ExecutionError> {
-    let order_id = client.submit_order(intent).await?;
-    let deadline = tokio::time::Instant::now() + settings.fill_timeout;
+    let client_order_id = Uuid::new_v4().to_string();
+    let (shares, notional) = match intent {
+        OrderIntent::OpenShort { shares, .. } => (Some(f64::from(shares.get())), None),
+        OrderIntent::OpenLong { notional, .. } => (None, notional.value().to_f64()),
+    };
+    context
+        .session_log
+        .record(
+            context.correlation_id,
+            Utc::now(),
+            Observation::OrderSubmitted(OrderSubmitted {
+                client_order_id: client_order_id.clone(),
+                ticker: intent.ticker().to_string(),
+                side: intent.side().to_string(),
+                shares,
+                notional,
+            }),
+        )
+        .await;
+
+    let order_id = context
+        .client
+        .submit_order(intent, &client_order_id)
+        .await?;
+    let deadline = tokio::time::Instant::now() + context.settings.fill_timeout;
+
+    /// Records how the broker settled the order, then hands back what the caller returns.
+    macro_rules! resolved {
+        ($outcome:expr, $shares:expr, $price:expr, $after_cancel:expr) => {
+            context
+                .session_log
+                .record(
+                    context.correlation_id,
+                    Utc::now(),
+                    Observation::OrderResolved(OrderResolved {
+                        client_order_id: client_order_id.clone(),
+                        alpaca_order_id: order_id.clone(),
+                        ticker: intent.ticker().to_string(),
+                        outcome: $outcome,
+                        filled_shares: $shares,
+                        filled_average_price: $price,
+                        filled_after_cancel: $after_cancel,
+                    }),
+                )
+                .await
+        };
+    }
 
     loop {
-        let state = client.fetch_order(&order_id).await?;
+        let state = context.client.fetch_order(&order_id).await?;
         match state {
             OrderState::Filled {
                 filled_shares,
                 average_price,
             } => {
+                resolved!(
+                    "filled".to_string(),
+                    Some(filled_shares),
+                    Some(average_price),
+                    false
+                );
                 return Ok(Filled::Yes(LegFill {
                     ticker: intent.ticker().clone(),
                     order_id,
                     shares: filled_shares,
                     average_price,
-                }))
+                }));
             }
             OrderState::Abandoned {
                 status,
                 filled_shares,
             } => {
+                resolved!(status.clone(), Some(filled_shares), None, false);
                 // A partial fill that then terminated leaves shares held. Close the position rather
                 // than reporting the leg cleanly unfilled.
                 if filled_shares > 0.0 {
@@ -320,7 +388,7 @@ async fn submit_and_confirm(
                         filled_shares,
                         "Order terminated after a partial fill; closing the remainder"
                     );
-                    client.close_position(intent.ticker()).await?;
+                    context.client.close_position(intent.ticker()).await?;
                 }
                 return Ok(Filled::No(status));
             }
@@ -331,13 +399,19 @@ async fn submit_and_confirm(
                         order_id,
                         "Order did not reach a terminal state before the timeout; cancelling"
                     );
-                    client.cancel_order(&order_id).await?;
+                    context.client.cancel_order(&order_id).await?;
                     // Read once more: the cancel may have raced a fill.
                     if let OrderState::Filled {
                         filled_shares,
                         average_price,
-                    } = client.fetch_order(&order_id).await?
+                    } = context.client.fetch_order(&order_id).await?
                     {
+                        resolved!(
+                            "filled".to_string(),
+                            Some(filled_shares),
+                            Some(average_price),
+                            true
+                        );
                         return Ok(Filled::Yes(LegFill {
                             ticker: intent.ticker().clone(),
                             order_id,
@@ -345,10 +419,11 @@ async fn submit_and_confirm(
                             average_price,
                         }));
                     }
-                    client.close_position(intent.ticker()).await?;
+                    resolved!("timed_out".to_string(), None, None, false);
+                    context.client.close_position(intent.ticker()).await?;
                     return Ok(Filled::No("timed_out".to_string()));
                 }
-                tokio::time::sleep(settings.poll_interval).await;
+                tokio::time::sleep(context.settings.poll_interval).await;
             }
         }
     }
@@ -373,6 +448,23 @@ mod tests {
 
     fn settings() -> ExecutionSettings {
         ExecutionSettings::new(Duration::from_millis(50), Duration::from_millis(5))
+    }
+
+    /// A log in a directory of this test's own. Every order path writes to one, so the tests
+    /// exercise the record-before-submit ordering rather than mocking it away.
+    fn session_log(name: &str) -> SessionLog {
+        let directory = std::env::temp_dir().join(format!("fund-execute-{name}"));
+        let _ = std::fs::remove_dir_all(&directory);
+        SessionLog::new(directory).expect("the log directory must be creatable")
+    }
+
+    fn context<'a>(client: &'a TradingClient, log: &'a SessionLog) -> ExecutionContext<'a> {
+        ExecutionContext {
+            client,
+            settings: settings(),
+            session_log: log,
+            correlation_id: Uuid::nil(),
+        }
     }
 
     fn pair() -> SizedPair {
@@ -414,7 +506,8 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let outcome = open_pair(&client, &pair(), Some("run-1".to_string()), settings())
+        let log = session_log("fills-both-legs");
+        let outcome = open_pair(&context(&client, &log), &pair(), Some("run-1".to_string()))
             .await
             .expect("the open must succeed");
 
@@ -455,7 +548,8 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let outcome = open_pair(&client, &pair(), None, settings())
+        let log = session_log("rejected-short");
+        let outcome = open_pair(&context(&client, &log), &pair(), None)
             .await
             .expect("an unfilled leg is not an error");
 
@@ -511,7 +605,8 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let outcome = open_pair(&client, &pair(), None, settings())
+        let log = session_log("failed-long");
+        let outcome = open_pair(&context(&client, &log), &pair(), None)
             .await
             .expect("the unwind must succeed");
 
@@ -558,7 +653,8 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let outcome = open_pair(&client, &pair(), None, settings())
+        let log = session_log("timed-out");
+        let outcome = open_pair(&context(&client, &log), &pair(), None)
             .await
             .expect("a timeout is not an error");
 
@@ -596,7 +692,8 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let outcome = open_pair(&client, &pair(), None, settings())
+        let log = session_log("partial-fill");
+        let outcome = open_pair(&context(&client, &log), &pair(), None)
             .await
             .expect("a partial fill is not an error");
 
@@ -624,7 +721,8 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let outcome = close_pair(&client, &ticker("AAAA"), &ticker("BBBB"))
+        let log = session_log("close-both-legs");
+        let outcome = close_pair(&context(&client, &log), &ticker("AAAA"), &ticker("BBBB"))
             .await
             .expect("the close must succeed");
 
@@ -657,7 +755,8 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let result = close_pair(&client, &ticker("AAAA"), &ticker("BBBB")).await;
+        let log = session_log("close-long-errors");
+        let result = close_pair(&context(&client, &log), &ticker("AAAA"), &ticker("BBBB")).await;
 
         assert!(result.is_err(), "the broker failure must still be reported");
         long.assert_async().await;
@@ -680,7 +779,8 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let outcome = close_pair(&client, &ticker("AAAA"), &ticker("BBBB"))
+        let log = session_log("already-gone");
+        let outcome = close_pair(&context(&client, &log), &ticker("AAAA"), &ticker("BBBB"))
             .await
             .unwrap();
         assert!(outcome.was_already_gone());

--- a/src/portfolio/execute.rs
+++ b/src/portfolio/execute.rs
@@ -14,9 +14,11 @@ use rust_decimal::prelude::ToPrimitive;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-use crate::common::alpaca::{ClientError, OrderIntent, OrderState, TradingClient};
+use crate::common::alpaca::{ClientError, OrderIntent, OrderState, PositionClose, TradingClient};
 use crate::common::types::Ticker;
-use crate::data::session_log::{Observation, OrderResolved, OrderSubmitted, SessionLog};
+use crate::data::session_log::{
+    Observation, OrderResolved, OrderSubmitted, PositionCloseRequested, SessionLog,
+};
 use crate::portfolio::pairs::PairEntry;
 use crate::portfolio::size::SizedPair;
 
@@ -210,7 +212,16 @@ pub async fn open_pair(
             // for it — `PairEntry` is not built until below. Name the held symbol and its size
             // before propagating, because the error carries only the broker's message and the
             // warning above names the leg that *failed*, not the one still on the book.
-            if let Err(error) = context.client.close_position(&short_ticker).await {
+            let unwind = context.client.close_position(&short_ticker).await;
+            record_close(
+                context,
+                &short_ticker,
+                Some(candidate.pair_id().as_str()),
+                "entry_unwind",
+                &unwind,
+            )
+            .await;
+            if let Err(error) = unwind {
                 error!(
                     pair_id = %candidate.pair_id(),
                     held_ticker = %short_ticker,
@@ -256,11 +267,18 @@ pub async fn open_pair(
 /// situation where it is most likely still held. The error is reported after both attempts.
 pub async fn close_pair(
     context: &ExecutionContext<'_>,
+    pair_id: &str,
     long_ticker: &Ticker,
     short_ticker: &Ticker,
 ) -> Result<CloseOutcome, ExecutionError> {
     let long_result = context.client.close_position(long_ticker).await;
     let short_result = context.client.close_position(short_ticker).await;
+
+    // Recorded before the errors are propagated. A leg whose close failed is exactly the one worth
+    // having a record of, and `?` below returns without reaching any later write.
+    for (ticker, result) in [(long_ticker, &long_result), (short_ticker, &short_result)] {
+        record_close(context, ticker, Some(pair_id), "pair_exit", result).await;
+    }
 
     if let Err(error) = &long_result {
         warn!(ticker = %long_ticker, %error, "Closing the long leg failed");
@@ -269,8 +287,8 @@ pub async fn close_pair(
         warn!(ticker = %short_ticker, %error, "Closing the short leg failed");
     }
 
-    let long_closed = long_result?;
-    let short_closed = short_result?;
+    let long_closed = long_result?.is_some();
+    let short_closed = short_result?.is_some();
 
     if long_closed != short_closed {
         warn!(
@@ -285,6 +303,39 @@ pub async fn close_pair(
         long_closed,
         short_closed,
     })
+}
+
+/// Records one close attempt, whatever came of it.
+///
+/// Takes the `Result` rather than a success value so a refused close is as visible as an accepted
+/// one: a leg the broker would not let go of is the state the book is wrong about.
+async fn record_close(
+    context: &ExecutionContext<'_>,
+    ticker: &Ticker,
+    pair_id: Option<&str>,
+    reason: &str,
+    result: &Result<Option<PositionClose>, ClientError>,
+) {
+    let close = result.as_ref().ok().and_then(Option::as_ref);
+    context
+        .session_log
+        .record(
+            context.correlation_id,
+            Utc::now(),
+            Observation::PositionCloseRequested(PositionCloseRequested {
+                ticker: ticker.to_string(),
+                pair_id: pair_id.map(str::to_string),
+                alpaca_order_id: close
+                    .and_then(|close| close.alpaca_order_id())
+                    .map(str::to_string),
+                side: close.and_then(|close| close.side()).map(str::to_string),
+                quantity: close.and_then(PositionClose::quantity),
+                reason: reason.to_string(),
+                accepted: close.is_some(),
+                status: None,
+            }),
+        )
+        .await;
 }
 
 /// Whether a submitted order reached a fill.
@@ -388,7 +439,9 @@ async fn submit_and_confirm(
                         filled_shares,
                         "Order terminated after a partial fill; closing the remainder"
                     );
-                    context.client.close_position(intent.ticker()).await?;
+                    let cleanup = context.client.close_position(intent.ticker()).await;
+                    record_close(context, intent.ticker(), None, "entry_unwind", &cleanup).await;
+                    cleanup?;
                 }
                 return Ok(Filled::No(status));
             }
@@ -420,7 +473,9 @@ async fn submit_and_confirm(
                         }));
                     }
                     resolved!("timed_out".to_string(), None, None, false);
-                    context.client.close_position(intent.ticker()).await?;
+                    let cleanup = context.client.close_position(intent.ticker()).await;
+                    record_close(context, intent.ticker(), None, "entry_unwind", &cleanup).await;
+                    cleanup?;
                     return Ok(Filled::No("timed_out".to_string()));
                 }
                 tokio::time::sleep(context.settings.poll_interval).await;
@@ -456,6 +511,26 @@ mod tests {
         let directory = std::env::temp_dir().join(format!("fund-execute-{name}"));
         let _ = std::fs::remove_dir_all(&directory);
         SessionLog::new(directory).expect("the log directory must be creatable")
+    }
+
+    /// Every record a log holds, in the order it was written.
+    fn recorded(log: &SessionLog) -> Vec<serde_json::Value> {
+        let mut files: Vec<_> = std::fs::read_dir(log.directory())
+            .expect("the log directory must be readable")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .collect();
+        files.sort();
+        files
+            .iter()
+            .filter_map(|path| std::fs::read_to_string(path).ok())
+            .flat_map(|contents| {
+                contents
+                    .lines()
+                    .filter_map(|line| serde_json::from_str(line).ok())
+                    .collect::<Vec<serde_json::Value>>()
+            })
+            .collect()
     }
 
     fn context<'a>(client: &'a TradingClient, log: &'a SessionLog) -> ExecutionContext<'a> {
@@ -722,9 +797,14 @@ mod tests {
 
         let client = TradingClient::with_base_url(credentials(), server.url());
         let log = session_log("close-both-legs");
-        let outcome = close_pair(&context(&client, &log), &ticker("AAAA"), &ticker("BBBB"))
-            .await
-            .expect("the close must succeed");
+        let outcome = close_pair(
+            &context(&client, &log),
+            "AAAA-BBBB",
+            &ticker("AAAA"),
+            &ticker("BBBB"),
+        )
+        .await
+        .expect("the close must succeed");
 
         assert!(!outcome.long_closed());
         assert!(outcome.short_closed());
@@ -756,12 +836,71 @@ mod tests {
 
         let client = TradingClient::with_base_url(credentials(), server.url());
         let log = session_log("close-long-errors");
-        let result = close_pair(&context(&client, &log), &ticker("AAAA"), &ticker("BBBB")).await;
+        let result = close_pair(
+            &context(&client, &log),
+            "AAAA-BBBB",
+            &ticker("AAAA"),
+            &ticker("BBBB"),
+        )
+        .await;
 
         assert!(result.is_err(), "the broker failure must still be reported");
         long.assert_async().await;
         // The assertion that matters: the short close was attempted despite the long leg failing.
         short.assert_async().await;
+    }
+
+    /// Both legs of every exit are recorded, including the leg that had nothing to close.
+    ///
+    /// Exits were invisible for as long as entries were logged and closes were not, which made
+    /// realized profit and loss attributable in one direction only. A close that found no position
+    /// is recorded too: `accepted: false` with no order is a different fact from a filled exit.
+    #[tokio::test]
+    async fn test_closing_a_pair_records_both_legs() {
+        let mut server = mockito::Server::new_async().await;
+        let _long = server
+            .mock("DELETE", "/v2/positions/AAAA?percentage=100")
+            .with_status(200)
+            .with_body(r#"{"id":"close-1","qty":"50","side":"sell"}"#)
+            .create_async()
+            .await;
+        let _short = server
+            .mock("DELETE", "/v2/positions/BBBB?percentage=100")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(credentials(), server.url());
+        let log = session_log("records-both-legs");
+        close_pair(
+            &context(&client, &log),
+            "AAAA-BBBB",
+            &ticker("AAAA"),
+            &ticker("BBBB"),
+        )
+        .await
+        .expect("the close must succeed");
+
+        let records = recorded(&log);
+        assert_eq!(records.len(), 2, "one record per leg");
+        assert!(records
+            .iter()
+            .all(|record| record["event_type"] == "position_close_requested"
+                && record["payload"]["pair_id"] == "AAAA-BBBB"
+                && record["payload"]["reason"] == "pair_exit"));
+
+        let filled = &records[0];
+        assert_eq!(filled["payload"]["ticker"], "AAAA");
+        assert_eq!(filled["payload"]["accepted"], true);
+        // The order identifier is the join to the fill: a close is not polled, so the price
+        // arrives later through the post-close activity sync.
+        assert_eq!(filled["payload"]["alpaca_order_id"], "close-1");
+        assert_eq!(filled["payload"]["quantity"], 50.0);
+
+        let missing = &records[1];
+        assert_eq!(missing["payload"]["ticker"], "BBBB");
+        assert_eq!(missing["payload"]["accepted"], false);
+        assert!(missing["payload"]["alpaca_order_id"].is_null());
     }
 
     #[tokio::test]
@@ -780,9 +919,14 @@ mod tests {
 
         let client = TradingClient::with_base_url(credentials(), server.url());
         let log = session_log("already-gone");
-        let outcome = close_pair(&context(&client, &log), &ticker("AAAA"), &ticker("BBBB"))
-            .await
-            .unwrap();
+        let outcome = close_pair(
+            &context(&client, &log),
+            "AAAA-BBBB",
+            &ticker("AAAA"),
+            &ticker("BBBB"),
+        )
+        .await
+        .unwrap();
         assert!(outcome.was_already_gone());
     }
 }

--- a/src/portfolio/risk.rs
+++ b/src/portfolio/risk.rs
@@ -211,9 +211,8 @@ impl RiskGate {
 
     /// Runs `admit` across a selection, returning what passed and what each refusal was.
     ///
-    /// Refusals carry the pair they refused. A bare list of blocks says the gate turned three pairs
-    /// down and cannot say which three, which makes the refusal rate impossible to attribute back to
-    /// the candidates that produced it.
+    /// Refusals carry the pair they refused, so a refusal rate is attributable back to the
+    /// candidates that produced it.
     pub fn admit_all(&mut self, sized: &[SizedPair]) -> (Vec<SizedPair>, Vec<RefusedPair>) {
         let mut approved = Vec::with_capacity(sized.len());
         let mut refusals = Vec::new();
@@ -227,7 +226,10 @@ impl RiskGate {
                         maximum: self.parameters.maximum_concurrent_pairs(),
                     },
                 });
-                break;
+                // `continue`, not `break`: a full book still has to say which candidates it turned
+                // away, and every one after the first would otherwise be recorded as though the
+                // screen dropped it.
+                continue;
             }
             match self.admit(pair) {
                 Some(block) => {
@@ -416,14 +418,22 @@ mod tests {
         assert_eq!(approved.len(), 1);
         assert!(matches!(
             refusals.as_slice(),
-            [RefusedPair {
-                block: RiskBlock::PairCapacity { .. },
-                ..
-            }]
+            [
+                RefusedPair {
+                    block: RiskBlock::PairCapacity { .. },
+                    ..
+                },
+                RefusedPair {
+                    block: RiskBlock::PairCapacity { .. },
+                    ..
+                }
+            ]
         ));
-        // The refusal names the pair it refused, which is what makes a refusal rate attributable
-        // back to the candidate that produced it.
+        // Each refusal names the pair it refused, which is what makes a refusal rate attributable
+        // back to the candidate that produced it — and every pair behind the first is refused too,
+        // rather than left looking as though the screen dropped it.
         assert_eq!(refusals[0].pair_id.as_str(), "CCCC-DDDD");
+        assert_eq!(refusals[1].pair_id.as_str(), "EEEE-FFFF");
     }
 
     #[test]

--- a/src/portfolio/risk.rs
+++ b/src/portfolio/risk.rs
@@ -12,6 +12,7 @@ use rust_decimal::Decimal;
 use tracing::{info, warn};
 
 use crate::common::alpaca::AccountSnapshot;
+use crate::common::types::PairID;
 use crate::portfolio::size::{SizedPair, SizingParameters};
 
 /// Fraction of the previous session's equity the account may lose before entries stop.
@@ -209,15 +210,22 @@ impl RiskGate {
     }
 
     /// Runs `admit` across a selection, returning what passed and what each refusal was.
-    pub fn admit_all(&mut self, sized: &[SizedPair]) -> (Vec<SizedPair>, Vec<RiskBlock>) {
+    ///
+    /// Refusals carry the pair they refused. A bare list of blocks says the gate turned three pairs
+    /// down and cannot say which three, which makes the refusal rate impossible to attribute back to
+    /// the candidates that produced it.
+    pub fn admit_all(&mut self, sized: &[SizedPair]) -> (Vec<SizedPair>, Vec<RefusedPair>) {
         let mut approved = Vec::with_capacity(sized.len());
-        let mut blocks = Vec::new();
+        let mut refusals = Vec::new();
 
         for pair in sized {
             if self.vacant_slots() == 0 {
-                blocks.push(RiskBlock::PairCapacity {
-                    open: self.open_pair_count,
-                    maximum: self.parameters.maximum_concurrent_pairs(),
+                refusals.push(RefusedPair {
+                    pair_id: pair.candidate().pair_id().clone(),
+                    block: RiskBlock::PairCapacity {
+                        open: self.open_pair_count,
+                        maximum: self.parameters.maximum_concurrent_pairs(),
+                    },
                 });
                 break;
             }
@@ -229,7 +237,10 @@ impl RiskGate {
                         reason = %block,
                         "Pair refused by the risk gate"
                     );
-                    blocks.push(block);
+                    refusals.push(RefusedPair {
+                        pair_id: pair.candidate().pair_id().clone(),
+                        block,
+                    });
                 }
                 None => approved.push(pair.clone()),
             }
@@ -237,11 +248,18 @@ impl RiskGate {
 
         info!(
             approved = approved.len(),
-            refused = blocks.len(),
+            refused = refusals.len(),
             "Risk gate applied"
         );
-        (approved, blocks)
+        (approved, refusals)
     }
+}
+
+/// One pair the gate turned down, and why.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RefusedPair {
+    pub pair_id: PairID,
+    pub block: RiskBlock,
 }
 
 #[cfg(test)]
@@ -393,13 +411,19 @@ mod tests {
             sized("CCCC", "DDDD", 100.0, 1_000),
             sized("EEEE", "FFFF", 100.0, 1_000),
         ];
-        let (approved, blocks) = gate.admit_all(&pairs);
+        let (approved, refusals) = gate.admit_all(&pairs);
 
         assert_eq!(approved.len(), 1);
         assert!(matches!(
-            blocks.as_slice(),
-            [RiskBlock::PairCapacity { .. }]
+            refusals.as_slice(),
+            [RefusedPair {
+                block: RiskBlock::PairCapacity { .. },
+                ..
+            }]
         ));
+        // The refusal names the pair it refused, which is what makes a refusal rate attributable
+        // back to the candidate that produced it.
+        assert_eq!(refusals[0].pair_id.as_str(), "CCCC-DDDD");
     }
 
     #[test]

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -17,6 +17,7 @@ use fund::common::alpaca::{
 use fund::common::types::{BarInterval, Ticker};
 use fund::data::bars;
 use fund::data::calendar::{SessionDate, TradingCalendar};
+use fund::data::session_log::SessionLog;
 use fund::data::universe::{LiquidityRow, Universe};
 use fund::portfolio::evaluate::{self, EvaluationContext};
 use fund::portfolio::execute::ExecutionSettings;
@@ -63,6 +64,44 @@ fn calendar_for_today() -> TradingCalendar {
         })
         .collect();
     TradingCalendar::from_days(days)
+}
+
+/// A session log in a directory of this test's own.
+///
+/// Every path under test writes one, so a shared directory would let one test's records be read as
+/// another's — and these tests already share a database.
+fn session_log(name: &str) -> SessionLog {
+    let directory = std::env::temp_dir().join(format!("fund-test-handlers-{name}"));
+    let _ = std::fs::remove_dir_all(&directory);
+    SessionLog::new(directory).expect("the log directory must be creatable")
+}
+
+/// Every record a log holds, in the order it was written.
+fn recorded(log: &SessionLog) -> Vec<serde_json::Value> {
+    let mut files: Vec<_> = std::fs::read_dir(log.directory())
+        .expect("the log directory must be readable")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .collect();
+    files.sort();
+    files
+        .iter()
+        .filter_map(|path| std::fs::read_to_string(path).ok())
+        .flat_map(|contents| {
+            contents
+                .lines()
+                .filter_map(|line| serde_json::from_str(line).ok())
+                .collect::<Vec<serde_json::Value>>()
+        })
+        .collect()
+}
+
+/// The records of one type, preserving write order.
+fn of_type<'a>(records: &'a [serde_json::Value], event_type: &str) -> Vec<&'a serde_json::Value> {
+    records
+        .iter()
+        .filter(|record| record["event_type"] == event_type)
+        .collect()
 }
 
 /// The five most recent weekday sessions ending at `session_date`.
@@ -203,6 +242,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
     let universe = universe_of(&["AAAA", "BBBB"]);
 
     let running = CancellationToken::new();
+    let session_log = session_log("test-a-pass-opens-a-pair-and-records-it");
     let context = EvaluationContext {
         pool: &pool,
         trading: &trading,
@@ -212,6 +252,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
         close_history: &close_history,
         sizing: SizingParameters::default(),
         execution: settings(),
+        session_log: &session_log,
         shutdown: &running,
         now: session_instant(),
     };
@@ -237,6 +278,46 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
         open[0].entry_z_score() > 0.0,
         "the stored entry score must be positive by the orientation invariant"
     );
+
+    // The pass is only useful to a replay if the observation reached the disk. One evaluation
+    // record, and one submission and one resolution per leg, all threaded by the pass's identifier.
+    let records = recorded(&session_log);
+    let passes = of_type(&records, "evaluation_pass");
+    assert_eq!(passes.len(), 1, "one record per pass");
+    let pass = &passes[0];
+    let correlation_id = pass["correlation_id"]
+        .as_str()
+        .expect("a pass is correlated");
+
+    assert_eq!(pass["payload"]["candidates"].as_array().unwrap().len(), 1);
+    assert_eq!(pass["payload"]["candidates"][0]["decision"], "opened");
+    assert!(
+        !pass["payload"]["prices"].as_array().unwrap().is_empty(),
+        "the prices the pass decided on must be recorded"
+    );
+    assert!(
+        pass["payload"]["prices"][0]["price_source"].is_string(),
+        "a price without its source cannot be compared across passes"
+    );
+
+    let submitted = of_type(&records, "order_submitted");
+    let resolved = of_type(&records, "order_resolved");
+    assert_eq!(submitted.len(), 2, "one submission per leg");
+    assert_eq!(resolved.len(), 2, "every submission is resolved");
+    for record in submitted.iter().chain(resolved.iter()) {
+        assert_eq!(
+            record["correlation_id"], correlation_id,
+            "orders thread back to the pass that decided them"
+        );
+    }
+    // The submission is keyed by an identifier chosen before the request was sent, which is what
+    // makes an order recoverable if the process dies between the write and Alpaca's response.
+    assert_eq!(
+        submitted[0]["payload"]["client_order_id"],
+        resolved[0]["payload"]["client_order_id"]
+    );
+    assert_eq!(resolved[0]["payload"]["outcome"], "filled");
+
     submit.assert_async().await;
 }
 
@@ -306,6 +387,7 @@ async fn test_a_pass_opens_nothing_once_shutdown_is_requested() {
     let running = CancellationToken::new();
     running.cancel();
 
+    let session_log = session_log("test-a-pass-opens-nothing-once-shutdown-is-requested");
     let context = EvaluationContext {
         pool: &pool,
         trading: &trading,
@@ -315,6 +397,7 @@ async fn test_a_pass_opens_nothing_once_shutdown_is_requested() {
         close_history: &close_history,
         sizing: SizingParameters::default(),
         execution: settings(),
+        session_log: &session_log,
         shutdown: &running,
         now: session_instant(),
     };
@@ -420,6 +503,7 @@ async fn test_a_pass_closes_a_converged_pair_from_a_full_book() {
     let sizing = SizingParameters::new(4, 1.0).unwrap();
 
     let running = CancellationToken::new();
+    let session_log = session_log("test-a-pass-closes-a-converged-pair-from-a-full-book");
     let context = EvaluationContext {
         pool: &pool,
         trading: &trading,
@@ -429,6 +513,7 @@ async fn test_a_pass_closes_a_converged_pair_from_a_full_book() {
         close_history: &close_history,
         sizing,
         execution: settings(),
+        session_log: &session_log,
         shutdown: &running,
         now: session_instant(),
     };
@@ -503,6 +588,7 @@ async fn test_a_pair_that_cannot_be_priced_is_held_and_counted() {
     let universe = universe_of(&["AAAA", "BBBB"]);
 
     let running = CancellationToken::new();
+    let session_log = session_log("test-a-pair-that-cannot-be-priced-is-held-and-counted");
     let context = EvaluationContext {
         pool: &pool,
         trading: &trading,
@@ -512,6 +598,7 @@ async fn test_a_pair_that_cannot_be_priced_is_held_and_counted() {
         close_history: &close_history,
         sizing: SizingParameters::default(),
         execution: settings(),
+        session_log: &session_log,
         shutdown: &running,
         now: session_instant(),
     };
@@ -559,9 +646,14 @@ async fn test_liquidation_flattens_the_book_and_marks_every_pair() {
         .await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
-    let summary = evaluate::run_liquidation(&pool, &trading, Utc::now())
-        .await
-        .expect("the liquidation must run");
+    let summary = evaluate::run_liquidation(
+        &pool,
+        &trading,
+        &session_log("test-liquidation-flattens-the-book-and-marks-every-pair"),
+        Utc::now(),
+    )
+    .await
+    .expect("the liquidation must run");
 
     assert_eq!(summary.pairs_closed, 2);
     assert!(summary.pairs_still_open.is_empty());
@@ -602,9 +694,14 @@ async fn test_a_refused_leg_leaves_its_pair_open() {
         .await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
-    let summary = evaluate::run_liquidation(&pool, &trading, Utc::now())
-        .await
-        .unwrap();
+    let summary = evaluate::run_liquidation(
+        &pool,
+        &trading,
+        &session_log("test-a-refused-leg-leaves-its-pair-open"),
+        Utc::now(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.positions_refused, 1);
     assert_eq!(summary.pairs_closed, 1);
@@ -691,6 +788,7 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
     let summary = account::sync_account(
         &pool,
         &trading,
+        &session_log("test-the-account-sync-stores-and-attributes-a-session"),
         &calendar_ending_at(session_date),
         session_date,
     )
@@ -751,10 +849,12 @@ async fn test_the_account_sync_is_idempotent() {
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
     let calendar = calendar_ending_at(session_date);
-    let first = account::sync_account(&pool, &trading, &calendar, session_date)
+    let log = session_log("test-the-account-sync-is-idempotent-0");
+    let first = account::sync_account(&pool, &trading, &log, &calendar, session_date)
         .await
         .unwrap();
-    let second = account::sync_account(&pool, &trading, &calendar, session_date)
+    let log = session_log("test-the-account-sync-is-idempotent-1");
+    let second = account::sync_account(&pool, &trading, &log, &calendar, session_date)
         .await
         .unwrap();
 
@@ -834,6 +934,7 @@ async fn test_the_account_sync_stores_transfers_without_attributing_them() {
     let summary = account::sync_account(
         &pool,
         &trading,
+        &session_log("test-the-account-sync-stores-transfers-without-attributing-them"),
         &calendar_ending_at(session_date),
         session_date,
     )
@@ -901,7 +1002,8 @@ async fn test_the_account_sync_reports_a_missing_previous_session() {
     }
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
-    let with_gap = account::sync_account(&pool, &trading, &calendar, session_date)
+    let log = session_log("test-the-account-sync-reports-a-missing-previous-session-2");
+    let with_gap = account::sync_account(&pool, &trading, &log, &calendar, session_date)
         .await
         .expect("the sync must run");
     assert_eq!(
@@ -911,10 +1013,10 @@ async fn test_the_account_sync_reports_a_missing_previous_session() {
     );
 
     // Fill the hole and the same sync stops reporting it.
-    account::sync_account(&pool, &trading, &calendar, previous)
+    account::sync_account(&pool, &trading, &log, &calendar, previous)
         .await
         .expect("the sync must run");
-    let repaired = account::sync_account(&pool, &trading, &calendar, session_date)
+    let repaired = account::sync_account(&pool, &trading, &log, &calendar, session_date)
         .await
         .expect("the sync must run");
     assert_eq!(repaired.previous_session_gap, None);

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -71,7 +71,13 @@ fn calendar_for_today() -> TradingCalendar {
 /// Every path under test writes one, so a shared directory would let one test's records be read as
 /// another's — and these tests already share a database.
 fn session_log(name: &str) -> SessionLog {
-    let directory = std::env::temp_dir().join(format!("fund-test-handlers-{name}"));
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let directory = std::env::temp_dir().join(format!(
+        "fund-test-handlers-{name}-{}-{unique}",
+        std::process::id()
+    ));
     let _ = std::fs::remove_dir_all(&directory);
     SessionLog::new(directory).expect("the log directory must be creatable")
 }
@@ -290,7 +296,16 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
         .expect("a pass is correlated");
 
     assert_eq!(pass["payload"]["candidates"].as_array().unwrap().len(), 1);
-    assert_eq!(pass["payload"]["candidates"][0]["decision"], "opened");
+    let candidate = &pass["payload"]["candidates"][0];
+    assert_eq!(candidate["decision"], "opened");
+    // Sizing is recorded on the candidate, not only on the orders that went out, so a pair the risk
+    // gate refuses is still answerable in the dimension that caused the refusal.
+    assert!(
+        candidate["long_notional"].is_number()
+            && candidate["short_shares"].is_number()
+            && candidate["gross_exposure"].is_number(),
+        "a candidate that reached the sizer carries what it was sized to"
+    );
     assert!(
         !pass["payload"]["prices"].as_array().unwrap().is_empty(),
         "the prices the pass decided on must be recorded"

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -300,6 +300,26 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
         "a price without its source cannot be compared across passes"
     );
 
+    // What the model offered the screen, as rows rather than a count. `expected_return` and
+    // `confidence` are derived from the stored quantiles, so `equity_predictions` alone cannot
+    // reconstruct what the screen actually consumed.
+    let screen_inputs = pass["payload"]["screen_inputs"]
+        .as_array()
+        .expect("screen inputs are recorded");
+    assert_eq!(screen_inputs.len(), 2, "both forecasts reached the screen");
+    assert!(screen_inputs
+        .iter()
+        .all(|input| input["expected_return"].is_number()
+            && input["confidence"].is_number()
+            && input["is_shortable"].is_boolean()));
+    assert!(
+        pass["payload"]["excluded"]
+            .as_array()
+            .expect("the funnel is recorded")
+            .is_empty(),
+        "nothing was filtered out in this fixture"
+    );
+
     let submitted = of_type(&records, "order_submitted");
     let resolved = of_type(&records, "order_resolved");
     assert_eq!(submitted.len(), 2, "one submission per leg");
@@ -540,6 +560,38 @@ async fn test_a_pass_closes_a_converged_pair_from_a_full_book() {
     // distinguishes that from a gate refusal, which an empty `pairs_opened` alone cannot.
     assert_eq!(summary.entries_blocked, None);
     assert_eq!(summary.candidates_screened, 0);
+
+    // The exit half is recorded to the same standard as the entry half. Both legs of the pair that
+    // closed, each carrying the order that will settle it — without these, realized profit and loss
+    // is attributable in one direction only.
+    let records = recorded(&session_log);
+    let closes = of_type(&records, "position_close_requested");
+    assert_eq!(closes.len(), 2, "one record per leg of the closed pair");
+    for record in &closes {
+        assert_eq!(record["payload"]["pair_id"], "AAAA-BBBB");
+        assert_eq!(record["payload"]["reason"], "pair_exit");
+        assert_eq!(record["payload"]["accepted"], true);
+    }
+
+    // And the pass that measured every open pair says so, whether or not the pair closed.
+    let pass = of_type(&records, "evaluation_pass");
+    let measured = pass[0]["payload"]["open_pairs"]
+        .as_array()
+        .expect("open pairs are recorded");
+    assert_eq!(
+        measured.len(),
+        4,
+        "every open pair is measured, not just the one that closed"
+    );
+    let closed = measured
+        .iter()
+        .find(|reading| reading["pair_id"] == "AAAA-BBBB")
+        .expect("the converged pair is among them");
+    assert_eq!(closed["decision"], "convergence");
+    assert!(
+        closed["z_score"].is_number() && closed["spread_mean"].is_number(),
+        "the inputs that produced the exit decision are recorded with it"
+    );
 }
 
 /// A pair with no price this pass is held, not closed and not crashed. The pre-close liquidation


### PR DESCRIPTION
# Overview

Adds an append-only session log: one JSONL file per trading session on local disk, fsynced before the process acts on what it wrote, sealed at the close and written to S3 as Parquet.

This is the capture layer the platform has been missing. Prices fetched at decision time were discarded, candidates that failed the screen were never written down, and `equity_pairs.entry_z_score` survived only for pairs that opened — a survivor-only record. That is why the entry/exit z discrepancy has been unresolvable: the reading that produced z 6.09 existed nowhere on disk five minutes later, so a price move, a refitted distribution, and a bug were indistinguishable.

It is also why nothing downstream of the model can be evaluated. Prediction accuracy was already scorable offline from `equity_predictions` and the stored bars; the screen, the sizing, and the risk gate — the layers actually producing returns while the model sits at roughly even odds — had no record at all.

## Changes

- Adds `data::session_log`: the record types, the fsyncing writer, and the seal-to-Parquet export
- Records the whole five-minute pass: every price with the snapshot field it came from, every open pair with all five inputs to its z-score, every forecast the screen consumed, every forecast the funnel removed with the first test it failed, and every scored candidate with its sizing and its decision
- Records orders before they are sent, keyed by a caller-chosen `client_order_id`, with a resolution record following every submission
- Records every position close: pair exits, entry unwinds, partial-fill and timeout cleanups, and each symbol of the bulk liquidation
- Records the pre-open inference run and the post-close account state
- Adds `Snapshot::reference_price_with_source`, so a price carries whether it came from the quote midpoint or the last trade
- `TradingClient::submit_order` takes a caller-chosen `client_order_id`; `close_position` returns the order Alpaca raised rather than a bool
- `RiskGate::admit_all` returns refusals paired with the pair they refused
- Exports to `exports/session_log/year=/month=/day=/data.parquet`, one object per session
- Adds `FUND_SESSION_LOG_DIR`, defaulting beneath `FUND_LOG_DIR`

## Context

**Four properties are load-bearing.**

*Observations only.* No slippage, no realized profit and loss, no exposure totals. Each is a query over these rows, and storing a computed value creates a second thing that can disagree with the first — the hot/cold drift problem restated one layer down.

*The file is the unit of export, not the record.* One sealed file at a deterministic key means a repeat export is a byte-identical overwrite, so there is no cursor to keep in sync. Every file present is exported rather than only the retention window, which self-heals a failed run, picks up a straggler that landed after the last export, and ships everything a process that was down for a fortnight still holds. Local files are deleted only after a clean run. `event_type` is a column rather than a partition, so new record types need no export changes at all.

*Orders are recorded before they are sent.* The broker's identifier does not exist at the moment the intent must be durable, hence the caller-chosen one. A crash in the gap leaves a record of an order that may exist, which is recoverable; the reverse is not.

*Schema evolution maps forward, never rewrites.* Every record carries `schema_version`; past files are immutable and readers upcast. A rewritable archive is not an archive.

**Two asymmetries are deliberate.** An exit is recorded as a request with no fill price, because entries are polled to a terminal state and exits are not — blocking on an exit fill would delay every other exit behind it. The order identifier is the join to the fill when the post-close activity sync lands it. Making exits poll would have been a behavioural change wearing an observability commit's clothes. And a log write never fails a trade: refusing to act because an observation could not be stored is worse than acting unobserved, so a write failure is reported and execution continues.

**Verified beyond the test suite.** A sealed session file was converted to Parquet and queried with the DuckDB CLI: envelope typed as columns, payload queryable as JSON, timestamps recovering the correct Eastern session.

**Known gaps, all deliberate.**

- Exit fill prices come from joining `position_close_requested.alpaca_order_id` to the exported `account_activities.order_id`, not from the log alone
- The 60-session close window is not recorded; the spread mean and deviation summarise it well enough to detect a refit, and the raw closes remain in `equity_bars` and the S3 archive
- A pass that returns an error after the exit half writes no observation; the `_errored` event in `events` remains the record of it
- Fees and commissions are not recorded anywhere
- Universe liquidity figures are not recorded, though membership and shortability are recoverable per session from the screen inputs and the exclusion reasons

**Operational note.** The log defaults beneath `FUND_LOG_DIR`, which is already provisioned and already falls back to a writable path on an un-bootstrapped machine, so this needs no VM change. The `client_order_id` addition is the only change touching the live order path and is worth watching on the first entry after deploy.

Tests: 596 passing, 82.5% line coverage overall, 85.9% on the new module.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added session activity logging for evaluations, predictions, orders, position closures, liquidations, and account updates.
  - Added export, retention, and recovery support for recorded session activity.
  - Order and position-close results now include more detailed broker identifiers, sides, and quantities.
  - Reference prices now indicate whether they came from quote midpoint or last trade data.
  - Risk refusals now identify the affected trading pair and reason.

- **Improvements**
  - Export responses now report session-log results, including partial failures and cleanup activity.
  - Individual position-close failures no longer prevent other close operations from continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->