### PR TITLE
Refuse a fit window that is not one distribution

### DIFF
--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -213,9 +213,14 @@ pub struct ScreenInputReading {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ExcludedTickerReading {
     pub ticker: String,
-    /// `already_held`, `no_sector`, `no_close_history`, `outside_universe`, `unpriced`, or
-    /// `unusable_input`.
+    /// `already_held`, `no_sector`, `no_close_history`, `outside_universe`, `unpriced`,
+    /// `unusable_input`, or `structural_break`.
     pub reason: String,
+    /// The reading the reason ruled on, where the name alone does not say how far outside it fell.
+    ///
+    /// Set for `structural_break` and absent for the set-membership tests, which have no number to
+    /// report. A limit can only be moved from the readings it refused.
+    pub detail: Option<String>,
 }
 
 /// One symbol's reference price, and which snapshot field it came from.

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -1015,6 +1015,7 @@ async fn build_screen_inputs(
             Some(reason) => excluded.push(ExcludedTickerReading {
                 ticker: ticker.to_string(),
                 reason: reason.to_string(),
+                detail: None,
             }),
             None => eligible.push(prediction),
         }
@@ -1039,22 +1040,27 @@ async fn build_screen_inputs(
             excluded.push(ExcludedTickerReading {
                 ticker: ticker.to_string(),
                 reason: "unpriced".to_string(),
+                detail: None,
             });
             continue;
         };
-        let Some(input) = ScreenInput::new(
+        let input = match ScreenInput::new(
             ticker.clone(),
             window.clone(),
             reference.price(),
             prediction.expected_return(),
             prediction.confidence(),
             context.universe.is_shortable(ticker),
-        ) else {
-            excluded.push(ExcludedTickerReading {
-                ticker: ticker.to_string(),
-                reason: "unusable_input".to_string(),
-            });
-            continue;
+        ) {
+            Ok(input) => input,
+            Err(rejection) => {
+                excluded.push(ExcludedTickerReading {
+                    ticker: ticker.to_string(),
+                    reason: rejection.as_str().to_string(),
+                    detail: rejection.detail(),
+                });
+                continue;
+            }
         };
         readings.push(ScreenInputReading {
             ticker: ticker.to_string(),

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -89,6 +89,55 @@ const MINIMUM_ELIGIBLE_TICKERS: usize = 2;
 /// quantities, and a change to the ticker threshold must not silently move the statistical floor.
 const MINIMUM_SPREAD_OBSERVATIONS: usize = 2;
 
+/// Largest single-session log return a fit window may contain and still be screened.
+///
+/// A window holding a larger move is not one distribution. The standard deviation and the ordinary
+/// least squares slope then both describe a series that changed level partway through, and the
+/// hedge ratio that comes out of it does not hedge — which is a directional bet wearing a
+/// market-neutral name. The cause is deliberately not consulted: a split artifact and a real
+/// collapse damage the fit identically, and only one of them is fixable by re-fetching.
+///
+/// Provisional and deliberately loose, on the same terms as
+/// [`crate::common::alpaca::MAXIMUM_QUOTE_AGE_SECONDS`]. Measured across 1,903 eligible tickers over
+/// 2026-05-01 to 2026-08-12, the worst single-session move has a median of 0.084 and a ninetieth
+/// percentile of 0.247, so this sits clear of ordinary earnings gaps and excludes 3.9% of them.
+pub const MAXIMUM_SESSION_LOG_RETURN: f64 = 0.40;
+
+/// Why a symbol could not be screened.
+///
+/// Carried out of [`ScreenInput::new`] rather than collapsed into `None`, so the session log can say
+/// which test a ticker failed and — where the test is a number — by how much.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ScreenRejection {
+    /// Too short a history, or a close, live price, or prediction that is not a usable number.
+    UnusableInput,
+    /// One session's move is large enough to dominate the window it sits in.
+    StructuralBreak { log_return: f64, limit: f64 },
+}
+
+impl ScreenRejection {
+    /// The stable name this rejection is recorded under.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ScreenRejection::UnusableInput => "unusable_input",
+            ScreenRejection::StructuralBreak { .. } => "structural_break",
+        }
+    }
+
+    /// The numbers behind the rejection, for the ones that have any.
+    ///
+    /// A bound can only be moved from readings it refused, so the reading is recorded and not just
+    /// the verdict. `UnusableInput` has nothing to report beyond its own name.
+    pub fn detail(&self) -> Option<String> {
+        match self {
+            ScreenRejection::UnusableInput => None,
+            ScreenRejection::StructuralBreak { log_return, limit } => Some(format!(
+                "session log return of {log_return:.4} exceeds the limit of {limit:.4}"
+            )),
+        }
+    }
+}
+
 /// One symbol's inputs to the screen.
 ///
 /// `closes` must be aligned across every input in a batch — position `i` the same session in each
@@ -116,23 +165,34 @@ impl ScreenInput {
         expected_return: f64,
         confidence: f64,
         is_shortable: bool,
-    ) -> Option<Self> {
+    ) -> Result<Self, ScreenRejection> {
         if closes.len() < CORRELATION_WINDOW_SESSIONS {
-            return None;
+            return Err(ScreenRejection::UnusableInput);
         }
         if !price.is_finite() || price <= 0.0 {
-            return None;
+            return Err(ScreenRejection::UnusableInput);
         }
         if closes
             .iter()
             .any(|close| !close.is_finite() || *close <= 0.0)
         {
-            return None;
+            return Err(ScreenRejection::UnusableInput);
         }
         if !expected_return.is_finite() || !confidence.is_finite() {
-            return None;
+            return Err(ScreenRejection::UnusableInput);
         }
-        Some(Self {
+        // The fitted window and not the whole series: a break older than the window cannot reach
+        // the spread model, so excluding on it would refuse a name whose history has since settled.
+        let window = &closes[closes.len() - CORRELATION_WINDOW_SESSIONS..];
+        if let Some(log_return) = worst_session_move(window) {
+            if log_return.abs() > MAXIMUM_SESSION_LOG_RETURN {
+                return Err(ScreenRejection::StructuralBreak {
+                    log_return,
+                    limit: MAXIMUM_SESSION_LOG_RETURN,
+                });
+            }
+        }
+        Ok(Self {
             ticker,
             closes,
             price,
@@ -617,6 +677,17 @@ fn aligned_logs(long_closes: &[f64], short_closes: &[f64]) -> Option<(Vec<f64>, 
     Some((to_logs(long_closes)?, to_logs(short_closes)?))
 }
 
+/// The window's largest single-session move, by magnitude, as a signed log return.
+///
+/// Signed so the recorded detail says which way the series jumped, and largest rather than first so
+/// the number a bound gets calibrated against is the worst one present. Assumes positive closes,
+/// which [`ScreenInput::new`] establishes before calling.
+fn worst_session_move(window: &[f64]) -> Option<f64> {
+    log_returns(window)
+        .into_iter()
+        .max_by(|left, right| left.abs().total_cmp(&right.abs()))
+}
+
 /// Period-over-period log returns. One shorter than its input.
 fn log_returns(prices: &[f64]) -> Vec<f64> {
     prices
@@ -1073,19 +1144,140 @@ mod tests {
 
     #[test]
     fn test_screen_input_rejects_a_short_or_unusable_history() {
+        assert_eq!(
+            ScreenInput::new(
+                ticker("AAAA"),
+                vec![100.0; CORRELATION_WINDOW_SESSIONS - 1],
+                100.0,
+                0.01,
+                0.9,
+                true
+            )
+            .expect_err("too short a history must be refused"),
+            ScreenRejection::UnusableInput
+        );
+
+        let mut with_zero = vec![100.0; CORRELATION_WINDOW_SESSIONS];
+        with_zero[3] = 0.0;
+        assert_eq!(
+            ScreenInput::new(ticker("AAAA"), with_zero, 100.0, 0.01, 0.9, true)
+                .expect_err("a non-positive close must be refused"),
+            ScreenRejection::UnusableInput
+        );
+    }
+
+    // --- structural breaks ---
+
+    /// A window holding one persistent level change, the shape a collapse or a split leaves behind.
+    fn window_with_one_move(log_return: f64) -> Vec<f64> {
+        let mut closes = vec![100.0; CORRELATION_WINDOW_SESSIONS];
+        for close in closes.iter_mut().skip(CORRELATION_WINDOW_SESSIONS / 2) {
+            *close = 100.0 * log_return.exp();
+        }
+        closes
+    }
+
+    /// The reason the guard exists. A collapse partway through leaves a series that is not one
+    /// distribution, and nothing about the fit says so — it succeeds, and the dispersion it reports
+    /// describes the level change rather than the spread it is supposed to measure.
+    #[test]
+    fn test_a_broken_window_silently_inflates_the_fitted_dispersion() {
+        let (leader, follower) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
+        let clean = SpreadModel::fit(&leader, &follower).expect("the clean fit must succeed");
+
+        let mut broken = follower.clone();
+        for close in broken.iter_mut().skip(CORRELATION_WINDOW_SESSIONS / 2) {
+            *close *= 0.1;
+        }
+        let damaged = SpreadModel::fit(&leader, &broken).expect("the broken fit still succeeds");
+
+        assert!(
+            damaged.standard_deviation() > clean.standard_deviation() * 5.0,
+            "broken standard deviation {} should dwarf the clean {}",
+            damaged.standard_deviation(),
+            clean.standard_deviation()
+        );
+    }
+
+    #[test]
+    fn test_screen_input_rejects_a_window_containing_a_structural_break() {
+        let breached = MAXIMUM_SESSION_LOG_RETURN + 0.01;
+        let rejection = ScreenInput::new(
+            ticker("AAAA"),
+            window_with_one_move(-breached),
+            100.0,
+            0.01,
+            0.9,
+            true,
+        )
+        .expect_err("a window with a break must be refused");
+
+        // The payload, not only the variant: the recorded number is the entire reason the rejection
+        // is written down, and a sign flip or a swapped pair reads as a pass against `matches!`.
+        let ScreenRejection::StructuralBreak { log_return, limit } = rejection else {
+            panic!("expected a structural break, got {rejection:?}");
+        };
+        assert!((log_return + breached).abs() < 1e-9, "got {log_return}");
+        assert_eq!(limit, MAXIMUM_SESSION_LOG_RETURN);
+    }
+
+    /// The limit has to admit ordinary moves, or the guard costs more universe than it saves.
+    #[test]
+    fn test_screen_input_accepts_a_move_inside_the_limit() {
         assert!(ScreenInput::new(
             ticker("AAAA"),
-            vec![100.0; CORRELATION_WINDOW_SESSIONS - 1],
+            window_with_one_move(MAXIMUM_SESSION_LOG_RETURN - 0.01),
             100.0,
             0.01,
             0.9,
             true
         )
-        .is_none());
+        .is_ok());
+    }
 
-        let mut with_zero = vec![100.0; CORRELATION_WINDOW_SESSIONS];
-        with_zero[3] = 0.0;
-        assert!(ScreenInput::new(ticker("AAAA"), with_zero, 100.0, 0.01, 0.9, true).is_none());
+    /// Only the fitted window can reach the spread model, so a name whose history has since settled
+    /// is screenable again rather than excluded for as long as the break stays in its series.
+    #[test]
+    fn test_a_break_older_than_the_fitted_window_is_not_rejected() {
+        let mut closes = vec![10.0; 5];
+        closes.extend(vec![100.0; CORRELATION_WINDOW_SESSIONS]);
+        assert!(ScreenInput::new(ticker("AAAA"), closes, 100.0, 0.01, 0.9, true).is_ok());
+    }
+
+    /// Entry only, deliberately. Refusing to measure a pair already on the book would leave it with
+    /// no signal to close on, and a close reduces risk — the asymmetry runs one way.
+    #[test]
+    fn test_the_exit_path_still_measures_a_broken_window() {
+        let (leader, follower) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
+        let mut broken = follower.clone();
+        for close in broken.iter_mut().skip(CORRELATION_WINDOW_SESSIONS / 2) {
+            *close *= 0.1;
+        }
+        assert!(SpreadModel::with_hedge_ratio(0.9, &leader, &broken).is_some());
+    }
+
+    #[test]
+    fn test_every_rejection_has_a_stable_name_and_only_breaks_carry_detail() {
+        assert_eq!(ScreenRejection::UnusableInput.as_str(), "unusable_input");
+        assert_eq!(ScreenRejection::UnusableInput.detail(), None);
+
+        let broken = ScreenRejection::StructuralBreak {
+            log_return: -2.28,
+            limit: MAXIMUM_SESSION_LOG_RETURN,
+        };
+        assert_eq!(broken.as_str(), "structural_break");
+        assert!(broken
+            .detail()
+            .expect("a break reports its reading")
+            .contains("-2.2800"));
+    }
+
+    #[test]
+    fn test_worst_session_move_reports_the_largest_by_magnitude_with_its_sign() {
+        assert_eq!(worst_session_move(&[100.0]), None);
+
+        let move_down = worst_session_move(&[100.0, 110.0, 55.0]).expect("a move must be found");
+        assert!((move_down - (55.0_f64 / 110.0).ln()).abs() < 1e-12);
     }
 
     // --- selection ---

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -91,16 +91,11 @@ const MINIMUM_SPREAD_OBSERVATIONS: usize = 2;
 
 /// Largest single-session log return a fit window may contain and still be screened.
 ///
-/// A window holding a larger move is not one distribution. The standard deviation and the ordinary
-/// least squares slope then both describe a series that changed level partway through, and the
-/// hedge ratio that comes out of it does not hedge — which is a directional bet wearing a
-/// market-neutral name. The cause is deliberately not consulted: a split artifact and a real
-/// collapse damage the fit identically, and only one of them is fixable by re-fetching.
+/// A window holding a larger move is not one distribution, so the hedge ratio fitted across it does
+/// not hedge. The cause is deliberately not consulted: a split artifact and a real collapse damage
+/// the fit identically, and only one of them is fixable by re-fetching.
 ///
-/// Provisional and deliberately loose, on the same terms as
-/// [`crate::common::alpaca::MAXIMUM_QUOTE_AGE_SECONDS`]. Measured across 1,903 eligible tickers over
-/// 2026-05-01 to 2026-08-12, the worst single-session move has a median of 0.084 and a ninetieth
-/// percentile of 0.247, so this sits clear of ordinary earnings gaps and excludes 3.9% of them.
+/// Provisional, on the same terms as [`crate::common::alpaca::MAXIMUM_QUOTE_AGE_SECONDS`].
 pub const MAXIMUM_SESSION_LOG_RETURN: f64 = 0.40;
 
 /// Why a symbol could not be screened.
@@ -131,9 +126,9 @@ impl ScreenRejection {
     pub fn detail(&self) -> Option<String> {
         match self {
             ScreenRejection::UnusableInput => None,
-            ScreenRejection::StructuralBreak { log_return, limit } => Some(format!(
-                "session log return of {log_return:.4} exceeds the limit of {limit:.4}"
-            )),
+            ScreenRejection::StructuralBreak { log_return, limit } => {
+                Some(format!("log_return={log_return:.4} limit={limit:.4}"))
+            }
         }
     }
 }
@@ -184,13 +179,14 @@ impl ScreenInput {
         // The fitted window and not the whole series: a break older than the window cannot reach
         // the spread model, so excluding on it would refuse a name whose history has since settled.
         let window = &closes[closes.len() - CORRELATION_WINDOW_SESSIONS..];
-        if let Some(log_return) = worst_session_move(window) {
-            if log_return.abs() > MAXIMUM_SESSION_LOG_RETURN {
+        match worst_session_move(window) {
+            Some(log_return) if log_return.abs() > MAXIMUM_SESSION_LOG_RETURN => {
                 return Err(ScreenRejection::StructuralBreak {
                     log_return,
                     limit: MAXIMUM_SESSION_LOG_RETURN,
                 });
             }
+            Some(_) | None => {}
         }
         Ok(Self {
             ticker,
@@ -680,11 +676,13 @@ fn aligned_logs(long_closes: &[f64], short_closes: &[f64]) -> Option<(Vec<f64>, 
 /// The window's largest single-session move, by magnitude, as a signed log return.
 ///
 /// Signed so the recorded detail says which way the series jumped, and largest rather than first so
-/// the number a bound gets calibrated against is the worst one present. Assumes positive closes,
-/// which [`ScreenInput::new`] establishes before calling.
+/// the number a bound gets calibrated against is the worst one present. Iterates rather than reusing
+/// [`log_returns`], which would collect a vector per ticker on a pass that screens over a thousand.
 fn worst_session_move(window: &[f64]) -> Option<f64> {
-    log_returns(window)
-        .into_iter()
+    window
+        .windows(2)
+        .filter(|pair| pair[0] > 0.0 && pair[1] > 0.0)
+        .map(|pair| (pair[1] / pair[0]).ln())
         .max_by(|left, right| left.abs().total_cmp(&right.abs()))
 }
 
@@ -1221,12 +1219,13 @@ mod tests {
         assert_eq!(limit, MAXIMUM_SESSION_LOG_RETURN);
     }
 
-    /// The limit has to admit ordinary moves, or the guard costs more universe than it saves.
+    /// At the limit exactly, not merely inside it. The comparison is strict, so a move equal to the
+    /// bound is admitted, and testing below the bound would let a change to `>=` pass unnoticed.
     #[test]
-    fn test_screen_input_accepts_a_move_inside_the_limit() {
+    fn test_screen_input_accepts_a_move_at_the_limit() {
         assert!(ScreenInput::new(
             ticker("AAAA"),
-            window_with_one_move(MAXIMUM_SESSION_LOG_RETURN - 0.01),
+            window_with_one_move(MAXIMUM_SESSION_LOG_RETURN),
             100.0,
             0.01,
             0.9,
@@ -1266,10 +1265,12 @@ mod tests {
             limit: MAXIMUM_SESSION_LOG_RETURN,
         };
         assert_eq!(broken.as_str(), "structural_break");
-        assert!(broken
-            .detail()
-            .expect("a break reports its reading")
-            .contains("-2.2800"));
+        // The whole string: the detail exists to be aggregated out of session logs, so the format
+        // is the contract and a `contains` check would not notice it drifting.
+        assert_eq!(
+            broken.detail().expect("a break reports its reading"),
+            format!("log_return=-2.2800 limit={MAXIMUM_SESSION_LOG_RETURN:.4}")
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Overview

Rejects a pair-screening input whose sixty-session fit window contains a structural break, so a
hedge ratio fitted across a level change never sizes a position.

## Changes

- Add `MAXIMUM_SESSION_LOG_RETURN` (0.40) and refuse a fit window whose worst single-session log
  return exceeds it.
- Change `ScreenInput::new` to return `Result<Self, ScreenRejection>` rather than `Option`, so the
  reason a ticker was refused survives into the session log instead of collapsing into
  `unusable_input`.
- Add an optional `detail` to `ExcludedTickerReading`, carrying the log return that was refused.
- Add `worst_session_move`, and seven tests covering the failure being fixed, the boundary, the
  window edge, the recorded payload, and the exit path.

## Context

`TENX` read 13.44 on 2026-08-07 and 1.375 on 08-10; `CLBK` read 24.50 on 07-20 and 11.08 on 07-21.
Both are in the live eligible set, and both are real price collapses rather than data faults — which
is the point. The spread model fits sixty daily closes, so a single -2.28 log return inside that
window makes the standard deviation and the ordinary least squares slope describe a series that
changed level partway through rather than the spread they are meant to measure. The resulting hedge
ratio does not hedge, which is the same failure the correlation band already refuses anti-correlated
pairs to avoid.

The guard deliberately does not ask why the break happened. A split artifact and a genuine collapse
damage the fit identically, and only one of them is fixable by re-fetching, so a break detector
catches strictly more than a split detector could and cannot be obsoleted by a corporate actions
feed later.

Only the fitted window is inspected rather than the whole series, so a name whose history has since
settled becomes screenable again instead of staying excluded for as long as the break sits in its
closes. `SpreadModel::with_hedge_ratio` is untouched: a pair already on the book stays measurable
and can still close on a signal, because refusing to measure it would leave the book holding
something it has no way to let go of.

The bound is provisional and deliberately loose, on the same terms as the quote limits in #1060.
Measured across 1,903 eligible tickers over 2026-05-01 to 2026-08-12, the worst single-session move
has a median of 0.084 and a ninetieth percentile of 0.247, so 0.40 sits clear of ordinary earnings
gaps. Against the application's own store it excludes 14 of the 1,279 tickers screened on
2026-08-13, `TENX` and `CLBK` among them. The recorded detail is what allows the limit to be moved
from readings it actually refused rather than from this first guess.

`ExcludedTickerReading.detail` is additive and optional, so there is no schema version bump: an
older record reads as a missing key rather than a plausible wrong answer.

### Surfaced, not fixed here

`MNST` closed at 96.38 on 2026-07-02 and 48.685 on 07-06 in the S3 bar archive, and at 48.19 and
48.685 in Postgres — a two-for-one split landing exactly on the seam between the partitions written
2026-08-06 and those written 08-11. Each write block is internally consistent and the seams between
them are not. Twenty-nine tickers cross that seam and only `MNST` is liquid, but the trainer reads S3
while the application reads Postgres, so the two are training and trading on different histories for
those names. That belongs to the separate work on unadjusted bars and a splits dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structural-break detection when screening fitted close windows.
  * Screening now identifies the largest session return exceeding the configured limit.
  * Exclusion records can include diagnostic details about rejected readings.

* **Bug Fixes**
  * Replaced generic unusable-input reporting with specific rejection reasons and details for clearer screening results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->