### PR TITLE
Refuse a quote midpoint the book cannot support

### DIFF
--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -531,12 +531,18 @@ impl OrderIntent {
 /// Alpaca publishes fifteen order statuses. Collapsing them here rather than at each call site is
 /// what makes the caller's `match` exhaustive over outcomes it can actually respond to — keep
 /// waiting, use the fill, or unwind — instead of over a string it has to remember the meaning of.
+/// Every variant carries the broker's own status alongside the collapse, because the collapse is
+/// what the caller acts on and the raw status is what explains it afterwards. An order this process
+/// gave up on is recorded as `timed_out`, which is our word; whether Alpaca had it as `pending_new`
+/// or `accepted` at that moment is the difference between never reaching the market and reaching it
+/// with no contra side.
 #[derive(Debug, Clone, PartialEq)]
 pub enum OrderState {
     /// Alpaca still has it: accepted, queued, or partially filled. Ask again.
-    Working { filled_shares: f64 },
+    Working { status: String, filled_shares: f64 },
     /// Terminal and completely filled.
     Filled {
+        status: String,
         filled_shares: f64,
         average_price: f64,
     },
@@ -548,6 +554,15 @@ pub enum OrderState {
 }
 
 impl OrderState {
+    /// Alpaca's own word for where the order stood when this state was read.
+    pub fn broker_status(&self) -> &str {
+        match self {
+            OrderState::Working { status, .. }
+            | OrderState::Filled { status, .. }
+            | OrderState::Abandoned { status, .. } => status,
+        }
+    }
+
     /// Whether Alpaca is finished with this order, however it ended.
     pub fn is_terminal(&self) -> bool {
         match self {
@@ -559,7 +574,7 @@ impl OrderState {
     /// Shares Alpaca reports as filled, whatever state the order reached.
     pub fn filled_shares(&self) -> f64 {
         match self {
-            OrderState::Working { filled_shares }
+            OrderState::Working { filled_shares, .. }
             | OrderState::Filled { filled_shares, .. }
             | OrderState::Abandoned { filled_shares, .. } => *filled_shares,
         }
@@ -1378,7 +1393,8 @@ fn order_state_from(order: OrderResponse) -> Result<OrderState, ClientError> {
         .and_then(|raw| raw.parse::<f64>().ok())
         .unwrap_or(0.0);
 
-    match order.status.as_str() {
+    let status = order.status.clone();
+    match status.as_str() {
         "filled" => {
             let average_price = order
                 .filled_avg_price
@@ -1391,6 +1407,7 @@ fn order_state_from(order: OrderResponse) -> Result<OrderState, ClientError> {
                     ))
                 })?;
             Ok(OrderState::Filled {
+                status: order.status,
                 filled_shares,
                 average_price,
             })
@@ -1401,7 +1418,10 @@ fn order_state_from(order: OrderResponse) -> Result<OrderState, ClientError> {
                 filled_shares,
             })
         }
-        _ => Ok(OrderState::Working { filled_shares }),
+        _ => Ok(OrderState::Working {
+            status: order.status,
+            filled_shares,
+        }),
     }
 }
 
@@ -1626,8 +1646,9 @@ impl Snapshot {
     ///
     /// The midpoint leads because it reflects where the market currently is willing to transact,
     /// while the last trade reports where someone already did — possibly a long time ago in a thin
-    /// name. Callers needing to reject a wide or stale book should read [`Snapshot::latest_quote`]
-    /// directly; this is the convenience path, not the careful one.
+    /// name. It takes any book at all, though, including one too wide or too stale to be a price:
+    /// anything deciding on the number wants [`Snapshot::reference_price_checked`]. This is the
+    /// convenience path, not the careful one.
     pub fn reference_price(&self) -> Option<f64> {
         self.reference_price_with_source().map(|(price, _)| price)
     }
@@ -1644,6 +1665,182 @@ impl Snapshot {
                 self.latest_trade_price
                     .map(|price| (price, PriceSource::LastTrade))
             })
+    }
+
+    /// The careful path: the reference price, with a book that fails `limits` refused.
+    ///
+    /// A refused midpoint falls through to the last trade, and a refusal with no last trade behind
+    /// it yields `None` so the symbol goes unpriced rather than silently mispriced. The refusal
+    /// travels with the price because a caller that cannot see which quotes were rejected cannot
+    /// tell whether `limits` is set anywhere near right.
+    pub fn reference_price_checked(
+        &self,
+        now: DateTime<Utc>,
+        limits: QuoteLimits,
+    ) -> Option<CheckedPrice> {
+        let rejection = match self.latest_quote.as_ref() {
+            Some(quote) => match limits.refusal(quote, now) {
+                None => {
+                    return Some(CheckedPrice {
+                        price: quote.mid_price(),
+                        source: PriceSource::QuoteMidpoint,
+                        rejection: None,
+                    });
+                }
+                Some(rejection) => Some(rejection),
+            },
+            None => None,
+        };
+
+        self.latest_trade_price.map(|price| CheckedPrice {
+            price,
+            source: PriceSource::LastTrade,
+            rejection,
+        })
+    }
+}
+
+/// Seconds a quote may be old before its midpoint stops describing the current market.
+///
+/// Provisional. Chosen loose enough that the last-trade fallback stays the exception, and meant to
+/// be replaced once a session has logged quote ages.
+pub const MAXIMUM_QUOTE_AGE_SECONDS: i64 = 60;
+
+/// Widest bid-ask spread, as a fraction of the midpoint, a quote may carry and still be priced.
+///
+/// Provisional, on the same terms as [`MAXIMUM_QUOTE_AGE_SECONDS`]. A liquid name quotes inside
+/// 0.1%; the readings that produced false entries on 2026-08-12 were an order of magnitude wider.
+pub const MAXIMUM_RELATIVE_QUOTE_SPREAD: f64 = 0.01;
+
+/// What a book must satisfy for its midpoint to be worth taking.
+///
+/// Both bounds describe the book rather than the symbol, so one set covers the universe.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct QuoteLimits {
+    maximum_age: chrono::Duration,
+    maximum_relative_spread: f64,
+}
+
+impl QuoteLimits {
+    /// Constructs limits, refusing bounds that would admit everything or nothing.
+    pub fn new(maximum_age: chrono::Duration, maximum_relative_spread: f64) -> Option<Self> {
+        if maximum_age <= chrono::Duration::zero() {
+            return None;
+        }
+        if !maximum_relative_spread.is_finite() || maximum_relative_spread <= 0.0 {
+            return None;
+        }
+        Some(Self {
+            maximum_age,
+            maximum_relative_spread,
+        })
+    }
+
+    /// Why this book cannot be priced, or `None` if it can.
+    ///
+    /// The midpoint is a safe divisor because [`EquityQuote::new`] has already refused a
+    /// non-positive side.
+    fn refusal(&self, quote: &EquityQuote, now: DateTime<Utc>) -> Option<QuoteRejection> {
+        let age = now.signed_duration_since(quote.timestamp());
+        if age > self.maximum_age {
+            return Some(QuoteRejection::Stale {
+                age_seconds: age.num_seconds(),
+                limit_seconds: self.maximum_age.num_seconds(),
+            });
+        }
+
+        let relative_spread = (quote.ask_price() - quote.bid_price()) / quote.mid_price();
+        if relative_spread > self.maximum_relative_spread {
+            return Some(QuoteRejection::Wide {
+                relative_spread,
+                limit: self.maximum_relative_spread,
+            });
+        }
+
+        None
+    }
+}
+
+impl Default for QuoteLimits {
+    /// The production limits, from [`MAXIMUM_QUOTE_AGE_SECONDS`] and
+    /// [`MAXIMUM_RELATIVE_QUOTE_SPREAD`].
+    fn default() -> Self {
+        Self {
+            maximum_age: chrono::Duration::seconds(MAXIMUM_QUOTE_AGE_SECONDS),
+            maximum_relative_spread: MAXIMUM_RELATIVE_QUOTE_SPREAD,
+        }
+    }
+}
+
+/// Why a quote midpoint was not taken as the reference price.
+///
+/// Each variant carries the reading that produced it, so the session log can say how far outside
+/// the bound the book was rather than only that it was.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum QuoteRejection {
+    /// The quote is older than the market it is supposed to describe.
+    Stale {
+        age_seconds: i64,
+        limit_seconds: i64,
+    },
+    /// The book is too wide for its midpoint to be a price anyone would transact at.
+    Wide { relative_spread: f64, limit: f64 },
+}
+
+impl QuoteRejection {
+    /// A stable short name for the session log and the structured logs.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            QuoteRejection::Stale { .. } => "stale_quote",
+            QuoteRejection::Wide { .. } => "wide_quote",
+        }
+    }
+}
+
+impl std::fmt::Display for QuoteRejection {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QuoteRejection::Stale {
+                age_seconds,
+                limit_seconds,
+            } => write!(
+                formatter,
+                "the quote is {age_seconds} seconds old, past the {limit_seconds} second limit"
+            ),
+            QuoteRejection::Wide {
+                relative_spread,
+                limit,
+            } => write!(
+                formatter,
+                "the book is {relative_spread:.4} wide, past the {limit:.4} limit"
+            ),
+        }
+    }
+}
+
+/// A reference price together with the verdict on the book that was offered.
+///
+/// `rejection` is set when a quote existed and was refused, which is the case the price alone
+/// cannot express: the price then came from the last trade, and the reason it had to is the part
+/// worth recording.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CheckedPrice {
+    price: f64,
+    source: PriceSource,
+    rejection: Option<QuoteRejection>,
+}
+
+impl CheckedPrice {
+    pub fn price(&self) -> f64 {
+        self.price
+    }
+
+    pub fn source(&self) -> PriceSource {
+        self.source
+    }
+
+    pub fn rejection(&self) -> Option<QuoteRejection> {
+        self.rejection
     }
 }
 
@@ -2434,6 +2631,7 @@ mod tests {
         assert_eq!(
             order_state_from(order_response("filled", "12", "101.25")).unwrap(),
             OrderState::Filled {
+                status: "filled".to_string(),
                 filled_shares: 12.0,
                 average_price: 101.25,
             }
@@ -3046,6 +3244,132 @@ mod tests {
         );
         assert_eq!(snapshots.snapshots[0].reference_price(), Some(150.0));
         mock.assert_async().await;
+    }
+
+    // --- the quote guard ---
+
+    /// The `AER` reading from 2026-08-12: a book wide enough that its midpoint sat seven percent
+    /// below where the symbol filled all session. The last trade is one of that day's real fills.
+    fn wide_book_snapshot(quoted_at: DateTime<Utc>) -> Snapshot {
+        let ticker = Ticker::new("AER").unwrap();
+        Snapshot {
+            latest_quote: Some(
+                EquityQuote::new(ticker.clone(), quoted_at, 128.0, 150.86, 10, 12).unwrap(),
+            ),
+            latest_trade_price: Some(150.60),
+            minute_bar: None,
+            daily_bar: None,
+            previous_daily_bar: None,
+            ticker,
+        }
+    }
+
+    fn sound_book_snapshot(quoted_at: DateTime<Utc>) -> Snapshot {
+        let ticker = Ticker::new("AER").unwrap();
+        Snapshot {
+            latest_quote: Some(
+                EquityQuote::new(ticker.clone(), quoted_at, 150.58, 150.62, 10, 12).unwrap(),
+            ),
+            latest_trade_price: Some(150.60),
+            minute_bar: None,
+            daily_bar: None,
+            previous_daily_bar: None,
+            ticker,
+        }
+    }
+
+    /// The bug this guard exists for. `reference_price_with_source` is documented as the
+    /// convenience path and takes the midpoint whatever the book looks like; a pair entered on
+    /// 139.43 and read the spread back as converged once a sound quote arrived.
+    #[test]
+    fn test_the_unguarded_path_still_takes_a_wide_midpoint() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 12, 14, 40, 0).unwrap();
+        let snapshot = wide_book_snapshot(now);
+
+        assert_eq!(
+            snapshot.reference_price_with_source(),
+            Some((139.43, PriceSource::QuoteMidpoint))
+        );
+    }
+
+    #[test]
+    fn test_a_wide_book_is_refused_and_falls_back_to_the_last_trade() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 12, 14, 40, 0).unwrap();
+        let checked = wide_book_snapshot(now)
+            .reference_price_checked(now, QuoteLimits::default())
+            .unwrap();
+
+        assert_eq!(checked.price(), 150.60);
+        assert_eq!(checked.source(), PriceSource::LastTrade);
+        assert!(matches!(
+            checked.rejection(),
+            Some(QuoteRejection::Wide { .. })
+        ));
+    }
+
+    #[test]
+    fn test_a_stale_quote_is_refused_however_tight_the_book() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 12, 14, 40, 0).unwrap();
+        let quoted_at = now - chrono::Duration::seconds(MAXIMUM_QUOTE_AGE_SECONDS + 1);
+        let checked = sound_book_snapshot(quoted_at)
+            .reference_price_checked(now, QuoteLimits::default())
+            .unwrap();
+
+        assert_eq!(checked.source(), PriceSource::LastTrade);
+        assert!(matches!(
+            checked.rejection(),
+            Some(QuoteRejection::Stale { .. })
+        ));
+    }
+
+    #[test]
+    fn test_a_sound_quote_is_taken_and_records_no_rejection() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 12, 14, 40, 0).unwrap();
+        let checked = sound_book_snapshot(now)
+            .reference_price_checked(now, QuoteLimits::default())
+            .unwrap();
+
+        assert!((checked.price() - 150.60).abs() < 1e-9);
+        assert_eq!(checked.source(), PriceSource::QuoteMidpoint);
+        assert_eq!(checked.rejection(), None);
+    }
+
+    /// The whole point of refusing a book is that the symbol goes unpriced rather than priced
+    /// wrongly, so a refusal with nothing behind it must not fall through to the midpoint.
+    #[test]
+    fn test_a_refused_quote_with_no_last_trade_leaves_the_symbol_unpriced() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 12, 14, 40, 0).unwrap();
+        let mut snapshot = wide_book_snapshot(now);
+        snapshot.latest_trade_price = None;
+
+        assert_eq!(
+            snapshot.reference_price_checked(now, QuoteLimits::default()),
+            None
+        );
+    }
+
+    /// No quote at all is not a rejection — it is the ordinary fallback the unguarded path already
+    /// took, and recording it as a refusal would overstate how often the guard fired.
+    #[test]
+    fn test_a_missing_quote_falls_back_without_a_rejection() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 12, 14, 40, 0).unwrap();
+        let mut snapshot = wide_book_snapshot(now);
+        snapshot.latest_quote = None;
+
+        let checked = snapshot
+            .reference_price_checked(now, QuoteLimits::default())
+            .unwrap();
+        assert_eq!(checked.source(), PriceSource::LastTrade);
+        assert_eq!(checked.rejection(), None);
+    }
+
+    #[test]
+    fn test_quote_limits_reject_bounds_that_measure_nothing() {
+        assert!(QuoteLimits::new(chrono::Duration::zero(), 0.01).is_none());
+        assert!(QuoteLimits::new(chrono::Duration::seconds(-1), 0.01).is_none());
+        assert!(QuoteLimits::new(chrono::Duration::seconds(60), 0.0).is_none());
+        assert!(QuoteLimits::new(chrono::Duration::seconds(60), f64::NAN).is_none());
+        assert!(QuoteLimits::new(chrono::Duration::seconds(60), 0.01).is_some());
     }
 
     #[tokio::test]

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -1738,11 +1738,16 @@ impl QuoteLimits {
 
     /// Why this book cannot be priced, or `None` if it can.
     ///
+    /// Public because a refused book with no last trade behind it leaves no [`CheckedPrice`] to
+    /// carry the verdict, and that is the reading most worth recording.
+    ///
     /// The midpoint is a safe divisor because [`EquityQuote::new`] has already refused a
     /// non-positive side.
-    fn refusal(&self, quote: &EquityQuote, now: DateTime<Utc>) -> Option<QuoteRejection> {
+    pub fn refusal(&self, quote: &EquityQuote, now: DateTime<Utc>) -> Option<QuoteRejection> {
+        // Magnitude, not sign. A quote stamped after `now` — feed clock skew is ordinary — describes
+        // the current market no better than one stamped too far before it.
         let age = now.signed_duration_since(quote.timestamp());
-        if age > self.maximum_age {
+        if age.abs() > self.maximum_age {
             return Some(QuoteRejection::Stale {
                 age_seconds: age.num_seconds(),
                 limit_seconds: self.maximum_age.num_seconds(),
@@ -3301,10 +3306,17 @@ mod tests {
 
         assert_eq!(checked.price(), 150.60);
         assert_eq!(checked.source(), PriceSource::LastTrade);
-        assert!(matches!(
-            checked.rejection(),
-            Some(QuoteRejection::Wide { .. })
-        ));
+        // The payload, not only the variant: these numbers are the entire reason the rejection is
+        // recorded, and a wrong divisor or a swapped pair reads as a pass against `matches!`.
+        let Some(QuoteRejection::Wide {
+            relative_spread,
+            limit,
+        }) = checked.rejection()
+        else {
+            panic!("a wide book must be refused as wide");
+        };
+        assert!((relative_spread - (150.86 - 128.0) / 139.43).abs() < 1e-9);
+        assert_eq!(limit, MAXIMUM_RELATIVE_QUOTE_SPREAD);
     }
 
     #[test]
@@ -3316,10 +3328,61 @@ mod tests {
             .unwrap();
 
         assert_eq!(checked.source(), PriceSource::LastTrade);
-        assert!(matches!(
-            checked.rejection(),
-            Some(QuoteRejection::Stale { .. })
-        ));
+        let Some(QuoteRejection::Stale {
+            age_seconds,
+            limit_seconds,
+        }) = checked.rejection()
+        else {
+            panic!("a stale quote must be refused as stale");
+        };
+        assert_eq!(age_seconds, MAXIMUM_QUOTE_AGE_SECONDS + 1);
+        assert_eq!(limit_seconds, MAXIMUM_QUOTE_AGE_SECONDS);
+    }
+
+    /// Age is signed, so a quote stamped after `now` reads as negative and would slip past a
+    /// comparison against the limit alone. Feed clock skew is ordinary and a future-dated book
+    /// describes the current market no better than a stale one.
+    #[test]
+    fn test_a_future_dated_quote_is_refused_as_stale() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 12, 14, 40, 0).unwrap();
+        let quoted_at = now + chrono::Duration::seconds(MAXIMUM_QUOTE_AGE_SECONDS + 1);
+        let checked = sound_book_snapshot(quoted_at)
+            .reference_price_checked(now, QuoteLimits::default())
+            .unwrap();
+
+        assert_eq!(checked.source(), PriceSource::LastTrade);
+        let Some(QuoteRejection::Stale { age_seconds, .. }) = checked.rejection() else {
+            panic!("a future-dated quote must be refused as stale");
+        };
+        assert_eq!(
+            age_seconds,
+            -(MAXIMUM_QUOTE_AGE_SECONDS + 1),
+            "the sign is kept so the log shows a future stamp rather than disguising it"
+        );
+    }
+
+    /// The rendered forms reach the structured logs, where a swapped pair would be read as fact.
+    #[test]
+    fn test_a_rejection_renders_its_own_numbers() {
+        let stale = QuoteRejection::Stale {
+            age_seconds: 90,
+            limit_seconds: 60,
+        };
+        assert_eq!(
+            stale.to_string(),
+            "the quote is 90 seconds old, past the 60 second limit"
+        );
+        assert_eq!(stale.as_str(), "stale_quote");
+
+        let wide = QuoteRejection::Wide {
+            relative_spread: 0.1639,
+            limit: 0.01,
+        };
+        assert_eq!(
+            wide.to_string(),
+            "the book is 0.1639 wide, past the 0.0100 limit"
+        );
+        assert_eq!(wide.as_str(), "wide_quote");
     }
 
     #[test]

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -167,7 +167,8 @@ pub struct PricesObserved {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct UnavailablePrice {
     pub ticker: String,
-    /// `no_quote` or `chunk_failed`.
+    /// `no_quote`, `chunk_failed`, or `quote_rejected` when the guard refused the only book there
+    /// was and no last trade stood behind it.
     pub cause: String,
 }
 
@@ -210,11 +211,22 @@ pub struct ExcludedTickerReading {
 }
 
 /// One symbol's reference price, and which snapshot field it came from.
+///
+/// The book is recorded whether or not the price came from it. A reading that fell back to the last
+/// trade still carries the quote that was refused and the reason, because a log holding only the
+/// quotes that passed cannot say whether the limits are set anywhere near right.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PriceReading {
     pub ticker: String,
     pub price: f64,
     pub price_source: String,
+    /// The book as it was offered. Absent when the snapshot carried no quote at all.
+    pub bid_price: Option<f64>,
+    pub ask_price: Option<f64>,
+    /// When the quote was published, not when it was read — the gap between them is the staleness.
+    pub quote_timestamp: Option<DateTime<Utc>>,
+    /// `stale_quote` or `wide_quote`, set only when a quote existed and the guard refused it.
+    pub quote_rejection: Option<String>,
 }
 
 /// An open pair as this pass measured it, whether or not it closed.
@@ -280,6 +292,17 @@ pub struct PairOpened {
     pub signal_strength: f64,
     pub model_run_id: Option<String>,
     pub opened_at: DateTime<Utc>,
+    /// The prices `entry_z_score` was computed from.
+    ///
+    /// Recorded because the z-score alone cannot be checked after the fact: the spread model is fit
+    /// from daily closes and held for the session, so a z that disagrees with the next pass's is a
+    /// disagreement about these two numbers and nothing else.
+    pub long_decision_price: f64,
+    pub short_decision_price: f64,
+    /// What the legs actually filled at. Distinct from the decision prices, and the gap between
+    /// them is entry slippage.
+    pub long_fill_price: f64,
+    pub short_fill_price: f64,
 }
 
 /// A pair as it was marked closed.
@@ -340,6 +363,12 @@ pub struct OrderResolved {
     pub filled_average_price: Option<f64>,
     /// True when the fill was read after a cancel raced it.
     pub filled_after_cancel: bool,
+    /// Alpaca's own status when this resolution was written, absent when nothing reached it.
+    ///
+    /// `outcome` is this application's word and `timed_out` is the case it cannot explain alone:
+    /// an order Alpaca still held at `pending_new` never reached the market, while one at
+    /// `accepted` reached it and found no contra side.
+    pub broker_status: Option<String>,
     /// The broker's error, when the order failed rather than settled.
     pub error: Option<String>,
 }
@@ -722,6 +751,10 @@ mod tests {
                 signal_strength: 0.03,
                 model_run_id: None,
                 opened_at: instant("2026-08-11T14:35:00Z"),
+                long_decision_price: 100.0,
+                short_decision_price: 50.0,
+                long_fill_price: 100.05,
+                short_fill_price: 49.95,
             }),
             Observation::PairClosed(PairClosed {
                 pair_uuid: Uuid::nil().to_string(),
@@ -749,6 +782,7 @@ mod tests {
                 filled_shares: Some(10.0),
                 filled_average_price: Some(100.0),
                 filled_after_cancel: false,
+                broker_status: Some("filled".to_string()),
                 error: None,
             }),
             Observation::PositionCloseRequested(PositionCloseRequested {
@@ -875,12 +909,38 @@ mod tests {
             filled_shares: Some(412.0),
             filled_average_price: Some(62.44),
             filled_after_cancel: false,
+            broker_status: Some("filled".to_string()),
             error: None,
         };
         let value = serde_json::to_value(&filled).expect("fill must serialize");
         let object = value.as_object().expect("a fill is an object");
         assert!(!object.contains_key("slippage"));
         assert!(!object.contains_key("realized_profit_and_loss"));
+    }
+
+    /// A refused quote has to survive into the record. A log holding only the books that passed
+    /// says nothing about where the limits should sit, which is the whole reason they are recorded.
+    #[test]
+    fn test_a_refused_quote_is_recorded_with_the_book_that_was_refused() {
+        let refused = PriceReading {
+            ticker: "AER".to_string(),
+            price: 150.60,
+            price_source: "last_trade".to_string(),
+            bid_price: Some(128.0),
+            ask_price: Some(150.86),
+            quote_timestamp: Some(instant("2026-08-12T14:40:00Z")),
+            quote_rejection: Some("wide_quote".to_string()),
+        };
+
+        let value = serde_json::to_value(&refused).expect("a reading must serialize");
+        assert_eq!(value["price_source"], "last_trade");
+        assert_eq!(value["quote_rejection"], "wide_quote");
+        assert_eq!(value["bid_price"], 128.0);
+        assert_eq!(value["ask_price"], 150.86);
+        assert!(
+            value["quote_timestamp"].is_string(),
+            "staleness is the gap between the quote and the read, so the quote's own time is kept"
+        );
     }
 
     #[tokio::test]

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -163,13 +163,21 @@ pub struct PricesObserved {
 /// A symbol the fetch asked for and did not get a usable price for.
 ///
 /// Distinguishing the causes is the point: an absent price with no cause is indistinguishable from
-/// a symbol nobody asked about.
+/// a symbol nobody asked about. A `quote_rejected` row carries the book it was refused on, because
+/// that is the reading the limits most need to be judged against — the guard cost the pass this
+/// symbol entirely, and "how far outside" is not answerable from the cause alone.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct UnavailablePrice {
     pub ticker: String,
     /// `no_quote`, `chunk_failed`, or `quote_rejected` when the guard refused the only book there
     /// was and no last trade stood behind it.
     pub cause: String,
+    /// The refused book, set only on `quote_rejected`.
+    pub bid_price: Option<f64>,
+    pub ask_price: Option<f64>,
+    pub quote_timestamp: Option<DateTime<Utc>>,
+    /// `stale_quote` or `wide_quote`.
+    pub quote_rejection: Option<String>,
 }
 
 /// The eligibility funnel for one pass.

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -17,14 +17,14 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::common::alpaca::{
-    CheckedPrice, ClientError, MarketDataClient, QuoteLimits, TradingClient,
+    CheckedPrice, ClientError, MarketDataClient, QuoteLimits, QuoteRejection, TradingClient,
 };
 use crate::common::session_log::{
     CandidateReading, ExcludedTickerReading, LiquidationAttempted, Observation, OpenPairReading,
     OpenPairsObserved, PairClosed, PairOpened, PassEvaluated, PositionCloseRequested, PriceReading,
     PricesObserved, ScreenInputReading, SessionLog, UnavailablePrice, UniverseScreened,
 };
-use crate::common::types::{EquityPrediction, SessionDate, Ticker};
+use crate::common::types::{EquityPrediction, EquityQuote, SessionDate, Ticker};
 use crate::data::calendar::TradingCalendar;
 use crate::data::details::{self, DetailsError};
 use crate::data::universe::Universe;
@@ -608,12 +608,12 @@ async fn fetch_prices(
     let limits = QuoteLimits::default();
 
     // Each snapshot is read once, with the book kept beside the price it produced. The map the
-    // callers receive has already collapsed the quote away, so this is the only place a refused
-    // book can be recorded — and a log holding only the quotes that passed cannot say whether
-    // `limits` is set anywhere near right.
+    // callers receive has already collapsed the quote away, so a refused book is recorded here or
+    // nowhere — and a log holding only the quotes that passed cannot say whether `limits` is set
+    // anywhere near right.
     let mut prices: HashMap<Ticker, CheckedPrice> = HashMap::new();
     let mut readings: Vec<PriceReading> = Vec::new();
-    let mut refused: HashSet<&str> = HashSet::new();
+    let mut refused: HashMap<&str, (&EquityQuote, QuoteRejection)> = HashMap::new();
 
     for snapshot in &fetched.snapshots {
         let quote = snapshot.latest_quote();
@@ -633,11 +633,15 @@ async fn fetch_prices(
                 prices.insert(snapshot.ticker().clone(), checked);
             }
             // A refused book with no last trade behind it. The symbol goes unpriced, which is the
-            // point of refusing it, but "no quote" would be a lie about why.
-            None if quote.is_some() => {
-                refused.insert(snapshot.ticker().as_str());
+            // point of refusing it, and this is the reading the limits most need judging against —
+            // the guard cost the pass the symbol outright, so the book travels with the cause.
+            None => {
+                if let Some((quote, rejection)) =
+                    quote.and_then(|quote| Some((quote, limits.refusal(quote, context.now)?)))
+                {
+                    refused.insert(snapshot.ticker().as_str(), (quote, rejection));
+                }
             }
-            None => {}
         }
     }
     readings.sort_by(|left, right| left.ticker.cmp(&right.ticker));
@@ -649,16 +653,23 @@ async fn fetch_prices(
                 .keys()
                 .any(|ticker| ticker.as_str() == symbol.as_str())
         })
-        .map(|symbol| UnavailablePrice {
-            ticker: symbol.clone(),
-            cause: if failed.contains(symbol.as_str()) {
-                "chunk_failed"
-            } else if refused.contains(symbol.as_str()) {
-                "quote_rejected"
-            } else {
-                "no_quote"
+        .map(|symbol| {
+            let refusal = refused.get(symbol.as_str());
+            UnavailablePrice {
+                ticker: symbol.clone(),
+                cause: if failed.contains(symbol.as_str()) {
+                    "chunk_failed"
+                } else if refusal.is_some() {
+                    "quote_rejected"
+                } else {
+                    "no_quote"
+                }
+                .to_string(),
+                bid_price: refusal.map(|(quote, _)| quote.bid_price()),
+                ask_price: refusal.map(|(quote, _)| quote.ask_price()),
+                quote_timestamp: refusal.map(|(quote, _)| quote.timestamp()),
+                quote_rejection: refusal.map(|(_, rejection)| rejection.as_str().to_string()),
             }
-            .to_string(),
         })
         .collect();
     unavailable.sort_by(|left, right| left.ticker.cmp(&right.ticker));

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -16,7 +16,9 @@ use sqlx::PgPool;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-use crate::common::alpaca::{ClientError, MarketDataClient, PriceSource, TradingClient};
+use crate::common::alpaca::{
+    CheckedPrice, ClientError, MarketDataClient, QuoteLimits, TradingClient,
+};
 use crate::common::session_log::{
     CandidateReading, ExcludedTickerReading, LiquidationAttempted, Observation, OpenPairReading,
     OpenPairsObserved, PairClosed, PairOpened, PassEvaluated, PositionCloseRequested, PriceReading,
@@ -82,26 +84,6 @@ pub struct EvaluationContext<'a> {
     /// this is what keeps the drain's bound honest.
     pub shutdown: &'a CancellationToken,
     pub now: DateTime<Utc>,
-}
-
-/// A price as one pass read it, with the snapshot field it came from.
-///
-/// A midpoint moves with the book while a last trade can be minutes stale, so the same symbol read
-/// from different fields on consecutive passes is not one series.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ReferencePrice {
-    price: f64,
-    source: PriceSource,
-}
-
-impl ReferencePrice {
-    pub fn price(self) -> f64 {
-        self.price
-    }
-
-    pub fn source(self) -> PriceSource {
-        self.source
-    }
 }
 
 /// One pair the pass closed.
@@ -431,6 +413,10 @@ async fn evaluate_pass(
                             signal_strength: entry.signal_strength(),
                             model_run_id: entry.model_run_id().map(str::to_string),
                             opened_at: context.now,
+                            long_decision_price: pair.candidate().long_price(),
+                            short_decision_price: pair.candidate().short_price(),
+                            long_fill_price: long_fill.average_price(),
+                            short_fill_price: short_fill.average_price(),
                         }),
                     )
                     .await;
@@ -613,29 +599,47 @@ async fn fetch_prices(
     correlation_id: uuid::Uuid,
     purpose: &str,
     symbols: &[String],
-) -> Result<HashMap<Ticker, ReferencePrice>, EvaluationError> {
+) -> Result<HashMap<Ticker, CheckedPrice>, EvaluationError> {
     if symbols.is_empty() {
         return Ok(HashMap::new());
     }
     let fetched = context.market_data.fetch_snapshots(symbols).await?;
     let failed: HashSet<&str> = fetched.failed_symbols.iter().map(String::as_str).collect();
-    let prices: HashMap<Ticker, ReferencePrice> = fetched
-        .snapshots
-        .iter()
-        .filter_map(|snapshot| {
-            let (price, source) = snapshot.reference_price_with_source()?;
-            Some((snapshot.ticker().clone(), ReferencePrice { price, source }))
-        })
-        .collect();
+    let limits = QuoteLimits::default();
 
-    let mut readings: Vec<PriceReading> = prices
-        .iter()
-        .map(|(ticker, reference)| PriceReading {
-            ticker: ticker.to_string(),
-            price: reference.price,
-            price_source: reference.source.as_str().to_string(),
-        })
-        .collect();
+    // Each snapshot is read once, with the book kept beside the price it produced. The map the
+    // callers receive has already collapsed the quote away, so this is the only place a refused
+    // book can be recorded — and a log holding only the quotes that passed cannot say whether
+    // `limits` is set anywhere near right.
+    let mut prices: HashMap<Ticker, CheckedPrice> = HashMap::new();
+    let mut readings: Vec<PriceReading> = Vec::new();
+    let mut refused: HashSet<&str> = HashSet::new();
+
+    for snapshot in &fetched.snapshots {
+        let quote = snapshot.latest_quote();
+        match snapshot.reference_price_checked(context.now, limits) {
+            Some(checked) => {
+                readings.push(PriceReading {
+                    ticker: snapshot.ticker().to_string(),
+                    price: checked.price(),
+                    price_source: checked.source().as_str().to_string(),
+                    bid_price: quote.map(|quote| quote.bid_price()),
+                    ask_price: quote.map(|quote| quote.ask_price()),
+                    quote_timestamp: quote.map(|quote| quote.timestamp()),
+                    quote_rejection: checked
+                        .rejection()
+                        .map(|rejection| rejection.as_str().to_string()),
+                });
+                prices.insert(snapshot.ticker().clone(), checked);
+            }
+            // A refused book with no last trade behind it. The symbol goes unpriced, which is the
+            // point of refusing it, but "no quote" would be a lie about why.
+            None if quote.is_some() => {
+                refused.insert(snapshot.ticker().as_str());
+            }
+            None => {}
+        }
+    }
     readings.sort_by(|left, right| left.ticker.cmp(&right.ticker));
 
     let mut unavailable: Vec<UnavailablePrice> = symbols
@@ -649,6 +653,8 @@ async fn fetch_prices(
             ticker: symbol.clone(),
             cause: if failed.contains(symbol.as_str()) {
                 "chunk_failed"
+            } else if refused.contains(symbol.as_str()) {
+                "quote_rejected"
             } else {
                 "no_quote"
             }
@@ -682,7 +688,7 @@ async fn close_what_should_close(
     execution: &ExecutionContext<'_>,
     correlation_id: uuid::Uuid,
     open_pairs: &[OpenPair],
-    prices: &HashMap<Ticker, ReferencePrice>,
+    prices: &HashMap<Ticker, CheckedPrice>,
     summary: &mut EvaluationSummary,
 ) -> Result<HashSet<uuid::Uuid>, EvaluationError> {
     let mut readings: Vec<OpenPairReading> = Vec::with_capacity(open_pairs.len());
@@ -715,7 +721,7 @@ async fn close_and_measure(
     context: &EvaluationContext<'_>,
     execution: &ExecutionContext<'_>,
     open_pairs: &[OpenPair],
-    prices: &HashMap<Ticker, ReferencePrice>,
+    prices: &HashMap<Ticker, CheckedPrice>,
     summary: &mut EvaluationSummary,
     readings: &mut Vec<OpenPairReading>,
 ) -> Result<HashSet<uuid::Uuid>, EvaluationError> {
@@ -767,7 +773,7 @@ async fn close_and_measure(
         reading.spread_mean = Some(model.mean());
         reading.spread_standard_deviation = Some(model.standard_deviation());
 
-        let Some(z_score) = model.z_score(long_price.price, short_price.price) else {
+        let Some(z_score) = model.z_score(long_price.price(), short_price.price()) else {
             reading.decision = "unreadable_spread".to_string();
             readings.push(reading);
             continue;
@@ -790,10 +796,10 @@ async fn close_and_measure(
             spread_standard_deviation = model.standard_deviation(),
             hedge_ratio = model.hedge_ratio(),
             stored_hedge_ratio = pair.hedge_ratio(),
-            long_price = long_price.price,
-            long_price_source = %long_price.source,
-            short_price = short_price.price,
-            short_price_source = %short_price.source,
+            long_price = long_price.price(),
+            long_price_source = %long_price.source(),
+            short_price = short_price.price(),
+            short_price_source = %short_price.source(),
             "Priced an open pair"
         );
 
@@ -942,7 +948,7 @@ async fn build_screen_inputs(
     context: &EvaluationContext<'_>,
     correlation_id: uuid::Uuid,
     held: &HashSet<Ticker>,
-    prices: &mut HashMap<Ticker, ReferencePrice>,
+    prices: &mut HashMap<Ticker, CheckedPrice>,
 ) -> Result<ScreenedUniverse, EvaluationError> {
     let (start, end) = SessionDate::at(context.now).bounds();
     let predictions = predict::load_predictions_between(context.pool, start, end).await?;
@@ -1028,7 +1034,7 @@ async fn build_screen_inputs(
         let Some(input) = ScreenInput::new(
             ticker.clone(),
             window.clone(),
-            reference.price,
+            reference.price(),
             prediction.expected_return(),
             prediction.confidence(),
             context.universe.is_shortable(ticker),

--- a/src/portfolio/execute.rs
+++ b/src/portfolio/execute.rs
@@ -389,6 +389,7 @@ async fn submit_and_confirm(
                     filled_shares: None,
                     filled_average_price: None,
                     filled_after_cancel: false,
+                    broker_status: None,
                     error: Some(error.to_string()),
                 },
             )
@@ -409,6 +410,7 @@ async fn submit_and_confirm(
                 filled_shares: None,
                 filled_average_price: None,
                 filled_after_cancel: false,
+                broker_status: None,
                 error: Some(error.to_string()),
             },
         )
@@ -430,7 +432,7 @@ async fn confirm_fill(
     let deadline = tokio::time::Instant::now() + context.settings.fill_timeout;
 
     macro_rules! resolved {
-        ($outcome:expr, $shares:expr, $price:expr, $after_cancel:expr) => {
+        ($outcome:expr, $shares:expr, $price:expr, $after_cancel:expr, $broker_status:expr) => {
             record_resolution(
                 context,
                 OrderResolved {
@@ -441,6 +443,7 @@ async fn confirm_fill(
                     filled_shares: $shares,
                     filled_average_price: $price,
                     filled_after_cancel: $after_cancel,
+                    broker_status: $broker_status,
                     error: None,
                 },
             )
@@ -451,6 +454,7 @@ async fn confirm_fill(
     loop {
         match context.client.fetch_order(order_id).await? {
             OrderState::Filled {
+                status,
                 filled_shares,
                 average_price,
             } => {
@@ -458,7 +462,8 @@ async fn confirm_fill(
                     "filled".to_string(),
                     Some(filled_shares),
                     Some(average_price),
-                    false
+                    false,
+                    Some(status)
                 );
                 return Ok(Filled::Yes(LegFill {
                     ticker: intent.ticker().clone(),
@@ -471,7 +476,13 @@ async fn confirm_fill(
                 status,
                 filled_shares,
             } => {
-                resolved!(status.clone(), Some(filled_shares), None, false);
+                resolved!(
+                    status.clone(),
+                    Some(filled_shares),
+                    None,
+                    false,
+                    Some(status.clone())
+                );
                 // A partial fill that then terminated leaves shares held. Close the position rather
                 // than reporting the leg cleanly unfilled.
                 if filled_shares > 0.0 {
@@ -487,16 +498,18 @@ async fn confirm_fill(
                 }
                 return Ok(Filled::No(status));
             }
-            OrderState::Working { .. } => {
+            OrderState::Working { status, .. } => {
                 if tokio::time::Instant::now() >= deadline {
                     warn!(
                         ticker = %intent.ticker(),
                         order_id,
+                        broker_status = status.as_str(),
                         "Order did not reach a terminal state before the timeout; cancelling"
                     );
                     context.client.cancel_order(order_id).await?;
                     // Read once more: the cancel may have raced a fill.
                     if let OrderState::Filled {
+                        status: filled_status,
                         filled_shares,
                         average_price,
                     } = context.client.fetch_order(order_id).await?
@@ -505,7 +518,8 @@ async fn confirm_fill(
                             "filled".to_string(),
                             Some(filled_shares),
                             Some(average_price),
-                            true
+                            true,
+                            Some(filled_status)
                         );
                         return Ok(Filled::Yes(LegFill {
                             ticker: intent.ticker().clone(),
@@ -514,7 +528,9 @@ async fn confirm_fill(
                             average_price,
                         }));
                     }
-                    resolved!("timed_out".to_string(), None, None, false);
+                    // The status Alpaca last held it at, not the one after the cancel: whether it
+                    // had reached the market at all is the thing a timeout cannot otherwise say.
+                    resolved!("timed_out".to_string(), None, None, false, Some(status));
                     let cleanup = context.client.close_position(intent.ticker()).await;
                     record_close(context, intent.ticker(), None, "entry_unwind", &cleanup).await;
                     cleanup?;

--- a/src/portfolio/execute.rs
+++ b/src/portfolio/execute.rs
@@ -508,29 +508,37 @@ async fn confirm_fill(
                     );
                     context.client.cancel_order(order_id).await?;
                     // Read once more: the cancel may have raced a fill.
+                    let after_cancel = context.client.fetch_order(order_id).await?;
                     if let OrderState::Filled {
                         status: filled_status,
                         filled_shares,
                         average_price,
-                    } = context.client.fetch_order(order_id).await?
+                    } = &after_cancel
                     {
                         resolved!(
                             "filled".to_string(),
-                            Some(filled_shares),
-                            Some(average_price),
+                            Some(*filled_shares),
+                            Some(*average_price),
                             true,
-                            Some(filled_status)
+                            Some(filled_status.clone())
                         );
                         return Ok(Filled::Yes(LegFill {
                             ticker: intent.ticker().clone(),
                             order_id: order_id.to_string(),
-                            shares: filled_shares,
-                            average_price,
+                            shares: *filled_shares,
+                            average_price: *average_price,
                         }));
                     }
-                    // The status Alpaca last held it at, not the one after the cancel: whether it
-                    // had reached the market at all is the thing a timeout cannot otherwise say.
-                    resolved!("timed_out".to_string(), None, None, false, Some(status));
+                    // The state after the cancel, not the working one that preceded it. An order
+                    // terminated with a partial fill reports those shares here, and recording the
+                    // pre-cancel status would contradict what `broker_status` claims to be.
+                    resolved!(
+                        "timed_out".to_string(),
+                        Some(after_cancel.filled_shares()),
+                        None,
+                        false,
+                        Some(after_cancel.broker_status().to_string())
+                    );
                     let cleanup = context.client.close_position(intent.ticker()).await;
                     record_close(context, intent.ticker(), None, "entry_unwind", &cleanup).await;
                     cleanup?;
@@ -815,6 +823,78 @@ mod tests {
         ));
         cancel.assert_async().await;
         flatten.assert_async().await;
+    }
+
+    /// The cancel can land on an order that had partially filled. The resolution has to report the
+    /// state read *after* the cancel — `broker_status` says it is the status when the row was
+    /// written, and shares that really filled must not be recorded as unknown.
+    #[tokio::test]
+    async fn test_a_timeout_records_the_state_read_after_the_cancel() {
+        let mut server = mockito::Server::new_async().await;
+        let _submit = server
+            .mock("POST", "/v2/orders")
+            .with_status(200)
+            .with_body(r#"{"id":"order-1","status":"accepted"}"#)
+            .create_async()
+            .await;
+        // Working on the first read, terminal on the read after the cancel.
+        let _working = server
+            .mock("GET", "/v2/orders/order-1")
+            .with_status(200)
+            .with_body(r#"{"id":"order-1","status":"pending_new","filled_qty":"0"}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let _after_cancel = server
+            .mock("GET", "/v2/orders/order-1")
+            .with_status(200)
+            .with_body(r#"{"id":"order-1","status":"canceled","filled_qty":"12"}"#)
+            .create_async()
+            .await;
+        let _cancel = server
+            .mock("DELETE", "/v2/orders/order-1")
+            .with_status(204)
+            .create_async()
+            .await;
+        let _flatten = server
+            .mock("DELETE", "/v2/positions/BBBB?percentage=100")
+            .with_status(200)
+            .with_body(r#"{"id":"cleanup-1"}"#)
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(credentials(), server.url());
+        let log = session_log("timeout-after-cancel");
+        let context = ExecutionContext {
+            client: &client,
+            // No timeout at all, so the first poll is already past the deadline and the second read
+            // is unambiguously the post-cancel one.
+            settings: ExecutionSettings::new(Duration::from_millis(0), Duration::from_millis(5)),
+            session_log: &log,
+            correlation_id: Uuid::nil(),
+        };
+
+        open_pair(&context, &pair(), None)
+            .await
+            .expect("a timeout is not an error");
+
+        let resolved: Vec<serde_json::Value> = recorded(&log)
+            .into_iter()
+            .filter(|record| record["event_type"] == "order_resolved")
+            .collect();
+        let timed_out = resolved
+            .iter()
+            .find(|record| record["payload"]["outcome"] == "timed_out")
+            .expect("the timeout must be resolved");
+
+        assert_eq!(
+            timed_out["payload"]["broker_status"], "canceled",
+            "the post-cancel status, not the working one that preceded it"
+        );
+        assert_eq!(
+            timed_out["payload"]["filled_shares"], 12.0,
+            "shares that filled before the cancel are not unknown"
+        );
     }
 
     /// A partial fill that then terminates leaves shares held. Reporting the leg cleanly unfilled

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -203,8 +203,21 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
     // stretched decides which becomes the short, so both orderings are quoted and the screen picks.
     // 1.2% rather than 50%: the seeded series is near-deterministic, so a 50% dislocation scores a
     // z in the hundreds, which the screen now refuses as a data-quality artifact.
+    // `AAAA` is quoted as well as traded, so the guard's accepting path is exercised end to end and
+    // the assertion on the recorded book is not vacuous. The book straddles the last trade evenly,
+    // leaving the midpoint equal to it — the fixture's economics are unchanged, only its source.
+    let long_price = last_close(&close_history, "AAAA");
     let snapshot_body = serde_json::json!({
-        "AAAA": { "latestTrade": { "p": last_close(&close_history, "AAAA") } },
+        "AAAA": {
+            "latestTrade": { "p": long_price },
+            "latestQuote": {
+                "t": session_instant().to_rfc3339(),
+                "bp": long_price * 0.9995,
+                "ap": long_price * 1.0005,
+                "bs": 10,
+                "as": 12,
+            },
+        },
         "BBBB": { "latestTrade": { "p": last_close(&close_history, "BBBB") * 1.012 } },
     });
 
@@ -331,6 +344,23 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
             .iter()
             .all(|reading| reading["price"].is_number() && reading["price_source"].is_string()),
         "a price without its source cannot be compared across passes"
+    );
+    // Asserted before the check below, which is otherwise vacuously true the moment the fixture
+    // stops quoting anything.
+    assert!(
+        readings
+            .iter()
+            .any(|reading| reading["price_source"] == "quote_midpoint"),
+        "the fixture must exercise the guard's accepting path"
+    );
+    assert!(
+        readings.iter().all(|reading| {
+            reading["price_source"] != "quote_midpoint"
+                || (reading["bid_price"].is_number()
+                    && reading["ask_price"].is_number()
+                    && reading["quote_timestamp"].is_string())
+        }),
+        "a midpoint must carry the book it was taken from, or the guard cannot be tuned"
     );
     assert!(
         priced

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -203,9 +203,8 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
     // stretched decides which becomes the short, so both orderings are quoted and the screen picks.
     // 1.2% rather than 50%: the seeded series is near-deterministic, so a 50% dislocation scores a
     // z in the hundreds, which the screen now refuses as a data-quality artifact.
-    // `AAAA` is quoted as well as traded, so the guard's accepting path is exercised end to end and
-    // the assertion on the recorded book is not vacuous. The book straddles the last trade evenly,
-    // leaving the midpoint equal to it — the fixture's economics are unchanged, only its source.
+    // `AAAA` is quoted as well as traded so the accepted-midpoint path is exercised and the
+    // assertion on the recorded book is not vacuous. The book straddles the trade, so prices hold.
     let long_price = last_close(&close_history, "AAAA");
     let snapshot_body = serde_json::json!({
         "AAAA": {
@@ -852,6 +851,110 @@ async fn test_a_pair_that_cannot_be_priced_is_held_and_counted() {
     assert_eq!(summary.pairs_unpriced, 1);
     assert!(summary.pairs_closed.is_empty());
     assert_eq!(pairs::load_open_pairs(&pool).await.unwrap().len(), 1);
+}
+
+/// A book refused with no last trade behind it is where the guard has its largest effect: the
+/// symbol goes unpriced and neither half of the pass can use it. The refused book has to reach the
+/// record, or the limits cannot be judged against the readings that cost the most.
+#[tokio::test]
+#[serial]
+async fn test_a_refused_book_with_no_trade_records_what_was_refused() {
+    let pool = fresh_pool().await;
+    let mut server = mockito::Server::new_async().await;
+
+    common::seed_correlated_bars(&pool, &["AAAA", "BBBB"], SESSIONS).await;
+    let close_history = bars::load_aligned_closes(&pool, BarInterval::OneDay, 60)
+        .await
+        .unwrap();
+
+    let entry = PairEntry::new(
+        fund::common::types::PairID::new(ticker("AAAA"), ticker("BBBB")),
+        1.0,
+        2.5,
+        0.03,
+        None,
+    )
+    .unwrap();
+    pairs::record_open(&pool, &entry, Utc::now()).await.unwrap();
+
+    // A book far too wide to price, and no trade to fall back to.
+    let snapshot_body = serde_json::json!({
+        "AAAA": {
+            "latestQuote": {
+                "t": session_instant().to_rfc3339(),
+                "bp": 90.0, "ap": 110.0, "bs": 10, "as": 12,
+            },
+        },
+        "BBBB": {},
+    });
+    let _snapshots = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"^/v2/stocks/snapshots".into()),
+        )
+        .with_status(200)
+        .with_body(snapshot_body.to_string())
+        .create_async()
+        .await;
+    let _account = server
+        .mock("GET", "/v2/account")
+        .with_status(200)
+        .with_body(account_body(100_000))
+        .create_async()
+        .await;
+
+    let trading = TradingClient::with_base_url(credentials(), server.url());
+    let market_data = MarketDataClient::with_base_url(credentials(), server.url(), DataFeed::Iex);
+    let calendar = calendar_for_today();
+    let universe = universe_of(&["AAAA", "BBBB"]);
+
+    let running = CancellationToken::new();
+    let session_log = session_log("test-a-refused-book-with-no-trade-records-what-was-refused");
+    let context = EvaluationContext {
+        pool: &pool,
+        trading: &trading,
+        market_data: &market_data,
+        calendar: &calendar,
+        universe: &universe,
+        close_history: &close_history,
+        sizing: SizingParameters::default(),
+        execution: settings(),
+        session_log: &session_log,
+        correlation_id: uuid::Uuid::new_v4(),
+        shutdown: &running,
+        now: session_instant(),
+    };
+
+    let summary = evaluate::run_pass(&context)
+        .await
+        .expect("the pass must survive");
+    assert_eq!(summary.pairs_unpriced, 1, "a refused book leaves no price");
+
+    let records = recorded(&session_log);
+    let unavailable: Vec<&serde_json::Value> = of_type(&records, "prices_observed")
+        .iter()
+        .flat_map(|record| record["payload"]["unavailable"].as_array().unwrap())
+        .collect();
+    let refused = unavailable
+        .iter()
+        .find(|entry| entry["ticker"] == "AAAA")
+        .expect("the refused symbol must be named");
+
+    assert_eq!(refused["cause"], "quote_rejected");
+    assert_eq!(refused["quote_rejection"], "wide_quote");
+    assert_eq!(refused["bid_price"], 90.0);
+    assert_eq!(refused["ask_price"], 110.0);
+    assert!(refused["quote_timestamp"].is_string());
+
+    let absent = unavailable
+        .iter()
+        .find(|entry| entry["ticker"] == "BBBB")
+        .expect("a symbol with nothing at all is still named");
+    assert_eq!(absent["cause"], "no_quote");
+    assert!(
+        absent["bid_price"].is_null(),
+        "no book means no book, not a defaulted one"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Overview

## Changes

- Add `Snapshot::reference_price_checked`, which refuses a quote past a staleness or relative-width
  bound and falls through to the last trade. A refusal with no last trade behind it leaves the symbol
  unpriced, recorded as `quote_rejected`, rather than priced wrongly.
- Route the evaluation pass through it. It is now the only production caller of any pricing path, so
  the guard cannot be bypassed; `reference_price` and `reference_price_with_source` remain as the
  documented convenience path.
- Record the book before the guard rules on it. `PriceReading` gains `bid_price`, `ask_price`,
  `quote_timestamp` and `quote_rejection`, so a refused quote survives into the log alongside the
  last-trade price used in its place.
- `PairOpened` gains both legs' decision and fill prices, so an entry z-score can be checked against
  the prices it was computed from and entry slippage becomes a query rather than an inference.
- `OrderState` carries Alpaca's own status on every variant and `OrderResolved` records it.
- Replace `ReferencePrice` with `CheckedPrice`, which is the same three fields plus the verdict.

No `SCHEMA_VERSION` bump: the additions are optional and self-describing, so an older record reads as
a missing key rather than a plausible wrong answer.

## Context

The 2026-08-12 session log on the development application VM shows entries firing on prices that were
not prices. `AER` was recorded at 149.96, 139.43, 150.71, 139.12 on consecutive passes while its three
fills that day were 151.24, 151.12 and 150.60. Across the twelve passes that recorded a full price
map, 669 of 1265 priced tickers swing more than five percent, non-monotonically, liquid large caps
included.

The spread model is not the variable. It is fit from daily closes held in `CloseHistoryCache` for the
session, so `spread_mean` and `spread_standard_deviation` are identical across all 73 passes of a
pair's life — the only free term in the z-score is the intraday price. Pairs entered on the bad
reading and converged on the good one: `STT-NWG` entered at 3.795 and read 0.849 a pass later,
`PNC-BAC` 3.903 to 0.260, `HD-AOS` 4.306 to -1.243. Three closed as `convergence` within three passes,
paying a round trip for a quote artifact, and `AER-NU` was opened three times in one session. The
eight pairs that held their entry z within 0.15 all day are what rule the arithmetic out.

`reference_price_with_source` took the midpoint of any book it was handed. Its own docstring
anticipated exactly this case and no caller acted on it, and with `ALPACA_DATA_FEED` unset the feed is
IEX, whose thin single-venue book is what `alpaca.rs` already warns produces noise that looks like
signal.

### On the thresholds

`MAXIMUM_QUOTE_AGE_SECONDS = 60` and `MAXIMUM_RELATIVE_QUOTE_SPREAD = 0.01` are provisional and
deliberately loose. They were chosen to reject the readings that produced false entries, not measured
against a session that logged the book — which is why the guard and its diagnostics ship together and
why the reading is recorded before the guard rules on it. A log holding only the quotes that passed
could never say where the bounds belong. After one session, group `quote_rejection` by reason and
count `price_source`; if `last_trade` comes back as the majority, the bounds are too tight and want
widening before anything else is read into the session.

### Testing

The bug is reproduced before it is fixed: a test asserts the unguarded path still returns the 139.43
midpoint for the `AER` book, then that the guard refuses it as `Wide` and falls back to 150.60. The
rest cover a stale quote, a sound quote recording no rejection, a refusal with no last trade leaving
the symbol unpriced, and a missing quote falling back without a rejection.

The handler fixture now quotes `AAAA` as well as trading it, with a book straddling the last trade so
the midpoint is unchanged and only the source differs. Without it the new integration assertion was
vacuously true, since the fixtures emitted `latestTrade` only; an `any(price_source ==
"quote_midpoint")` assertion sits ahead of it so it cannot silently go vacuous again.

`devenv tasks run checks:rust` passes.

### Deliberately not in this change

- The SIP feed. `DataFeed::Sip` already exists behind `ALPACA_DATA_FEED` if that decision changes.
- Moving the first evaluation pass off 09:30 Eastern. Eight short legs timed out at the bell and the
  same tickers filled at 09:35, but `broker_status` is what will confirm whether their symbols had
  opened yet, so the schedule stays put until a session says so.
- Letting a higher-z candidate displace a weaker incumbent when the book is full. The book saturated
  at 10 of 10 by 09:40 and 62 of 74 passes were capacity-blocked, which is real and is a strategy
  change unrelated to this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer reference pricing that rejects stale or unusually wide quotes and falls back to the latest trade when available.
  * Order records now preserve and display the broker’s latest status.
  * Market and execution records now include bid/ask prices, quote timing, decision prices, and fill prices.
* **Bug Fixes**
  * Refused quotes are clearly recorded with the reason they were rejected.
  * Timeout and failed-order records now accurately reflect available broker status.
* **Tests**
  * Added coverage for quote validation, fallback pricing, and midpoint price metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[session-2026-08-12.jsonl.gz](https://github.com/user-attachments/files/31010545/session-2026-08-12.jsonl.gz)