### PR TITLE
Expand the session log to cover the flows that were silent

### DIFF
--- a/src/bin/backfill_account_snapshots.rs
+++ b/src/bin/backfill_account_snapshots.rs
@@ -17,7 +17,8 @@ use tracing::{error, info, warn};
 use fund::common::alpaca::{AlpacaCredentials, TradingClient};
 use fund::common::database::connect_pool;
 use fund::common::observability::init_tracing;
-use fund::data::calendar::{SessionDate, TradingCalendar};
+use fund::common::types::SessionDate;
+use fund::data::calendar::TradingCalendar;
 use fund::portfolio::account;
 
 const USAGE: &str =

--- a/src/bin/seed_equity_bars_postgres.rs
+++ b/src/bin/seed_equity_bars_postgres.rs
@@ -18,8 +18,8 @@ use tracing::{error, info, warn};
 use fund::common::database::connect_pool;
 use fund::common::massive::MassiveClient;
 use fund::common::observability::init_tracing;
+use fund::common::types::SessionDate;
 use fund::data::bars;
-use fund::data::calendar::SessionDate;
 
 const USAGE: &str = "Usage: seed_equity_bars_postgres <start YYYY-MM-DD> [end YYYY-MM-DD]";
 

--- a/src/bin/seed_equity_bars_s3.rs
+++ b/src/bin/seed_equity_bars_s3.rs
@@ -18,8 +18,8 @@ use tracing::{error, info};
 
 use fund::common::massive::MassiveClient;
 use fund::common::observability::init_tracing;
+use fund::common::types::SessionDate;
 use fund::data::archive;
-use fund::data::calendar::SessionDate;
 
 const USAGE: &str = "Usage: seed_equity_bars_s3 [start YYYY-MM-DD] [end YYYY-MM-DD]";
 

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -21,9 +21,9 @@ use tracing::{error, info, warn};
 use fund::common::aws::date_partitioned_key;
 use fund::common::massive::MassiveClient;
 use fund::common::observability::init_tracing;
-use fund::common::types::{MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
+use fund::common::types::{SessionDate, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
 use fund::data::archive;
-use fund::data::calendar::SessionDate;
+
 use fund::data::details;
 use fund::models::tide::artifact::{
     candidate_folders_descending, list_run_folders, package_dir_to_tar_gz, upload_artifact,

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,6 +4,8 @@
 //! so it answers everything about our account and the current moment. [`massive`] answers only what
 //! the whole market did on a given date — its grouped endpoint takes no symbol list, which is what
 //! keeps historical bars free of survivorship bias.
+//!
+//! [`session_log`] lives here rather than under `data` because every module writes to it.
 
 pub mod alpaca;
 pub mod aws;
@@ -12,4 +14,5 @@ pub mod database;
 pub mod events;
 pub mod massive;
 pub mod observability;
+pub mod session_log;
 pub mod types;

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -2745,6 +2745,10 @@ mod tests {
 
         assert_eq!(activities.activities.len(), ACTIVITIES_PAGE_SIZE + 1);
         assert_eq!(activities.activities.last().unwrap().id(), "activity-tail");
+        assert!(
+            !activities.truncated,
+            "this fetch finished inside the page bound"
+        );
         first.assert_async().await;
         second.assert_async().await;
     }
@@ -2823,6 +2827,10 @@ mod tests {
 
         assert_eq!(activities.activities.len(), 1);
         assert_eq!(activities.activities[0].id(), "dated");
+        assert_eq!(
+            activities.undated, 1,
+            "the dropped record is counted, not silently absent"
+        );
         mock.assert_async().await;
     }
 

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -741,6 +741,19 @@ pub const FILL_ACTIVITY_TYPE: &str = "FILL";
 /// accounts on Alpaca's own books, which is how paper accounts are funded.
 pub const TRANSFER_ACTIVITY_TYPES: [&str; 3] = ["CSD", "CSW", "JNLC"];
 
+/// What one activity fetch returned, and what it knows it missed.
+///
+/// `truncated` is the one that matters: the page bound is a bound on a loop, not on reality, and a
+/// session that hit it is holding an incomplete record of itself rather than an empty one.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ActivityFetch {
+    pub activities: Vec<AccountActivity>,
+    /// Activities dropped for carrying neither a transaction time nor a date.
+    pub undated: usize,
+    /// True when pagination stopped at its bound with more to fetch.
+    pub truncated: bool,
+}
+
 /// One account activity: a fill, a fee, a dividend, a transfer.
 ///
 /// Fields beyond the identity are optional because Alpaca omits rather than zeroes, and which ones
@@ -1165,6 +1178,7 @@ impl TradingClient {
 
     /// Fetches one activity type for a single session date, walking pagination.
     ///
+    ///
     /// Activities with neither a `transaction_time` nor a `date` are dropped with a warning. They
     /// cannot be stored — `account_activities.transaction_time` is `NOT NULL` — and synthesizing a
     /// timestamp would put a fabricated time into the record the dashboard reads as fact.
@@ -1172,7 +1186,7 @@ impl TradingClient {
         &self,
         activity_type: &str,
         date: NaiveDate,
-    ) -> Result<Vec<AccountActivity>, ClientError> {
+    ) -> Result<ActivityFetch, ClientError> {
         let url = format!("{}/v2/account/activities/{activity_type}", self.base_url);
         let date_text = date.to_string();
         let page_size = ACTIVITIES_PAGE_SIZE.to_string();
@@ -1180,6 +1194,7 @@ impl TradingClient {
         let mut activities: Vec<AccountActivity> = Vec::new();
         let mut page_token: Option<String> = None;
         let mut undated: usize = 0;
+        let mut truncated = false;
 
         for page in 0..ACTIVITIES_MAXIMUM_PAGES {
             let mut query: Vec<(&str, &str)> = vec![
@@ -1238,6 +1253,7 @@ impl TradingClient {
             page_token = Some(token);
 
             if page + 1 == ACTIVITIES_MAXIMUM_PAGES {
+                truncated = true;
                 warn!(
                     activity_type,
                     %date,
@@ -1254,7 +1270,11 @@ impl TradingClient {
             );
         }
         debug!(activity_type, %date, activities = activities.len(), "Account activities fetched");
-        Ok(activities)
+        Ok(ActivityFetch {
+            activities,
+            undated,
+            truncated,
+        })
     }
 
     /// Fetches the daily equity curve over an inclusive date range.
@@ -1550,6 +1570,16 @@ impl std::fmt::Display for DataFeed {
     }
 }
 
+/// What one snapshot fetch returned, and what it could not ask about.
+///
+/// A symbol is absent from `snapshots` either because Alpaca had no usable price for it or because
+/// the request carrying it failed. `failed_symbols` is what separates the two.
+#[derive(Debug, Clone, Default)]
+pub struct SnapshotFetch {
+    pub snapshots: Vec<Snapshot>,
+    pub failed_symbols: Vec<String>,
+}
+
 /// One symbol's point-in-time market state.
 ///
 /// Every field is optional because Alpaca omits rather than zeroes: a symbol that has not traded
@@ -1704,12 +1734,16 @@ impl MarketDataClient {
     /// narrows the entry set and holds the exits it cannot price, both of which beat pricing
     /// nothing at all. Only a total failure — every chunk failing — is reported as an error, which
     /// keeps that report meaningful for the common single-chunk case.
-    pub async fn fetch_snapshots(&self, symbols: &[String]) -> Result<Vec<Snapshot>, ClientError> {
+    ///
+    /// The failed chunk's symbols come back named. Downstream, a symbol Alpaca had no quote for and
+    /// one whose request never completed are the same absence, and they are not the same problem.
+    pub async fn fetch_snapshots(&self, symbols: &[String]) -> Result<SnapshotFetch, ClientError> {
         if symbols.is_empty() {
-            return Ok(Vec::new());
+            return Ok(SnapshotFetch::default());
         }
 
         let mut snapshots: Vec<Snapshot> = Vec::new();
+        let mut failed_symbols: Vec<String> = Vec::new();
         let mut failed_chunks: usize = 0;
         let mut requests: usize = 0;
         let mut last_error: Option<ClientError> = None;
@@ -1725,6 +1759,7 @@ impl MarketDataClient {
                         "Snapshot chunk failed; its symbols stay unpriced"
                     );
                     failed_chunks += 1;
+                    failed_symbols.extend(chunk.iter().cloned());
                     last_error = Some(error);
                 }
             }
@@ -1741,7 +1776,10 @@ impl MarketDataClient {
             failed_chunks,
             "Snapshots fetched"
         );
-        Ok(snapshots)
+        Ok(SnapshotFetch {
+            snapshots,
+            failed_symbols,
+        })
     }
 
     async fn fetch_snapshot_chunk(&self, symbols: &[String]) -> Result<Vec<Snapshot>, ClientError> {
@@ -2705,8 +2743,8 @@ mod tests {
             .await
             .expect("activities must parse");
 
-        assert_eq!(activities.len(), ACTIVITIES_PAGE_SIZE + 1);
-        assert_eq!(activities.last().unwrap().id(), "activity-tail");
+        assert_eq!(activities.activities.len(), ACTIVITIES_PAGE_SIZE + 1);
+        assert_eq!(activities.activities.last().unwrap().id(), "activity-tail");
         first.assert_async().await;
         second.assert_async().await;
     }
@@ -2783,8 +2821,8 @@ mod tests {
             .await
             .expect("activities must parse");
 
-        assert_eq!(activities.len(), 1);
-        assert_eq!(activities[0].id(), "dated");
+        assert_eq!(activities.activities.len(), 1);
+        assert_eq!(activities.activities[0].id(), "dated");
         mock.assert_async().await;
     }
 
@@ -2812,7 +2850,7 @@ mod tests {
             .expect("activities must parse");
 
         assert_eq!(
-            activities[0]
+            activities.activities[0]
                 .transaction_time()
                 .with_timezone(&New_York)
                 .date_naive(),
@@ -2852,15 +2890,21 @@ mod tests {
             .await
             .expect("activities must parse");
 
-        assert_eq!(activities.len(), 3);
-        assert_eq!(activities[0].net_amount(), Some(Decimal::new(20000, 0)));
-        assert_eq!(activities[1].net_amount(), Some(Decimal::new(1000050, 2)));
+        assert_eq!(activities.activities.len(), 3);
         assert_eq!(
-            activities[2].net_amount(),
+            activities.activities[0].net_amount(),
+            Some(Decimal::new(20000, 0))
+        );
+        assert_eq!(
+            activities.activities[1].net_amount(),
+            Some(Decimal::new(1000050, 2))
+        );
+        assert_eq!(
+            activities.activities[2].net_amount(),
             Some(Decimal::new(-250025, 2)),
             "a withdrawal must keep its sign"
         );
-        for activity in &activities {
+        for activity in &activities.activities {
             assert_eq!(
                 activity.signed_cash_flow(),
                 None,
@@ -2892,7 +2936,7 @@ mod tests {
             .expect("activities must parse");
 
         assert_eq!(
-            activities[0].transaction_time(),
+            activities.activities[0].transaction_time(),
             "2026-05-15T13:45:00Z".parse::<DateTime<Utc>>().unwrap()
         );
         mock.assert_async().await;
@@ -2932,8 +2976,8 @@ mod tests {
             .await
             .expect("snapshot must parse");
 
-        assert_eq!(snapshots.len(), 1);
-        let snapshot = &snapshots[0];
+        assert_eq!(snapshots.snapshots.len(), 1);
+        let snapshot = &snapshots.snapshots[0];
         assert_eq!(snapshot.ticker().as_str(), "AAPL");
         assert_eq!(snapshot.latest_trade_price(), Some(201.5));
         assert_eq!(snapshot.latest_quote().unwrap().bid_price(), 201.0);
@@ -2964,7 +3008,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(snapshots[0].reference_price(), Some(201.5));
+        assert_eq!(snapshots.snapshots[0].reference_price(), Some(201.5));
         mock.assert_async().await;
     }
 
@@ -2989,10 +3033,10 @@ mod tests {
             .unwrap();
 
         assert!(
-            snapshots[0].latest_quote().is_none(),
+            snapshots.snapshots[0].latest_quote().is_none(),
             "half a book is no book"
         );
-        assert_eq!(snapshots[0].reference_price(), Some(150.0));
+        assert_eq!(snapshots.snapshots[0].reference_price(), Some(150.0));
         mock.assert_async().await;
     }
 
@@ -3000,6 +3044,6 @@ mod tests {
     async fn test_empty_symbol_list_makes_no_request() {
         let server = mockito::Server::new_async().await;
         let snapshots = client(server.url()).fetch_snapshots(&[]).await.unwrap();
-        assert!(snapshots.is_empty());
+        assert!(snapshots.snapshots.is_empty());
     }
 }

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -66,8 +66,8 @@ pub enum Observation {
     OrderResolved(OrderResolved),
     /// A position the application asked Alpaca to close.
     PositionCloseRequested(PositionCloseRequested),
-    /// The pre-close flattening.
-    LiquidationRun(LiquidationRun),
+    /// The pre-close flattening, whether or not it flattened anything.
+    LiquidationAttempted(LiquidationAttempted),
     /// The pre-open inference run, the artifact it resolved, and the forecasts it produced.
     PredictionsGenerated(Box<PredictionsGenerated>),
     /// One activity as Alpaca reported it, fill or transfer.
@@ -91,7 +91,7 @@ impl Observation {
             Observation::OrderSubmitted(_) => "order_submitted",
             Observation::OrderResolved(_) => "order_resolved",
             Observation::PositionCloseRequested(_) => "position_close_requested",
-            Observation::LiquidationRun(_) => "liquidation_run",
+            Observation::LiquidationAttempted(_) => "liquidation_attempted",
             Observation::PredictionsGenerated(_) => "predictions_generated",
             Observation::ActivityObserved(_) => "activity_observed",
             Observation::AccountObserved(_) => "account_observed",
@@ -369,11 +369,18 @@ pub struct PositionCloseRequested {
 }
 
 /// The pre-close flattening.
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct LiquidationRun {
+///
+/// Written whether or not the flattening succeeded. This is the last fail-safe before positions
+/// carry overnight, and a run that failed at the broker used to leave no trace of having been
+/// attempted at all.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct LiquidationAttempted {
     pub pairs_closed: usize,
     pub positions_refused: usize,
     pub pairs_still_open: Vec<String>,
+    /// The error that ended the run early, if one did. Its absence is the claim that the run
+    /// finished, not that the book is flat — `pairs_still_open` answers that.
+    pub failure: Option<String>,
 }
 
 /// The pre-open inference run and everything it produced.

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -72,7 +72,7 @@ pub enum Observation {
     PositionCloseRequested(PositionCloseRequested),
     /// The pre-close flattening, whether or not it flattened anything.
     LiquidationAttempted(LiquidationAttempted),
-    /// The pre-open inference run, the artifact it resolved, and the forecasts it produced.
+    /// The pre-open inference run, the artifact it resolved, and the predictions it produced.
     PredictionsGenerated(Box<PredictionsGenerated>),
     /// One activity as Alpaca reported it, fill or transfer.
     ActivityObserved(ActivityObserved),
@@ -398,14 +398,14 @@ pub struct PredictionsGenerated {
     pub model_run_id: String,
     pub artifact_key: String,
     pub artifact_staleness_sessions: Option<i64>,
-    /// Rows the database accepted, which is not the forecast count when an upsert collapses a
+    /// Rows the database accepted, which is not the prediction count when an upsert collapses a
     /// re-run.
     pub rows_written: u64,
     pub universe_size: usize,
     pub predictions: Vec<PredictionReading>,
 }
 
-/// One ticker's forecast, as the model produced it.
+/// One ticker's prediction, as the model produced it.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PredictionReading {
     pub ticker: String,

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -44,6 +44,8 @@ pub enum SessionLogError {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(tag = "event_type", content = "payload", rename_all = "snake_case")]
 pub enum Observation {
+    /// One scheduled command, however it ended.
+    CommandFinished(CommandFinished),
     /// One five-minute pass: what it decided, and what stopped it doing more.
     PassEvaluated(Box<PassEvaluated>),
     /// What one price fetch returned, and what it asked for and did not get.
@@ -70,6 +72,7 @@ impl Observation {
     /// The stable name this observation serializes under.
     pub fn event_type(&self) -> &'static str {
         match self {
+            Observation::CommandFinished(_) => "command_finished",
             Observation::PassEvaluated(_) => "pass_evaluated",
             Observation::PricesObserved(_) => "prices_observed",
             Observation::UniverseScreened(_) => "universe_screened",
@@ -82,6 +85,24 @@ impl Observation {
             Observation::AccountObserved(_) => "account_observed",
         }
     }
+}
+
+/// One scheduled command, however it ended.
+///
+/// Written for every firing, including the ones that do no work: a holiday, a duplicate dropped
+/// while the previous run is still going, and a crashed process are otherwise the same absence.
+/// Sharing `correlation_id` with everything the command did is what makes the duration attributable.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CommandFinished {
+    pub command: String,
+    /// `completed`, `errored`, `dropped_in_flight`, or `skipped_` and the handler's reason.
+    pub outcome: String,
+    /// Absent for a command that never ran.
+    pub duration_milliseconds: Option<u64>,
+    /// The rendered error, when the command failed.
+    pub error: Option<String>,
+    /// The handler's own summary, as it reached the completion event.
+    pub summary: Option<serde_json::Value>,
 }
 
 /// One evaluation pass: what it decided and what stopped it.

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -68,8 +68,10 @@ pub enum Observation {
     PositionCloseRequested(PositionCloseRequested),
     /// The pre-close flattening.
     LiquidationRun(LiquidationRun),
-    /// The pre-open inference run and the artifact it resolved.
-    PredictionsGenerated(PredictionsGenerated),
+    /// The pre-open inference run, the artifact it resolved, and the forecasts it produced.
+    PredictionsGenerated(Box<PredictionsGenerated>),
+    /// One activity as Alpaca reported it, fill or transfer.
+    ActivityObserved(ActivityObserved),
     /// The post-close account state, which Alpaca cannot fully report again for a past date.
     AccountObserved(AccountObserved),
 }
@@ -91,6 +93,7 @@ impl Observation {
             Observation::PositionCloseRequested(_) => "position_close_requested",
             Observation::LiquidationRun(_) => "liquidation_run",
             Observation::PredictionsGenerated(_) => "predictions_generated",
+            Observation::ActivityObserved(_) => "activity_observed",
             Observation::AccountObserved(_) => "account_observed",
         }
     }
@@ -373,18 +376,55 @@ pub struct LiquidationRun {
     pub pairs_still_open: Vec<String>,
 }
 
-/// The pre-open inference run.
+/// The pre-open inference run and everything it produced.
 ///
-/// The forecasts live in `equity_predictions`; what only this run knows is which artifact made
-/// them.
+/// The quantiles are here rather than left to `equity_predictions` and the nightly export, because
+/// those are the model's actual output and the log is meant to hold the originals. They arrive at
+/// one moment from one place, so unlike the pass readings there is nothing to gain by splitting
+/// them out.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PredictionsGenerated {
     pub model_run_id: String,
     pub artifact_key: String,
     pub artifact_staleness_sessions: Option<i64>,
-    pub predictions: usize,
+    /// Rows the database accepted, which is not the forecast count when an upsert collapses a
+    /// re-run.
     pub rows_written: u64,
     pub universe_size: usize,
+    pub predictions: Vec<PredictionReading>,
+}
+
+/// One ticker's forecast, as the model produced it.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PredictionReading {
+    pub ticker: String,
+    pub timestamp: DateTime<Utc>,
+    pub quantile_10: f64,
+    pub quantile_50: f64,
+    pub quantile_90: f64,
+}
+
+/// One activity as Alpaca reported it.
+///
+/// Kept as our own record rather than re-fetched, because Alpaca's retention bounds how long the
+/// question can be asked. `net_amount` is the reason this matters most: it is the only field
+/// saying how much a deposit or withdrawal moved, and it reaches no other store the application
+/// owns.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ActivityObserved {
+    /// Alpaca's activity identifier, which is what makes the sync idempotent.
+    pub activity_id: String,
+    /// `FILL`, `CSD`, `CSW`, or `JNLC`.
+    pub activity_type: String,
+    pub transaction_time: DateTime<Utc>,
+    pub ticker: Option<String>,
+    pub side: Option<String>,
+    pub quantity: Option<f64>,
+    pub price: Option<f64>,
+    /// Set on transfers, which carry this instead of a quantity and price.
+    pub net_amount: Option<f64>,
+    /// Joins a fill back to the order that produced it.
+    pub order_id: Option<String>,
 }
 
 /// The post-close account state.

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -44,8 +44,14 @@ pub enum SessionLogError {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(tag = "event_type", content = "payload", rename_all = "snake_case")]
 pub enum Observation {
-    /// One five-minute pass: what it saw, what it decided, and what stopped it doing more.
-    EvaluationPass(Box<EvaluationPass>),
+    /// One five-minute pass: what it decided, and what stopped it doing more.
+    PassEvaluated(Box<PassEvaluated>),
+    /// What one price fetch returned, and what it asked for and did not get.
+    PricesObserved(PricesObserved),
+    /// The eligibility funnel: what reached the screen and what did not.
+    UniverseScreened(UniverseScreened),
+    /// Every open pair as one pass measured it, closed or held.
+    OpenPairsObserved(OpenPairsObserved),
     /// An order as it was sent, written before the request leaves the process.
     OrderSubmitted(OrderSubmitted),
     /// How the broker settled that order, filled or not.
@@ -64,7 +70,10 @@ impl Observation {
     /// The stable name this observation serializes under.
     pub fn event_type(&self) -> &'static str {
         match self {
-            Observation::EvaluationPass(_) => "evaluation_pass",
+            Observation::PassEvaluated(_) => "pass_evaluated",
+            Observation::PricesObserved(_) => "prices_observed",
+            Observation::UniverseScreened(_) => "universe_screened",
+            Observation::OpenPairsObserved(_) => "open_pairs_observed",
             Observation::OrderSubmitted(_) => "order_submitted",
             Observation::OrderResolved(_) => "order_resolved",
             Observation::PositionCloseRequested(_) => "position_close_requested",
@@ -75,12 +84,13 @@ impl Observation {
     }
 }
 
-/// One evaluation pass, whole.
+/// One evaluation pass: what it decided and what stopped it.
 ///
-/// `prices` holds every reading once; pair and candidate rows name tickers without repeating it.
-/// `candidates` holds only the pairs the screen scored, not the quadratic cross product.
+/// The readings it acted on are their own records sharing this pass's `correlation_id` — prices,
+/// the screen funnel, the open book. `candidates` stays here because a candidate's decision is not
+/// known until the pass ends.
 #[derive(Debug, Clone, PartialEq, Default, Serialize)]
-pub struct EvaluationPass {
+pub struct PassEvaluated {
     pub account_equity: Option<f64>,
     pub previous_session_equity: Option<f64>,
     pub gross_exposure_used: Option<f64>,
@@ -96,16 +106,53 @@ pub struct EvaluationPass {
     pub model_run_id: Option<String>,
     /// Why the entry half did not run at all, if it did not.
     pub session_block: Option<String>,
-    pub prices: Vec<PriceReading>,
-    pub open_pairs: Vec<OpenPairReading>,
-    /// Every forecast that reached the screen, as the screen received it.
-    pub screen_inputs: Vec<ScreenInputReading>,
-    /// Every forecast that did not, and the first test it failed.
-    pub excluded: Vec<ExcludedTickerReading>,
+    /// The error that ended the pass early, if one did.
+    ///
+    /// Set on every failing path, so a pass that died after pricing the book still says what it had
+    /// measured. Its absence is the claim that the pass ran to completion.
+    pub failure: Option<String>,
     pub candidates: Vec<CandidateReading>,
 }
 
-/// One forecast as the screen consumed it.
+/// What one price fetch returned.
+///
+/// Written per fetch rather than per pass: the exit half prices the open book and the entry half
+/// asks only for what it is missing, and those are two separate readings of the market.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct PricesObserved {
+    /// What the fetch was for — `open_pairs` or `screen_candidates`.
+    pub purpose: String,
+    pub readings: Vec<PriceReading>,
+    pub unavailable: Vec<UnavailablePrice>,
+}
+
+/// A symbol the fetch asked for and did not get a usable price for.
+///
+/// Distinguishing the causes is the point: an absent price with no cause is indistinguishable from
+/// a symbol nobody asked about.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct UnavailablePrice {
+    pub ticker: String,
+    /// `no_quote` or `chunk_failed`.
+    pub cause: String,
+}
+
+/// The eligibility funnel for one pass.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct UniverseScreened {
+    /// Every prediction that reached the screen, as the screen received it.
+    pub inputs: Vec<ScreenInputReading>,
+    /// Every prediction that did not, and the first test it failed.
+    pub excluded: Vec<ExcludedTickerReading>,
+}
+
+/// Every open pair as one pass measured it.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct OpenPairsObserved {
+    pub readings: Vec<OpenPairReading>,
+}
+
+/// One prediction as the screen consumed it.
 ///
 /// Derived from the stored quantiles and the session's universe, so not recoverable from
 /// `equity_predictions` alone.
@@ -117,7 +164,7 @@ pub struct ScreenInputReading {
     pub is_shortable: bool,
 }
 
-/// One forecast the eligibility filter removed, and why.
+/// One prediction the eligibility filter removed, and why.
 ///
 /// Written every pass, because `held` changes within a session even though the other tests do not.
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -1,7 +1,7 @@
 //! Append-only record of what the application observed before it acted.
 //!
-//! One JSONL file per session on local disk. This is the only original the application owns: every
-//! other store is a fold or a query over it. Sealing and shipping it is [`crate::data::export`]'s.
+//! One JSONL file per session on local disk, and the only original this application owns — every
+//! other store is a fold over it. Sealing and shipping it is [`crate::data::export`]'s.
 
 use std::path::{Path, PathBuf};
 
@@ -15,11 +15,8 @@ use crate::common::types::SessionDate;
 
 /// Version stamped on every record written by this build.
 ///
-/// Readers map old versions forward rather than rewriting files, so this only ever goes up. Nothing
-/// branches on it yet; it exists so that when something does, it can tell the shapes apart. Version
-/// 1 carried the pass's prices, screen inputs, exclusions, and open book inline on `evaluation_pass`
-/// and had no `command_finished`, `pair_opened`, `pair_closed`, `pair_attributed`, or
-/// `activity_observed` at all.
+/// Readers map old versions forward rather than rewriting files, so this only ever goes up. What
+/// each version held is documented beside the DuckDB view in `tools/duckdb_initialization.sql`.
 pub const SCHEMA_VERSION: u32 = 2;
 
 /// Anything that stops a record reaching the disk.
@@ -105,9 +102,9 @@ impl Observation {
 
 /// One scheduled command, however it ended.
 ///
-/// Written for every firing, including the ones that do no work: a holiday, a duplicate dropped
-/// while the previous run is still going, and a crashed process are otherwise the same absence.
-/// Sharing `correlation_id` with everything the command did is what makes the duration attributable.
+/// Written for every firing, including the ones that do no work: a holiday, a dropped duplicate,
+/// and a crashed process are otherwise the same absence. `correlation_id` is shared with everything
+/// the command did, which is what makes the duration attributable.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct CommandFinished {
     pub command: String,
@@ -654,6 +651,139 @@ mod tests {
             long_market_value: Some(50_000.0),
             short_market_value: Some(-50_000.0),
         })
+    }
+
+    /// The wire names are a contract: `tests/test_handlers.rs` selects records by them and the
+    /// DuckDB view documents them as query filters. A typo in one arm compiles and breaks a reader.
+    ///
+    /// Matched exhaustively rather than iterated over a list, so a new variant does not compile
+    /// until it is named here.
+    #[test]
+    fn test_every_observation_serializes_under_its_documented_name() {
+        fn expected(observation: &Observation) -> &'static str {
+            match observation {
+                Observation::CommandFinished(_) => "command_finished",
+                Observation::PassEvaluated(_) => "pass_evaluated",
+                Observation::PricesObserved(_) => "prices_observed",
+                Observation::UniverseScreened(_) => "universe_screened",
+                Observation::OpenPairsObserved(_) => "open_pairs_observed",
+                Observation::PairOpened(_) => "pair_opened",
+                Observation::PairClosed(_) => "pair_closed",
+                Observation::PairAttributed(_) => "pair_attributed",
+                Observation::OrderSubmitted(_) => "order_submitted",
+                Observation::OrderResolved(_) => "order_resolved",
+                Observation::PositionCloseRequested(_) => "position_close_requested",
+                Observation::LiquidationAttempted(_) => "liquidation_attempted",
+                Observation::PredictionsGenerated(_) => "predictions_generated",
+                Observation::ActivityObserved(_) => "activity_observed",
+                Observation::AccountObserved(_) => "account_observed",
+            }
+        }
+
+        for observation in every_observation() {
+            // Against `event_type()`, which the writer logs by, and against the serialized tag,
+            // which is what actually reaches the archive. The two are separate code paths.
+            assert_eq!(observation.event_type(), expected(&observation));
+            let value = serde_json::to_value(Record::new(
+                Uuid::nil(),
+                instant("2026-08-11T20:15:00Z"),
+                observation.clone(),
+            ))
+            .expect("every observation must serialize");
+            assert_eq!(
+                value["event_type"],
+                expected(&observation),
+                "the serialized tag is what a reader filters on"
+            );
+        }
+    }
+
+    /// One value per variant, so the compiler forces this list to grow with the enum.
+    fn every_observation() -> Vec<Observation> {
+        vec![
+            Observation::CommandFinished(CommandFinished {
+                command: "portfolio_evaluation".to_string(),
+                outcome: "completed".to_string(),
+                duration_milliseconds: Some(12),
+                error: None,
+                summary: None,
+            }),
+            Observation::PassEvaluated(Box::default()),
+            Observation::PricesObserved(PricesObserved::default()),
+            Observation::UniverseScreened(UniverseScreened::default()),
+            Observation::OpenPairsObserved(OpenPairsObserved::default()),
+            Observation::PairOpened(PairOpened {
+                pair_uuid: Uuid::nil().to_string(),
+                pair_id: "AAAA-BBBB".to_string(),
+                long_ticker: "AAAA".to_string(),
+                short_ticker: "BBBB".to_string(),
+                hedge_ratio: 1.0,
+                entry_z_score: 2.5,
+                signal_strength: 0.03,
+                model_run_id: None,
+                opened_at: instant("2026-08-11T14:35:00Z"),
+            }),
+            Observation::PairClosed(PairClosed {
+                pair_uuid: Uuid::nil().to_string(),
+                reason: "convergence".to_string(),
+                closed_at: instant("2026-08-11T18:00:00Z"),
+                updated: true,
+            }),
+            Observation::PairAttributed(PairAttributed {
+                pair_uuid: Uuid::nil().to_string(),
+                realized_profit_and_loss: Some(100.0),
+                updated: true,
+            }),
+            Observation::OrderSubmitted(OrderSubmitted {
+                client_order_id: "k-long".to_string(),
+                ticker: "AAAA".to_string(),
+                side: "buy".to_string(),
+                shares: None,
+                notional: Some(1_000.0),
+            }),
+            Observation::OrderResolved(OrderResolved {
+                client_order_id: "k-long".to_string(),
+                alpaca_order_id: Some("o1".to_string()),
+                ticker: "AAAA".to_string(),
+                outcome: "filled".to_string(),
+                filled_shares: Some(10.0),
+                filled_average_price: Some(100.0),
+                filled_after_cancel: false,
+                error: None,
+            }),
+            Observation::PositionCloseRequested(PositionCloseRequested {
+                ticker: "AAAA".to_string(),
+                pair_id: None,
+                alpaca_order_id: None,
+                side: None,
+                quantity: None,
+                reason: "liquidation".to_string(),
+                accepted: true,
+                status: Some(200),
+                error: None,
+            }),
+            Observation::LiquidationAttempted(LiquidationAttempted::default()),
+            Observation::PredictionsGenerated(Box::new(PredictionsGenerated {
+                model_run_id: "run-1".to_string(),
+                artifact_key: "models/tide/run-1".to_string(),
+                artifact_staleness_sessions: None,
+                rows_written: 0,
+                universe_size: 0,
+                predictions: Vec::new(),
+            })),
+            Observation::ActivityObserved(ActivityObserved {
+                activity_id: "a1".to_string(),
+                activity_type: "FILL".to_string(),
+                transaction_time: instant("2026-08-11T18:00:00Z"),
+                ticker: Some("AAAA".to_string()),
+                side: Some("buy".to_string()),
+                quantity: Some(10.0),
+                price: Some(100.0),
+                net_amount: None,
+                order_id: Some("o1".to_string()),
+            }),
+            account_observation(),
+        ]
     }
 
     /// A directory unique to this run.

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -1,35 +1,22 @@
 //! Append-only record of what the application observed before it acted.
 //!
-//! One JSONL file per session on local disk, sealed at the close and written to S3 as Parquet.
-//! This is the only original the application owns: every other store is a fold or a query over it.
+//! One JSONL file per session on local disk. This is the only original the application owns: every
+//! other store is a fold or a query over it. Sealing and shipping it is [`crate::data::export`]'s.
 
 use std::path::{Path, PathBuf};
 
-use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_s3::Client as S3Client;
 use chrono::{DateTime, NaiveDate, Utc};
-use polars::prelude::*;
 use serde::Serialize;
-use serde_json::Value;
 use tokio::io::AsyncWriteExt;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error};
 use uuid::Uuid;
 
-use crate::common::aws::date_partitioned_key;
-use crate::data::calendar::SessionDate;
+use crate::common::types::SessionDate;
 
 /// Version stamped on every record written by this build.
 ///
 /// Readers map old versions forward rather than rewriting files, so this only ever goes up.
 pub const SCHEMA_VERSION: u32 = 1;
-
-/// S3 prefix the sealed sessions are written under.
-pub const EXPORT_PREFIX: &str = "exports/session_log";
-
-/// Calendar days of sealed sessions kept on local disk after a clean export.
-///
-/// The window in which a bad Parquet conversion can still be repaired from the original bytes.
-pub const RETENTION_DAYS: i64 = 7;
 
 /// Anything that stops a record reaching the disk.
 #[derive(Debug, thiserror::Error)]
@@ -434,15 +421,24 @@ impl SessionLog {
     ///
     /// The export takes this before reading, so no reader sees a half-written line. The open handle
     /// is dropped, so the next append reopens the file.
-    async fn seal(&self) -> tokio::sync::MutexGuard<'_, Option<OpenSession>> {
+    pub async fn seal(&self) -> SessionLogGuard<'_> {
         let mut open_session = self.open_session.lock().await;
         *open_session = None;
-        open_session
+        SessionLogGuard {
+            _appends_blocked: open_session,
+        }
     }
 }
 
+/// Proof that no append can run while it is alive.
+///
+/// Opaque on purpose: holding it is the whole contract, and there is nothing inside worth reading.
+pub struct SessionLogGuard<'a> {
+    _appends_blocked: tokio::sync::MutexGuard<'a, Option<OpenSession>>,
+}
+
 /// The file one session's records live in.
-fn file_name(session_date: SessionDate) -> String {
+pub(crate) fn file_name(session_date: SessionDate) -> String {
     format!("session-{}.jsonl", session_date.date())
 }
 
@@ -450,7 +446,7 @@ fn file_name(session_date: SessionDate) -> String {
 ///
 /// `None` rather than an error, because a stray file is something to skip, not to fail a run
 /// over.
-fn session_from_file_name(name: &str) -> Option<SessionDate> {
+pub(crate) fn session_from_file_name(name: &str) -> Option<SessionDate> {
     let date = name.strip_prefix("session-")?.strip_suffix(".jsonl")?;
     let session_date = SessionDate::from_date(NaiveDate::parse_from_str(date, "%Y-%m-%d").ok()?);
     // Accepted only if it is exactly what the writer would have produced. `%Y-%m-%d` also parses
@@ -459,245 +455,10 @@ fn session_from_file_name(name: &str) -> Option<SessionDate> {
     (file_name(session_date) == name).then_some(session_date)
 }
 
-// ---------------------------------------------------------------------------
-// Export
-// ---------------------------------------------------------------------------
-
-/// What one export run accomplished.
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct SessionLogExportSummary {
-    /// `(session_date, records)` for each session written to S3.
-    pub exported: Vec<(NaiveDate, usize)>,
-    /// `(session_date, error)` for each session that failed.
-    pub failed: Vec<(NaiveDate, String)>,
-    /// Sessions whose local file was deleted after the retention window.
-    pub deleted: Vec<NaiveDate>,
-    /// Lines skipped as unreadable, across every session.
-    ///
-    /// A torn final line per crashed session is expected; more than that means something else is
-    /// wrong.
-    pub unparsable_lines: usize,
-}
-
-impl SessionLogExportSummary {
-    pub fn total_records(&self) -> usize {
-        self.exported.iter().map(|(_, records)| records).sum()
-    }
-
-    pub fn is_clean(&self) -> bool {
-        self.failed.is_empty()
-    }
-}
-
-/// Converts every sealed session on disk to Parquet in S3, then deletes what has aged out.
-///
-/// Every file present is exported, not just the retention window: one whole file at a deterministic
-/// key makes a repeat a byte-identical overwrite, so a failed run repairs itself. Local files are
-/// deleted only after a clean run.
-pub async fn export_session_logs(
-    log: &SessionLog,
-    s3_client: &S3Client,
-    bucket: &str,
-    today: SessionDate,
-) -> SessionLogExportSummary {
-    let mut summary = SessionLogExportSummary::default();
-
-    let mut sessions = match sealed_sessions(log.directory(), today) {
-        Ok(sessions) => sessions,
-        Err(error) => {
-            warn!(%error, "Session log directory could not be read; nothing exported");
-            return summary;
-        }
-    };
-    sessions.sort();
-
-    // Held across the reads so no append can interleave with one. Today's file is sealed by the
-    // clock rather than by anything structural, and a recovery replay can run a pass at any hour.
-    let sealed = log.seal().await;
-
-    for session_date in &sessions {
-        let path = log.directory().join(file_name(*session_date));
-        match read_session_frame(&path) {
-            Ok((mut frame, unparsable)) => {
-                summary.unparsable_lines += unparsable;
-                let key = date_partitioned_key(EXPORT_PREFIX, session_date.date());
-                match write_frame(s3_client, bucket, &key, &mut frame).await {
-                    Ok(()) => summary.exported.push((session_date.date(), frame.height())),
-                    Err(error) => summary.failed.push((session_date.date(), error)),
-                }
-            }
-            Err(error) => summary.failed.push((session_date.date(), error)),
-        }
-    }
-
-    drop(sealed);
-
-    if summary.is_clean() {
-        summary.deleted = delete_aged_out(log.directory(), &sessions, today);
-    }
-
-    info!(
-        sessions = summary.exported.len(),
-        records = summary.total_records(),
-        failed = summary.failed.len(),
-        deleted = summary.deleted.len(),
-        unparsable_lines = summary.unparsable_lines,
-        "Session log export finished"
-    );
-    for (session_date, error) in &summary.failed {
-        warn!(%session_date, error, "Session log failed to export");
-    }
-    summary
-}
-
-/// Sessions on disk whose trading day has finished.
-///
-/// Today counts, because this runs after the close; a future-dated file does not, and exporting one
-/// would seal a session still being written.
-fn sealed_sessions(
-    directory: &Path,
-    today: SessionDate,
-) -> Result<Vec<SessionDate>, std::io::Error> {
-    let mut sessions = Vec::new();
-    for entry in std::fs::read_dir(directory)? {
-        let entry = entry?;
-        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
-            continue;
-        };
-        let Some(session_date) = session_from_file_name(&name) else {
-            continue;
-        };
-        if session_date > today {
-            warn!(%session_date, %today, "Session log is dated ahead of today; not sealed");
-            continue;
-        }
-        sessions.push(session_date);
-    }
-    Ok(sessions)
-}
-
-/// Removes the local copies of sessions older than the retention window.
-///
-/// Called only after a clean run, so a session cannot age out without reaching S3. A file that will
-/// not delete is a warning: a stale local copy costs disk and nothing else.
-fn delete_aged_out(
-    directory: &Path,
-    sessions: &[SessionDate],
-    today: SessionDate,
-) -> Vec<NaiveDate> {
-    let oldest_kept = today.plus_calendar_days(-RETENTION_DAYS);
-    let mut deleted = Vec::new();
-    for session_date in sessions.iter().filter(|session| **session < oldest_kept) {
-        let path = directory.join(file_name(*session_date));
-        match std::fs::remove_file(&path) {
-            Ok(()) => deleted.push(session_date.date()),
-            Err(error) => warn!(
-                path = %path.display(),
-                %error,
-                "Aged-out session log could not be deleted"
-            ),
-        }
-    }
-    deleted
-}
-
-/// Reads one session file into a frame, returning it with the number of lines skipped.
-///
-/// Discarding a torn final line is why the original is JSONL rather than Parquet.
-fn read_session_frame(path: &Path) -> Result<(DataFrame, usize), String> {
-    let contents = std::fs::read_to_string(path)
-        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
-
-    let mut schema_versions: Vec<Option<i64>> = Vec::new();
-    let mut event_ids: Vec<Option<String>> = Vec::new();
-    let mut correlation_ids: Vec<Option<String>> = Vec::new();
-    let mut event_types: Vec<Option<String>> = Vec::new();
-    let mut session_dates: Vec<Option<String>> = Vec::new();
-    let mut created_ats: Vec<Option<i64>> = Vec::new();
-    let mut payloads: Vec<Option<String>> = Vec::new();
-    let mut unparsable = 0usize;
-
-    for line in contents.lines().filter(|line| !line.trim().is_empty()) {
-        let Ok(Value::Object(record)) = serde_json::from_str::<Value>(line) else {
-            unparsable += 1;
-            continue;
-        };
-        let text = |key: &str| record.get(key).and_then(Value::as_str).map(str::to_string);
-
-        // A record missing any of its envelope is discarded rather than written with nulls, so a
-        // query cannot mistake an unaddressable row for a good one.
-        let (Some(event_id), Some(event_type), Some(created_at)) = (
-            text("event_id"),
-            text("event_type"),
-            text("created_at").and_then(|stamp| {
-                DateTime::parse_from_rfc3339(&stamp)
-                    .ok()
-                    .map(|instant| instant.timestamp_millis())
-            }),
-        ) else {
-            unparsable += 1;
-            continue;
-        };
-
-        schema_versions.push(record.get("schema_version").and_then(Value::as_i64));
-        event_ids.push(Some(event_id));
-        correlation_ids.push(text("correlation_id"));
-        event_types.push(Some(event_type));
-        session_dates.push(text("session_date"));
-        created_ats.push(Some(created_at));
-        payloads.push(record.get("payload").map(Value::to_string));
-    }
-
-    if unparsable > 0 {
-        warn!(
-            path = %path.display(),
-            unparsable,
-            "Skipped session log lines that would not parse"
-        );
-    }
-
-    let frame = DataFrame::new(vec![
-        Column::new("schema_version".into(), schema_versions),
-        Column::new("event_id".into(), event_ids),
-        Column::new("correlation_id".into(), correlation_ids),
-        Column::new("event_type".into(), event_types),
-        Column::new("session_date".into(), session_dates),
-        Column::new("created_at".into(), created_ats),
-        Column::new("payload".into(), payloads),
-    ])
-    .map_err(|error| format!("failed to build frame for {}: {error}", path.display()))?;
-
-    Ok((frame, unparsable))
-}
-
-/// Serializes a frame to Parquet and puts it at `key`.
-async fn write_frame(
-    s3_client: &S3Client,
-    bucket: &str,
-    key: &str,
-    frame: &mut DataFrame,
-) -> Result<(), String> {
-    let mut buffer: Vec<u8> = Vec::new();
-    ParquetWriter::new(&mut buffer)
-        .finish(frame)
-        .map_err(|error| format!("failed to serialize Parquet: {error}"))?;
-
-    s3_client
-        .put_object()
-        .bucket(bucket)
-        .key(key)
-        .body(ByteStream::from(buffer))
-        .content_type("application/vnd.apache.parquet")
-        .send()
-        .await
-        .map_err(|error| format!("failed to write s3://{bucket}/{key}: {error}"))?;
-
-    info!(key, records = frame.height(), "Session log exported");
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
+    use serde_json::Value;
+
     use super::*;
 
     fn session(year: i32, month: u32, day: u32) -> SessionDate {
@@ -870,126 +631,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&directory);
     }
 
-    /// A crash mid-append leaves a partial final line. Discarding it is the whole reason the
-    /// original is JSONL: the same truncation in a Parquet file loses the entire session.
-    #[test]
-    fn test_a_torn_final_line_is_skipped_rather_than_failing_the_session() {
-        let directory = temporary_directory("torn");
-        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
-        let path = directory.join("session-2026-08-11.jsonl");
-        let complete = serde_json::to_string(&Record::new(
-            Uuid::nil(),
-            instant("2026-08-11T14:35:00Z"),
-            account_observation(),
-        ))
-        .expect("the record must serialize");
-        std::fs::write(&path, format!("{complete}\n{{\"schema_version\":1,\"eve"))
-            .expect("the file must be writable");
-
-        let (frame, unparsable) = read_session_frame(&path).expect("the session must still read");
-        assert_eq!(frame.height(), 1);
-        assert_eq!(unparsable, 1);
-        let _ = std::fs::remove_dir_all(&directory);
-    }
-
-    /// Valid JSON is not enough: a row without an addressable envelope would reach Parquet with
-    /// nulls no query could tell apart from a good record.
-    #[test]
-    fn test_a_record_missing_its_envelope_is_counted_unparsable() {
-        let directory = temporary_directory("envelope");
-        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
-        let path = directory.join("session-2026-08-11.jsonl");
-        let complete = serde_json::to_string(&Record::new(
-            Uuid::nil(),
-            instant("2026-08-11T20:15:00Z"),
-            account_observation(),
-        ))
-        .expect("the record must serialize");
-        let lines = [
-            complete.as_str(),
-            r#"{"schema_version":1,"event_type":"account_observed","created_at":"2026-08-11T20:15:00Z"}"#,
-            r#"{"schema_version":1,"event_id":"a","event_type":"account_observed","created_at":"not a time"}"#,
-        ]
-        .join("\n");
-        std::fs::write(&path, lines).expect("the file must be writable");
-
-        let (frame, unparsable) = read_session_frame(&path).expect("the session must read");
-        assert_eq!(
-            frame.height(),
-            1,
-            "only the complete record reaches the frame"
-        );
-        assert_eq!(
-            unparsable, 2,
-            "a missing event_id and an unparseable instant"
-        );
-    }
-
-    #[test]
-    fn test_a_frame_carries_the_envelope_as_columns_and_the_payload_as_json() {
-        let directory = temporary_directory("frame");
-        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
-        let path = directory.join("session-2026-08-11.jsonl");
-        let record = Record::new(
-            Uuid::nil(),
-            instant("2026-08-11T20:15:00Z"),
-            account_observation(),
-        );
-        std::fs::write(
-            &path,
-            format!(
-                "{}\n",
-                serde_json::to_string(&record).expect("the record must serialize")
-            ),
-        )
-        .expect("the file must be writable");
-
-        let (frame, _) = read_session_frame(&path).expect("the session must read");
-        assert_eq!(
-            frame.get_column_names(),
-            [
-                "schema_version",
-                "event_id",
-                "correlation_id",
-                "event_type",
-                "session_date",
-                "created_at",
-                "payload"
-            ]
-        );
-        let payload = frame
-            .column("payload")
-            .expect("payload column")
-            .str()
-            .expect("payload is text")
-            .get(0)
-            .expect("one row");
-        let parsed: Value = serde_json::from_str(payload).expect("the payload stays valid JSON");
-        assert_eq!(parsed["equity"], 104_812.55);
-        let _ = std::fs::remove_dir_all(&directory);
-    }
-
-    /// Today's file is sealed because the export runs after the close; a future-dated one is not,
-    /// and exporting it would seal a session still being written.
-    #[test]
-    fn test_only_sessions_up_to_today_are_sealed() {
-        let directory = temporary_directory("sealed");
-        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
-        for name in [
-            "session-2026-08-09.jsonl",
-            "session-2026-08-11.jsonl",
-            "session-2026-08-12.jsonl",
-            "notes.txt",
-        ] {
-            std::fs::write(directory.join(name), "").expect("the file must be writable");
-        }
-
-        let mut sealed = sealed_sessions(&directory, session(2026, 8, 11)).expect("readable");
-        sealed.sort();
-        assert_eq!(sealed, vec![session(2026, 8, 9), session(2026, 8, 11)]);
-        let _ = std::fs::remove_dir_all(&directory);
-    }
-
     /// RAII guard that restores an environment variable on drop, panic-safe.
     ///
     /// Tests using this must be marked `#[serial]` to prevent concurrent env access.
@@ -1057,114 +698,5 @@ mod tests {
         assert_eq!(log.directory(), log_directory.join("sessions"));
         assert!(log.directory().is_dir());
         let _ = std::fs::remove_dir_all(&log_directory);
-    }
-
-    /// The frame survives a Parquet round trip with its envelope typed and its payload intact.
-    ///
-    /// This is the artifact DuckDB reads, so a serialization that silently dropped a column or
-    /// widened the payload out of shape would take the whole archive with it.
-    #[test]
-    fn test_a_session_frame_round_trips_through_parquet() {
-        let directory = temporary_directory("parquet");
-        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
-        let path = directory.join("session-2026-08-11.jsonl");
-        let mut lines = String::new();
-        for equity in [104_812.55_f64, 105_000.0] {
-            let record = Record::new(
-                Uuid::new_v4(),
-                instant("2026-08-11T20:15:00Z"),
-                Observation::AccountObserved(AccountObserved {
-                    session_date: session(2026, 8, 11),
-                    equity: Some(equity),
-                    cash: Some(12_000.0),
-                    buying_power: Some(200_000.0),
-                    long_market_value: Some(50_000.0),
-                    short_market_value: Some(-50_000.0),
-                }),
-            );
-            lines.push_str(&serde_json::to_string(&record).expect("the record must serialize"));
-            lines.push('\n');
-        }
-        std::fs::write(&path, lines).expect("the file must be writable");
-
-        let (mut frame, _) = read_session_frame(&path).expect("the session must read");
-        let mut buffer: Vec<u8> = Vec::new();
-        ParquetWriter::new(&mut buffer)
-            .finish(&mut frame)
-            .expect("the frame must serialize to Parquet");
-
-        let restored = ParquetReader::new(std::io::Cursor::new(buffer))
-            .finish()
-            .expect("the Parquet must read back");
-        assert_eq!(restored.height(), 2);
-        assert_eq!(restored.get_column_names(), frame.get_column_names());
-        // The instant survives as milliseconds, which is what lets a reader recover 16:15 Eastern.
-        assert_eq!(
-            restored
-                .column("created_at")
-                .expect("created_at column")
-                .i64()
-                .expect("created_at is an integer")
-                .get(0),
-            Some(instant("2026-08-11T20:15:00Z").timestamp_millis())
-        );
-        let payload = restored
-            .column("payload")
-            .expect("payload column")
-            .str()
-            .expect("payload is text")
-            .get(0)
-            .expect("one row");
-        let parsed: Value = serde_json::from_str(payload).expect("the payload stays valid JSON");
-        assert_eq!(parsed["equity"], 104_812.55);
-        let _ = std::fs::remove_dir_all(&directory);
-    }
-
-    /// Only what has aged out goes, and the window's own edge stays. The local file is the
-    /// crash-exact original, so deleting one still inside the window would remove the only thing a
-    /// bad Parquet conversion could be repaired from.
-    #[test]
-    fn test_only_sessions_past_the_retention_window_are_deleted() {
-        let directory = temporary_directory("retention");
-        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
-
-        let today = session(2026, 8, 11);
-        let sessions = [
-            today.plus_calendar_days(-RETENTION_DAYS - 1),
-            today.plus_calendar_days(-RETENTION_DAYS),
-            today.plus_calendar_days(-1),
-            today,
-        ];
-        for session_date in sessions {
-            std::fs::write(directory.join(file_name(session_date)), "")
-                .expect("the file must be writable");
-        }
-
-        let deleted = delete_aged_out(&directory, &sessions, today);
-
-        assert_eq!(deleted, vec![sessions[0].date()]);
-        assert!(!directory.join(file_name(sessions[0])).exists());
-        for session_date in &sessions[1..] {
-            assert!(
-                directory.join(file_name(*session_date)).exists(),
-                "{session_date} is still inside the window"
-            );
-        }
-        let _ = std::fs::remove_dir_all(&directory);
-    }
-
-    /// The key is a pure function of the session, which is what makes a repeat export an overwrite
-    /// rather than a duplicate — and why there is no cursor to keep in sync.
-    #[test]
-    fn test_the_export_key_is_determined_by_the_session_alone() {
-        let key = date_partitioned_key(EXPORT_PREFIX, session(2026, 8, 11).date());
-        assert_eq!(
-            key,
-            "exports/session_log/year=2026/month=08/day=11/data.parquet"
-        );
-        assert_eq!(
-            key,
-            date_partitioned_key(EXPORT_PREFIX, session(2026, 8, 11).date())
-        );
     }
 }

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -54,6 +54,12 @@ pub enum Observation {
     UniverseScreened(UniverseScreened),
     /// Every open pair as one pass measured it, closed or held.
     OpenPairsObserved(OpenPairsObserved),
+    /// A pair as it was written to the book.
+    PairOpened(PairOpened),
+    /// A pair as it was marked closed.
+    PairClosed(PairClosed),
+    /// What the post-close sync attributed to a closed pair.
+    PairAttributed(PairAttributed),
     /// An order as it was sent, written before the request leaves the process.
     OrderSubmitted(OrderSubmitted),
     /// How the broker settled that order, filled or not.
@@ -77,6 +83,9 @@ impl Observation {
             Observation::PricesObserved(_) => "prices_observed",
             Observation::UniverseScreened(_) => "universe_screened",
             Observation::OpenPairsObserved(_) => "open_pairs_observed",
+            Observation::PairOpened(_) => "pair_opened",
+            Observation::PairClosed(_) => "pair_closed",
+            Observation::PairAttributed(_) => "pair_attributed",
             Observation::OrderSubmitted(_) => "order_submitted",
             Observation::OrderResolved(_) => "order_resolved",
             Observation::PositionCloseRequested(_) => "position_close_requested",
@@ -248,6 +257,52 @@ pub struct CandidateReading {
     pub decision: String,
     /// The risk gate's rendered reason, when `decision` is `risk_refused`.
     pub refusal: Option<String>,
+}
+
+/// A pair as it was written to the book.
+///
+/// `equity_pairs` is mutated in place three times over a pair's life, so the log needs three
+/// records where the table has one row. This is the only one carrying the entry rationale: nothing
+/// external knows which long was paired with which short, or on what.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PairOpened {
+    /// The `equity_pairs` primary key, which the two later records join on.
+    pub pair_uuid: String,
+    pub pair_id: String,
+    pub long_ticker: String,
+    pub short_ticker: String,
+    pub hedge_ratio: f64,
+    pub entry_z_score: f64,
+    pub signal_strength: f64,
+    pub model_run_id: Option<String>,
+    pub opened_at: DateTime<Utc>,
+}
+
+/// A pair as it was marked closed.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PairClosed {
+    pub pair_uuid: String,
+    /// `convergence`, `stop_loss`, `end_of_day`, or `position_missing`.
+    pub reason: String,
+    pub closed_at: DateTime<Utc>,
+    /// False when the pair was already closed, so this write changed nothing.
+    ///
+    /// A pass racing the pre-close liquidation is the ordinary way to reach it, and the collision
+    /// is worth seeing.
+    pub updated: bool,
+}
+
+/// What the post-close sync attributed to a closed pair.
+///
+/// The one derived value the log keeps. It is what the database will serve, and recording it
+/// beside the fills it was computed from is what makes a disagreement between the two visible at
+/// all — everything else here stays an observation precisely so it cannot disagree with anything.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PairAttributed {
+    pub pair_uuid: String,
+    pub realized_profit_and_loss: Option<f64>,
+    /// False when no closed pair matched, so the attribution landed nowhere.
+    pub updated: bool,
 }
 
 /// An order at the moment it was sent, before the broker has said anything about it.

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -299,11 +299,11 @@ pub struct PairClosed {
     pub updated: bool,
 }
 
-/// What the post-close sync attributed to a closed pair.
+/// The attribution the post-close sync wrote to a closed pair.
 ///
-/// The one derived value the log keeps. It is what the database will serve, and recording it
-/// beside the fills it was computed from is what makes a disagreement between the two visible at
-/// all — everything else here stays an observation precisely so it cannot disagree with anything.
+/// A record of a write, not of a conclusion — the same kind of thing as [`OrderSubmitted`]. The
+/// amount is derivable from [`PairOpened`], [`PairClosed`], and the session's [`ActivityObserved`]
+/// rows; what is not derivable is that this process put that number on that row and that it landed.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PairAttributed {
     pub pair_uuid: String,

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -15,8 +15,12 @@ use crate::common::types::SessionDate;
 
 /// Version stamped on every record written by this build.
 ///
-/// Readers map old versions forward rather than rewriting files, so this only ever goes up.
-pub const SCHEMA_VERSION: u32 = 1;
+/// Readers map old versions forward rather than rewriting files, so this only ever goes up. Nothing
+/// branches on it yet; it exists so that when something does, it can tell the shapes apart. Version
+/// 1 carried the pass's prices, screen inputs, exclusions, and open book inline on `evaluation_pass`
+/// and had no `command_finished`, `pair_opened`, `pair_closed`, `pair_attributed`, or
+/// `activity_observed` at all.
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Anything that stops a record reaching the disk.
 #[derive(Debug, thiserror::Error)]

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -7,7 +7,8 @@
 //! Both keep fields private and validate in the constructor, so a value in scope is proof its
 //! invariants held and downstream code never re-checks.
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Datelike, Duration, NaiveDate, TimeZone, Utc};
+use chrono_tz::America::New_York;
 use rust_decimal::Decimal;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
@@ -183,6 +184,113 @@ impl<'de> Deserialize<'de> for Notional {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let amount = Dollars::deserialize(deserializer)?;
         Ok(Notional::new(amount))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SessionDate
+// ---------------------------------------------------------------------------
+
+/// A trading day, identified by its `America/New_York` calendar date.
+///
+/// The type exists to make a session and an instant impossible to confuse. Both used to be spelled
+/// `NaiveDate`/`DateTime`, and every timekeeping bug this system has had was that confusion: a
+/// session derived from `Utc::now().date_naive()`, a prediction stamped at UTC midnight, a session
+/// and its label computed from two separate expressions. None of those is expressible here.
+///
+/// There are exactly two ways in. [`SessionDate::at`] converts an instant, which is the only
+/// correct way to answer "what trading day is it now". [`SessionDate::from_date`] takes a date
+/// already expressed in Eastern terms — parsed from a command-line argument, read from a `DATE`
+/// column, or returned by an exchange API that publishes Eastern dates. A `NaiveDate` obtained any
+/// other way, and a UTC date in particular, has no business becoming one of these.
+///
+/// **What it guarantees is the timezone, not tradability.** A `SessionDate` is a calendar date in
+/// the frame the exchange keeps; it is not proof that the market opens that day. Weekends and
+/// holidays are perfectly representable, and [`SessionDate::plus_calendar_days`] will land on them.
+/// Whether a date trades is [`crate::data::calendar::TradingCalendar::is_trading_day`]'s question,
+/// and it is the only thing that can answer it — the calendar is fetched from Alpaca, and a holiday
+/// table in the type system would be a second source that can disagree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct SessionDate(NaiveDate);
+
+impl SessionDate {
+    /// The trading day an instant falls in.
+    ///
+    /// The trading day rolls over at Eastern midnight, not UTC midnight, and the two differ for
+    /// four or five hours of every day. Every cache key, session comparison, and "is this still
+    /// today" check in the system goes through here.
+    pub fn at(instant: DateTime<Utc>) -> Self {
+        Self(instant.with_timezone(&New_York).date_naive())
+    }
+
+    /// Wraps a date that is already known to be a session.
+    ///
+    /// For values that arrive as session dates rather than being derived from a clock: a parsed
+    /// argument, a `DATE` column, an exchange calendar entry. Deriving one from an instant is
+    /// [`SessionDate::at`]'s job, and going through `date_naive()` to reach here is the bug this
+    /// type prevents.
+    pub fn from_date(date: NaiveDate) -> Self {
+        Self(date)
+    }
+
+    /// The underlying calendar date, for formatting and for binding to a `DATE` column.
+    pub fn date(self) -> NaiveDate {
+        self.0
+    }
+
+    /// Midnight Eastern on this session, as the equivalent UTC instant.
+    ///
+    /// Eastern shifts at 02:00 so local midnight always exists, but `earliest()` with a UTC
+    /// fallback is used anyway so a timezone database change cannot panic a caller.
+    pub fn midnight(self) -> DateTime<Utc> {
+        let local_midnight = self
+            .0
+            .and_hms_opt(0, 0, 0)
+            .expect("midnight is a valid wall-clock time");
+        New_York
+            .from_local_datetime(&local_midnight)
+            .earliest()
+            .map(|zoned| zoned.with_timezone(&Utc))
+            .unwrap_or_else(|| local_midnight.and_utc())
+    }
+
+    /// The half-open UTC interval `[start, end)` covering this session.
+    ///
+    /// The inverse of [`SessionDate::at`], so queries can bound a timestamp column directly. A
+    /// predicate like `(created_at AT TIME ZONE 'America/New_York')::date = $1` hides the column
+    /// behind an expression, defeating chunk exclusion and the index — a one-day export becomes a
+    /// full scan. Resolving bounds here keeps `column >= $start AND column < $end` sargable.
+    pub fn bounds(self) -> (DateTime<Utc>, DateTime<Utc>) {
+        (self.midnight(), self.plus_calendar_days(1).midnight())
+    }
+
+    /// This session shifted by whole **calendar** days.
+    ///
+    /// Named for the distinction it must not lose: this steps over weekends and holidays, unlike
+    /// [`crate::data::calendar::TradingCalendar::previous_trading_day`] and
+    /// [`crate::data::calendar::TradingCalendar::next_trading_day`], which land on published
+    /// sessions. Used to bound fetch ranges, where overshooting is free.
+    pub fn plus_calendar_days(self, days: i64) -> Self {
+        Self(self.0 + Duration::days(days))
+    }
+
+    /// Whether this date falls on a weekend.
+    ///
+    /// Not a substitute for [`crate::data::calendar::TradingCalendar::is_trading_day`] — it knows
+    /// nothing about holidays — but useful for bounding a fetch range before the calendar is
+    /// available.
+    pub fn is_weekend(self) -> bool {
+        matches!(
+            self.0.weekday(),
+            chrono::Weekday::Sat | chrono::Weekday::Sun
+        )
+    }
+}
+
+impl std::fmt::Display for SessionDate {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(formatter)
     }
 }
 
@@ -864,6 +972,77 @@ mod tests {
 
     fn ticker(raw: &str) -> Ticker {
         Ticker::new(raw).expect("test ticker must be valid")
+    }
+
+    fn session(year: i32, month: u32, day: u32) -> SessionDate {
+        SessionDate::from_date(NaiveDate::from_ymd_opt(year, month, day).unwrap())
+    }
+
+    /// The Eastern date must roll at Eastern midnight. 03:00 UTC is still the previous evening in
+    /// New York, and a UTC-based key would put it on the wrong trading day.
+    #[test]
+    fn test_eastern_date_rolls_at_eastern_midnight() {
+        let late_evening = "2026-06-11T03:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        assert_eq!(SessionDate::at(late_evening), session(2026, 6, 10));
+
+        let morning = "2026-06-11T13:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        assert_eq!(SessionDate::at(morning), session(2026, 6, 11));
+    }
+
+    /// The bounds must be half-open and must span exactly 24 hours on an ordinary day. In summer
+    /// Eastern is UTC-4, so the day runs 04:00 to 04:00 UTC.
+    #[test]
+    fn test_eastern_day_bounds_span_the_local_day_in_summer() {
+        let (start, end) = session(2026, 6, 10).bounds();
+        assert_eq!(start.to_rfc3339(), "2026-06-10T04:00:00+00:00");
+        assert_eq!(end.to_rfc3339(), "2026-06-11T04:00:00+00:00");
+        assert_eq!((end - start).num_hours(), 24);
+    }
+
+    /// In winter Eastern is UTC-5, so the same local day is offset by an hour. A fixed offset would
+    /// get one of these two cases wrong.
+    #[test]
+    fn test_eastern_day_bounds_span_the_local_day_in_winter() {
+        let (start, end) = session(2026, 1, 14).bounds();
+        assert_eq!(start.to_rfc3339(), "2026-01-14T05:00:00+00:00");
+        assert_eq!(end.to_rfc3339(), "2026-01-15T05:00:00+00:00");
+    }
+
+    /// The transition days are 23 and 25 hours long. Bounds computed by adding a fixed 24 hours
+    /// would silently include or exclude an hour of rows on exactly these two days a year.
+    #[test]
+    fn test_eastern_day_bounds_handle_daylight_saving_transitions() {
+        let (spring_start, spring_end) = session(2026, 3, 8).bounds();
+        assert_eq!(
+            (spring_end - spring_start).num_hours(),
+            23,
+            "spring forward is a 23-hour day"
+        );
+
+        let (autumn_start, autumn_end) = session(2026, 11, 1).bounds();
+        assert_eq!(
+            (autumn_end - autumn_start).num_hours(),
+            25,
+            "fall back is a 25-hour day"
+        );
+    }
+
+    /// The bounds must round-trip against [`SessionDate::at`]: every instant inside them is that
+    /// Eastern date, and the exclusive end already belongs to the next one.
+    #[test]
+    fn test_eastern_day_bounds_round_trip_against_eastern_date() {
+        let day = session(2026, 6, 10);
+        let (start, end) = day.bounds();
+        assert_eq!(SessionDate::at(start), day);
+        assert_eq!(SessionDate::at(end - Duration::seconds(1)), day);
+        assert_eq!(SessionDate::at(end), day.plus_calendar_days(1));
+    }
+
+    #[test]
+    fn test_is_weekend() {
+        assert!(session(2026, 11, 28).is_weekend());
+        assert!(session(2026, 11, 29).is_weekend());
+        assert!(!session(2026, 11, 27).is_weekend());
     }
 
     #[test]

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -855,7 +855,7 @@ impl EquityDetail {
     }
 }
 
-/// One ticker's quantile forecast from a single prediction batch.
+/// One ticker's quantile prediction from a single batch.
 ///
 /// The three quantiles are ordered by construction: [`EquityPrediction::new`] rejects a set where
 /// `quantile_10 > quantile_50` or `quantile_50 > quantile_90`. A crossed quantile set is a model or
@@ -951,7 +951,7 @@ impl EquityPrediction {
         self.quantile_90
     }
 
-    /// The median forecast, which is the expected forward return the strategy trades on.
+    /// The median prediction, which is the expected forward return the strategy trades on.
     pub fn expected_return(&self) -> f64 {
         self.quantile_50
     }

--- a/src/dashboard/cache.rs
+++ b/src/dashboard/cache.rs
@@ -20,8 +20,8 @@ use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
 use crate::common::events::Notification;
-use crate::common::types::{PairID, Ticker};
-use crate::data::calendar::SessionDate;
+use crate::common::types::{PairID, SessionDate, Ticker};
+
 use crate::portfolio::pairs::CloseReason;
 
 /// How often the background task refreshes every view from PostgreSQL.

--- a/src/dashboard/cache.rs
+++ b/src/dashboard/cache.rs
@@ -97,7 +97,7 @@ impl ClosedPair {
     }
 }
 
-/// One ticker's quantile forecast from the most recent prediction batch.
+/// One ticker's quantile prediction from the most recent batch.
 #[derive(Debug, Clone)]
 pub struct Prediction {
     pub ticker: Ticker,

--- a/src/dashboard/database.rs
+++ b/src/dashboard/database.rs
@@ -256,7 +256,7 @@ async fn fetch_closed_pairs(pool: &PgPool) -> Result<Vec<ClosedPair>, sqlx::Erro
     Ok(pairs)
 }
 
-/// Fetches the most recent prediction batch, ranked by median forecast.
+/// Fetches the most recent prediction batch, ranked by median prediction.
 ///
 /// A batch is identified by its shared `correlation_id`, not by timestamp: selecting on the maximum
 /// timestamp alone would mix rows from two runs if one ever wrote a ticker the other did not.

--- a/src/dashboard/database.rs
+++ b/src/dashboard/database.rs
@@ -15,11 +15,11 @@ use sqlx::{PgPool, Row};
 use tracing::warn;
 
 use crate::common::alpaca::TRANSFER_ACTIVITY_TYPES;
-use crate::common::types::{PairID, Ticker};
+use crate::common::types::{PairID, SessionDate, Ticker};
 use crate::dashboard::cache::{
     AccountSnapshot, ClosedPair, ClosedSummary, EventEntry, OpenPair, PeriodReturns, Prediction,
 };
-use crate::data::calendar::SessionDate;
+
 use crate::portfolio::pairs::CloseReason;
 
 /// Sessions of account snapshots fetched: the equity curve, and the newest row's balances.

--- a/src/dashboard/html.rs
+++ b/src/dashboard/html.rs
@@ -250,7 +250,7 @@ fn render_predictions_section(state: &DashboardState) -> String {
 <tr><th>Ticker</th><th>Q10</th><th>Q50</th><th>Q90</th></tr>
 {rows}
 </table>
-<p class="summary">{run} — {} tickers, ranked by median forecast</p>"#,
+<p class="summary">{run} — {} tickers, ranked by median prediction</p>"#,
         state.predictions.len()
     );
     section("Predictions", body)

--- a/src/dashboard/html.rs
+++ b/src/dashboard/html.rs
@@ -590,7 +590,7 @@ mod tests {
 
         DashboardState {
             account: Some(AccountSnapshot {
-                session_date: crate::data::calendar::SessionDate::from_date(
+                session_date: crate::common::types::SessionDate::from_date(
                     NaiveDate::from_ymd_opt(2026, 7, 31).expect("a valid date"),
                 ),
                 equity: decimal("1234567.89"),

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,8 +9,8 @@
 //! term record of them; [`export`] owns `exports/`, the application's own tables, which the purge
 //! deletes from PostgreSQL only once they are safely written. Neither writes the other's prefix.
 //!
-//! [`session_log`] is the exception to "tables first": it is written to local disk as it happens and
-//! is the original that PostgreSQL and S3 are both derived from.
+//! [`export`] also seals and ships [`crate::common::session_log`], the local original that both
+//! PostgreSQL and S3 are derived from.
 
 pub mod archive;
 pub mod bars;
@@ -18,5 +18,4 @@ pub mod calendar;
 pub mod details;
 pub mod export;
 pub mod purge;
-pub mod session_log;
 pub mod universe;

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -32,8 +32,8 @@ use tracing::{info, warn};
 
 use crate::common::aws::{date_from_partitioned_key, date_partitioned_key};
 use crate::common::massive::MassiveClient;
+use crate::common::types::SessionDate;
 use crate::data::bars;
-use crate::data::calendar::SessionDate;
 
 /// S3 prefix for the bar archive.
 ///

--- a/src/data/bars.rs
+++ b/src/data/bars.rs
@@ -16,8 +16,7 @@ use sqlx::PgPool;
 use tracing::{info, warn};
 
 use crate::common::massive::{MassiveClient, MassiveError};
-use crate::common::types::{BarInterval, EquityBar, Ticker};
-use crate::data::calendar::SessionDate;
+use crate::common::types::{BarInterval, EquityBar, SessionDate, Ticker};
 
 /// Rows per insert chunk.
 ///

--- a/src/data/calendar.rs
+++ b/src/data/calendar.rs
@@ -14,11 +14,12 @@
 
 use std::collections::BTreeMap;
 
-use chrono::{DateTime, Datelike, Duration, NaiveDate, NaiveTime, TimeZone, Utc};
+use chrono::{DateTime, NaiveTime, Utc};
 use chrono_tz::America::New_York;
 use tracing::{info, warn};
 
 use crate::common::alpaca::{CalendarDay, ClientError, TradingClient};
+use crate::common::types::SessionDate;
 
 /// How far forward to fetch published sessions.
 ///
@@ -31,107 +32,6 @@ const HORIZON_DAYS_FORWARD: i64 = 90;
 /// The bar sync asks for the previous trading day, and a long weekend plus a holiday is the worst
 /// case. Thirty days is generous.
 const HORIZON_DAYS_BACKWARD: i64 = 30;
-
-/// A trading day, identified by its `America/New_York` calendar date.
-///
-/// The type exists to make a session and an instant impossible to confuse. Both used to be spelled
-/// `NaiveDate`/`DateTime`, and every timekeeping bug this system has had was that confusion: a
-/// session derived from `Utc::now().date_naive()`, a forecast stamped at UTC midnight, a session
-/// and its label computed from two separate expressions. None of those is expressible here.
-///
-/// There are exactly two ways in. [`SessionDate::at`] converts an instant, which is the only
-/// correct way to answer "what trading day is it now". [`SessionDate::from_date`] takes a date
-/// already expressed in Eastern terms — parsed from a command-line argument, read from a `DATE`
-/// column, or returned by an exchange API that publishes Eastern dates. A `NaiveDate` obtained any
-/// other way, and a UTC date in particular, has no business becoming one of these.
-///
-/// **What it guarantees is the timezone, not tradability.** A `SessionDate` is a calendar date in
-/// the frame the exchange keeps; it is not proof that the market opens that day. Weekends and
-/// holidays are perfectly representable, and [`SessionDate::plus_calendar_days`] will land on them.
-/// Whether a date trades is [`TradingCalendar::is_trading_day`]'s question, and it is the only
-/// thing that can answer it — the calendar is fetched from Alpaca, and a holiday table in the type
-/// system would be a second source that can disagree.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
-#[serde(transparent)]
-pub struct SessionDate(NaiveDate);
-
-impl SessionDate {
-    /// The trading day an instant falls in.
-    ///
-    /// The trading day rolls over at Eastern midnight, not UTC midnight, and the two differ for
-    /// four or five hours of every day. Every cache key, session comparison, and "is this still
-    /// today" check in the system goes through here.
-    pub fn at(instant: DateTime<Utc>) -> Self {
-        Self(instant.with_timezone(&New_York).date_naive())
-    }
-
-    /// Wraps a date that is already known to be a session.
-    ///
-    /// For values that arrive as session dates rather than being derived from a clock: a parsed
-    /// argument, a `DATE` column, an exchange calendar entry. Deriving one from an instant is
-    /// [`SessionDate::at`]'s job, and going through `date_naive()` to reach here is the bug this
-    /// type prevents.
-    pub fn from_date(date: NaiveDate) -> Self {
-        Self(date)
-    }
-
-    /// The underlying calendar date, for formatting and for binding to a `DATE` column.
-    pub fn date(self) -> NaiveDate {
-        self.0
-    }
-
-    /// Midnight Eastern on this session, as the equivalent UTC instant.
-    ///
-    /// Eastern shifts at 02:00 so local midnight always exists, but `earliest()` with a UTC
-    /// fallback is used anyway so a timezone database change cannot panic a caller.
-    pub fn midnight(self) -> DateTime<Utc> {
-        let local_midnight = self
-            .0
-            .and_hms_opt(0, 0, 0)
-            .expect("midnight is a valid wall-clock time");
-        New_York
-            .from_local_datetime(&local_midnight)
-            .earliest()
-            .map(|zoned| zoned.with_timezone(&Utc))
-            .unwrap_or_else(|| local_midnight.and_utc())
-    }
-
-    /// The half-open UTC interval `[start, end)` covering this session.
-    ///
-    /// The inverse of [`SessionDate::at`], so queries can bound a timestamp column directly. A
-    /// predicate like `(created_at AT TIME ZONE 'America/New_York')::date = $1` hides the column
-    /// behind an expression, defeating chunk exclusion and the index — a one-day export becomes a
-    /// full scan. Resolving bounds here keeps `column >= $start AND column < $end` sargable.
-    pub fn bounds(self) -> (DateTime<Utc>, DateTime<Utc>) {
-        (self.midnight(), self.plus_calendar_days(1).midnight())
-    }
-
-    /// This session shifted by whole **calendar** days.
-    ///
-    /// Named for the distinction it must not lose: this steps over weekends and holidays, unlike
-    /// [`TradingCalendar::previous_trading_day`] and [`TradingCalendar::next_trading_day`], which
-    /// land on published sessions. Used to bound fetch ranges, where overshooting is free.
-    pub fn plus_calendar_days(self, days: i64) -> Self {
-        Self(self.0 + Duration::days(days))
-    }
-
-    /// Whether this date falls on a weekend.
-    ///
-    /// Not a substitute for [`TradingCalendar::is_trading_day`] — it knows nothing about holidays —
-    /// but useful for bounding a fetch range before the calendar is available.
-    pub fn is_weekend(self) -> bool {
-        matches!(
-            self.0.weekday(),
-            chrono::Weekday::Sat | chrono::Weekday::Sun
-        )
-    }
-}
-
-impl std::fmt::Display for SessionDate {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(formatter)
-    }
-}
 
 /// The Eastern wall-clock time at an instant.
 pub fn eastern_time(instant: DateTime<Utc>) -> NaiveTime {
@@ -321,6 +221,8 @@ impl CalendarCache {
 
 #[cfg(test)]
 mod tests {
+    use chrono::NaiveDate;
+
     use super::*;
 
     fn date(year: i32, month: u32, day: u32) -> SessionDate {
@@ -464,17 +366,6 @@ mod tests {
         assert_eq!(calendar.minutes_until_close(holiday), None);
     }
 
-    /// The Eastern date must roll at Eastern midnight. 03:00 UTC is still the previous evening in
-    /// New York, and a UTC-based key would put it on the wrong trading day.
-    #[test]
-    fn test_eastern_date_rolls_at_eastern_midnight() {
-        let late_evening = "2026-06-11T03:00:00Z".parse::<DateTime<Utc>>().unwrap();
-        assert_eq!(SessionDate::at(late_evening), date(2026, 6, 10));
-
-        let morning = "2026-06-11T13:00:00Z".parse::<DateTime<Utc>>().unwrap();
-        assert_eq!(SessionDate::at(morning), date(2026, 6, 11));
-    }
-
     /// Daylight saving must be handled by the timezone database, not by an offset constant.
     /// 13:30 UTC is 09:30 Eastern in summer and 08:30 in winter.
     #[test]
@@ -489,55 +380,6 @@ mod tests {
             eastern_time(winter),
             NaiveTime::from_hms_opt(8, 30, 0).unwrap()
         );
-    }
-
-    /// The bounds must be half-open and must span exactly 24 hours on an ordinary day. In summer
-    /// Eastern is UTC-4, so the day runs 04:00 to 04:00 UTC.
-    #[test]
-    fn test_eastern_day_bounds_span_the_local_day_in_summer() {
-        let (start, end) = date(2026, 6, 10).bounds();
-        assert_eq!(start.to_rfc3339(), "2026-06-10T04:00:00+00:00");
-        assert_eq!(end.to_rfc3339(), "2026-06-11T04:00:00+00:00");
-        assert_eq!((end - start).num_hours(), 24);
-    }
-
-    /// In winter Eastern is UTC-5, so the same local day is offset by an hour. A fixed offset would
-    /// get one of these two cases wrong.
-    #[test]
-    fn test_eastern_day_bounds_span_the_local_day_in_winter() {
-        let (start, end) = date(2026, 1, 14).bounds();
-        assert_eq!(start.to_rfc3339(), "2026-01-14T05:00:00+00:00");
-        assert_eq!(end.to_rfc3339(), "2026-01-15T05:00:00+00:00");
-    }
-
-    /// The transition days are 23 and 25 hours long. Bounds computed by adding a fixed 24 hours
-    /// would silently include or exclude an hour of rows on exactly these two days a year.
-    #[test]
-    fn test_eastern_day_bounds_handle_daylight_saving_transitions() {
-        let (spring_start, spring_end) = date(2026, 3, 8).bounds();
-        assert_eq!(
-            (spring_end - spring_start).num_hours(),
-            23,
-            "spring forward is a 23-hour day"
-        );
-
-        let (autumn_start, autumn_end) = date(2026, 11, 1).bounds();
-        assert_eq!(
-            (autumn_end - autumn_start).num_hours(),
-            25,
-            "fall back is a 25-hour day"
-        );
-    }
-
-    /// The bounds must round-trip against `eastern_date`: every instant inside them is that Eastern
-    /// date, and the exclusive end already belongs to the next one.
-    #[test]
-    fn test_eastern_day_bounds_round_trip_against_eastern_date() {
-        let day = date(2026, 6, 10);
-        let (start, end) = day.bounds();
-        assert_eq!(SessionDate::at(start), day);
-        assert_eq!(SessionDate::at(end - Duration::seconds(1)), day);
-        assert_eq!(SessionDate::at(end), day.plus_calendar_days(1));
     }
 
     /// The case the trainer's artifact identifier depends on. A run that starts at 23:00 UTC and
@@ -580,13 +422,6 @@ mod tests {
                 "{instant} disagreed"
             );
         }
-    }
-
-    #[test]
-    fn test_is_weekend() {
-        assert!(date(2026, 11, 28).is_weekend());
-        assert!(date(2026, 11, 29).is_weekend());
-        assert!(!date(2026, 11, 27).is_weekend());
     }
 
     #[tokio::test]

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -974,11 +974,15 @@ mod tests {
         std::fs::create_dir_all(&directory).unwrap();
         let path = directory.join("session-2026-08-12.jsonl");
 
-        // Verbatim v1 shapes, as the currently deployed build writes them.
+        // The five shapes a real v1 session file holds, taken from one on disk rather than guessed.
+        // `predictions_generated` carries `predictions` as a *count* here; in v2 the same field is
+        // an array, which is the one field whose type the version bump changes.
         let v1 = [
             r#"{"schema_version":1,"event_id":"11111111-1111-1111-1111-111111111111","correlation_id":"22222222-2222-2222-2222-222222222222","session_date":"2026-08-12","created_at":"2026-08-12T14:35:00Z","event_type":"evaluation_pass","payload":{"universe_size":7000,"prices":[{"ticker":"AAAA","price":100.0,"price_source":"last_trade"}],"open_pairs":[],"screen_inputs":[],"excluded":[],"candidates":[]}}"#,
             r#"{"schema_version":1,"event_id":"33333333-3333-3333-3333-333333333333","correlation_id":"22222222-2222-2222-2222-222222222222","session_date":"2026-08-12","created_at":"2026-08-12T14:35:01Z","event_type":"order_submitted","payload":{"client_order_id":"k-long","ticker":"AAAA","side":"buy","shares":null,"notional":1000.0}}"#,
-            r#"{"schema_version":1,"event_id":"44444444-4444-4444-4444-444444444444","correlation_id":"22222222-2222-2222-2222-222222222222","session_date":"2026-08-12","created_at":"2026-08-12T14:35:02Z","event_type":"liquidation_run","payload":{"pairs_closed":1,"positions_refused":0,"pairs_still_open":[]}}"#,
+            r#"{"schema_version":1,"event_id":"44444444-4444-4444-4444-444444444444","correlation_id":"22222222-2222-2222-2222-222222222222","session_date":"2026-08-12","created_at":"2026-08-12T14:35:02Z","event_type":"order_resolved","payload":{"client_order_id":"k-long","alpaca_order_id":"o1","ticker":"AAAA","outcome":"filled","filled_shares":10.0,"filled_average_price":100.4,"filled_after_cancel":false,"error":null}}"#,
+            r#"{"schema_version":1,"event_id":"55555555-5555-5555-5555-555555555555","correlation_id":"22222222-2222-2222-2222-222222222222","session_date":"2026-08-12","created_at":"2026-08-12T14:35:03Z","event_type":"position_close_requested","payload":{"ticker":"AAAA","pair_id":"AAAA-BBBB","alpaca_order_id":"o2","side":"long","quantity":10.0,"reason":"pair_exit","accepted":true,"status":null,"error":null}}"#,
+            r#"{"schema_version":1,"event_id":"66666666-6666-6666-6666-666666666666","correlation_id":"77777777-7777-7777-7777-777777777777","session_date":"2026-08-12","created_at":"2026-08-12T13:00:00Z","event_type":"predictions_generated","payload":{"model_run_id":"run-1","artifact_key":"models/tide/run-1","artifact_staleness_sessions":0,"predictions":1043,"rows_written":1043,"universe_size":7000}}"#,
         ];
         // A v2 record appended after the restart, into the same file.
         let v2 = serde_json::to_string(&Record::new(
@@ -1000,10 +1004,10 @@ mod tests {
             unparsable, 0,
             "no v1 record may be dropped by the new reader"
         );
-        assert_eq!(frame.height(), 4, "three v1 records plus one v2");
+        assert_eq!(frame.height(), 6, "five v1 records plus one v2");
         let versions = frame.column("schema_version").unwrap().i64().unwrap();
         assert_eq!(
-            (versions.get(0), versions.get(3)),
+            (versions.get(0), versions.get(5)),
             (Some(1), Some(2)),
             "both versions coexist in one file, each row carrying its own"
         );

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -457,13 +457,27 @@ pub async fn export_session_logs(
             .collect::<Vec<_>>()
     };
 
+    // Only the sessions whose Parquet holds everything their original did. A session is deletable
+    // when it uploaded cleanly *and* skipped nothing, and both are per-session questions: a run-wide
+    // gate would let one bad line in one file stop every other file from ever aging out.
+    let mut deletable: Vec<SessionDate> = Vec::with_capacity(sessions.len());
+    let mut held_back: Vec<NaiveDate> = Vec::new();
     for (session_date, frame) in frames {
         match frame {
             Ok((mut frame, unparsable)) => {
                 summary.unparsable_lines += unparsable;
                 let key = date_partitioned_key(SESSION_LOG_PREFIX, session_date.date());
                 match write_frame(s3_client, bucket, &key, &mut frame).await {
-                    Ok(()) => summary.exported.push((session_date.date(), frame.height())),
+                    Ok(()) => {
+                        summary.exported.push((session_date.date(), frame.height()));
+                        // A skipped line is in the original and not in the Parquet, which makes the
+                        // original its only copy. Keeping one file costs kilobytes; deleting it
+                        // makes a merely unreadable record permanently gone.
+                        match unparsable {
+                            0 => deletable.push(session_date),
+                            _ => held_back.push(session_date.date()),
+                        }
+                    }
                     Err(error) => summary.failed.push((session_date.date(), error)),
                 }
             }
@@ -471,15 +485,11 @@ pub async fn export_session_logs(
         }
     }
 
-    // A skipped line is in the original and not in the Parquet, so the original is the only copy of
-    // it. Keeping the file costs a few kilobytes until someone looks; deleting it makes a record
-    // that was merely unreadable permanently gone.
-    if summary.is_clean() && summary.unparsable_lines == 0 {
-        summary.deleted = delete_aged_out(log.directory(), &sessions, today);
-    } else if summary.unparsable_lines > 0 {
+    summary.deleted = delete_aged_out(log.directory(), &deletable, today);
+    for session_date in &held_back {
         warn!(
-            unparsable_lines = summary.unparsable_lines,
-            "Session logs held back from deletion: their originals hold lines the Parquet does not"
+            %session_date,
+            "Session log held back from deletion: its original holds lines the Parquet does not"
         );
     }
 
@@ -921,6 +931,38 @@ mod tests {
             "only the complete record reaches Parquet"
         );
         assert_eq!(unparsable, 6, "one per missing envelope column");
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// Holding a file back must not hold every other file back with it.
+    ///
+    /// The gate is per session because the reason for it is: one session's original holds a line
+    /// its Parquet does not. A run-wide gate would let a single bad line stop the whole directory
+    /// from ever ageing out, which on a 25 GB disk is a leak rather than a safeguard.
+    #[test]
+    fn test_one_session_held_back_does_not_hold_back_the_rest() {
+        let directory = temporary_directory("held-back-is-per-session");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+
+        let today = session(2026, 8, 11);
+        let aged_out = [
+            today.plus_calendar_days(-SESSION_LOG_RETENTION_DAYS - 2),
+            today.plus_calendar_days(-SESSION_LOG_RETENTION_DAYS - 1),
+        ];
+        for session_date in aged_out {
+            std::fs::write(directory.join(file_name(session_date)), "")
+                .expect("the file must be writable");
+        }
+
+        // Only the first is deletable; the second skipped a line and is held back.
+        let deleted = delete_aged_out(&directory, &aged_out[..1], today);
+
+        assert_eq!(deleted, vec![aged_out[0].date()]);
+        assert!(!directory.join(file_name(aged_out[0])).exists());
+        assert!(
+            directory.join(file_name(aged_out[1])).exists(),
+            "the held-back session keeps its original"
+        );
         let _ = std::fs::remove_dir_all(&directory);
     }
 

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -423,7 +423,7 @@ impl SessionLogExportSummary {
 ///
 /// Every file present is exported, not just the retention window: one whole file at a deterministic
 /// key makes a repeat a byte-identical overwrite, so a failed run repairs itself. Local files are
-/// deleted only after a clean run.
+/// deleted only after a clean run that skipped nothing.
 pub async fn export_session_logs(
     log: &SessionLog,
     s3_client: &S3Client,
@@ -441,13 +441,24 @@ pub async fn export_session_logs(
     };
     sessions.sort();
 
-    // Held across the reads so no append can interleave with one. Today's file is sealed by the
-    // clock rather than by anything structural, and a recovery replay can run a pass at any hour.
-    let sealed = log.seal().await;
+    // The seal covers the reads and nothing else. Holding it across the uploads would leave a
+    // concurrent `record` waiting on S3, and a log write that blocks on the network is the one
+    // thing this module promises never to be.
+    let frames = {
+        let _sealed = log.seal().await;
+        sessions
+            .iter()
+            .map(|session_date| {
+                (
+                    *session_date,
+                    read_session_frame(&log.directory().join(file_name(*session_date))),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
 
-    for session_date in &sessions {
-        let path = log.directory().join(file_name(*session_date));
-        match read_session_frame(&path) {
+    for (session_date, frame) in frames {
+        match frame {
             Ok((mut frame, unparsable)) => {
                 summary.unparsable_lines += unparsable;
                 let key = date_partitioned_key(SESSION_LOG_PREFIX, session_date.date());
@@ -460,10 +471,16 @@ pub async fn export_session_logs(
         }
     }
 
-    drop(sealed);
-
-    if summary.is_clean() {
+    // A skipped line is in the original and not in the Parquet, so the original is the only copy of
+    // it. Keeping the file costs a few kilobytes until someone looks; deleting it makes a record
+    // that was merely unreadable permanently gone.
+    if summary.is_clean() && summary.unparsable_lines == 0 {
         summary.deleted = delete_aged_out(log.directory(), &sessions, today);
+    } else if summary.unparsable_lines > 0 {
+        warn!(
+            unparsable_lines = summary.unparsable_lines,
+            "Session logs held back from deletion: their originals hold lines the Parquet does not"
+        );
     }
 
     info!(
@@ -554,26 +571,39 @@ fn read_session_frame(path: &Path) -> Result<(DataFrame, usize), String> {
         };
         let text = |key: &str| record.get(key).and_then(Value::as_str).map(str::to_string);
 
-        // A record missing any of its envelope is discarded rather than written with nulls, so a
-        // query cannot mistake an unaddressable row for a good one.
-        let (Some(event_id), Some(event_type), Some(created_at)) = (
+        // Every envelope column or none of the row. All six carry a query: correlation_id is the
+        // join, session_date the partition filter, schema_version the shape. A row admitted with
+        // any of them null is unreachable by the queries this archive exists to answer, and is
+        // indistinguishable from a good one until someone counts.
+        let (
+            Some(schema_version),
+            Some(event_id),
+            Some(correlation_id),
+            Some(event_type),
+            Some(session_date),
+            Some(created_at),
+        ) = (
+            record.get("schema_version").and_then(Value::as_i64),
             text("event_id"),
+            text("correlation_id"),
             text("event_type"),
+            text("session_date"),
             text("created_at").and_then(|stamp| {
                 DateTime::parse_from_rfc3339(&stamp)
                     .ok()
                     .map(|instant| instant.timestamp_millis())
             }),
-        ) else {
+        )
+        else {
             unparsable += 1;
             continue;
         };
 
-        schema_versions.push(record.get("schema_version").and_then(Value::as_i64));
+        schema_versions.push(Some(schema_version));
         event_ids.push(Some(event_id));
-        correlation_ids.push(text("correlation_id"));
+        correlation_ids.push(Some(correlation_id));
         event_types.push(Some(event_type));
-        session_dates.push(text("session_date"));
+        session_dates.push(Some(session_date));
         created_ats.push(Some(created_at));
         payloads.push(record.get("payload").map(Value::to_string));
     }
@@ -723,6 +753,7 @@ mod tests {
             unparsable, 2,
             "a missing event_id and an unparseable instant"
         );
+        let _ = std::fs::remove_dir_all(&directory);
     }
 
     #[test]
@@ -848,6 +879,48 @@ mod tests {
             .expect("one row");
         let parsed: Value = serde_json::from_str(payload).expect("the payload stays valid JSON");
         assert_eq!(parsed["equity"], 104_812.55);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// A row missing any envelope column is unreachable by the queries the archive exists for: no
+    /// correlation join, no partition filter, no way to tell which shape it is. Admitting it with
+    /// nulls would make it indistinguishable from a good row until someone counted.
+    #[test]
+    fn test_a_record_missing_any_envelope_column_is_counted_unparsable() {
+        let directory = temporary_directory("envelope-columns");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("session-2026-08-11.jsonl");
+        let complete = serde_json::to_string(&Record::new(
+            Uuid::nil(),
+            instant("2026-08-11T20:15:00Z"),
+            account_observation(),
+        ))
+        .expect("the record must serialize");
+
+        // One line per envelope column, each complete but for that column.
+        let mut lines = vec![complete.clone()];
+        for column in [
+            "schema_version",
+            "event_id",
+            "correlation_id",
+            "event_type",
+            "session_date",
+            "created_at",
+        ] {
+            let mut record: serde_json::Map<String, Value> =
+                serde_json::from_str(&complete).expect("the record must parse");
+            record.remove(column);
+            lines.push(Value::Object(record).to_string());
+        }
+        std::fs::write(&path, lines.join("\n")).expect("the file must be writable");
+
+        let (frame, unparsable) = read_session_frame(&path).expect("the session must read");
+        assert_eq!(
+            frame.height(),
+            1,
+            "only the complete record reaches Parquet"
+        );
+        assert_eq!(unparsable, 6, "one per missing envelope column");
         let _ = std::fs::remove_dir_all(&directory);
     }
 

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -18,16 +18,23 @@
 //! A failure on one table is logged and the rest continue; the caller receives the list so the
 //! completion event can report it. That list is also the purge's gate: [`crate::data::purge`] runs
 //! only when every dataset here wrote cleanly.
+//!
+//! [`export_session_logs`] ships a third shape: whole local JSONL files, one object per session,
+//! independent of the database entirely.
+
+use std::path::Path;
 
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client as S3Client;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use polars::prelude::*;
+use serde_json::Value;
 use sqlx::PgPool;
 use tracing::{info, warn};
 
 use crate::common::aws::date_partitioned_key;
-use crate::data::calendar::SessionDate;
+use crate::common::session_log::{file_name, session_from_file_name, SessionLog};
+use crate::common::types::SessionDate;
 
 /// What one nightly export accomplished.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -374,9 +381,270 @@ fn to_polars_error(error: sqlx::Error) -> PolarsError {
     PolarsError::ComputeError(error.to_string().into())
 }
 
+// ---------------------------------------------------------------------------
+// Session log
+// ---------------------------------------------------------------------------
+
+/// S3 prefix the sealed sessions are written under.
+pub const SESSION_LOG_PREFIX: &str = "exports/session_log";
+
+/// Calendar days of sealed sessions kept on local disk after a clean export.
+///
+/// The window in which a bad Parquet conversion can still be repaired from the original bytes.
+pub const SESSION_LOG_RETENTION_DAYS: i64 = 7;
+
+/// What one export run accomplished.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SessionLogExportSummary {
+    /// `(session_date, records)` for each session written to S3.
+    pub exported: Vec<(NaiveDate, usize)>,
+    /// `(session_date, error)` for each session that failed.
+    pub failed: Vec<(NaiveDate, String)>,
+    /// Sessions whose local file was deleted after the retention window.
+    pub deleted: Vec<NaiveDate>,
+    /// Lines skipped as unreadable, across every session.
+    ///
+    /// A torn final line per crashed session is expected; more than that means something else is
+    /// wrong.
+    pub unparsable_lines: usize,
+}
+
+impl SessionLogExportSummary {
+    pub fn total_records(&self) -> usize {
+        self.exported.iter().map(|(_, records)| records).sum()
+    }
+
+    pub fn is_clean(&self) -> bool {
+        self.failed.is_empty()
+    }
+}
+
+/// Converts every sealed session on disk to Parquet in S3, then deletes what has aged out.
+///
+/// Every file present is exported, not just the retention window: one whole file at a deterministic
+/// key makes a repeat a byte-identical overwrite, so a failed run repairs itself. Local files are
+/// deleted only after a clean run.
+pub async fn export_session_logs(
+    log: &SessionLog,
+    s3_client: &S3Client,
+    bucket: &str,
+    today: SessionDate,
+) -> SessionLogExportSummary {
+    let mut summary = SessionLogExportSummary::default();
+
+    let mut sessions = match sealed_sessions(log.directory(), today) {
+        Ok(sessions) => sessions,
+        Err(error) => {
+            warn!(%error, "Session log directory could not be read; nothing exported");
+            return summary;
+        }
+    };
+    sessions.sort();
+
+    // Held across the reads so no append can interleave with one. Today's file is sealed by the
+    // clock rather than by anything structural, and a recovery replay can run a pass at any hour.
+    let sealed = log.seal().await;
+
+    for session_date in &sessions {
+        let path = log.directory().join(file_name(*session_date));
+        match read_session_frame(&path) {
+            Ok((mut frame, unparsable)) => {
+                summary.unparsable_lines += unparsable;
+                let key = date_partitioned_key(SESSION_LOG_PREFIX, session_date.date());
+                match write_frame(s3_client, bucket, &key, &mut frame).await {
+                    Ok(()) => summary.exported.push((session_date.date(), frame.height())),
+                    Err(error) => summary.failed.push((session_date.date(), error)),
+                }
+            }
+            Err(error) => summary.failed.push((session_date.date(), error)),
+        }
+    }
+
+    drop(sealed);
+
+    if summary.is_clean() {
+        summary.deleted = delete_aged_out(log.directory(), &sessions, today);
+    }
+
+    info!(
+        sessions = summary.exported.len(),
+        records = summary.total_records(),
+        failed = summary.failed.len(),
+        deleted = summary.deleted.len(),
+        unparsable_lines = summary.unparsable_lines,
+        "Session log export finished"
+    );
+    for (session_date, error) in &summary.failed {
+        warn!(%session_date, error, "Session log failed to export");
+    }
+    summary
+}
+
+/// Sessions on disk whose trading day has finished.
+///
+/// Today counts, because this runs after the close; a future-dated file does not, and exporting one
+/// would seal a session still being written.
+fn sealed_sessions(
+    directory: &Path,
+    today: SessionDate,
+) -> Result<Vec<SessionDate>, std::io::Error> {
+    let mut sessions = Vec::new();
+    for entry in std::fs::read_dir(directory)? {
+        let entry = entry?;
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let Some(session_date) = session_from_file_name(&name) else {
+            continue;
+        };
+        if session_date > today {
+            warn!(%session_date, %today, "Session log is dated ahead of today; not sealed");
+            continue;
+        }
+        sessions.push(session_date);
+    }
+    Ok(sessions)
+}
+
+/// Removes the local copies of sessions older than the retention window.
+///
+/// Called only after a clean run, so a session cannot age out without reaching S3. A file that will
+/// not delete is a warning: a stale local copy costs disk and nothing else.
+fn delete_aged_out(
+    directory: &Path,
+    sessions: &[SessionDate],
+    today: SessionDate,
+) -> Vec<NaiveDate> {
+    let oldest_kept = today.plus_calendar_days(-SESSION_LOG_RETENTION_DAYS);
+    let mut deleted = Vec::new();
+    for session_date in sessions.iter().filter(|session| **session < oldest_kept) {
+        let path = directory.join(file_name(*session_date));
+        match std::fs::remove_file(&path) {
+            Ok(()) => deleted.push(session_date.date()),
+            Err(error) => warn!(
+                path = %path.display(),
+                %error,
+                "Aged-out session log could not be deleted"
+            ),
+        }
+    }
+    deleted
+}
+
+/// Reads one session file into a frame, returning it with the number of lines skipped.
+///
+/// Discarding a torn final line is why the original is JSONL rather than Parquet.
+fn read_session_frame(path: &Path) -> Result<(DataFrame, usize), String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+
+    let mut schema_versions: Vec<Option<i64>> = Vec::new();
+    let mut event_ids: Vec<Option<String>> = Vec::new();
+    let mut correlation_ids: Vec<Option<String>> = Vec::new();
+    let mut event_types: Vec<Option<String>> = Vec::new();
+    let mut session_dates: Vec<Option<String>> = Vec::new();
+    let mut created_ats: Vec<Option<i64>> = Vec::new();
+    let mut payloads: Vec<Option<String>> = Vec::new();
+    let mut unparsable = 0usize;
+
+    for line in contents.lines().filter(|line| !line.trim().is_empty()) {
+        let Ok(Value::Object(record)) = serde_json::from_str::<Value>(line) else {
+            unparsable += 1;
+            continue;
+        };
+        let text = |key: &str| record.get(key).and_then(Value::as_str).map(str::to_string);
+
+        // A record missing any of its envelope is discarded rather than written with nulls, so a
+        // query cannot mistake an unaddressable row for a good one.
+        let (Some(event_id), Some(event_type), Some(created_at)) = (
+            text("event_id"),
+            text("event_type"),
+            text("created_at").and_then(|stamp| {
+                DateTime::parse_from_rfc3339(&stamp)
+                    .ok()
+                    .map(|instant| instant.timestamp_millis())
+            }),
+        ) else {
+            unparsable += 1;
+            continue;
+        };
+
+        schema_versions.push(record.get("schema_version").and_then(Value::as_i64));
+        event_ids.push(Some(event_id));
+        correlation_ids.push(text("correlation_id"));
+        event_types.push(Some(event_type));
+        session_dates.push(text("session_date"));
+        created_ats.push(Some(created_at));
+        payloads.push(record.get("payload").map(Value::to_string));
+    }
+
+    if unparsable > 0 {
+        warn!(
+            path = %path.display(),
+            unparsable,
+            "Skipped session log lines that would not parse"
+        );
+    }
+
+    let frame = DataFrame::new(vec![
+        Column::new("schema_version".into(), schema_versions),
+        Column::new("event_id".into(), event_ids),
+        Column::new("correlation_id".into(), correlation_ids),
+        Column::new("event_type".into(), event_types),
+        Column::new("session_date".into(), session_dates),
+        Column::new("created_at".into(), created_ats),
+        Column::new("payload".into(), payloads),
+    ])
+    .map_err(|error| format!("failed to build frame for {}: {error}", path.display()))?;
+
+    Ok((frame, unparsable))
+}
+
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
+    use uuid::Uuid;
+
     use super::*;
+    use crate::common::session_log::{AccountObserved, Observation, Record};
+
+    fn session(year: i32, month: u32, day: u32) -> SessionDate {
+        SessionDate::from_date(NaiveDate::from_ymd_opt(year, month, day).expect("valid date"))
+    }
+
+    fn instant(raw: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(raw)
+            .expect("valid instant")
+            .with_timezone(&Utc)
+    }
+
+    fn account_observation() -> Observation {
+        Observation::AccountObserved(AccountObserved {
+            session_date: session(2026, 8, 11),
+            equity: Some(104_812.55),
+            cash: Some(12_000.0),
+            buying_power: Some(200_000.0),
+            long_market_value: Some(50_000.0),
+            short_market_value: Some(-50_000.0),
+        })
+    }
+
+    /// A directory unique to this run.
+    ///
+    /// The process and counter suffix stop two overlapping `cargo test` invocations deleting and
+    /// recreating one path underneath each other.
+    fn temporary_directory(name: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let directory = std::env::temp_dir().join(format!(
+            "fund-session-export-{name}-{}-{unique}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&directory);
+        directory
+    }
 
     #[test]
     fn test_summary_totals_only_successful_datasets() {
@@ -400,5 +668,234 @@ mod tests {
         let rows = vec![(1_i64, "a"), (2, "b")];
         assert_eq!(collect(&rows, |row| row.0), vec![1, 2]);
         assert_eq!(collect(&rows, |row| row.1.to_string()), vec!["a", "b"]);
+    }
+
+    /// A crash mid-append leaves a partial final line. Discarding it is the whole reason the
+    /// original is JSONL: the same truncation in a Parquet file loses the entire session.
+    #[test]
+    fn test_a_torn_final_line_is_skipped_rather_than_failing_the_session() {
+        let directory = temporary_directory("torn");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("session-2026-08-11.jsonl");
+        let complete = serde_json::to_string(&Record::new(
+            Uuid::nil(),
+            instant("2026-08-11T14:35:00Z"),
+            account_observation(),
+        ))
+        .expect("the record must serialize");
+        std::fs::write(&path, format!("{complete}\n{{\"schema_version\":1,\"eve"))
+            .expect("the file must be writable");
+
+        let (frame, unparsable) = read_session_frame(&path).expect("the session must still read");
+        assert_eq!(frame.height(), 1);
+        assert_eq!(unparsable, 1);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// Valid JSON is not enough: a row without an addressable envelope would reach Parquet with
+    /// nulls no query could tell apart from a good record.
+    #[test]
+    fn test_a_record_missing_its_envelope_is_counted_unparsable() {
+        let directory = temporary_directory("envelope");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("session-2026-08-11.jsonl");
+        let complete = serde_json::to_string(&Record::new(
+            Uuid::nil(),
+            instant("2026-08-11T20:15:00Z"),
+            account_observation(),
+        ))
+        .expect("the record must serialize");
+        let lines = [
+            complete.as_str(),
+            r#"{"schema_version":1,"event_type":"account_observed","created_at":"2026-08-11T20:15:00Z"}"#,
+            r#"{"schema_version":1,"event_id":"a","event_type":"account_observed","created_at":"not a time"}"#,
+        ]
+        .join("\n");
+        std::fs::write(&path, lines).expect("the file must be writable");
+
+        let (frame, unparsable) = read_session_frame(&path).expect("the session must read");
+        assert_eq!(
+            frame.height(),
+            1,
+            "only the complete record reaches the frame"
+        );
+        assert_eq!(
+            unparsable, 2,
+            "a missing event_id and an unparseable instant"
+        );
+    }
+
+    #[test]
+    fn test_a_frame_carries_the_envelope_as_columns_and_the_payload_as_json() {
+        let directory = temporary_directory("frame");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("session-2026-08-11.jsonl");
+        let record = Record::new(
+            Uuid::nil(),
+            instant("2026-08-11T20:15:00Z"),
+            account_observation(),
+        );
+        std::fs::write(
+            &path,
+            format!(
+                "{}\n",
+                serde_json::to_string(&record).expect("the record must serialize")
+            ),
+        )
+        .expect("the file must be writable");
+
+        let (frame, _) = read_session_frame(&path).expect("the session must read");
+        assert_eq!(
+            frame.get_column_names(),
+            [
+                "schema_version",
+                "event_id",
+                "correlation_id",
+                "event_type",
+                "session_date",
+                "created_at",
+                "payload"
+            ]
+        );
+        let payload = frame
+            .column("payload")
+            .expect("payload column")
+            .str()
+            .expect("payload is text")
+            .get(0)
+            .expect("one row");
+        let parsed: Value = serde_json::from_str(payload).expect("the payload stays valid JSON");
+        assert_eq!(parsed["equity"], 104_812.55);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// Today's file is sealed because the export runs after the close; a future-dated one is not,
+    /// and exporting it would seal a session still being written.
+    #[test]
+    fn test_only_sessions_up_to_today_are_sealed() {
+        let directory = temporary_directory("sealed");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        for name in [
+            "session-2026-08-09.jsonl",
+            "session-2026-08-11.jsonl",
+            "session-2026-08-12.jsonl",
+            "notes.txt",
+        ] {
+            std::fs::write(directory.join(name), "").expect("the file must be writable");
+        }
+
+        let mut sealed = sealed_sessions(&directory, session(2026, 8, 11)).expect("readable");
+        sealed.sort();
+        assert_eq!(sealed, vec![session(2026, 8, 9), session(2026, 8, 11)]);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// The frame survives a Parquet round trip with its envelope typed and its payload intact.
+    ///
+    /// This is the artifact DuckDB reads, so a serialization that silently dropped a column or
+    /// widened the payload out of shape would take the whole archive with it.
+    #[test]
+    fn test_a_session_frame_round_trips_through_parquet() {
+        let directory = temporary_directory("parquet");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("session-2026-08-11.jsonl");
+        let mut lines = String::new();
+        for equity in [104_812.55_f64, 105_000.0] {
+            let record = Record::new(
+                Uuid::new_v4(),
+                instant("2026-08-11T20:15:00Z"),
+                Observation::AccountObserved(AccountObserved {
+                    session_date: session(2026, 8, 11),
+                    equity: Some(equity),
+                    cash: Some(12_000.0),
+                    buying_power: Some(200_000.0),
+                    long_market_value: Some(50_000.0),
+                    short_market_value: Some(-50_000.0),
+                }),
+            );
+            lines.push_str(&serde_json::to_string(&record).expect("the record must serialize"));
+            lines.push('\n');
+        }
+        std::fs::write(&path, lines).expect("the file must be writable");
+
+        let (mut frame, _) = read_session_frame(&path).expect("the session must read");
+        let mut buffer: Vec<u8> = Vec::new();
+        ParquetWriter::new(&mut buffer)
+            .finish(&mut frame)
+            .expect("the frame must serialize to Parquet");
+
+        let restored = ParquetReader::new(std::io::Cursor::new(buffer))
+            .finish()
+            .expect("the Parquet must read back");
+        assert_eq!(restored.height(), 2);
+        assert_eq!(restored.get_column_names(), frame.get_column_names());
+        // The instant survives as milliseconds, which is what lets a reader recover 16:15 Eastern.
+        assert_eq!(
+            restored
+                .column("created_at")
+                .expect("created_at column")
+                .i64()
+                .expect("created_at is an integer")
+                .get(0),
+            Some(instant("2026-08-11T20:15:00Z").timestamp_millis())
+        );
+        let payload = restored
+            .column("payload")
+            .expect("payload column")
+            .str()
+            .expect("payload is text")
+            .get(0)
+            .expect("one row");
+        let parsed: Value = serde_json::from_str(payload).expect("the payload stays valid JSON");
+        assert_eq!(parsed["equity"], 104_812.55);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// Only what has aged out goes, and the window's own edge stays. The local file is the
+    /// crash-exact original, so deleting one still inside the window would remove the only thing a
+    /// bad Parquet conversion could be repaired from.
+    #[test]
+    fn test_only_sessions_past_the_retention_window_are_deleted() {
+        let directory = temporary_directory("retention");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+
+        let today = session(2026, 8, 11);
+        let sessions = [
+            today.plus_calendar_days(-SESSION_LOG_RETENTION_DAYS - 1),
+            today.plus_calendar_days(-SESSION_LOG_RETENTION_DAYS),
+            today.plus_calendar_days(-1),
+            today,
+        ];
+        for session_date in sessions {
+            std::fs::write(directory.join(file_name(session_date)), "")
+                .expect("the file must be writable");
+        }
+
+        let deleted = delete_aged_out(&directory, &sessions, today);
+
+        assert_eq!(deleted, vec![sessions[0].date()]);
+        assert!(!directory.join(file_name(sessions[0])).exists());
+        for session_date in &sessions[1..] {
+            assert!(
+                directory.join(file_name(*session_date)).exists(),
+                "{session_date} is still inside the window"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// The key is a pure function of the session, which is what makes a repeat export an overwrite
+    /// rather than a duplicate — and why there is no cursor to keep in sync.
+    #[test]
+    fn test_the_export_key_is_determined_by_the_session_alone() {
+        let key = date_partitioned_key(SESSION_LOG_PREFIX, session(2026, 8, 11).date());
+        assert_eq!(
+            key,
+            "exports/session_log/year=2026/month=08/day=11/data.parquet"
+        );
+        assert_eq!(
+            key,
+            date_partitioned_key(SESSION_LOG_PREFIX, session(2026, 8, 11).date())
+        );
     }
 }

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -924,6 +924,50 @@ mod tests {
         let _ = std::fs::remove_dir_all(&directory);
     }
 
+    /// A file written across a mid-session deploy holds both shapes. Every v1 record must survive
+    /// the stricter envelope check, or the deploy silently drops the morning from the archive.
+    #[test]
+    fn test_a_file_written_across_a_deploy_keeps_both_schema_versions() {
+        let directory = temporary_directory("mixed-versions");
+        std::fs::create_dir_all(&directory).unwrap();
+        let path = directory.join("session-2026-08-12.jsonl");
+
+        // Verbatim v1 shapes, as the currently deployed build writes them.
+        let v1 = [
+            r#"{"schema_version":1,"event_id":"11111111-1111-1111-1111-111111111111","correlation_id":"22222222-2222-2222-2222-222222222222","session_date":"2026-08-12","created_at":"2026-08-12T14:35:00Z","event_type":"evaluation_pass","payload":{"universe_size":7000,"prices":[{"ticker":"AAAA","price":100.0,"price_source":"last_trade"}],"open_pairs":[],"screen_inputs":[],"excluded":[],"candidates":[]}}"#,
+            r#"{"schema_version":1,"event_id":"33333333-3333-3333-3333-333333333333","correlation_id":"22222222-2222-2222-2222-222222222222","session_date":"2026-08-12","created_at":"2026-08-12T14:35:01Z","event_type":"order_submitted","payload":{"client_order_id":"k-long","ticker":"AAAA","side":"buy","shares":null,"notional":1000.0}}"#,
+            r#"{"schema_version":1,"event_id":"44444444-4444-4444-4444-444444444444","correlation_id":"22222222-2222-2222-2222-222222222222","session_date":"2026-08-12","created_at":"2026-08-12T14:35:02Z","event_type":"liquidation_run","payload":{"pairs_closed":1,"positions_refused":0,"pairs_still_open":[]}}"#,
+        ];
+        // A v2 record appended after the restart, into the same file.
+        let v2 = serde_json::to_string(&Record::new(
+            Uuid::nil(),
+            DateTime::parse_from_rfc3339("2026-08-12T18:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            Observation::PricesObserved(Default::default()),
+        ))
+        .unwrap();
+
+        let mut lines = v1.join("\n");
+        lines.push('\n');
+        lines.push_str(&v2);
+        std::fs::write(&path, lines).unwrap();
+
+        let (frame, unparsable) = read_session_frame(&path).unwrap();
+        assert_eq!(
+            unparsable, 0,
+            "no v1 record may be dropped by the new reader"
+        );
+        assert_eq!(frame.height(), 4, "three v1 records plus one v2");
+        let versions = frame.column("schema_version").unwrap().i64().unwrap();
+        assert_eq!(
+            (versions.get(0), versions.get(3)),
+            (Some(1), Some(2)),
+            "both versions coexist in one file, each row carrying its own"
+        );
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
     /// Only what has aged out goes, and the window's own edge stays. The local file is the
     /// crash-exact original, so deleting one still inside the window would remove the only thing a
     /// bad Parquet conversion could be repaired from.

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -20,8 +20,7 @@ use sqlx::PgPool;
 use tracing::info;
 
 use crate::common::alpaca::{ClientError, TradableAssets, TradingClient};
-use crate::common::types::{BarInterval, Ticker, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
-use crate::data::calendar::SessionDate;
+use crate::common::types::{BarInterval, SessionDate, Ticker, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
 
 /// Trailing window over which liquidity is averaged.
 ///

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -112,7 +112,7 @@ impl Universe {
     /// Whether `ticker` is eligible to trade at all.
     ///
     /// Backed by a set rather than a scan of [`Universe::tickers`]. The screen asks this once per
-    /// forecast, and a linear scan there turns a seven-thousand-symbol universe into forty-nine
+    /// prediction, and a linear scan there turns a seven-thousand-symbol universe into forty-nine
     /// million comparisons on a pass that runs every five minutes.
     pub fn contains(&self, ticker: &Ticker) -> bool {
         self.eligible.contains(ticker)

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -19,7 +19,9 @@ use uuid::Uuid;
 use crate::common::alpaca::{AlpacaCredentials, ClientError, MarketDataClient, TradingClient};
 use crate::common::events::{self, Command, EventError};
 use crate::common::massive::MassiveClient;
-use crate::common::session_log::{Observation, PredictionsGenerated, SessionLog, SessionLogError};
+use crate::common::session_log::{
+    CommandFinished, Observation, PredictionsGenerated, SessionLog, SessionLogError,
+};
 use crate::common::types::{BarInterval, SessionDate};
 use crate::data::bars::{self, CloseHistoryCache, HISTORY_LOOKBACK_DAYS};
 use crate::data::calendar::{CalendarCache, TradingCalendar};
@@ -188,31 +190,66 @@ impl Drop for CommandGuard<'_> {
 
 /// Dispatches one command, emitting its terminal event either way.
 ///
-/// A command already in flight is dropped with a log line and no event: the request it came from
-/// will be answered by the run that is already going, and emitting a second terminal outcome would
-/// make the recovery scan's "requested with no terminal outcome" test wrong.
+/// A command already in flight is dropped with no *event*: the request it came from will be
+/// answered by the run that is already going, and emitting a second terminal outcome would make the
+/// recovery scan's "requested with no terminal outcome" test wrong. It is still recorded, because a
+/// drop and a crash are otherwise the same absence.
 pub async fn handle(state: &ServiceState, command: Command) {
+    // Minted here rather than inside each handler, so the command's own record and everything it
+    // did carry one identifier. That is what turns a duration into "where the time went".
+    let correlation_id = Uuid::new_v4();
+    let now = Utc::now();
+
     let Some(_guard) = state.claim(command) else {
         warn!(
             command = command.as_str(),
             "Command already in flight; this request is dropped"
         );
+        record_command(
+            state,
+            correlation_id,
+            now,
+            CommandFinished {
+                command: command.as_str().to_string(),
+                outcome: "dropped_in_flight".to_string(),
+                duration_milliseconds: None,
+                error: None,
+                summary: None,
+            },
+        )
+        .await;
         return;
     };
 
     let started = std::time::Instant::now();
-    let result = dispatch(state, command).await;
+    let result = dispatch(state, command, correlation_id).await;
     let duration_milliseconds = started.elapsed().as_millis() as u64;
 
     match result {
         Ok(mut summary) => {
             if let Value::Object(map) = &mut summary {
-                map.insert("duration_ms".to_string(), json!(duration_milliseconds));
+                map.insert(
+                    "duration_milliseconds".to_string(),
+                    json!(duration_milliseconds),
+                );
             }
             info!(
                 command = command.as_str(),
                 duration_milliseconds, "Command completed"
             );
+            record_command(
+                state,
+                correlation_id,
+                now,
+                CommandFinished {
+                    command: command.as_str().to_string(),
+                    outcome: completion_outcome(&summary),
+                    duration_milliseconds: Some(duration_milliseconds),
+                    error: None,
+                    summary: Some(summary.clone()),
+                },
+            )
+            .await;
             if let Err(error) = events::emit_completed(state.pool(), command, summary).await {
                 error!(command = command.as_str(), %error, "Failed to record completion");
             }
@@ -224,6 +261,19 @@ pub async fn handle(state: &ServiceState, command: Command) {
                 duration_milliseconds,
                 "Command failed"
             );
+            record_command(
+                state,
+                correlation_id,
+                now,
+                CommandFinished {
+                    command: command.as_str().to_string(),
+                    outcome: "errored".to_string(),
+                    duration_milliseconds: Some(duration_milliseconds),
+                    error: Some(error.to_string()),
+                    summary: None,
+                },
+            )
+            .await;
             if let Err(emit_error) =
                 events::emit_errored(state.pool(), command, &error.to_string()).await
             {
@@ -233,12 +283,40 @@ pub async fn handle(state: &ServiceState, command: Command) {
     }
 }
 
-async fn dispatch(state: &ServiceState, command: Command) -> Result<Value, HandlerError> {
+/// Whether a successful run did its work or declined to.
+///
+/// A handler that returns early names its reason under `skipped`; today the only one is
+/// `not_a_trading_day`. Reading it here rather than matching on it keeps a new skip reason from
+/// silently reading as a completed run.
+fn completion_outcome(summary: &Value) -> String {
+    match summary.get("skipped").and_then(Value::as_str) {
+        Some(reason) => format!("skipped_{reason}"),
+        None => "completed".to_string(),
+    }
+}
+
+async fn record_command(
+    state: &ServiceState,
+    correlation_id: Uuid,
+    now: DateTime<Utc>,
+    finished: CommandFinished,
+) {
+    state
+        .session_log
+        .record(correlation_id, now, Observation::CommandFinished(finished))
+        .await;
+}
+
+async fn dispatch(
+    state: &ServiceState,
+    command: Command,
+    correlation_id: Uuid,
+) -> Result<Value, HandlerError> {
     match command {
-        Command::Predictions => handle_predictions(state).await,
-        Command::PortfolioEvaluation => handle_portfolio_evaluation(state).await,
-        Command::PortfolioLiquidation => handle_portfolio_liquidation(state).await,
-        Command::AccountSync => handle_account_sync(state).await,
+        Command::Predictions => handle_predictions(state, correlation_id).await,
+        Command::PortfolioEvaluation => handle_portfolio_evaluation(state, correlation_id).await,
+        Command::PortfolioLiquidation => handle_portfolio_liquidation(state, correlation_id).await,
+        Command::AccountSync => handle_account_sync(state, correlation_id).await,
         Command::MarketDataSync => handle_market_data_sync(state).await,
         Command::DatabaseExport => handle_database_export(state).await,
     }
@@ -248,7 +326,10 @@ async fn dispatch(state: &ServiceState, command: Command) -> Result<Value, Handl
 ///
 /// The previous session's post-close commands are checked here, and the artifact resolved here,
 /// rather than on schedules of their own — both only matter immediately before a session.
-async fn handle_predictions(state: &ServiceState) -> Result<Value, HandlerError> {
+async fn handle_predictions(
+    state: &ServiceState,
+    correlation_id: Uuid,
+) -> Result<Value, HandlerError> {
     let now = Utc::now();
     let today = SessionDate::at(now);
 
@@ -305,7 +386,6 @@ async fn handle_predictions(state: &ServiceState) -> Result<Value, HandlerError>
         );
     }
 
-    let correlation_id = Uuid::new_v4();
     let (predictions, rows) = run_inference(state, &model_state, correlation_id).await?;
 
     // The forecasts themselves are not repeated into the log — they are rows in
@@ -391,7 +471,10 @@ async fn run_inference(
 }
 
 /// Every five minutes: price the book, close what should close, open into vacant slots.
-async fn handle_portfolio_evaluation(state: &ServiceState) -> Result<Value, HandlerError> {
+async fn handle_portfolio_evaluation(
+    state: &ServiceState,
+    correlation_id: Uuid,
+) -> Result<Value, HandlerError> {
     let now = Utc::now();
     let today = SessionDate::at(now);
 
@@ -426,6 +509,7 @@ async fn handle_portfolio_evaluation(state: &ServiceState) -> Result<Value, Hand
         sizing: state.sizing,
         execution: state.execution,
         session_log: &state.session_log,
+        correlation_id,
         shutdown: &state.shutdown,
         now,
     };
@@ -439,15 +523,26 @@ async fn handle_portfolio_evaluation(state: &ServiceState) -> Result<Value, Hand
 /// The calendar is deliberately not consulted. A liquidation on a day with no session closes
 /// nothing and costs one API call; a liquidation skipped because the calendar was wrong or
 /// unreachable carries positions overnight. The asymmetry is the whole argument.
-async fn handle_portfolio_liquidation(state: &ServiceState) -> Result<Value, HandlerError> {
-    let summary =
-        evaluate::run_liquidation(&state.pool, &state.trading, &state.session_log, Utc::now())
-            .await?;
+async fn handle_portfolio_liquidation(
+    state: &ServiceState,
+    correlation_id: Uuid,
+) -> Result<Value, HandlerError> {
+    let summary = evaluate::run_liquidation(
+        &state.pool,
+        &state.trading,
+        &state.session_log,
+        correlation_id,
+        Utc::now(),
+    )
+    .await?;
     Ok(serde_json::to_value(summary).unwrap_or_else(|_| json!({})))
 }
 
 /// Post-close: balances, activities, and pair attribution from Alpaca.
-async fn handle_account_sync(state: &ServiceState) -> Result<Value, HandlerError> {
+async fn handle_account_sync(
+    state: &ServiceState,
+    correlation_id: Uuid,
+) -> Result<Value, HandlerError> {
     let now = Utc::now();
     let today = SessionDate::at(now);
 
@@ -460,6 +555,7 @@ async fn handle_account_sync(state: &ServiceState) -> Result<Value, HandlerError
         &state.pool,
         &state.trading,
         &state.session_log,
+        correlation_id,
         &calendar,
         today,
     )
@@ -717,6 +813,27 @@ mod tests {
         SessionDate::from_date(
             NaiveDate::from_ymd_opt(year, month, day).expect("test date must be valid"),
         )
+    }
+
+    /// A holiday and a completed run must not read the same. The handlers say why they declined by
+    /// naming a reason, and the outcome carries it rather than collapsing to "it finished".
+    #[test]
+    fn test_a_skipped_run_is_not_recorded_as_completed() {
+        assert_eq!(
+            completion_outcome(
+                &json!({ "skipped": "not_a_trading_day", "session_date": "2026-08-11" })
+            ),
+            "skipped_not_a_trading_day"
+        );
+        assert_eq!(
+            completion_outcome(&json!({ "pairs_opened": ["AAAA-BBBB"] })),
+            "completed"
+        );
+        // A reason this function has never seen still reads as a skip, not as a finished run.
+        assert_eq!(
+            completion_outcome(&json!({ "skipped": "market_halted" })),
+            "skipped_market_halted"
+        );
     }
 
     /// Weekday sessions spanning 2026-07-27 to 2026-08-07. 2026-08-01 is a Saturday and

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -20,7 +20,8 @@ use crate::common::alpaca::{AlpacaCredentials, ClientError, MarketDataClient, Tr
 use crate::common::events::{self, Command, EventError};
 use crate::common::massive::MassiveClient;
 use crate::common::session_log::{
-    CommandFinished, Observation, PredictionsGenerated, SessionLog, SessionLogError,
+    CommandFinished, Observation, PredictionReading, PredictionsGenerated, SessionLog,
+    SessionLogError,
 };
 use crate::common::types::{BarInterval, SessionDate};
 use crate::data::bars::{self, CloseHistoryCache, HISTORY_LOOKBACK_DAYS};
@@ -386,24 +387,30 @@ async fn handle_predictions(
         );
     }
 
-    let (predictions, rows) = run_inference(state, &model_state, correlation_id).await?;
+    let (rows, predictions) = run_inference(state, &model_state, correlation_id).await?;
 
-    // The forecasts themselves are not repeated into the log — they are rows in
-    // `equity_predictions` and reach S3 through the nightly export. What only this run knows is
-    // which artifact produced them.
     state
         .session_log
         .record(
             correlation_id,
             now,
-            Observation::PredictionsGenerated(PredictionsGenerated {
+            Observation::PredictionsGenerated(Box::new(PredictionsGenerated {
                 model_run_id: model_state.run_id().to_string(),
                 artifact_key: artifact_key.clone(),
                 artifact_staleness_sessions,
-                predictions,
                 rows_written: rows,
                 universe_size: universe.len(),
-            }),
+                predictions: predictions
+                    .iter()
+                    .map(|prediction| PredictionReading {
+                        ticker: prediction.ticker().to_string(),
+                        timestamp: prediction.timestamp(),
+                        quantile_10: prediction.quantile_10(),
+                        quantile_50: prediction.quantile_50(),
+                        quantile_90: prediction.quantile_90(),
+                    })
+                    .collect(),
+            })),
         )
         .await;
 
@@ -413,7 +420,7 @@ async fn handle_predictions(
         "model_run_id": model_state.run_id(),
         "artifact_key": artifact_key,
         "artifact_staleness_sessions": artifact_staleness_sessions,
-        "predictions": predictions,
+        "predictions": predictions.len(),
         "rows_written": rows,
         "universe": universe.len(),
         "close_history_tickers": close_history.len(),
@@ -426,7 +433,7 @@ async fn run_inference(
     state: &ServiceState,
     model_state: &artifact::ModelState,
     correlation_id: Uuid,
-) -> Result<(usize, u64), HandlerError> {
+) -> Result<(u64, Vec<crate::common::types::EquityPrediction>), HandlerError> {
     fn at(stage: &'static str) -> impl Fn(String) -> HandlerError {
         move |message| HandlerError::Prediction { stage, message }
     }
@@ -459,7 +466,7 @@ async fn run_inference(
     // Split back apart rather than propagated as one error: a malformed payload is a bug in the
     // model output this function just produced, and belongs with the other pipeline stages; a
     // database failure is the database, and keeps reading as one.
-    let rows =
+    let (rows, predictions) =
         predict::insert_predictions(&state.pool, &array, correlation_id, model_state.run_id())
             .await
             .map_err(|error| match error {
@@ -467,7 +474,7 @@ async fn run_inference(
                 predict::InsertPredictionsError::Database(error) => HandlerError::Database(error),
             })?;
 
-    Ok((array.len(), rows))
+    Ok((rows, predictions))
 }
 
 /// Every five minutes: price the book, close what should close, open into vacant slots.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -19,15 +19,13 @@ use uuid::Uuid;
 use crate::common::alpaca::{AlpacaCredentials, ClientError, MarketDataClient, TradingClient};
 use crate::common::events::{self, Command, EventError};
 use crate::common::massive::MassiveClient;
-use crate::common::types::BarInterval;
+use crate::common::session_log::{Observation, PredictionsGenerated, SessionLog, SessionLogError};
+use crate::common::types::{BarInterval, SessionDate};
 use crate::data::bars::{self, CloseHistoryCache, HISTORY_LOOKBACK_DAYS};
-use crate::data::calendar::{CalendarCache, SessionDate, TradingCalendar};
+use crate::data::calendar::{CalendarCache, TradingCalendar};
 use crate::data::details;
 use crate::data::export;
 use crate::data::purge;
-use crate::data::session_log::{
-    self, Observation, PredictionsGenerated, SessionLog, SessionLogError,
-};
 use crate::data::universe::{UniverseCache, UniverseError};
 use crate::models::tide::{artifact, predict};
 use crate::portfolio::account;
@@ -557,13 +555,9 @@ async fn handle_market_data_sync(state: &ServiceState) -> Result<Value, HandlerE
 async fn handle_database_export(state: &ServiceState) -> Result<Value, HandlerError> {
     let today = SessionDate::at(Utc::now());
 
-    let sessions = session_log::export_session_logs(
-        &state.session_log,
-        &state.s3_client,
-        &state.bucket,
-        today,
-    )
-    .await;
+    let sessions =
+        export::export_session_logs(&state.session_log, &state.s3_client, &state.bucket, today)
+            .await;
     let session_log_summary = json!({
         "sessions_exported": sessions.exported.len(),
         "records_exported": sessions.total_records(),

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -191,15 +191,14 @@ impl Drop for CommandGuard<'_> {
 
 /// Dispatches one command, emitting its terminal event either way.
 ///
-/// A command already in flight is dropped with no *event*: the request it came from will be
-/// answered by the run that is already going, and emitting a second terminal outcome would make the
-/// recovery scan's "requested with no terminal outcome" test wrong. It is still recorded, because a
-/// drop and a crash are otherwise the same absence.
+/// A command already in flight is dropped with no *event*: the run already going will answer the
+/// request, and a second terminal outcome would make the recovery scan's "requested with no
+/// terminal outcome" test wrong. It is still recorded, because a drop and a crash are otherwise the
+/// same absence.
 pub async fn handle(state: &ServiceState, command: Command) {
     // Minted here rather than inside each handler, so the command's own record and everything it
     // did carry one identifier. That is what turns a duration into "where the time went".
     let correlation_id = Uuid::new_v4();
-    let now = Utc::now();
 
     let Some(_guard) = state.claim(command) else {
         warn!(
@@ -209,7 +208,7 @@ pub async fn handle(state: &ServiceState, command: Command) {
         record_command(
             state,
             correlation_id,
-            now,
+            Utc::now(),
             CommandFinished {
                 command: command.as_str().to_string(),
                 outcome: "dropped_in_flight".to_string(),
@@ -241,7 +240,7 @@ pub async fn handle(state: &ServiceState, command: Command) {
             record_command(
                 state,
                 correlation_id,
-                now,
+                Utc::now(),
                 CommandFinished {
                     command: command.as_str().to_string(),
                     outcome: completion_outcome(&summary),
@@ -265,7 +264,7 @@ pub async fn handle(state: &ServiceState, command: Command) {
             record_command(
                 state,
                 correlation_id,
-                now,
+                Utc::now(),
                 CommandFinished {
                     command: command.as_str().to_string(),
                     outcome: "errored".to_string(),

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use chrono::Datelike;
 use polars::prelude::*;
 
-use crate::data::calendar::SessionDate;
+use crate::common::types::SessionDate;
 use crate::data::details::UNKNOWN as UNKNOWN_SECTOR_OR_INDUSTRY;
 
 pub type CategoryMapping = HashMap<String, i32>;

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -575,9 +575,9 @@ pub async fn insert_predictions(
     predictions: &[serde_json::Value],
     correlation_id: Uuid,
     model_run_id: &str,
-) -> Result<u64, InsertPredictionsError> {
+) -> Result<(u64, Vec<EquityPrediction>), InsertPredictionsError> {
     if predictions.is_empty() {
-        return Ok(0);
+        return Ok((0, Vec::new()));
     }
 
     let validated: Vec<EquityPrediction> = predictions
@@ -620,7 +620,9 @@ pub async fn insert_predictions(
 
     transaction.commit().await?;
     info!(rows = rows_affected, "Predictions inserted into PostgreSQL");
-    Ok(rows_affected)
+    // Returned rather than reparsed by the caller: these are the exact values that were written,
+    // so the session log records what the database holds and not a second reading of the payload.
+    Ok((rows_affected, validated))
 }
 
 /// Loads the most recent prediction per ticker within a half-open instant range.

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -297,9 +297,9 @@ pub(crate) fn unscale_and_sort_quantiles(
 
 /// Timestamp for horizon step `step`, where step 0 is the Eastern session `now` falls in.
 ///
-/// Midnight *Eastern*, not UTC. The evaluation pass selects forecasts with
+/// Midnight *Eastern*, not UTC. The evaluation pass selects predictions with
 /// [`crate::data::calendar::eastern_day_bounds`], and a UTC midnight sits at 20:00 the previous
-/// Eastern day under daylight time -- so a UTC-stamped forecast lands in the wrong session's
+/// Eastern day under daylight time -- so a UTC-stamped prediction lands in the wrong session's
 /// window and the morning's inference run is never read by that day's passes.
 pub(crate) fn step_timestamp_milliseconds(now: chrono::DateTime<Utc>, step: usize) -> i64 {
     let session = SessionDate::at(now).plus_calendar_days(step as i64);
@@ -407,7 +407,7 @@ pub fn generate_predictions(
     }
 
     // Step 0 -- the coming close -- is the only horizon the book can act on: the pre-close
-    // liquidation flattens every position the same session, so a forecast further out describes a
+    // liquidation flattens every position the same session, so a prediction further out describes a
     // holding period this strategy never has. Selected explicitly rather than as the last step, so
     // widening `output_length` for research does not silently move the traded signal.
     let target_date = step_timestamp_milliseconds(now, 0);
@@ -628,7 +628,7 @@ pub async fn insert_predictions(
 /// Loads the most recent prediction per ticker within a half-open instant range.
 ///
 /// The range is the current session's Eastern day, so a pass on a morning when the pre-open
-/// inference failed reads nothing rather than reading yesterday's forecast as though it were
+/// inference failed reads nothing rather than reading yesterday's prediction as though it were
 /// today's. A stale artifact is acceptable and logged; a stale *prediction* silently presented as
 /// current is not, because nothing downstream carries the timestamp far enough to notice.
 ///
@@ -884,7 +884,7 @@ mod tests {
     fn test_predictions_are_visible_to_the_same_session_evaluation() {
         // The 09:00 Eastern run exists to feed the same session's evaluation passes, which select
         // rows with `eastern_day_bounds`. A stamp built at UTC midnight falls in the *previous*
-        // Eastern day's window -- 20:00 the day before, under EDT -- so the forecast written this
+        // Eastern day's window -- 20:00 the day before, under EDT -- so the prediction written this
         // morning is never the one read this afternoon.
         use crate::common::types::SessionDate;
 
@@ -904,7 +904,7 @@ mod tests {
             let (start, end) = SessionDate::at(now).bounds();
             assert!(
                 stamp >= start && stamp < end,
-                "{day}: forecast stamped {stamp} is outside the session window [{start}, {end})"
+                "{day}: prediction stamped {stamp} is outside the session window [{start}, {end})"
             );
         }
     }
@@ -932,7 +932,7 @@ mod tests {
     #[test]
     fn test_late_evening_eastern_still_stamps_the_current_session() {
         // 01:00Z is 21:00 the previous Eastern day. Stamping off the UTC date would jump the
-        // forecast a session forward, which is the failure this function exists to avoid.
+        // prediction a session forward, which is the failure this function exists to avoid.
         use crate::common::types::SessionDate;
 
         let now = chrono::DateTime::parse_from_rfc3339("2026-06-10T01:00:00Z")

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -11,8 +11,8 @@ use sqlx::PgPool;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::common::types::{EquityPrediction, Ticker};
-use crate::data::calendar::SessionDate;
+use crate::common::types::{EquityPrediction, SessionDate, Ticker};
+
 use crate::models::tide::artifact::ModelState;
 use crate::models::tide::data::{Data, DatasetKind};
 
@@ -884,7 +884,7 @@ mod tests {
         // rows with `eastern_day_bounds`. A stamp built at UTC midnight falls in the *previous*
         // Eastern day's window -- 20:00 the day before, under EDT -- so the forecast written this
         // morning is never the one read this afternoon.
-        use crate::data::calendar::SessionDate;
+        use crate::common::types::SessionDate;
 
         for day in [
             "2026-08-03",
@@ -911,7 +911,7 @@ mod tests {
     fn test_step_timestamp_step_zero_is_the_current_eastern_session() {
         // Step t is the Eastern session t days out, stamped at Eastern midnight. 15:30Z is 11:30
         // Eastern, so step 0 is that same session rather than the one UTC is already into.
-        use crate::data::calendar::SessionDate;
+        use crate::common::types::SessionDate;
 
         let now = chrono::DateTime::parse_from_rfc3339("2026-06-09T15:30:00Z")
             .unwrap()
@@ -931,7 +931,7 @@ mod tests {
     fn test_late_evening_eastern_still_stamps_the_current_session() {
         // 01:00Z is 21:00 the previous Eastern day. Stamping off the UTC date would jump the
         // forecast a session forward, which is the failure this function exists to avoid.
-        use crate::data::calendar::SessionDate;
+        use crate::common::types::SessionDate;
 
         let now = chrono::DateTime::parse_from_rfc3339("2026-06-10T01:00:00Z")
             .unwrap()
@@ -1274,7 +1274,7 @@ mod tests {
         // Compared against `eastern_midnight` rather than a fixed 86,400,000 ms stride: successive
         // Eastern midnights are 23 or 25 hours apart across a daylight-saving transition, so a
         // fixed stride asserts something that is only true away from March and November.
-        use crate::data::calendar::SessionDate;
+        use crate::common::types::SessionDate;
 
         let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
             .unwrap()
@@ -1298,7 +1298,7 @@ mod tests {
         // Eastern time springs forward 2026-03-08 and falls back 2026-11-01. Stepping across either
         // boundary must still land on the session's own midnight, which a fixed day-length stride
         // would miss by an hour in each direction.
-        use crate::data::calendar::SessionDate;
+        use crate::common::types::SessionDate;
 
         for (start, label) in [
             ("2026-03-06T17:00:00Z", "spring forward"),

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -122,6 +122,14 @@ pub async fn sync_account(
         activities.extend(fetched.activities);
     }
     let activities_stored = store_activities(pool, &activities).await?;
+    if activities_truncated || activities_undated > 0 {
+        warn!(
+            activities_truncated,
+            activities_undated,
+            %session_date,
+            "Alpaca activities are incomplete for this session"
+        );
+    }
 
     // Our own record of every activity, not just the ones the attribution used. Alpaca's retention
     // bounds how long these can be re-fetched, and `net_amount` — the only field saying how much a

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -25,8 +25,9 @@ use crate::common::alpaca::{
     AccountActivity, AccountSnapshot, ClientError, TradingClient, FILL_ACTIVITY_TYPE,
     TRANSFER_ACTIVITY_TYPES,
 };
-use crate::data::calendar::{SessionDate, TradingCalendar};
-use crate::data::session_log::{AccountObserved, Observation, SessionLog};
+use crate::common::session_log::{AccountObserved, Observation, SessionLog};
+use crate::common::types::SessionDate;
+use crate::data::calendar::TradingCalendar;
 use crate::portfolio::pairs::{self, ClosedPair, PairsError};
 
 /// The activity types this sync fetches and stores.

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -68,6 +68,11 @@ pub struct AccountSyncSummary {
     /// The previous trading session, when it has no snapshot — a hole in the equity series that a
     /// future time-weighted return cannot chain across.
     pub previous_session_gap: Option<SessionDate>,
+    /// True when Alpaca's pagination stopped at its bound, so this session's activities are
+    /// incomplete rather than merely few.
+    pub activities_truncated: bool,
+    /// Activities Alpaca sent with no usable timestamp, which cannot be stored at all.
+    pub activities_undated: usize,
 }
 
 /// Runs the whole post-close sync for one session date.
@@ -106,12 +111,15 @@ pub async fn sync_account(
     // One request per type: Alpaca puts the activity type in the URL path, and the sync already
     // tolerates several round trips.
     let mut activities = Vec::new();
+    let mut activities_truncated = false;
+    let mut activities_undated = 0;
     for activity_type in synced_activity_types() {
-        activities.extend(
-            client
-                .fetch_activities(activity_type, session_date.date())
-                .await?,
-        );
+        let fetched = client
+            .fetch_activities(activity_type, session_date.date())
+            .await?;
+        activities_truncated |= fetched.truncated;
+        activities_undated += fetched.undated;
+        activities.extend(fetched.activities);
     }
     let activities_stored = store_activities(pool, &activities).await?;
 
@@ -192,6 +200,8 @@ pub async fn sync_account(
         pairs_attributed,
         previous_session_gap,
         activities_unattributed: attribution.unattributed,
+        activities_truncated,
+        activities_undated,
     })
 }
 

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -73,6 +73,7 @@ pub async fn sync_account(
     pool: &PgPool,
     client: &TradingClient,
     session_log: &SessionLog,
+    correlation_id: uuid::Uuid,
     calendar: &TradingCalendar,
     session_date: SessionDate,
 ) -> Result<AccountSyncSummary, AccountError> {
@@ -84,7 +85,7 @@ pub async fn sync_account(
     // only moment they are observable at all.
     session_log
         .record(
-            uuid::Uuid::new_v4(),
+            correlation_id,
             Utc::now(),
             Observation::AccountObserved(AccountObserved {
                 // The session this describes, which a sync re-run after Eastern midnight would

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -25,7 +25,9 @@ use crate::common::alpaca::{
     AccountActivity, AccountSnapshot, ClientError, TradingClient, FILL_ACTIVITY_TYPE,
     TRANSFER_ACTIVITY_TYPES,
 };
-use crate::common::session_log::{AccountObserved, Observation, PairAttributed, SessionLog};
+use crate::common::session_log::{
+    AccountObserved, ActivityObserved, Observation, PairAttributed, SessionLog,
+};
 use crate::common::types::SessionDate;
 use crate::data::calendar::TradingCalendar;
 use crate::portfolio::pairs::{self, ClosedPair, PairsError};
@@ -112,6 +114,29 @@ pub async fn sync_account(
         );
     }
     let activities_stored = store_activities(pool, &activities).await?;
+
+    // Our own record of every activity, not just the ones the attribution used. Alpaca's retention
+    // bounds how long these can be re-fetched, and `net_amount` — the only field saying how much a
+    // deposit or withdrawal moved — reaches no other store this application owns.
+    for activity in &activities {
+        session_log
+            .record(
+                correlation_id,
+                Utc::now(),
+                Observation::ActivityObserved(ActivityObserved {
+                    activity_id: activity.id().to_string(),
+                    activity_type: activity.activity_type().to_string(),
+                    transaction_time: activity.transaction_time(),
+                    ticker: activity.ticker().map(|ticker| ticker.to_string()),
+                    side: activity.side().map(str::to_string),
+                    quantity: activity.shares().and_then(|shares| shares.to_f64()),
+                    price: activity.price().and_then(|price| price.to_f64()),
+                    net_amount: activity.net_amount().and_then(|amount| amount.to_f64()),
+                    order_id: activity.order_id().map(str::to_string),
+                }),
+            )
+            .await;
+    }
 
     let (start, end) = session_date.bounds();
     let closed = pairs::load_closed_between(pool, start, end).await?;

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -25,7 +25,7 @@ use crate::common::alpaca::{
     AccountActivity, AccountSnapshot, ClientError, TradingClient, FILL_ACTIVITY_TYPE,
     TRANSFER_ACTIVITY_TYPES,
 };
-use crate::common::session_log::{AccountObserved, Observation, SessionLog};
+use crate::common::session_log::{AccountObserved, Observation, PairAttributed, SessionLog};
 use crate::common::types::SessionDate;
 use crate::data::calendar::TradingCalendar;
 use crate::portfolio::pairs::{self, ClosedPair, PairsError};
@@ -126,7 +126,19 @@ pub async fn sync_account(
 
     let mut pairs_attributed = 0;
     for (id, amount) in &attribution.realized {
-        if pairs::record_realized_profit_and_loss(pool, *id, *amount).await? {
+        let updated = pairs::record_realized_profit_and_loss(pool, *id, *amount).await?;
+        session_log
+            .record(
+                correlation_id,
+                Utc::now(),
+                Observation::PairAttributed(PairAttributed {
+                    pair_uuid: id.to_string(),
+                    realized_profit_and_loss: amount.to_f64(),
+                    updated,
+                }),
+            )
+            .await;
+        if updated {
             pairs_attributed += 1;
         }
     }

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -18,8 +18,9 @@ use tracing::{debug, error, info, warn};
 
 use crate::common::alpaca::{ClientError, MarketDataClient, PriceSource, TradingClient};
 use crate::common::session_log::{
-    CandidateReading, EvaluationPass, ExcludedTickerReading, LiquidationRun, Observation,
-    OpenPairReading, PositionCloseRequested, PriceReading, ScreenInputReading, SessionLog,
+    CandidateReading, ExcludedTickerReading, LiquidationRun, Observation, OpenPairReading,
+    OpenPairsObserved, PassEvaluated, PositionCloseRequested, PriceReading, PricesObserved,
+    ScreenInputReading, SessionLog, UnavailablePrice, UniverseScreened,
 };
 use crate::common::types::{EquityPrediction, SessionDate, Ticker};
 use crate::data::calendar::TradingCalendar;
@@ -189,7 +190,11 @@ pub fn convergence_only(z_score: f64) -> Option<CloseReason> {
     (z_score <= CONVERGENCE_Z_SCORE).then_some(CloseReason::Convergence)
 }
 
-/// Runs one evaluation pass.
+/// Runs one evaluation pass, recording what it measured whether or not it finished.
+///
+/// The pass is written on every path out, failures included: a pass that died after pricing the
+/// book had already observed something, and discarding it leaves the log silent at exactly the
+/// moment it is worth reading.
 pub async fn run_pass(
     context: &EvaluationContext<'_>,
 ) -> Result<EvaluationSummary, EvaluationError> {
@@ -197,11 +202,33 @@ pub async fn run_pass(
     // That thread is what turns "the session lost money" into "it was lost at sizing" or "it was
     // lost at execution".
     let correlation_id = uuid::Uuid::new_v4();
-    let mut summary = EvaluationSummary::default();
-    let mut observation = EvaluationPass {
+    let mut observation = PassEvaluated {
         universe_size: context.universe.len(),
-        ..EvaluationPass::default()
+        ..PassEvaluated::default()
     };
+
+    let result = evaluate_pass(context, correlation_id, &mut observation).await;
+    if let Err(error) = &result {
+        observation.failure = Some(error.to_string());
+    }
+    context
+        .session_log
+        .record(
+            correlation_id,
+            context.now,
+            Observation::PassEvaluated(Box::new(observation)),
+        )
+        .await;
+    result
+}
+
+/// The pass itself, free to propagate: [`run_pass`] records the observation either way.
+async fn evaluate_pass(
+    context: &EvaluationContext<'_>,
+    correlation_id: uuid::Uuid,
+    observation: &mut PassEvaluated,
+) -> Result<EvaluationSummary, EvaluationError> {
+    let mut summary = EvaluationSummary::default();
     let execution = ExecutionContext {
         client: context.trading,
         settings: context.execution,
@@ -215,14 +242,20 @@ pub async fn run_pass(
 
     // --- exits, unconditionally ---
 
-    let mut prices = fetch_prices(context.market_data, &leg_symbols(&open_pairs)).await?;
+    let mut prices = fetch_prices(
+        context,
+        correlation_id,
+        "open_pairs",
+        &leg_symbols(&open_pairs),
+    )
+    .await?;
     let closed = close_what_should_close(
         context,
         &execution,
+        correlation_id,
         &open_pairs,
         &prices,
         &mut summary,
-        &mut observation,
     )
     .await?;
 
@@ -267,15 +300,12 @@ pub async fn run_pass(
         info!(block = block.as_str(), reason = %block, "Entry half skipped");
         summary.entries_blocked = Some(format!("{}: {block}", block.as_str()));
         observation.session_block = summary.entries_blocked.clone();
-        record_pass(context, correlation_id, &mut observation, &prices).await;
         return Ok(summary);
     }
 
-    let screened = build_screen_inputs(context, &held, &mut prices).await?;
+    let screened = build_screen_inputs(context, correlation_id, &held, &mut prices).await?;
     observation.predictions_available = screened.predictions_available;
     observation.eligible_tickers = screened.eligible;
-    observation.screen_inputs = screened.readings.clone();
-    observation.excluded = screened.excluded.clone();
 
     let candidates = screen::score_candidates(&screened.inputs);
     summary.candidates_screened = candidates.len();
@@ -402,7 +432,6 @@ pub async fn run_pass(
     observation
         .candidates
         .sort_by(|left, right| left.pair_id.cmp(&right.pair_id));
-    record_pass(context, correlation_id, &mut observation, &prices).await;
 
     info!(
         closed = summary.pairs_closed.len(),
@@ -411,27 +440,6 @@ pub async fn run_pass(
         "Evaluation pass complete"
     );
     Ok(summary)
-}
-
-/// Writes the pass observation, attaching every price it read.
-///
-/// Called on both paths out of a pass, including the one the risk gate blocks: those two look
-/// identical in a count and are very different days.
-async fn record_pass(
-    context: &EvaluationContext<'_>,
-    correlation_id: uuid::Uuid,
-    observation: &mut EvaluationPass,
-    prices: &HashMap<Ticker, ReferencePrice>,
-) {
-    observation.prices = price_readings(prices);
-    context
-        .session_log
-        .record(
-            correlation_id,
-            context.now,
-            Observation::EvaluationPass(Box::new(std::mem::take(observation))),
-        )
-        .await;
 }
 
 /// What the pre-close liquidation did.
@@ -546,31 +554,29 @@ fn leg_symbols(open_pairs: &[OpenPair]) -> Vec<String> {
     tickers.iter().map(|ticker| ticker.to_string()).collect()
 }
 
-/// Fetches reference prices for a symbol list, keyed by ticker.
+/// Fetches reference prices for a symbol list, keyed by ticker, and records the reading.
 ///
 /// Symbols Alpaca returns with no usable price are simply absent from the map. The callers treat an
-/// absent price as "no reading", never as zero.
+/// absent price as "no reading", never as zero — and the record names them, so an absence has a
+/// cause rather than only a gap.
 async fn fetch_prices(
-    client: &MarketDataClient,
+    context: &EvaluationContext<'_>,
+    correlation_id: uuid::Uuid,
+    purpose: &str,
     symbols: &[String],
 ) -> Result<HashMap<Ticker, ReferencePrice>, EvaluationError> {
     if symbols.is_empty() {
         return Ok(HashMap::new());
     }
-    let snapshots = client.fetch_snapshots(symbols).await?;
-    Ok(snapshots
+    let snapshots = context.market_data.fetch_snapshots(symbols).await?;
+    let prices: HashMap<Ticker, ReferencePrice> = snapshots
         .into_iter()
         .filter_map(|snapshot| {
             let (price, source) = snapshot.reference_price_with_source()?;
             Some((snapshot.ticker().clone(), ReferencePrice { price, source }))
         })
-        .collect())
-}
+        .collect();
 
-/// Every price the pass used, as rows for the session log.
-///
-/// Recorded once at pass level, so rows sharing a leg are provably reading the same number.
-fn price_readings(prices: &HashMap<Ticker, ReferencePrice>) -> Vec<PriceReading> {
     let mut readings: Vec<PriceReading> = prices
         .iter()
         .map(|(ticker, reference)| PriceReading {
@@ -580,7 +586,34 @@ fn price_readings(prices: &HashMap<Ticker, ReferencePrice>) -> Vec<PriceReading>
         })
         .collect();
     readings.sort_by(|left, right| left.ticker.cmp(&right.ticker));
-    readings
+
+    let mut unavailable: Vec<UnavailablePrice> = symbols
+        .iter()
+        .filter(|symbol| {
+            !prices
+                .keys()
+                .any(|ticker| ticker.as_str() == symbol.as_str())
+        })
+        .map(|symbol| UnavailablePrice {
+            ticker: symbol.clone(),
+            cause: "no_quote".to_string(),
+        })
+        .collect();
+    unavailable.sort_by(|left, right| left.ticker.cmp(&right.ticker));
+
+    context
+        .session_log
+        .record(
+            correlation_id,
+            context.now,
+            Observation::PricesObserved(PricesObserved {
+                purpose: purpose.to_string(),
+                readings,
+                unavailable,
+            }),
+        )
+        .await;
+    Ok(prices)
 }
 
 /// Prices the open book and closes whatever the spread says to close.
@@ -591,10 +624,10 @@ fn price_readings(prices: &HashMap<Ticker, ReferencePrice>) -> Vec<PriceReading>
 async fn close_what_should_close(
     context: &EvaluationContext<'_>,
     execution: &ExecutionContext<'_>,
+    correlation_id: uuid::Uuid,
     open_pairs: &[OpenPair],
     prices: &HashMap<Ticker, ReferencePrice>,
     summary: &mut EvaluationSummary,
-    observation: &mut EvaluationPass,
 ) -> Result<HashSet<uuid::Uuid>, EvaluationError> {
     let models = screen::exit_models(
         open_pairs
@@ -604,6 +637,7 @@ async fn close_what_should_close(
     );
 
     let mut closed = HashSet::new();
+    let mut readings: Vec<OpenPairReading> = Vec::with_capacity(open_pairs.len());
     for pair in open_pairs {
         // Filled in as the pair is measured and pushed on every path out of the iteration, so a
         // pair that could not be priced is as visible in the log as one that closed.
@@ -630,13 +664,13 @@ async fn close_what_should_close(
             summary.pairs_unpriced += 1;
             warn!(pair_id = %pair.pair_id(), "Open pair could not be priced this pass");
             reading.decision = "unpriced".to_string();
-            observation.open_pairs.push(reading);
+            readings.push(reading);
             continue;
         };
         let Some(model) = models.get(pair.pair_id()) else {
             warn!(pair_id = %pair.pair_id(), "Open pair has no rebuildable spread model");
             reading.decision = "no_spread_model".to_string();
-            observation.open_pairs.push(reading);
+            readings.push(reading);
             continue;
         };
 
@@ -646,7 +680,7 @@ async fn close_what_should_close(
 
         let Some(z_score) = model.z_score(long_price.price, short_price.price) else {
             reading.decision = "unreadable_spread".to_string();
-            observation.open_pairs.push(reading);
+            readings.push(reading);
             continue;
         };
         reading.z_score = Some(z_score);
@@ -698,7 +732,7 @@ async fn close_what_should_close(
             convergence_only(z_score)
         };
         let Some(mut reason) = reason else {
-            observation.open_pairs.push(reading);
+            readings.push(reading);
             continue;
         };
 
@@ -723,7 +757,7 @@ async fn close_what_should_close(
                 );
                 summary.exits_failed.push(pair.pair_id().to_string());
                 reading.decision = "close_failed".to_string();
-                observation.open_pairs.push(reading);
+                readings.push(reading);
                 continue;
             }
         };
@@ -734,12 +768,21 @@ async fn close_what_should_close(
 
         closed.insert(pair.id());
         reading.decision = reason.as_str().to_string();
-        observation.open_pairs.push(reading);
+        readings.push(reading);
         summary.pairs_closed.push(ClosedRecord {
             pair_id: pair.pair_id().to_string(),
             reason: reason.as_str().to_string(),
         });
     }
+
+    context
+        .session_log
+        .record(
+            correlation_id,
+            context.now,
+            Observation::OpenPairsObserved(OpenPairsObserved { readings }),
+        )
+        .await;
     Ok(closed)
 }
 
@@ -779,15 +822,11 @@ async fn previous_session_equity(
 /// The screen's inputs, and the model run they came from.
 struct ScreenedUniverse {
     inputs: Vec<ScreenInput>,
-    /// Forecasts that passed the eligibility filter, before pricing removed any.
+    /// Predictions that passed the eligibility filter, before pricing removed any.
     eligible: usize,
-    /// The same inputs as session-log rows: what the model offered, as the screen received it.
-    readings: Vec<ScreenInputReading>,
-    /// Every forecast the funnel removed, with the first test it failed.
-    excluded: Vec<ExcludedTickerReading>,
     model_run_id: Option<String>,
-    /// Forecasts the session had before any eligibility test, for the session log. The gap between
-    /// this and `inputs.len()` is how much the filters removed.
+    /// Predictions the session had before any eligibility test, for the session log. The gap
+    /// between this and `inputs.len()` is how much the filters removed.
     predictions_available: usize,
     /// Every ticker's sector, not just the screened ones. `select_disjoint` needs the held legs
     /// too, and those are filtered out of `inputs` before it ever sees them.
@@ -795,8 +834,12 @@ struct ScreenedUniverse {
 }
 
 /// Assembles the screen's inputs, fetching only the prices the exit half did not already have.
+///
+/// Records the funnel — what reached the screen and what each removed ticker failed on — before
+/// returning, so the reading exists whether or not the rest of the pass completes.
 async fn build_screen_inputs(
     context: &EvaluationContext<'_>,
+    correlation_id: uuid::Uuid,
     held: &HashSet<Ticker>,
     prices: &mut HashMap<Ticker, ReferencePrice>,
 ) -> Result<ScreenedUniverse, EvaluationError> {
@@ -807,8 +850,6 @@ async fn build_screen_inputs(
         return Ok(ScreenedUniverse {
             inputs: Vec::new(),
             eligible: 0,
-            readings: Vec::new(),
-            excluded: Vec::new(),
             model_run_id: None,
             predictions_available: 0,
             sectors: HashMap::new(),
@@ -866,7 +907,7 @@ async fn build_screen_inputs(
         .filter(|prediction| !prices.contains_key(prediction.ticker()))
         .map(|prediction| prediction.ticker().to_string())
         .collect();
-    prices.extend(fetch_prices(context.market_data, &missing).await?);
+    prices.extend(fetch_prices(context, correlation_id, "screen_candidates", &missing).await?);
 
     let mut inputs: Vec<ScreenInput> = Vec::with_capacity(eligible.len());
     let mut readings: Vec<ScreenInputReading> = Vec::with_capacity(eligible.len());
@@ -913,11 +954,20 @@ async fn build_screen_inputs(
         window = CORRELATION_WINDOW_SESSIONS,
         "Screen inputs assembled"
     );
+    context
+        .session_log
+        .record(
+            correlation_id,
+            context.now,
+            Observation::UniverseScreened(UniverseScreened {
+                inputs: readings,
+                excluded,
+            }),
+        )
+        .await;
     Ok(ScreenedUniverse {
         inputs,
         eligible: eligible.len(),
-        readings,
-        excluded,
         model_run_id,
         predictions_available: predictions.len(),
         sectors,

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -17,13 +17,13 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::common::alpaca::{ClientError, MarketDataClient, PriceSource, TradingClient};
-use crate::common::types::{EquityPrediction, Ticker};
-use crate::data::calendar::{SessionDate, TradingCalendar};
-use crate::data::details::{self, DetailsError};
-use crate::data::session_log::{
+use crate::common::session_log::{
     CandidateReading, EvaluationPass, ExcludedTickerReading, LiquidationRun, Observation,
     OpenPairReading, PositionCloseRequested, PriceReading, ScreenInputReading, SessionLog,
 };
+use crate::common::types::{EquityPrediction, SessionDate, Ticker};
+use crate::data::calendar::TradingCalendar;
+use crate::data::details::{self, DetailsError};
 use crate::data::universe::Universe;
 use crate::models::tide::predict;
 use crate::portfolio::account::{self, AccountError};

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -19,8 +19,8 @@ use tracing::{debug, error, info, warn};
 use crate::common::alpaca::{ClientError, MarketDataClient, PriceSource, TradingClient};
 use crate::common::session_log::{
     CandidateReading, ExcludedTickerReading, LiquidationRun, Observation, OpenPairReading,
-    OpenPairsObserved, PassEvaluated, PositionCloseRequested, PriceReading, PricesObserved,
-    ScreenInputReading, SessionLog, UnavailablePrice, UniverseScreened,
+    OpenPairsObserved, PairClosed, PairOpened, PassEvaluated, PositionCloseRequested, PriceReading,
+    PricesObserved, ScreenInputReading, SessionLog, UnavailablePrice, UniverseScreened,
 };
 use crate::common::types::{EquityPrediction, SessionDate, Ticker};
 use crate::data::calendar::TradingCalendar;
@@ -397,8 +397,10 @@ async fn evaluate_pass(
                 // so no later pass can exit it on a signal. The pre-close liquidation is the
                 // backstop, which is why it flattens the *account* rather than known pairs; this
                 // log is what makes the pair reconstructable by hand before then.
-                if let Err(error) = pairs::record_open(context.pool, &entry, context.now).await {
-                    error!(
+                let pair_uuid = match pairs::record_open(context.pool, &entry, context.now).await {
+                    Ok(pair_uuid) => pair_uuid,
+                    Err(error) => {
+                        error!(
                         pair_id = %entry.pair_id(),
                         long_ticker = %long_fill.ticker(),
                         long_shares = long_fill.shares(),
@@ -406,12 +408,32 @@ async fn evaluate_pass(
                         short_ticker = %short_fill.ticker(),
                         short_shares = short_fill.shares(),
                         short_price = short_fill.average_price(),
-                        %error,
-                        "Pair filled at the broker but could not be recorded; the position is live \
-                         with no pair row and will be flattened by the pre-close liquidation"
-                    );
-                    return Err(error.into());
-                }
+                            %error,
+                            "Pair filled at the broker but could not be recorded; the position is \
+                             live with no pair row and will be flattened by the pre-close \
+                             liquidation"
+                        );
+                        return Err(error.into());
+                    }
+                };
+                context
+                    .session_log
+                    .record(
+                        correlation_id,
+                        context.now,
+                        Observation::PairOpened(PairOpened {
+                            pair_uuid: pair_uuid.to_string(),
+                            pair_id: entry.pair_id().to_string(),
+                            long_ticker: entry.long_ticker().to_string(),
+                            short_ticker: entry.short_ticker().to_string(),
+                            hedge_ratio: entry.hedge_ratio(),
+                            entry_z_score: entry.entry_z_score(),
+                            signal_strength: entry.signal_strength(),
+                            model_run_id: entry.model_run_id().map(str::to_string),
+                            opened_at: context.now,
+                        }),
+                    )
+                    .await;
                 if let Some(reading) = candidate_decisions.get_mut(entry.pair_id().as_str()) {
                     reading.decision = "opened".to_string();
                 }
@@ -513,7 +535,20 @@ pub async fn run_liquidation(
             summary.pairs_still_open.push(pair.pair_id().to_string());
             continue;
         }
-        if pairs::record_close(pool, pair.id(), CloseReason::EndOfDay, now).await? {
+        let updated = pairs::record_close(pool, pair.id(), CloseReason::EndOfDay, now).await?;
+        session_log
+            .record(
+                correlation_id,
+                now,
+                Observation::PairClosed(PairClosed {
+                    pair_uuid: pair.id().to_string(),
+                    reason: CloseReason::EndOfDay.as_str().to_string(),
+                    closed_at: now,
+                    updated,
+                }),
+            )
+            .await;
+        if updated {
             summary.pairs_closed += 1;
         }
     }
@@ -766,7 +801,20 @@ async fn close_what_should_close(
         if outcome.was_already_gone() {
             reason = CloseReason::PositionMissing;
         }
-        pairs::record_close(context.pool, pair.id(), reason, context.now).await?;
+        let updated = pairs::record_close(context.pool, pair.id(), reason, context.now).await?;
+        context
+            .session_log
+            .record(
+                correlation_id,
+                context.now,
+                Observation::PairClosed(PairClosed {
+                    pair_uuid: pair.id().to_string(),
+                    reason: reason.as_str().to_string(),
+                    closed_at: context.now,
+                    updated,
+                }),
+            )
+            .await;
 
         closed.insert(pair.id());
         reading.decision = reason.as_str().to_string();

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -685,6 +685,40 @@ async fn close_what_should_close(
     prices: &HashMap<Ticker, ReferencePrice>,
     summary: &mut EvaluationSummary,
 ) -> Result<HashSet<uuid::Uuid>, EvaluationError> {
+    let mut readings: Vec<OpenPairReading> = Vec::with_capacity(open_pairs.len());
+    let result = close_and_measure(
+        context,
+        execution,
+        open_pairs,
+        prices,
+        summary,
+        &mut readings,
+    )
+    .await;
+
+    context
+        .session_log
+        .record(
+            correlation_id,
+            context.now,
+            Observation::OpenPairsObserved(OpenPairsObserved { readings }),
+        )
+        .await;
+    result
+}
+
+/// The exit loop itself, free to propagate: [`close_what_should_close`] records either way.
+///
+/// Every path out of an iteration pushes its reading first, so a pair measured before the failure
+/// is as visible as one measured after it.
+async fn close_and_measure(
+    context: &EvaluationContext<'_>,
+    execution: &ExecutionContext<'_>,
+    open_pairs: &[OpenPair],
+    prices: &HashMap<Ticker, ReferencePrice>,
+    summary: &mut EvaluationSummary,
+    readings: &mut Vec<OpenPairReading>,
+) -> Result<HashSet<uuid::Uuid>, EvaluationError> {
     let models = screen::exit_models(
         open_pairs
             .iter()
@@ -693,7 +727,6 @@ async fn close_what_should_close(
     );
 
     let mut closed = HashSet::new();
-    let mut readings: Vec<OpenPairReading> = Vec::with_capacity(open_pairs.len());
     for pair in open_pairs {
         // Filled in as the pair is measured and pushed on every path out of the iteration, so a
         // pair that could not be priced is as visible in the log as one that closed.
@@ -820,11 +853,19 @@ async fn close_what_should_close(
         if outcome.was_already_gone() {
             reason = CloseReason::PositionMissing;
         }
-        let updated = pairs::record_close(context.pool, pair.id(), reason, context.now).await?;
+        let updated = match pairs::record_close(context.pool, pair.id(), reason, context.now).await
+        {
+            Ok(updated) => updated,
+            Err(error) => {
+                reading.decision = "close_failed".to_string();
+                readings.push(reading);
+                return Err(error.into());
+            }
+        };
         context
             .session_log
             .record(
-                correlation_id,
+                execution.correlation_id,
                 context.now,
                 Observation::PairClosed(PairClosed {
                     pair_uuid: pair.id().to_string(),
@@ -843,15 +884,6 @@ async fn close_what_should_close(
             reason: reason.as_str().to_string(),
         });
     }
-
-    context
-        .session_log
-        .record(
-            correlation_id,
-            context.now,
-            Observation::OpenPairsObserved(OpenPairsObserved { readings }),
-        )
-        .await;
     Ok(closed)
 }
 

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -73,6 +73,8 @@ pub struct EvaluationContext<'a> {
     pub execution: ExecutionSettings,
     /// Where the pass records what it observed before acting on it.
     pub session_log: &'a SessionLog,
+    /// The dispatching command's identifier, carried onto every order the pass sends.
+    pub correlation_id: uuid::Uuid,
     /// Cancelled when the process is asked to stop.
     ///
     /// Checked between pairs in the entry half so the pass stops *starting* positions it could not
@@ -198,10 +200,10 @@ pub fn convergence_only(z_score: f64) -> Option<CloseReason> {
 pub async fn run_pass(
     context: &EvaluationContext<'_>,
 ) -> Result<EvaluationSummary, EvaluationError> {
-    // One identifier for the pass, carried onto every order it sends and every fill they produce.
-    // That thread is what turns "the session lost money" into "it was lost at sizing" or "it was
-    // lost at execution".
-    let correlation_id = uuid::Uuid::new_v4();
+    // The command's identifier, carried onto every order the pass sends and every fill they
+    // produce. That thread is what turns "the session lost money" into "it was lost at sizing" or
+    // "it was lost at execution".
+    let correlation_id = context.correlation_id;
     let mut observation = PassEvaluated {
         universe_size: context.universe.len(),
         ..PassEvaluated::default()
@@ -462,9 +464,9 @@ pub async fn run_liquidation(
     pool: &PgPool,
     client: &TradingClient,
     session_log: &SessionLog,
+    correlation_id: uuid::Uuid,
     now: DateTime<Utc>,
 ) -> Result<LiquidationSummary, EvaluationError> {
-    let correlation_id = uuid::Uuid::new_v4();
     let outcomes = client.close_all_positions().await?;
 
     // One record per position, not just the totals. The bulk close is the only path that touches

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -143,7 +143,7 @@ pub struct EvaluationSummary {
     pub entries_blocked: Option<String>,
     /// Why individual candidates were refused, if any were.
     pub entries_refused: Vec<String>,
-    /// The model run the session's forecasts came from.
+    /// The model run the session's predictions came from.
     ///
     /// Recorded on the pass rather than only on the pair, so a session that opened nothing still
     /// says which model it was deciding with. That is the difference between "the model saw no
@@ -293,7 +293,7 @@ async fn evaluate_pass(
     // Before the gate, not after. A pass blocked by drawdown, capacity, or the hold window is the
     // most common way a session opens nothing, and those are exactly the rows where "which model
     // was deciding" matters — the difference between the model seeing no opportunity and the model
-    // being three days old. Only the identifier is read here; the forecasts themselves stay behind
+    // being three days old. Only the identifier is read here; the predictions themselves stay behind
     // the gate, so a blocked pass still does not pay for the screen.
     summary.model_run_id = current_model_run_id(context).await?;
     observation.model_run_id = summary.model_run_id.clone();
@@ -855,7 +855,7 @@ async fn close_what_should_close(
     Ok(closed)
 }
 
-/// The model run behind the current session's forecasts, without loading the forecasts.
+/// The model run behind the current session's predictions, without loading them.
 ///
 /// One row rather than seven thousand, so this is cheap enough to run before the risk gate on every
 /// pass. See the call site for why it belongs there.
@@ -925,7 +925,7 @@ async fn build_screen_inputs(
         });
     }
 
-    // The newest forecast's run, not the first row's. A re-run leaves a mixed batch, and "whichever
+    // The newest prediction's run, not the first row's. A re-run leaves a mixed batch, and "whichever
     // ticker sorted first" is not an answer worth recording.
     let model_run_id = predictions
         .iter()
@@ -934,9 +934,9 @@ async fn build_screen_inputs(
 
     let sectors = details::load_sectors(context.pool).await?;
 
-    // Only forecasts that can produce a candidate: in the universe, with a sector, with enough
+    // Only predictions that can produce a candidate: in the universe, with a sector, with enough
     // history, and not already on the book. Every test here is a set lookup, because this runs once
-    // per forecast on a pass that runs every five minutes.
+    // per prediction on a pass that runs every five minutes.
     //
     // The sector test survives the removal of the different-sector rule, for a new reason. A ticker
     // whose sector is unknown cannot be counted against `MAXIMUM_LEGS_PER_SECTOR`, so admitting one

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -18,7 +18,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::common::alpaca::{ClientError, MarketDataClient, PriceSource, TradingClient};
 use crate::common::session_log::{
-    CandidateReading, ExcludedTickerReading, LiquidationRun, Observation, OpenPairReading,
+    CandidateReading, ExcludedTickerReading, LiquidationAttempted, Observation, OpenPairReading,
     OpenPairsObserved, PairClosed, PairOpened, PassEvaluated, PositionCloseRequested, PriceReading,
     PricesObserved, ScreenInputReading, SessionLog, UnavailablePrice, UniverseScreened,
 };
@@ -489,6 +489,33 @@ pub async fn run_liquidation(
     correlation_id: uuid::Uuid,
     now: DateTime<Utc>,
 ) -> Result<LiquidationSummary, EvaluationError> {
+    let mut summary = LiquidationSummary::default();
+    let result = liquidate(pool, client, session_log, correlation_id, now, &mut summary).await;
+
+    session_log
+        .record(
+            correlation_id,
+            now,
+            Observation::LiquidationAttempted(LiquidationAttempted {
+                pairs_closed: summary.pairs_closed,
+                positions_refused: summary.positions_refused,
+                pairs_still_open: summary.pairs_still_open.clone(),
+                failure: result.as_ref().err().map(ToString::to_string),
+            }),
+        )
+        .await;
+    result.map(|()| summary)
+}
+
+/// The flattening itself, free to propagate: [`run_liquidation`] records it either way.
+async fn liquidate(
+    pool: &PgPool,
+    client: &TradingClient,
+    session_log: &SessionLog,
+    correlation_id: uuid::Uuid,
+    now: DateTime<Utc>,
+    summary: &mut LiquidationSummary,
+) -> Result<(), EvaluationError> {
     let outcomes = client.close_all_positions().await?;
 
     // One record per position, not just the totals. The bulk close is the only path that touches
@@ -521,10 +548,7 @@ pub async fn run_liquidation(
         .map(|outcome| outcome.ticker().clone())
         .collect();
 
-    let mut summary = LiquidationSummary {
-        positions_refused: refused.len(),
-        ..Default::default()
-    };
+    summary.positions_refused = refused.len();
 
     for pair in pairs::load_open_pairs(pool).await? {
         if refused.contains(pair.long_ticker()) || refused.contains(pair.short_ticker()) {
@@ -564,19 +588,7 @@ pub async fn run_liquidation(
             "Liquidation did not flatten the book"
         );
     }
-
-    session_log
-        .record(
-            correlation_id,
-            now,
-            Observation::LiquidationRun(LiquidationRun {
-                pairs_closed: summary.pairs_closed,
-                positions_refused: summary.positions_refused,
-                pairs_still_open: summary.pairs_still_open.clone(),
-            }),
-        )
-        .await;
-    Ok(summary)
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -605,9 +617,11 @@ async fn fetch_prices(
     if symbols.is_empty() {
         return Ok(HashMap::new());
     }
-    let snapshots = context.market_data.fetch_snapshots(symbols).await?;
-    let prices: HashMap<Ticker, ReferencePrice> = snapshots
-        .into_iter()
+    let fetched = context.market_data.fetch_snapshots(symbols).await?;
+    let failed: HashSet<&str> = fetched.failed_symbols.iter().map(String::as_str).collect();
+    let prices: HashMap<Ticker, ReferencePrice> = fetched
+        .snapshots
+        .iter()
         .filter_map(|snapshot| {
             let (price, source) = snapshot.reference_price_with_source()?;
             Some((snapshot.ticker().clone(), ReferencePrice { price, source }))
@@ -633,7 +647,12 @@ async fn fetch_prices(
         })
         .map(|symbol| UnavailablePrice {
             ticker: symbol.clone(),
-            cause: "no_quote".to_string(),
+            cause: if failed.contains(symbol.as_str()) {
+                "chunk_failed"
+            } else {
+                "no_quote"
+            }
+            .to_string(),
         })
         .collect();
     unavailable.sort_by(|left, right| left.ticker.cmp(&right.ticker));

--- a/src/portfolio/execute.rs
+++ b/src/portfolio/execute.rs
@@ -15,10 +15,10 @@ use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::common::alpaca::{ClientError, OrderIntent, OrderState, PositionClose, TradingClient};
-use crate::common::types::Ticker;
-use crate::data::session_log::{
+use crate::common::session_log::{
     Observation, OrderResolved, OrderSubmitted, PositionCloseRequested, SessionLog,
 };
+use crate::common::types::Ticker;
 use crate::portfolio::pairs::PairEntry;
 use crate::portfolio::size::SizedPair;
 

--- a/src/portfolio/pairs.rs
+++ b/src/portfolio/pairs.rs
@@ -144,7 +144,7 @@ impl PairEntry {
                 value: entry_z_score,
             });
         }
-        // Strictly positive, matching `PairCandidate::new`. Zero means the forecast is neutral
+        // Strictly positive, matching `PairCandidate::new`. Zero means the prediction is neutral
         // between the legs, which `screen::orient` already refuses — so accepting it here would let
         // a future call site build a `PairEntry` the screen would never have produced.
         if !signal_strength.is_finite() || signal_strength <= 0.0 {
@@ -541,7 +541,7 @@ mod tests {
         assert!(PairEntry::new(pair(), 1.0, 2.5, 0.1, None).is_ok());
     }
 
-    /// Zero is rejected as well as negative. A neutral forecast is not a reason to hold a pair, and
+    /// Zero is rejected as well as negative. A neutral prediction is not a reason to hold a pair, and
     /// `PairCandidate::new` already refuses it — the two validators have to agree or a future call
     /// site could build an entry the screen would never have produced.
     #[test]

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -383,7 +383,7 @@ impl PairCandidate {
 /// 4. The model agrees with that orientation — it expects the long leg to out-return the short.
 ///
 /// Test four is the model doing more than gating eligibility: without it a pair can open whose
-/// spread says buy A and sell B while the forecast says the opposite.
+/// spread says buy A and sell B while the prediction says the opposite.
 ///
 /// **Sector is not tested here.** A same-sector spread is the canonical statistical arbitrage
 /// trade — two companies facing the same demand, the same input costs, and the same regulator,
@@ -976,7 +976,7 @@ mod tests {
         }
     }
 
-    /// The spread says buy AAAA and sell BBBB; the forecast says the opposite. Opening on that is a
+    /// The spread says buy AAAA and sell BBBB; the prediction says the opposite. Opening on that is a
     /// position whose two justifications cancel.
     #[test]
     fn test_a_pair_the_model_disagrees_with_is_not_opened() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,7 +8,7 @@
 #![allow(dead_code)]
 
 use chrono::{DateTime, Utc};
-use fund::data::calendar::SessionDate;
+
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -324,3 +324,4 @@ pub async fn seed_predictions(
         .expect("Failed to seed a prediction");
     }
 }
+use fund::common::types::SessionDate;

--- a/tests/test_dashboard.rs
+++ b/tests/test_dashboard.rs
@@ -173,7 +173,7 @@ async fn test_the_dashboard_reads_what_the_service_writes() {
     assert_eq!(data.period_returns.one_day, Some(1.0));
 
     assert_eq!(data.predictions.len(), 2);
-    // Ranked by median forecast, so the positive one leads.
+    // Ranked by median prediction, so the positive one leads.
     assert_eq!(data.predictions[0].ticker.as_str(), "AAPL");
     assert_eq!(
         data.prediction_model_run_id.as_deref(),

--- a/tests/test_dashboard.rs
+++ b/tests/test_dashboard.rs
@@ -15,9 +15,9 @@ mod common;
 use chrono::{Duration, Utc};
 use fund::common::alpaca::AccountSnapshot;
 use fund::common::events::{self, Command, EventType, Outcome};
-use fund::common::types::{PairID, Ticker};
+use fund::common::types::{PairID, SessionDate, Ticker};
 use fund::dashboard::database::fetch_dashboard_data;
-use fund::data::calendar::SessionDate;
+
 use fund::portfolio::account;
 use fund::portfolio::pairs::{self, CloseReason, PairEntry};
 use rust_decimal::Decimal;

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -420,8 +420,8 @@ async fn test_aligned_closes_reads_only_the_requested_interval() {
     assert_eq!(closes[&ticker("AAAA")], vec![100.0]);
 }
 
-/// The pass reads only the current session's forecasts. Reading yesterday's when this morning's
-/// inference failed would present a stale forecast as current, and nothing downstream carries the
+/// The pass reads only the current session's predictions. Reading yesterday's when this morning's
+/// inference failed would present a stale prediction as current, and nothing downstream carries the
 /// timestamp far enough to notice.
 #[tokio::test]
 #[serial]
@@ -447,7 +447,7 @@ async fn test_predictions_are_bounded_to_the_session_window() {
     assert_eq!(loaded[0].model_run_id(), "run-today");
 }
 
-/// One row per ticker, the newest. A re-run leaves two forecasts for the same symbol, and feeding
+/// One row per ticker, the newest. A re-run leaves two predictions for the same symbol, and feeding
 /// both into the screen would let one ticker appear on both legs of the same pair.
 #[tokio::test]
 #[serial]

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -15,9 +15,9 @@ mod common;
 
 use chrono::{Duration, NaiveDate, Utc};
 use fund::common::events::{self, Command, EventType, Outcome};
-use fund::common::types::{BarInterval, PairID, Ticker};
+use fund::common::types::{BarInterval, PairID, SessionDate, Ticker};
 use fund::data::bars;
-use fund::data::calendar::SessionDate;
+
 use fund::models::tide::predict;
 use fund::portfolio::account;
 use fund::portfolio::pairs::{self, CloseReason, PairEntry};

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -288,12 +288,16 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
     // The pass is only useful to a replay if the observation reached the disk. One evaluation
     // record, and one submission and one resolution per leg, all threaded by the pass's identifier.
     let records = recorded(&session_log);
-    let passes = of_type(&records, "evaluation_pass");
+    let passes = of_type(&records, "pass_evaluated");
     assert_eq!(passes.len(), 1, "one record per pass");
     let pass = &passes[0];
     let correlation_id = pass["correlation_id"]
         .as_str()
         .expect("a pass is correlated");
+    assert!(
+        pass["payload"]["failure"].is_null(),
+        "a pass that completed records no failure"
+    );
 
     assert_eq!(pass["payload"]["candidates"].as_array().unwrap().len(), 1);
     let candidate = &pass["payload"]["candidates"][0];
@@ -306,29 +310,48 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
             && candidate["gross_exposure"].is_number(),
         "a candidate that reached the sizer carries what it was sized to"
     );
+
+    // Prices are their own records, one per fetch, sharing the pass's identifier.
+    let priced = of_type(&records, "prices_observed");
+    assert!(!priced.is_empty(), "the prices the pass decided on");
+    let readings: Vec<&serde_json::Value> = priced
+        .iter()
+        .flat_map(|record| record["payload"]["readings"].as_array().unwrap())
+        .collect();
+    assert!(!readings.is_empty());
     assert!(
-        !pass["payload"]["prices"].as_array().unwrap().is_empty(),
-        "the prices the pass decided on must be recorded"
+        readings
+            .iter()
+            .all(|reading| reading["price"].is_number() && reading["price_source"].is_string()),
+        "a price without its source cannot be compared across passes"
     );
     assert!(
-        pass["payload"]["prices"][0]["price_source"].is_string(),
-        "a price without its source cannot be compared across passes"
+        priced
+            .iter()
+            .all(|record| record["payload"]["purpose"].is_string()),
+        "each fetch names what it was for"
     );
 
     // What the model offered the screen, as rows rather than a count. `expected_return` and
     // `confidence` are derived from the stored quantiles, so `equity_predictions` alone cannot
     // reconstruct what the screen actually consumed.
-    let screen_inputs = pass["payload"]["screen_inputs"]
+    let screened = of_type(&records, "universe_screened");
+    assert_eq!(screened.len(), 1, "one funnel per pass");
+    let screen_inputs = screened[0]["payload"]["inputs"]
         .as_array()
         .expect("screen inputs are recorded");
-    assert_eq!(screen_inputs.len(), 2, "both forecasts reached the screen");
+    assert_eq!(
+        screen_inputs.len(),
+        2,
+        "both predictions reached the screen"
+    );
     assert!(screen_inputs
         .iter()
         .all(|input| input["expected_return"].is_number()
             && input["confidence"].is_number()
             && input["is_shortable"].is_boolean()));
     assert!(
-        pass["payload"]["excluded"]
+        screened[0]["payload"]["excluded"]
             .as_array()
             .expect("the funnel is recorded")
             .is_empty(),
@@ -588,9 +611,10 @@ async fn test_a_pass_closes_a_converged_pair_from_a_full_book() {
         assert_eq!(record["payload"]["accepted"], true);
     }
 
-    // And the pass that measured every open pair says so, whether or not the pair closed.
-    let pass = of_type(&records, "evaluation_pass");
-    let measured = pass[0]["payload"]["open_pairs"]
+    // And the reading that measured every open pair says so, whether or not the pair closed.
+    let observed = of_type(&records, "open_pairs_observed");
+    assert_eq!(observed.len(), 1, "one book reading per pass");
+    let measured = observed[0]["payload"]["readings"]
         .as_array()
         .expect("open pairs are recorded");
     assert_eq!(
@@ -606,6 +630,99 @@ async fn test_a_pass_closes_a_converged_pair_from_a_full_book() {
     assert!(
         closed["z_score"].is_number() && closed["spread_mean"].is_number(),
         "the inputs that produced the exit decision are recorded with it"
+    );
+}
+
+/// A pass that dies partway through still says what it had measured.
+///
+/// The book was priced and read before the account call failed, so discarding the observation
+/// would leave the log silent about the one pass worth reading. The failure is named on the record
+/// rather than left as an absence, which is indistinguishable from a crashed process.
+#[tokio::test]
+#[serial]
+async fn test_a_failed_pass_records_what_it_had_already_observed() {
+    let pool = fresh_pool().await;
+    let mut server = mockito::Server::new_async().await;
+
+    common::seed_correlated_bars(&pool, &["AAAA", "BBBB"], SESSIONS).await;
+    let close_history = bars::load_aligned_closes(&pool, BarInterval::OneDay, 60)
+        .await
+        .unwrap();
+
+    let entry = PairEntry::new(
+        fund::common::types::PairID::new(ticker("AAAA"), ticker("BBBB")),
+        1.0,
+        2.5,
+        0.03,
+        None,
+    )
+    .unwrap();
+    pairs::record_open(&pool, &entry, Utc::now()).await.unwrap();
+
+    let _snapshots = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"^/v2/stocks/snapshots".into()),
+        )
+        .with_status(200)
+        .with_body(r#"{"AAAA":{"latestTrade":{"p":100.0}},"BBBB":{"latestTrade":{"p":50.0}}}"#)
+        .create_async()
+        .await;
+    // The exits are done; the entry half asks for the account and Alpaca is unreachable.
+    let _account = server
+        .mock("GET", "/v2/account")
+        .with_status(500)
+        .with_body("upstream is down")
+        .create_async()
+        .await;
+
+    let trading = TradingClient::with_base_url(credentials(), server.url());
+    let market_data = MarketDataClient::with_base_url(credentials(), server.url(), DataFeed::Iex);
+    let calendar = calendar_for_today();
+    let universe = universe_of(&["AAAA", "BBBB"]);
+
+    let running = CancellationToken::new();
+    let session_log = session_log("test-a-failed-pass-records-what-it-had-already-observed");
+    let context = EvaluationContext {
+        pool: &pool,
+        trading: &trading,
+        market_data: &market_data,
+        calendar: &calendar,
+        universe: &universe,
+        close_history: &close_history,
+        sizing: SizingParameters::default(),
+        execution: settings(),
+        session_log: &session_log,
+        shutdown: &running,
+        now: session_instant(),
+    };
+
+    evaluate::run_pass(&context)
+        .await
+        .expect_err("the account call must fail the pass");
+
+    let records = recorded(&session_log);
+    let passes = of_type(&records, "pass_evaluated");
+    assert_eq!(passes.len(), 1, "a failed pass is still recorded");
+    assert!(
+        passes[0]["payload"]["failure"]
+            .as_str()
+            .expect("the failure is named")
+            .contains("Alpaca"),
+        "the record says what ended the pass"
+    );
+    assert_eq!(
+        passes[0]["payload"]["open_pairs_at_start"], 1,
+        "what the pass had measured before the failure survives"
+    );
+    assert_eq!(
+        of_type(&records, "open_pairs_observed").len(),
+        1,
+        "the book reading was written before the failure and is unaffected by it"
+    );
+    assert!(
+        of_type(&records, "universe_screened").is_empty(),
+        "the pass never reached the screen"
     );
 }
 

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -863,8 +863,14 @@ async fn test_liquidation_flattens_the_book_and_marks_every_pair() {
     assert!(summary.pairs_still_open.is_empty());
     assert!(pairs::load_open_pairs(&pool).await.unwrap().is_empty());
 
-    // The table is mutated in place; the log needs its own record of the transition.
+    // The last fail-safe before positions carry overnight says it ran, and says the book is flat.
     let records = recorded(&log);
+    let attempted = of_type(&records, "liquidation_attempted");
+    assert_eq!(attempted.len(), 1);
+    assert!(attempted[0]["payload"]["failure"].is_null());
+    assert_eq!(attempted[0]["payload"]["pairs_closed"], 2);
+
+    // The table is mutated in place; the log needs its own record of the transition.
     let closed = of_type(&records, "pair_closed");
     assert_eq!(closed.len(), 2, "one record per pair marked closed");
     for record in &closed {
@@ -874,6 +880,46 @@ async fn test_liquidation_flattens_the_book_and_marks_every_pair() {
             "a pair that was open when the liquidation reached it"
         );
     }
+}
+
+/// A liquidation that could not reach the broker still records that it was attempted.
+///
+/// This is the last thing standing between an open book and an overnight position. A run that
+/// failed at the bulk close used to leave no trace of having happened at all, which reads exactly
+/// like a liquidation that was never scheduled.
+#[tokio::test]
+#[serial]
+async fn test_a_failed_liquidation_records_the_attempt() {
+    let pool = fresh_pool().await;
+    let mut server = mockito::Server::new_async().await;
+
+    let _bulk = server
+        .mock("DELETE", mockito::Matcher::Regex(r"^/v2/positions".into()))
+        .with_status(500)
+        .with_body("upstream is down")
+        .create_async()
+        .await;
+
+    let trading = TradingClient::with_base_url(credentials(), server.url());
+    let log = session_log("test-a-failed-liquidation-records-the-attempt");
+    evaluate::run_liquidation(&pool, &trading, &log, uuid::Uuid::new_v4(), Utc::now())
+        .await
+        .expect_err("the bulk close must fail");
+
+    let records = recorded(&log);
+    let attempted = of_type(&records, "liquidation_attempted");
+    assert_eq!(attempted.len(), 1, "the attempt is recorded even so");
+    assert!(
+        attempted[0]["payload"]["failure"]
+            .as_str()
+            .expect("the failure is named")
+            .contains("Alpaca"),
+        "the record says what stopped it"
+    );
+    assert_eq!(
+        attempted[0]["payload"]["pairs_closed"], 0,
+        "nothing was flattened"
+    );
 }
 
 /// A pair whose leg Alpaca refused to close stays open in the record. Marking it closed would leave

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -259,6 +259,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
         sizing: SizingParameters::default(),
         execution: settings(),
         session_log: &session_log,
+        correlation_id: uuid::Uuid::new_v4(),
         shutdown: &running,
         now: session_instant(),
     };
@@ -456,6 +457,7 @@ async fn test_a_pass_opens_nothing_once_shutdown_is_requested() {
         sizing: SizingParameters::default(),
         execution: settings(),
         session_log: &session_log,
+        correlation_id: uuid::Uuid::new_v4(),
         shutdown: &running,
         now: session_instant(),
     };
@@ -572,6 +574,7 @@ async fn test_a_pass_closes_a_converged_pair_from_a_full_book() {
         sizing,
         execution: settings(),
         session_log: &session_log,
+        correlation_id: uuid::Uuid::new_v4(),
         shutdown: &running,
         now: session_instant(),
     };
@@ -693,6 +696,7 @@ async fn test_a_failed_pass_records_what_it_had_already_observed() {
         sizing: SizingParameters::default(),
         execution: settings(),
         session_log: &session_log,
+        correlation_id: uuid::Uuid::new_v4(),
         shutdown: &running,
         now: session_instant(),
     };
@@ -783,6 +787,7 @@ async fn test_a_pair_that_cannot_be_priced_is_held_and_counted() {
         sizing: SizingParameters::default(),
         execution: settings(),
         session_log: &session_log,
+        correlation_id: uuid::Uuid::new_v4(),
         shutdown: &running,
         now: session_instant(),
     };
@@ -834,6 +839,7 @@ async fn test_liquidation_flattens_the_book_and_marks_every_pair() {
         &pool,
         &trading,
         &session_log("test-liquidation-flattens-the-book-and-marks-every-pair"),
+        uuid::Uuid::new_v4(),
         Utc::now(),
     )
     .await
@@ -882,6 +888,7 @@ async fn test_a_refused_leg_leaves_its_pair_open() {
         &pool,
         &trading,
         &session_log("test-a-refused-leg-leaves-its-pair-open"),
+        uuid::Uuid::new_v4(),
         Utc::now(),
     )
     .await
@@ -973,6 +980,7 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
         &pool,
         &trading,
         &session_log("test-the-account-sync-stores-and-attributes-a-session"),
+        uuid::Uuid::new_v4(),
         &calendar_ending_at(session_date),
         session_date,
     )
@@ -1034,13 +1042,27 @@ async fn test_the_account_sync_is_idempotent() {
     let trading = TradingClient::with_base_url(credentials(), server.url());
     let calendar = calendar_ending_at(session_date);
     let log = session_log("test-the-account-sync-is-idempotent-0");
-    let first = account::sync_account(&pool, &trading, &log, &calendar, session_date)
-        .await
-        .unwrap();
+    let first = account::sync_account(
+        &pool,
+        &trading,
+        &log,
+        uuid::Uuid::new_v4(),
+        &calendar,
+        session_date,
+    )
+    .await
+    .unwrap();
     let log = session_log("test-the-account-sync-is-idempotent-1");
-    let second = account::sync_account(&pool, &trading, &log, &calendar, session_date)
-        .await
-        .unwrap();
+    let second = account::sync_account(
+        &pool,
+        &trading,
+        &log,
+        uuid::Uuid::new_v4(),
+        &calendar,
+        session_date,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(first.activities_stored, 1);
     assert_eq!(second.activities_stored, 0);
@@ -1119,6 +1141,7 @@ async fn test_the_account_sync_stores_transfers_without_attributing_them() {
         &pool,
         &trading,
         &session_log("test-the-account-sync-stores-transfers-without-attributing-them"),
+        uuid::Uuid::new_v4(),
         &calendar_ending_at(session_date),
         session_date,
     )
@@ -1187,9 +1210,16 @@ async fn test_the_account_sync_reports_a_missing_previous_session() {
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
     let log = session_log("test-the-account-sync-reports-a-missing-previous-session-2");
-    let with_gap = account::sync_account(&pool, &trading, &log, &calendar, session_date)
-        .await
-        .expect("the sync must run");
+    let with_gap = account::sync_account(
+        &pool,
+        &trading,
+        &log,
+        uuid::Uuid::new_v4(),
+        &calendar,
+        session_date,
+    )
+    .await
+    .expect("the sync must run");
     assert_eq!(
         with_gap.previous_session_gap,
         Some(previous),
@@ -1197,12 +1227,26 @@ async fn test_the_account_sync_reports_a_missing_previous_session() {
     );
 
     // Fill the hole and the same sync stops reporting it.
-    account::sync_account(&pool, &trading, &log, &calendar, previous)
-        .await
-        .expect("the sync must run");
-    let repaired = account::sync_account(&pool, &trading, &log, &calendar, session_date)
-        .await
-        .expect("the sync must run");
+    account::sync_account(
+        &pool,
+        &trading,
+        &log,
+        uuid::Uuid::new_v4(),
+        &calendar,
+        previous,
+    )
+    .await
+    .expect("the sync must run");
+    let repaired = account::sync_account(
+        &pool,
+        &trading,
+        &log,
+        uuid::Uuid::new_v4(),
+        &calendar,
+        session_date,
+    )
+    .await
+    .expect("the sync must run");
     assert_eq!(repaired.previous_session_gap, None);
 }
 

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -14,10 +14,10 @@ use fund::common::alpaca::{
     AlpacaCredentials, CalendarDay, DataFeed, MarketDataClient, TradingClient,
     TRANSFER_ACTIVITY_TYPES,
 };
-use fund::common::types::{BarInterval, Ticker};
+use fund::common::session_log::SessionLog;
+use fund::common::types::{BarInterval, SessionDate, Ticker};
 use fund::data::bars;
-use fund::data::calendar::{SessionDate, TradingCalendar};
-use fund::data::session_log::SessionLog;
+use fund::data::calendar::TradingCalendar;
 use fund::data::universe::{LiquidityRow, Universe};
 use fund::portfolio::evaluate::{self, EvaluationContext};
 use fund::portfolio::execute::ExecutionSettings;

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -377,6 +377,24 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
     );
     assert_eq!(resolved[0]["payload"]["outcome"], "filled");
 
+    // The pair itself, with the rationale nothing outside this application knows: which long was
+    // paired with which short, on what hedge ratio, at what entry score.
+    let opened = of_type(&records, "pair_opened");
+    assert_eq!(opened.len(), 1, "the pair that opened is recorded");
+    assert_eq!(opened[0]["payload"]["pair_id"], "AAAA-BBBB");
+    assert_eq!(opened[0]["payload"]["model_run_id"], "run-1");
+    assert!(
+        opened[0]["payload"]["hedge_ratio"].is_number()
+            && opened[0]["payload"]["entry_z_score"].is_number()
+            && opened[0]["payload"]["signal_strength"].is_number()
+    );
+    // The identifier the close and the attribution will join on.
+    assert_eq!(
+        opened[0]["payload"]["pair_uuid"],
+        open[0].id().to_string(),
+        "the record names the row it wrote"
+    );
+
     submit.assert_async().await;
 }
 
@@ -835,19 +853,27 @@ async fn test_liquidation_flattens_the_book_and_marks_every_pair() {
         .await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
-    let summary = evaluate::run_liquidation(
-        &pool,
-        &trading,
-        &session_log("test-liquidation-flattens-the-book-and-marks-every-pair"),
-        uuid::Uuid::new_v4(),
-        Utc::now(),
-    )
-    .await
-    .expect("the liquidation must run");
+    let log = session_log("test-liquidation-flattens-the-book-and-marks-every-pair");
+    let summary =
+        evaluate::run_liquidation(&pool, &trading, &log, uuid::Uuid::new_v4(), Utc::now())
+            .await
+            .expect("the liquidation must run");
 
     assert_eq!(summary.pairs_closed, 2);
     assert!(summary.pairs_still_open.is_empty());
     assert!(pairs::load_open_pairs(&pool).await.unwrap().is_empty());
+
+    // The table is mutated in place; the log needs its own record of the transition.
+    let records = recorded(&log);
+    let closed = of_type(&records, "pair_closed");
+    assert_eq!(closed.len(), 2, "one record per pair marked closed");
+    for record in &closed {
+        assert_eq!(record["payload"]["reason"], "end_of_day");
+        assert_eq!(
+            record["payload"]["updated"], true,
+            "a pair that was open when the liquidation reached it"
+        );
+    }
 }
 
 /// A pair whose leg Alpaca refused to close stays open in the record. Marking it closed would leave
@@ -976,10 +1002,11 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
     mock_no_transfers(&mut server).await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
+    let log = session_log("test-the-account-sync-stores-and-attributes-a-session");
     let summary = account::sync_account(
         &pool,
         &trading,
-        &session_log("test-the-account-sync-stores-and-attributes-a-session"),
+        &log,
         uuid::Uuid::new_v4(),
         &calendar_ending_at(session_date),
         session_date,
@@ -1003,6 +1030,15 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
         account::load_equity_for(&pool, session_date).await.unwrap(),
         Some(rust_decimal::Decimal::from(102_000))
     );
+
+    // The attribution is the one derived value the log keeps, recorded beside the pair it landed
+    // on so the stored figure can be checked against the fills it came from.
+    let records = recorded(&log);
+    let attributed = of_type(&records, "pair_attributed");
+    assert_eq!(attributed.len(), 1);
+    assert_eq!(attributed[0]["payload"]["pair_uuid"], id.to_string());
+    assert_eq!(attributed[0]["payload"]["realized_profit_and_loss"], 100.0);
+    assert_eq!(attributed[0]["payload"]["updated"], true);
 }
 
 /// Re-running a sync must change nothing. Alpaca's activity identifier is the primary key, so the

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -249,6 +249,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
 
     let running = CancellationToken::new();
     let session_log = session_log("test-a-pass-opens-a-pair-and-records-it");
+    let dispatched_correlation_id = uuid::Uuid::new_v4();
     let context = EvaluationContext {
         pool: &pool,
         trading: &trading,
@@ -259,7 +260,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
         sizing: SizingParameters::default(),
         execution: settings(),
         session_log: &session_log,
-        correlation_id: uuid::Uuid::new_v4(),
+        correlation_id: dispatched_correlation_id,
         shutdown: &running,
         now: session_instant(),
     };
@@ -295,6 +296,11 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
     let correlation_id = pass["correlation_id"]
         .as_str()
         .expect("a pass is correlated");
+    assert_eq!(
+        correlation_id,
+        dispatched_correlation_id.to_string(),
+        "the pass records the identifier the dispatcher supplied, not one of its own"
+    );
     assert!(
         pass["payload"]["failure"].is_null(),
         "a pass that completed records no failure"
@@ -1089,8 +1095,8 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
     assert!(
         observed
             .iter()
-            .any(|record| record["payload"]["order_id"].is_string()),
-        "a fill joins back to the order that produced it"
+            .all(|record| record["payload"]["order_id"].is_string()),
+        "every fill joins back to the order that produced it"
     );
 
     // The attribution is the one derived value the log keeps, recorded beside the pair it landed

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -990,9 +990,9 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
         .with_status(200)
         .with_body(format!(
             r#"[{{"id":"a1","activity_type":"FILL","transaction_time":"{}",
-                  "symbol":"AAAA","side":"buy","qty":"10","price":"100"}},
+                  "symbol":"AAAA","side":"buy","qty":"10","price":"100","order_id":"o1"}},
                 {{"id":"a2","activity_type":"FILL","transaction_time":"{}",
-                  "symbol":"AAAA","side":"sell","qty":"10","price":"110"}}]"#,
+                  "symbol":"AAAA","side":"sell","qty":"10","price":"110","order_id":"o2"}}]"#,
             (opened + Duration::minutes(1)).to_rfc3339(),
             (closed - Duration::minutes(1)).to_rfc3339(),
         ))
@@ -1031,9 +1031,24 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
         Some(rust_decimal::Decimal::from(102_000))
     );
 
+    // Every activity Alpaca reported, as our own record. `net_amount` in particular reaches no
+    // other store the application owns.
+    let records = recorded(&log);
+    let observed = of_type(&records, "activity_observed");
+    assert_eq!(observed.len(), 2, "one record per activity, fills included");
+    assert!(observed
+        .iter()
+        .all(|record| record["payload"]["activity_id"].is_string()
+            && record["payload"]["activity_type"].is_string()));
+    assert!(
+        observed
+            .iter()
+            .any(|record| record["payload"]["order_id"].is_string()),
+        "a fill joins back to the order that produced it"
+    );
+
     // The attribution is the one derived value the log keeps, recorded beside the pair it landed
     // on so the stored figure can be checked against the fills it came from.
-    let records = recorded(&log);
     let attributed = of_type(&records, "pair_attributed");
     assert_eq!(attributed.len(), 1);
     assert_eq!(attributed[0]["payload"]["pair_uuid"], id.to_string());

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -140,10 +140,18 @@ SELECT
     correlation_id,
     event_type,
     session_date,
-    -- Stored as epoch milliseconds so the Parquet column is a plain integer; recovered here, since
-    -- every question worth asking of this table is ordered in time.
-    epoch_ms(created_at) AS created_at,
-    payload
+    -- Stored as epoch milliseconds so the Parquet column is a plain integer. to_timestamp, not
+    -- epoch_ms: the first returns a TIMESTAMPTZ anchored to UTC, the second a bare TIMESTAMP that
+    -- reads as whatever zone the session happens to be in. An instant is always UTC here, and
+    -- session_date beside it is always the Eastern trading day.
+    to_timestamp(created_at / 1000.0) AS created_at,
+    payload,
+    -- From the key layout rather than the file contents, so a filter on them skips whole files.
+    -- session_date is inside each Parquet, so filtering on that alone opens every one, and the
+    -- archive grows by a file per trading day forever.
+    year,
+    month,
+    day
 FROM read_parquet(
     's3://' || getvariable('bucket') || '/exports/session_log/**/*.parquet',
     hive_partitioning = true

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -11,8 +11,9 @@
 --            the long-term record of equity bars and ticker metadata; it
 --            accumulates for as long as the bucket keeps it.
 --   exports/ the application's nightly export of the tables only it knows
---            about -- events, predictions, pairs, account state. This is what
---            the retention window would otherwise discard.
+--            about -- events, predictions, pairs, account state -- plus the
+--            session log, which is the original those tables are derived from.
+--            This is what the retention window would otherwise discard.
 --
 -- Bars and ticker metadata appear under data/ and nowhere else. They used to be
 -- exported as well, from the same Massive endpoint by a second path, and two
@@ -107,6 +108,44 @@ CREATE OR REPLACE VIEW events AS
 SELECT *
 FROM read_parquet(
     's3://' || getvariable('bucket') || '/exports/events/**/*.parquet',
+    hive_partitioning = true
+);
+
+-- The session log is the application's own original: what it observed before it acted, appended to
+-- local disk as it happened and sealed to Parquet after the close. Everything above is a fold or a
+-- query over it, so this is where to go when the tables disagree with each other.
+--
+-- The envelope is columns and the body is a JSON string, so filter on event_type and reach into
+-- payload with the JSON operators:
+--
+--   SELECT payload->>'ticker', payload->>'outcome'
+--   FROM session_log WHERE event_type = 'order_resolved';
+--
+--   SELECT unnest(from_json(payload->'readings', '["json"]'))->>'ticker'
+--   FROM session_log WHERE event_type = 'prices_observed';
+--
+-- correlation_id threads a command to everything it did: one command_finished, the pass it ran, the
+-- prices it read, the orders it sent, the fills they produced. Joining on it is how a duration
+-- becomes an answer about where the time went.
+--
+-- schema_version is 2 for anything written after 2026-08-12. Version 1 carried the pass's prices,
+-- screen inputs, exclusions, and open book inline on an evaluation_pass record, and had no
+-- command_finished, pair_opened, pair_closed, pair_attributed, or activity_observed.
+.print 'Loading session_log...'
+DROP VIEW IF EXISTS session_log;
+CREATE OR REPLACE VIEW session_log AS
+SELECT
+    schema_version,
+    event_id,
+    correlation_id,
+    event_type,
+    session_date,
+    -- Stored as epoch milliseconds so the Parquet column is a plain integer; recovered here, since
+    -- every question worth asking of this table is ordered in time.
+    epoch_ms(created_at) AS created_at,
+    payload
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/exports/session_log/**/*.parquet',
     hive_partitioning = true
 );
 

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -131,6 +131,11 @@ FROM read_parquet(
 -- schema_version is 2 for anything written after 2026-08-12. Version 1 carried the pass's prices,
 -- screen inputs, exclusions, and open book inline on an evaluation_pass record, and had no
 -- command_finished, pair_opened, pair_closed, pair_attributed, or activity_observed.
+--
+-- One field changed type rather than name, which is the case a reader cannot detect on its own:
+-- predictions_generated.predictions was a count in v1 and is the array of quantiles in v2. A query
+-- reading it must filter on schema_version or check the type, or it silently reads a length as a
+-- number of tickers. Only the single v1 session, 2026-08-12, is affected.
 .print 'Loading session_log...'
 DROP VIEW IF EXISTS session_log;
 CREATE OR REPLACE VIEW session_log AS


### PR DESCRIPTION
# Overview

The session log shipped in #1058 recorded seven kinds of observation. This expands it to fifteen, closes the gaps between it and what PostgreSQL holds, and gives it a query surface.

One theme runs through most of it: **the log recorded what succeeded, not what happened.** Two of six commands wrote nothing at all, every error return out of `run_pass` discarded the observation it had built, and a liquidation that failed at the broker left no trace of having been attempted.

## Changes

**Module layout.** `session_log` moves to `common/`, where it belongs — it is written from `data/`, `portfolio/`, and `handlers.rs`. That required `SessionDate` to move to `common/types.rs` as well, since `common/` imports nothing from `data/` and leaving it behind would have inverted that. The export half went the other way, into `data/export.rs`: it is called from one place, next to the database export doing the same Parquet-to-S3 job, and the two had grown identical `write_frame` functions.

**Records split out of the pass.** `EvaluationPass` held five nested arrays, forcing `&mut observation` through six call sites plus a `HashMap` of candidate decisions kept alive across the whole function. Four of them are complete at the moment they are computed and are now their own records sharing the pass's `correlation_id` — `prices_observed`, `universe_screened`, `open_pairs_observed`. Candidates stay on the pass, because a candidate's decision is not known until the pass ends.

**New records.**

| Record | Closes |
|---|---|
| `command_finished` | Two silent handlers, plus the four skip/drop paths that were indistinguishable from a crash |
| `pair_opened` / `pair_closed` / `pair_attributed` | `equity_pairs` is mutated in place three times; the log needs three records where the table has one row |
| `activity_observed` | `net_amount` reaches no other store this application owns — the nightly export drops it |
| `prices_observed` | A failed request chunk and "no quote" were the same absence |
| `universe_screened` / `open_pairs_observed` | Split from the pass |

`predictions_generated` gains the quantiles themselves, which existed only in a table purged after seven days.

**Failure paths.** `run_pass` and `run_liquidation` are now wrappers that record on both paths and name what stopped them. The worst case this closes: a pair that filled at the broker but whose row could not be written — the orders were in the log and the pass tying them to a pair was thrown away.

**Naming.** Five of seven existing types followed `<subject>_<past participle>`. `evaluation_pass` was a bare noun phrase and `liquidation_run` read as one, so they become `pass_evaluated` and `liquidation_attempted` — the latter also more accurate now that it is written on the path where nothing ran. `SCHEMA_VERSION` goes to 2, since the pass changed shape rather than only gaining fields.

**Query surface.** `exports/session_log` had no DuckDB view — the archive was write-only. Added, with `created_at` resolved from epoch milliseconds to a timestamp and two worked examples for reaching into the JSON payload.

## Context

**One reported problem did not survive checking.** A leg cancelled by the 15:45 liquidation was said to leave an `OrderSubmitted` with no resolution, reading as a dead process. It does not: Alpaca reports the order as `canceled`, `confirm_fill` reaches `OrderState::Abandoned`, and the resolution is written with the broker's own terminal status. Adding a `cancelled_by_liquidation` outcome would have been a second spelling for a fact already recorded, so it is not here.

**What this deliberately does not do.** PostgreSQL stays. Beyond holding rows it is doing three jobs the log cannot take over by recording more: `pg_notify` is the wakeup mechanism, `events` is the restart-recovery input, and two cross-session reads (`account_snapshots.equity` for the drawdown gate, `equity_pairs WHERE status='open'` for the book) are on the hot path. Replacing those is separate work, and none of it gets easier by delaying the recording.

**`pair_attributed` is the one derived value the log keeps**, against the module's own "observations only" rule. The argument, and it is in the docstring: the fills it was computed from are now records too, so having both in one place is what makes a disagreement between the stored figure and its inputs visible at all.

**Verification.** 517 tests passing, `devenv tasks run checks:rust` clean, coverage 82.5% overall (`session_log.rs` 94.5%, `account.rs` 97.4%, `execute.rs` 93.2%, `pairs.rs` 93.5%, `alpaca.rs` 93.1%, `evaluate.rs` 87.9%). The DuckDB view was checked against a real exported Parquet file with the CLI rather than only in tests: the envelope reads back, `created_at` comes out a timestamp, both documented queries return their rows, and the correlation join finds the three records the command produced.

New tests cover the paths this PR exists for — a failed pass recording what it had already observed, a failed liquidation recording the attempt, a skip not reading as a completed run, and the three pair lifecycle records.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Eastern Time session-date handling, including daylight-saving transitions, weekend detection, and calendar-day boundaries.
  * Added structured session activity logging with command outcomes, prediction details, trading decisions, and failure information.
  * Added nightly session-log export to partitioned Parquet data with seven-day retention.
  * Added a DuckDB `session_log` view for querying exported records.
* **Improvements**
  * Enhanced account and market-data diagnostics to report pagination truncation, undated activities, and failed symbols.
  * Improved correlation tracking across commands and trading workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->