### PR TITLE
Date the trade the pass actually prices on

### DIFF
--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -19,7 +19,7 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 use tracing::{debug, info, warn};
 
-use crate::common::types::{BarInterval, Dollars, EquityBar, EquityQuote, Ticker};
+use crate::common::types::{BarInterval, Dollars, EquityBar, EquityQuote, EquityTrade, Ticker};
 
 // --------------------------------------------------------------------------
 // Shared configuration and errors
@@ -1610,7 +1610,7 @@ pub struct SnapshotFetch {
 pub struct Snapshot {
     ticker: Ticker,
     latest_quote: Option<EquityQuote>,
-    latest_trade_price: Option<f64>,
+    latest_trade: Option<EquityTrade>,
     minute_bar: Option<EquityBar>,
     daily_bar: Option<EquityBar>,
     previous_daily_bar: Option<EquityBar>,
@@ -1625,8 +1625,8 @@ impl Snapshot {
         self.latest_quote.as_ref()
     }
 
-    pub fn latest_trade_price(&self) -> Option<f64> {
-        self.latest_trade_price
+    pub fn latest_trade(&self) -> Option<&EquityTrade> {
+        self.latest_trade.as_ref()
     }
 
     pub fn minute_bar(&self) -> Option<&EquityBar> {
@@ -1662,8 +1662,9 @@ impl Snapshot {
             .as_ref()
             .map(|quote| (quote.mid_price(), PriceSource::QuoteMidpoint))
             .or_else(|| {
-                self.latest_trade_price
-                    .map(|price| (price, PriceSource::LastTrade))
+                self.latest_trade
+                    .as_ref()
+                    .map(|trade| (trade.price(), PriceSource::LastTrade))
             })
     }
 
@@ -1692,8 +1693,8 @@ impl Snapshot {
             None => None,
         };
 
-        self.latest_trade_price.map(|price| CheckedPrice {
-            price,
+        self.latest_trade.as_ref().map(|trade| CheckedPrice {
+            price: trade.price(),
             source: PriceSource::LastTrade,
             rejection,
         })
@@ -2009,7 +2010,9 @@ impl MarketDataClient {
                     latest_quote: snapshot
                         .latest_quote
                         .and_then(|quote| quote.into_equity_quote(&ticker)),
-                    latest_trade_price: snapshot.latest_trade.and_then(|trade| trade.price),
+                    latest_trade: snapshot
+                        .latest_trade
+                        .and_then(|trade| trade.into_equity_trade(&ticker)),
                     minute_bar: snapshot
                         .minute_bar
                         .and_then(|bar| bar.into_equity_bar(&ticker, BarInterval::OneMinute)),
@@ -2081,8 +2084,26 @@ impl QuotePayload {
 
 #[derive(Deserialize)]
 struct TradePayload {
+    #[serde(rename = "t")]
+    timestamp: Option<DateTime<Utc>>,
     #[serde(rename = "p")]
     price: Option<f64>,
+}
+
+impl TradePayload {
+    /// A trade missing its price or its timestamp is dropped, on the same terms as
+    /// [`QuotePayload::into_equity_quote`].
+    ///
+    /// Dropping an undated trade costs the symbol its fallback price, which is the intent: the last
+    /// trade is what a pass prices on once the book is refused, and one that cannot be dated cannot
+    /// be refused in turn.
+    fn into_equity_trade(self, ticker: &Ticker) -> Option<EquityTrade> {
+        EquityTrade::new(ticker.clone(), self.timestamp?, self.price?)
+            .inspect_err(|error| {
+                debug!(ticker = %ticker, error = %error, "Dropped an incoherent trade");
+            })
+            .ok()
+    }
 }
 
 #[derive(Deserialize)]
@@ -3190,7 +3211,7 @@ mod tests {
         assert_eq!(snapshots.snapshots.len(), 1);
         let snapshot = &snapshots.snapshots[0];
         assert_eq!(snapshot.ticker().as_str(), "AAPL");
-        assert_eq!(snapshot.latest_trade_price(), Some(201.5));
+        assert_eq!(snapshot.latest_trade().unwrap().price(), 201.5);
         assert_eq!(snapshot.latest_quote().unwrap().bid_price(), 201.0);
         assert_eq!(snapshot.minute_bar().unwrap().close_price(), 201.5);
         assert_eq!(snapshot.daily_bar().unwrap().volume(), 2_500_000);
@@ -3232,7 +3253,7 @@ mod tests {
             .mock("GET", "/v2/stocks/snapshots?symbols=AAPL&feed=iex")
             .with_status(200)
             .with_body(
-                r#"{"AAPL":{"latestTrade":{"p":150.0},
+                r#"{"AAPL":{"latestTrade":{"t":"2026-06-10T15:59:00Z","p":150.0},
                     "latestQuote":{"t":"2026-06-10T15:59:30Z","bp":149.0,"bs":10,"as":12}}}"#,
             )
             .create_async()
@@ -3251,6 +3272,60 @@ mod tests {
         mock.assert_async().await;
     }
 
+    /// The trade's `t` was the one timestamp the snapshot parse dropped, so a fallback price could
+    /// be any age and the record could not say. Every other component already kept its own.
+    #[tokio::test]
+    async fn test_a_snapshot_keeps_when_the_last_trade_printed() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/v2/stocks/snapshots?symbols=AAPL&feed=iex")
+            .with_status(200)
+            .with_body(FULL_SNAPSHOT)
+            .create_async()
+            .await;
+
+        let snapshots = client(server.url())
+            .fetch_snapshots(&["AAPL".to_string()])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            snapshots.snapshots[0].latest_trade().unwrap().timestamp(),
+            "2026-06-10T15:59:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
+        mock.assert_async().await;
+    }
+
+    /// An undated trade costs the symbol its fallback price rather than supplying an unjudgeable
+    /// one, which is the same call [`QuotePayload::into_equity_quote`] makes on a partial book.
+    #[tokio::test]
+    async fn test_a_trade_that_cannot_be_dated_or_priced_is_dropped() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(r"^/v2/stocks/snapshots".into()),
+            )
+            .with_status(200)
+            .with_body(
+                r#"{"AAPL":{"latestTrade":{"p":150.0}},
+                    "MSFT":{"latestTrade":{"t":"2026-06-10T15:59:00Z","p":0.0}}}"#,
+            )
+            .create_async()
+            .await;
+
+        let snapshots = client(server.url())
+            .fetch_snapshots(&["AAPL".to_string(), "MSFT".to_string()])
+            .await
+            .unwrap();
+
+        for snapshot in &snapshots.snapshots {
+            assert!(snapshot.latest_trade().is_none());
+            assert_eq!(snapshot.reference_price(), None);
+        }
+        mock.assert_async().await;
+    }
+
     // --- the quote guard ---
 
     /// The `AER` reading from 2026-08-12: a book wide enough that its midpoint sat seven percent
@@ -3261,7 +3336,7 @@ mod tests {
             latest_quote: Some(
                 EquityQuote::new(ticker.clone(), quoted_at, 128.0, 150.86, 10, 12).unwrap(),
             ),
-            latest_trade_price: Some(150.60),
+            latest_trade: Some(EquityTrade::new(ticker.clone(), quoted_at, 150.60).unwrap()),
             minute_bar: None,
             daily_bar: None,
             previous_daily_bar: None,
@@ -3275,7 +3350,7 @@ mod tests {
             latest_quote: Some(
                 EquityQuote::new(ticker.clone(), quoted_at, 150.58, 150.62, 10, 12).unwrap(),
             ),
-            latest_trade_price: Some(150.60),
+            latest_trade: Some(EquityTrade::new(ticker.clone(), quoted_at, 150.60).unwrap()),
             minute_bar: None,
             daily_bar: None,
             previous_daily_bar: None,
@@ -3403,7 +3478,7 @@ mod tests {
     fn test_a_refused_quote_with_no_last_trade_leaves_the_symbol_unpriced() {
         let now = Utc.with_ymd_and_hms(2026, 8, 12, 14, 40, 0).unwrap();
         let mut snapshot = wide_book_snapshot(now);
-        snapshot.latest_trade_price = None;
+        snapshot.latest_trade = None;
 
         assert_eq!(
             snapshot.reference_price_checked(now, QuoteLimits::default()),
@@ -3424,6 +3499,25 @@ mod tests {
             .unwrap();
         assert_eq!(checked.source(), PriceSource::LastTrade);
         assert_eq!(checked.rejection(), None);
+    }
+
+    /// [`QuoteLimits`] describes a book and nothing describes a trade, so the fallback price is
+    /// taken at any age. Pinning that here so it is a decision on the record rather than an
+    /// oversight; the trade's time now reaches the session log, which is what a bound would be set
+    /// from.
+    #[test]
+    fn test_an_hours_old_trade_is_still_taken_as_the_fallback_price() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 12, 14, 40, 0).unwrap();
+        let mut snapshot = wide_book_snapshot(now);
+        let ticker = snapshot.ticker().clone();
+        snapshot.latest_trade =
+            Some(EquityTrade::new(ticker, now - chrono::Duration::hours(6), 150.60).unwrap());
+
+        let checked = snapshot
+            .reference_price_checked(now, QuoteLimits::default())
+            .unwrap();
+        assert_eq!(checked.source(), PriceSource::LastTrade);
+        assert!((checked.price() - 150.60).abs() < 1e-9);
     }
 
     #[test]

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -2092,11 +2092,7 @@ struct TradePayload {
 
 impl TradePayload {
     /// A trade missing its price or its timestamp is dropped, on the same terms as
-    /// [`QuotePayload::into_equity_quote`].
-    ///
-    /// Dropping an undated trade costs the symbol its fallback price, which is the intent: the last
-    /// trade is what a pass prices on once the book is refused, and one that cannot be dated cannot
-    /// be refused in turn.
+    /// [`QuotePayload::into_equity_quote`], costing the symbol its fallback price.
     fn into_equity_trade(self, ticker: &Ticker) -> Option<EquityTrade> {
         EquityTrade::new(ticker.clone(), self.timestamp?, self.price?)
             .inspect_err(|error| {
@@ -3502,9 +3498,7 @@ mod tests {
     }
 
     /// [`QuoteLimits`] describes a book and nothing describes a trade, so the fallback price is
-    /// taken at any age. Pinning that here so it is a decision on the record rather than an
-    /// oversight; the trade's time now reaches the session log, which is what a bound would be set
-    /// from.
+    /// taken at any age. Pinned here so it reads as a decision rather than an oversight.
     #[test]
     fn test_an_hours_old_trade_is_still_taken_as_the_fallback_price() {
         let now = Utc.with_ymd_and_hms(2026, 8, 12, 14, 40, 0).unwrap();

--- a/src/common/session_log.rs
+++ b/src/common/session_log.rs
@@ -225,9 +225,10 @@ pub struct ExcludedTickerReading {
 
 /// One symbol's reference price, and which snapshot field it came from.
 ///
-/// The book is recorded whether or not the price came from it. A reading that fell back to the last
-/// trade still carries the quote that was refused and the reason, because a log holding only the
-/// quotes that passed cannot say whether the limits are set anywhere near right.
+/// Both readings behind the price are recorded whether or not the price came from them. A reading
+/// that fell back to the last trade still carries the quote that was refused and the reason, because
+/// a log holding only the quotes that passed cannot say whether the limits are set anywhere near
+/// right.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PriceReading {
     pub ticker: String,
@@ -240,6 +241,11 @@ pub struct PriceReading {
     pub quote_timestamp: Option<DateTime<Utc>>,
     /// `stale_quote` or `wide_quote`, set only when a quote existed and the guard refused it.
     pub quote_rejection: Option<String>,
+    /// When the last trade printed, on the same terms as `quote_timestamp`.
+    ///
+    /// Unlike the quote, nothing refuses a trade for being old, so this is the only place a stale
+    /// fallback price can be noticed at all. Absent when the snapshot carried no usable trade.
+    pub trade_timestamp: Option<DateTime<Utc>>,
 }
 
 /// An open pair as this pass measured it, whether or not it closed.
@@ -943,6 +949,7 @@ mod tests {
             ask_price: Some(150.86),
             quote_timestamp: Some(instant("2026-08-12T14:40:00Z")),
             quote_rejection: Some("wide_quote".to_string()),
+            trade_timestamp: Some(instant("2026-08-12T13:12:00Z")),
         };
 
         let value = serde_json::to_value(&refused).expect("a reading must serialize");
@@ -954,6 +961,7 @@ mod tests {
             value["quote_timestamp"].is_string(),
             "staleness is the gap between the quote and the read, so the quote's own time is kept"
         );
+        assert_eq!(value["trade_timestamp"], "2026-08-12T13:12:00Z");
     }
 
     #[tokio::test]

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -824,6 +824,50 @@ impl EquityQuote {
     }
 }
 
+/// The most recent trade in a symbol, as one snapshot reported it.
+///
+/// The timestamp is not optional because the last trade is what the pass prices on whenever the
+/// book is refused, and an undated one cannot be judged for staleness the way [`EquityQuote`] can.
+#[derive(Debug, Clone)]
+pub struct EquityTrade {
+    ticker: Ticker,
+    timestamp: DateTime<Utc>,
+    price: f64,
+}
+
+impl EquityTrade {
+    /// Constructs an `EquityTrade`, rejecting a price that is not one.
+    pub fn new(
+        ticker: Ticker,
+        timestamp: DateTime<Utc>,
+        price: f64,
+    ) -> Result<Self, InconsistentRecordError> {
+        if !price.is_finite() || price <= 0.0 {
+            return Err(reject(format!(
+                "trade price {price} is not a positive number"
+            )));
+        }
+
+        Ok(Self {
+            ticker,
+            timestamp,
+            price,
+        })
+    }
+
+    pub fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
+    }
+
+    pub fn price(&self) -> f64 {
+        self.price
+    }
+}
+
 /// Ticker metadata used to constrain pair selection to cross-sector matches.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EquityDetail {
@@ -1278,6 +1322,24 @@ mod tests {
         assert!(quote(103.0, 102.0, 5, 5).is_err(), "crossed book");
         assert!(quote(f64::NAN, 102.0, 5, 5).is_err(), "non-finite bid");
         assert!(quote(100.0, 102.0, -1, 5).is_err(), "negative size");
+    }
+
+    #[test]
+    fn test_trade_rejects_a_price_that_is_not_one() {
+        let at = Utc::now();
+        assert_eq!(
+            EquityTrade::new(ticker("AAPL"), at, 201.5).unwrap().price(),
+            201.5
+        );
+        assert!(EquityTrade::new(ticker("AAPL"), at, 0.0).is_err(), "zero");
+        assert!(
+            EquityTrade::new(ticker("AAPL"), at, -1.0).is_err(),
+            "signed"
+        );
+        assert!(
+            EquityTrade::new(ticker("AAPL"), at, f64::NAN).is_err(),
+            "non-finite"
+        );
     }
 
     fn prediction(

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -617,6 +617,7 @@ async fn fetch_prices(
 
     for snapshot in &fetched.snapshots {
         let quote = snapshot.latest_quote();
+        let trade = snapshot.latest_trade();
         match snapshot.reference_price_checked(context.now, limits) {
             Some(checked) => {
                 readings.push(PriceReading {
@@ -629,6 +630,7 @@ async fn fetch_prices(
                     quote_rejection: checked
                         .rejection()
                         .map(|rejection| rejection.as_str().to_string()),
+                    trade_timestamp: trade.map(|trade| trade.timestamp()),
                 });
                 prices.insert(snapshot.ticker().clone(), checked);
             }

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -208,7 +208,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
     let long_price = last_close(&close_history, "AAAA");
     let snapshot_body = serde_json::json!({
         "AAAA": {
-            "latestTrade": { "p": long_price },
+            "latestTrade": { "t": session_instant().to_rfc3339(), "p": long_price },
             "latestQuote": {
                 "t": session_instant().to_rfc3339(),
                 "bp": long_price * 0.9995,
@@ -217,7 +217,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
                 "as": 12,
             },
         },
-        "BBBB": { "latestTrade": { "p": last_close(&close_history, "BBBB") * 1.012 } },
+        "BBBB": { "latestTrade": { "t": session_instant().to_rfc3339(), "p": last_close(&close_history, "BBBB") * 1.012 } },
     });
 
     let _snapshots = server
@@ -361,6 +361,14 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
         }),
         "a midpoint must carry the book it was taken from, or the guard cannot be tuned"
     );
+    // Nothing refuses a trade for being old, so the record is the only place a stale fallback price
+    // can be noticed — and the fallback is the dominant source once the book guard starts firing.
+    assert!(
+        readings
+            .iter()
+            .all(|reading| reading["trade_timestamp"].is_string()),
+        "every reading carries when its last trade printed"
+    );
     assert!(
         priced
             .iter()
@@ -464,8 +472,8 @@ async fn test_a_pass_opens_nothing_once_shutdown_is_requested() {
         .expect("history must load");
 
     let snapshot_body = serde_json::json!({
-        "AAAA": { "latestTrade": { "p": last_close(&close_history, "AAAA") } },
-        "BBBB": { "latestTrade": { "p": last_close(&close_history, "BBBB") * 1.012 } },
+        "AAAA": { "latestTrade": { "t": session_instant().to_rfc3339(), "p": last_close(&close_history, "AAAA") } },
+        "BBBB": { "latestTrade": { "t": session_instant().to_rfc3339(), "p": last_close(&close_history, "BBBB") * 1.012 } },
     });
     let _snapshots = server
         .mock(
@@ -580,8 +588,8 @@ async fn test_a_pass_closes_a_converged_pair_from_a_full_book() {
     // Priced at the last close of each leg: the spread sits at roughly its fitted mean, which is
     // at or below the convergence threshold.
     let snapshot_body = serde_json::json!({
-        "AAAA": { "latestTrade": { "p": last_close(&close_history, "AAAA") } },
-        "BBBB": { "latestTrade": { "p": mean_reverting_short_price(&close_history) } },
+        "AAAA": { "latestTrade": { "t": session_instant().to_rfc3339(), "p": last_close(&close_history, "AAAA") } },
+        "BBBB": { "latestTrade": { "t": session_instant().to_rfc3339(), "p": mean_reverting_short_price(&close_history) } },
     });
 
     let _snapshots = server
@@ -721,7 +729,10 @@ async fn test_a_failed_pass_records_what_it_had_already_observed() {
             mockito::Matcher::Regex(r"^/v2/stocks/snapshots".into()),
         )
         .with_status(200)
-        .with_body(r#"{"AAAA":{"latestTrade":{"p":100.0}},"BBBB":{"latestTrade":{"p":50.0}}}"#)
+        .with_body(format!(
+            r#"{{"AAAA":{{"latestTrade":{{"t":"{traded_at}","p":100.0}}}},"BBBB":{{"latestTrade":{{"t":"{traded_at}","p":50.0}}}}}}"#,
+            traded_at = session_instant().to_rfc3339()
+        ))
         .create_async()
         .await;
     // The exits are done; the entry half asks for the account and Alpaca is unreachable.

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -361,13 +361,18 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
         }),
         "a midpoint must carry the book it was taken from, or the guard cannot be tuned"
     );
-    // Nothing refuses a trade for being old, so the record is the only place a stale fallback price
-    // can be noticed — and the fallback is the dominant source once the book guard starts firing.
+    // Nothing refuses a trade for being old, so the record is the only place to notice a stale one.
     assert!(
         readings
             .iter()
-            .all(|reading| reading["trade_timestamp"].is_string()),
-        "every reading carries when its last trade printed"
+            .any(|reading| reading["price_source"] == "last_trade"),
+        "the fixture must exercise the fallback path"
+    );
+    assert!(
+        readings.iter().all(|reading| {
+            reading["price_source"] != "last_trade" || reading["trade_timestamp"].is_string()
+        }),
+        "a fallback price must carry when it printed, or its staleness cannot be judged"
     );
     assert!(
         priced

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -136,6 +136,12 @@ FROM read_parquet(
 -- predictions_generated.predictions was a count in v1 and is the array of quantiles in v2. A query
 -- reading it must filter on schema_version or check the type, or it silently reads a length as a
 -- number of tickers. Only the single v1 session, 2026-08-12, is affected.
+--
+-- Fields are added within a version as well as across one, and an absent key reads as NULL either
+-- way, so "the build predated this field" and "there was nothing to record" are the same answer.
+-- prices_observed.readings[].trade_timestamp and universe_screened.excluded[].detail both start
+-- mid-v2; anything counting them should bound the query below by the first session that has them
+-- rather than treating an early NULL as a zero.
 .print 'Loading session_log...'
 DROP VIEW IF EXISTS session_log;
 CREATE OR REPLACE VIEW session_log AS


### PR DESCRIPTION
# Overview

## Changes

- Parse `t` off the snapshot's `latestTrade`, which was the one component whose timestamp the parse
  discarded — the quote and all three bars already kept theirs
- Replace `Snapshot.latest_trade_price: Option<f64>` with `latest_trade: Option<EquityTrade>`, a
  validated type that carries a price and the instant it printed together
- Record `trade_timestamp` on `PriceReading`, beside the `quote_timestamp` already there
- Drop a trade that arrives without a timestamp or with a non-positive price, on the same terms
  `QuotePayload::into_equity_quote` already drops a partial book
- Note in `tools/duckdb_initialization.sql` that this field, and `excluded[].detail` from #1061,
  both start mid-v2, so an early `NULL` is a missing field rather than a zero

## Context

The last trade is the fallback whenever the quote guard added in #1060 refuses a book. On the
2026-08-13 development session that fallback was not the exception:

| price source | readings |
| --- | --- |
| `last_trade` | 2,894 |
| `quote_midpoint` | 1,104 |

2,892 of those 2,894 followed a refusal — 2,766 wide books and 126 stale ones. The guard did its job
and handed the pass to a source nothing guards and nothing dates, so every entry and every stop that
session was measured against a price of unknown age. The record could not say whether a trade printed
a second earlier or at the previous close.

This only records the age; it does not bound it. `MAXIMUM_QUOTE_AGE_SECONDS` was set from a guess and
is still provisional, and a trade-age limit should come from the distribution this field is about to
produce rather than from a second guess.
`test_an_hours_old_trade_is_still_taken_as_the_fallback_price` pins the current behaviour so it
stays a decision on the record rather than an oversight.

**Behaviour change worth flagging.** A trade with no `t` no longer prices a symbol; the symbol goes
unpriced instead. Admitting an undated trade would reintroduce the hole this closes, since the whole
value of the field is that a fallback price can be judged for staleness. Alpaca's trade schema has
`t` as required — the integration fixtures had simply been abbreviating it, and now supply it.

Task 2 of the nine-task data-correctness plan; follows #1061.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timestamped trade data to market snapshots and price readings.
  * Added validation to reject invalid or incomplete trade prices and timestamps.
  * Improved fallback pricing by retaining and using the latest valid trade, including older trades.

* **Documentation**
  * Documented schema-version behavior and newly introduced optional fields in database initialization guidance.

* **Tests**
  * Expanded coverage for timestamp retention, invalid trades, fallback pricing, and recorded price metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->