### PR TITLE
Archive the splits table the bars will be adjusted against

### DIFF
--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -135,6 +135,14 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                     warn!(%error, "Archive stage failed; training on the existing archive")
                 }
             }
+
+            // Refreshed whole rather than topped up, and stepped over on failure like the bars
+            // above. Nothing reads it yet — adjustment is still Massive's, so this accumulates the
+            // history that makes the switch to raw prices possible.
+            match archive::archive_splits(&s3_client, &massive, &bucket, Utc::now()).await {
+                Ok(splits) => info!(splits, "Splits table refreshed"),
+                Err(error) => warn!(%error, "Splits refresh failed; the archive keeps its copy"),
+            }
         }
         Err(error) => warn!(%error, "No Massive client; training on the existing archive"),
     }

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -137,9 +137,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // Refreshed whole rather than topped up, and stepped over on failure like the bars
-            // above. Nothing reads it yet — adjustment is still Massive's, so this accumulates the
-            // history that makes the switch to raw prices possible.
-            match archive::archive_splits(&s3_client, &massive, &bucket, Utc::now()).await {
+            // above. No adjustment path consumes it yet; this accumulates the history first.
+            match archive::archive_splits(&s3_client, &massive, &bucket, now).await {
                 Ok(splits) => info!(splits, "Splits table refreshed"),
                 Err(error) => warn!(%error, "Splits refresh failed; the archive keeps its copy"),
             }

--- a/src/common/massive.rs
+++ b/src/common/massive.rs
@@ -21,7 +21,7 @@ use chrono::{DateTime, NaiveDate};
 use serde::Deserialize;
 use tracing::{info, warn};
 
-use crate::common::types::{BarInterval, EquityBar, Ticker};
+use crate::common::types::{BarInterval, EquityBar, EquitySplit, SessionDate, Ticker};
 
 /// Why the client could not be constructed.
 #[derive(Debug, thiserror::Error, PartialEq)]
@@ -96,6 +96,72 @@ fn grouped_bars_url(base: &str, date: NaiveDate) -> String {
         base.trim_end_matches('/'),
         date.format("%Y-%m-%d")
     )
+}
+
+/// Builds the first splits URL, on the same normalization as [`grouped_bars_url`].
+///
+/// Unfiltered by date. The whole table is 29 pages and three seconds, so bounding it would buy
+/// nothing and cost a start date nobody could later justify.
+fn splits_url(base: &str) -> String {
+    format!(
+        "{}/v3/reference/splits?limit={SPLITS_PAGE_SIZE}",
+        base.trim_end_matches('/')
+    )
+}
+
+/// Rows per splits page.
+///
+/// The endpoint's documented maximum is 1,000 and it answers a larger value with a validation error
+/// rather than a clamp, so this is a ceiling rather than a preference.
+const SPLITS_PAGE_SIZE: usize = 1_000;
+
+/// Pages followed before a splits fetch gives up.
+///
+/// The full table is 29 pages; this bounds a cursor that never terminates, which would otherwise
+/// spin against the API rather than fail. Generous enough that ordinary growth cannot reach it.
+const SPLITS_PAGE_LIMIT: usize = 200;
+
+/// One row of the splits response.
+///
+/// Massive publishes exactly these five fields — there is no adjustment factor to read, so the
+/// ratio is the whole of what a split says.
+///
+/// Both ratio sides are `f64` because the feed sends fractional ones: 5,344 of 28,135 live rows are
+/// mutual-fund reallocations like `1 -> 1.0056`. A whole-number type does not merely drop those
+/// rows, it fails the whole page they are on, and they are on most pages.
+#[derive(Deserialize, Debug)]
+struct SplitRow {
+    id: String,
+    ticker: String,
+    execution_date: NaiveDate,
+    split_from: f64,
+    split_to: f64,
+}
+
+/// The splits envelope. `next_url` is absent on the last page, which is how pagination ends.
+#[derive(Deserialize)]
+struct SplitsResponse {
+    results: Option<Vec<SplitRow>>,
+    next_url: Option<String>,
+}
+
+/// Converts an untrusted splits row into a validated [`EquitySplit`], or `None`.
+///
+/// Non-common-stock symbols are dropped for the reason [`is_common_stock_symbol`] gives, and a
+/// zero-sided ratio by the constructor's own validation. The execution date is already an exchange
+/// calendar date, so it is wrapped rather than derived from an instant.
+fn parse_split(row: &SplitRow) -> Option<EquitySplit> {
+    if !is_common_stock_symbol(&row.ticker) {
+        return None;
+    }
+    EquitySplit::new(
+        row.id.clone(),
+        Ticker::new(&row.ticker)?,
+        SessionDate::from_date(row.execution_date),
+        row.split_from,
+        row.split_to,
+    )
+    .ok()
 }
 
 /// One row of the grouped-daily response.
@@ -207,6 +273,17 @@ impl MassiveClient {
         Ok(Self::new(MassiveCredentials::from_env()?))
     }
 
+    /// Starts a request carrying the API key as a bearer token rather than a query parameter.
+    ///
+    /// Massive accepts either. The header is used because `reqwest` puts the full URL into the
+    /// `Display` of a decode failure, so a key in the query string reaches every error message and
+    /// log line that reports one — observed while building the splits fetch.
+    fn authorized(&self, url: &str) -> reqwest::RequestBuilder {
+        self.http_client
+            .get(url)
+            .bearer_auth(&self.credentials.api_key)
+    }
+
     /// Constructs a client pointed at an explicit base, for tests against a local HTTP mock.
     #[cfg(test)]
     fn for_tests(base_url: &str) -> Self {
@@ -231,12 +308,8 @@ impl MassiveClient {
         let url = grouped_bars_url(&self.credentials.base_url, date);
 
         let response = self
-            .http_client
-            .get(&url)
-            .query(&[
-                ("adjusted", "true"),
-                ("apiKey", self.credentials.api_key.as_str()),
-            ])
+            .authorized(&url)
+            .query(&[("adjusted", "true")])
             .send()
             .await?;
 
@@ -274,6 +347,56 @@ impl MassiveClient {
             "Grouped daily bars fetched"
         );
         Ok(bars)
+    }
+
+    /// Fetches every stock split Massive knows about, following the cursor to the last page.
+    ///
+    /// The response covers announced-but-unexecuted splits as well as historical ones, so a caller
+    /// holding the result has the feed's whole current opinion rather than a window of it — which is
+    /// what makes replacing the stored table safe when a split is cancelled and disappears.
+    pub async fn fetch_splits(&self) -> Result<Vec<EquitySplit>, MassiveError> {
+        let mut url = splits_url(&self.credentials.base_url);
+        let mut splits: Vec<EquitySplit> = Vec::new();
+        let mut received = 0usize;
+
+        for page in 1..=SPLITS_PAGE_LIMIT {
+            let response = self.authorized(&url).send().await?;
+
+            if !response.status().is_success() {
+                let status = response.status().as_u16();
+                let body = response.text().await.unwrap_or_default();
+                return Err(MassiveError::Api { status, body });
+            }
+
+            let payload: SplitsResponse = response
+                .json()
+                .await
+                .map_err(|error| MassiveError::Parse(format!("Failed to parse splits: {error}")))?;
+
+            let rows = payload.results.unwrap_or_default();
+            received += rows.len();
+            splits.extend(rows.iter().filter_map(parse_split));
+
+            let Some(next_url) = payload.next_url else {
+                let dropped = received.saturating_sub(splits.len());
+                if dropped > 0 {
+                    // Routine: the same preferreds, warrants, and units the bar path drops.
+                    warn!(
+                        dropped,
+                        received, "Dropped splits rows that failed validation"
+                    );
+                }
+                info!(splits = splits.len(), pages = page, "Splits fetched");
+                return Ok(splits);
+            };
+            // The cursor URL is absolute and carries no credential, so the key is re-attached by the
+            // `query` call above rather than being present in `next_url` already.
+            url = next_url;
+        }
+
+        Err(MassiveError::Parse(format!(
+            "splits pagination did not end within {SPLITS_PAGE_LIMIT} pages"
+        )))
     }
 }
 
@@ -334,10 +457,11 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let mock = server
             .mock("GET", "/v2/aggs/grouped/locale/us/market/stocks/2026-06-05")
-            .match_query(mockito::Matcher::AllOf(vec![
-                mockito::Matcher::UrlEncoded("adjusted".into(), "true".into()),
-                mockito::Matcher::UrlEncoded("apiKey".into(), "test-key".into()),
-            ]))
+            .match_query(mockito::Matcher::UrlEncoded(
+                "adjusted".into(),
+                "true".into(),
+            ))
+            .match_header("authorization", "Bearer test-key")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(body(APPLE))
@@ -495,5 +619,141 @@ mod tests {
             .await
             .expect_err("malformed JSON is an error");
         assert!(matches!(error, MassiveError::Parse(_)), "{error:?}");
+    }
+
+    // --- splits ---
+
+    /// Two rows as the live endpoint returns them: a forward split and a reverse one, with the
+    /// execution date already an Eastern calendar date and no adjustment factor to read.
+    const SPLIT_ROWS: &str = r#"{"execution_date":"2026-07-06","id":"E1","split_from":1,"split_to":2,"ticker":"MNST"},
+        {"execution_date":"2026-10-06","id":"E2","split_from":3,"split_to":1,"ticker":"ETHA"},
+        {"execution_date":"2026-09-14","id":"E3","split_from":1,"split_to":1.0056,"ticker":"NSRSX"}"#;
+
+    #[tokio::test]
+    async fn test_a_splits_response_becomes_validated_splits() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/v3/reference/splits")
+            .match_query(mockito::Matcher::UrlEncoded("limit".into(), "1000".into()))
+            .match_header("authorization", "Bearer test-key")
+            .with_status(200)
+            .with_body(format!(r#"{{"status":"OK","results":[{SPLIT_ROWS}]}}"#))
+            .create_async()
+            .await;
+
+        let splits = MassiveClient::for_tests(&server.url())
+            .fetch_splits()
+            .await
+            .expect("a successful fetch");
+
+        mock.assert_async().await;
+        assert_eq!(splits.len(), 3);
+        assert_eq!(splits[0].ticker().as_str(), "MNST");
+        assert_eq!(
+            splits[0].execution_date(),
+            SessionDate::from_date(date("2026-07-06"))
+        );
+        assert_eq!((splits[0].split_from(), splits[0].split_to()), (1.0, 2.0));
+        assert_eq!(
+            (splits[1].split_from(), splits[1].split_to()),
+            (3.0, 1.0),
+            "a reverse split keeps its ratio the way round the feed reported it"
+        );
+        // Nineteen percent of the live feed looks like this. A whole-number ratio does not drop the
+        // row, it fails the page, so the fetch returned nothing at all against the real endpoint.
+        assert_eq!(
+            (splits[2].split_from(), splits[2].split_to()),
+            (1.0, 1.0056),
+            "a fractional mutual-fund reallocation survives the parse"
+        );
+    }
+
+    /// The whole table is 29 pages, so a fetch that stopped at the first would silently hold the
+    /// most recent thousand splits and nothing older.
+    #[tokio::test]
+    async fn test_the_cursor_is_followed_to_the_last_page() {
+        let mut server = mockito::Server::new_async().await;
+        let cursor = format!("{}/v3/reference/splits?cursor=page-two", server.url());
+        let first = server
+            .mock("GET", "/v3/reference/splits")
+            .match_query(mockito::Matcher::UrlEncoded("limit".into(), "1000".into()))
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"status":"OK","results":[{{"execution_date":"2026-07-06","id":"E1","split_from":1,"split_to":2,"ticker":"MNST"}}],"next_url":"{cursor}"}}"#
+            ))
+            .create_async()
+            .await;
+        // The cursor URL carries no credential of its own, so the second request must re-attach it.
+        let second = server
+            .mock("GET", "/v3/reference/splits")
+            .match_query(mockito::Matcher::UrlEncoded("cursor".into(), "page-two".into()))
+            .match_header("authorization", "Bearer test-key")
+            .with_status(200)
+            .with_body(
+                r#"{"status":"OK","results":[{"execution_date":"2026-10-06","id":"E2","split_from":3,"split_to":1,"ticker":"ETHA"}]}"#,
+            )
+            .create_async()
+            .await;
+
+        let splits = MassiveClient::for_tests(&server.url())
+            .fetch_splits()
+            .await
+            .expect("a successful fetch");
+
+        first.assert_async().await;
+        second.assert_async().await;
+        assert_eq!(splits.len(), 2, "both pages reach the caller");
+    }
+
+    /// One unusable row must not cost the whole table, on the same terms the bar path drops a
+    /// malformed instrument: a preferred's lowercase symbol, and a ratio that cannot be divided by.
+    #[tokio::test]
+    async fn test_unusable_split_rows_are_dropped_rather_than_failing_the_fetch() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/v3/reference/splits")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(
+                r#"{"status":"OK","results":[
+                    {"execution_date":"2026-07-06","id":"E1","split_from":1,"split_to":2,"ticker":"MNST"},
+                    {"execution_date":"2026-07-06","id":"E2","split_from":1,"split_to":2,"ticker":"GSpD"},
+                    {"execution_date":"2026-07-06","id":"E3","split_from":0,"split_to":2,"ticker":"ZERO"}
+                ]}"#,
+            )
+            .create_async()
+            .await;
+
+        let splits = MassiveClient::for_tests(&server.url())
+            .fetch_splits()
+            .await
+            .expect("a bad row is dropped, not fatal");
+
+        mock.assert_async().await;
+        assert_eq!(splits.len(), 1);
+        assert_eq!(splits[0].ticker().as_str(), "MNST");
+    }
+
+    #[tokio::test]
+    async fn test_a_failed_splits_request_is_an_error() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/v3/reference/splits")
+            .match_query(mockito::Matcher::Any)
+            .with_status(429)
+            .with_body("slow down")
+            .create_async()
+            .await;
+
+        let error = MassiveClient::for_tests(&server.url())
+            .fetch_splits()
+            .await
+            .expect_err("a throttle is an error");
+
+        mock.assert_async().await;
+        assert!(
+            matches!(error, MassiveError::Api { status: 429, .. }),
+            "{error:?}"
+        );
     }
 }

--- a/src/common/massive.rs
+++ b/src/common/massive.rs
@@ -44,6 +44,9 @@ pub enum MassiveError {
     /// Massive answered successfully with something that could not be interpreted.
     #[error("Massive response could not be parsed: {0}")]
     Parse(String),
+    /// A paginated response pointed somewhere the credential must not follow.
+    #[error("Massive cursor pointed at {host}, which is not the configured API host")]
+    Cursor { host: String },
 }
 
 /// Massive API credentials.
@@ -100,13 +103,27 @@ fn grouped_bars_url(base: &str, date: NaiveDate) -> String {
 
 /// Builds the first splits URL, on the same normalization as [`grouped_bars_url`].
 ///
-/// Unfiltered by date. The whole table is 29 pages and three seconds, so bounding it would buy
-/// nothing and cost a start date nobody could later justify.
+/// Unfiltered by date, because the whole table is 29 pages and three seconds.
 fn splits_url(base: &str) -> String {
     format!(
         "{}/v3/reference/splits?limit={SPLITS_PAGE_SIZE}",
         base.trim_end_matches('/')
     )
+}
+
+/// Whether a cursor URL points at the same origin as the configured base.
+///
+/// `next_url` arrives in the response body and the request following it carries the API key, so
+/// without this the response chooses where the credential is sent. Anything unparseable is refused.
+fn same_origin(base: &str, cursor: &str) -> bool {
+    match (reqwest::Url::parse(base), reqwest::Url::parse(cursor)) {
+        (Ok(base), Ok(cursor)) => {
+            base.scheme() == cursor.scheme()
+                && base.host_str() == cursor.host_str()
+                && base.port_or_known_default() == cursor.port_or_known_default()
+        }
+        _ => false,
+    }
 }
 
 /// Rows per splits page.
@@ -121,14 +138,10 @@ const SPLITS_PAGE_SIZE: usize = 1_000;
 /// spin against the API rather than fail. Generous enough that ordinary growth cannot reach it.
 const SPLITS_PAGE_LIMIT: usize = 200;
 
-/// One row of the splits response.
+/// One row of the splits response; these five fields are all Massive publishes.
 ///
-/// Massive publishes exactly these five fields — there is no adjustment factor to read, so the
-/// ratio is the whole of what a split says.
-///
-/// Both ratio sides are `f64` because the feed sends fractional ones: 5,344 of 28,135 live rows are
-/// mutual-fund reallocations like `1 -> 1.0056`. A whole-number type does not merely drop those
-/// rows, it fails the whole page they are on, and they are on most pages.
+/// Both ratio sides are `f64` because a fifth of the feed is fractional, and a whole-number type
+/// fails the whole page such a row is on rather than dropping the row.
 #[derive(Deserialize, Debug)]
 struct SplitRow {
     id: String,
@@ -389,8 +402,16 @@ impl MassiveClient {
                 info!(splits = splits.len(), pages = page, "Splits fetched");
                 return Ok(splits);
             };
-            // The cursor URL is absolute and carries no credential, so the key is re-attached by the
-            // `query` call above rather than being present in `next_url` already.
+            // Checked before it is followed, because the request that follows re-attaches the bearer
+            // token and this URL came out of the response body.
+            if !same_origin(&self.credentials.base_url, &next_url) {
+                return Err(MassiveError::Cursor {
+                    host: reqwest::Url::parse(&next_url)
+                        .ok()
+                        .and_then(|cursor| cursor.host_str().map(str::to_string))
+                        .unwrap_or_else(|| "an unparseable URL".to_string()),
+                });
+            }
             url = next_url;
         }
 
@@ -732,6 +753,55 @@ mod tests {
         mock.assert_async().await;
         assert_eq!(splits.len(), 1);
         assert_eq!(splits[0].ticker().as_str(), "MNST");
+    }
+
+    /// The cursor comes out of the response body and the next request carries the API key, so a
+    /// response naming another host would choose where the credential is sent.
+    #[tokio::test]
+    async fn test_a_cursor_pointing_off_host_is_refused_before_the_key_follows_it() {
+        let mut server = mockito::Server::new_async().await;
+        let first = server
+            .mock("GET", "/v3/reference/splits")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(
+                r#"{"status":"OK","results":[{"execution_date":"2026-07-06","id":"E1","split_from":1,"split_to":2,"ticker":"MNST"}],"next_url":"https://attacker.example/v3/reference/splits?cursor=x"}"#,
+            )
+            .create_async()
+            .await;
+
+        let error = MassiveClient::for_tests(&server.url())
+            .fetch_splits()
+            .await
+            .expect_err("an off-host cursor must not be followed");
+
+        first.assert_async().await;
+        assert!(
+            matches!(&error, MassiveError::Cursor { host } if host == "attacker.example"),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn test_same_origin_admits_the_configured_host_and_nothing_else() {
+        let base = "https://api.massive.com";
+        assert!(same_origin(
+            base,
+            "https://api.massive.com/v3/reference/splits?cursor=x"
+        ));
+        assert!(
+            !same_origin(base, "https://api.massive.com.evil.test/v3"),
+            "suffix"
+        );
+        assert!(
+            !same_origin(base, "http://api.massive.com/v3"),
+            "scheme downgrade"
+        );
+        assert!(
+            !same_origin(base, "https://api.massive.com:8443/v3"),
+            "port"
+        );
+        assert!(!same_origin(base, "not a url"), "unparseable");
     }
 
     #[tokio::test]

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -870,13 +870,12 @@ impl EquityTrade {
 
 /// One stock split as the corporate-actions feed reported it.
 ///
-/// `execution_date` is the session the ratio takes effect on, and the feed publishes splits once
-/// they are announced, so a date in the future is ordinary here rather than a fault. The ratio reads
-/// `split_from` shares becoming `split_to` shares: a two-for-one forward split is `1 -> 2`, and a
-/// one-for-three reverse split is `3 -> 1`.
+/// The ratio reads `split_from` shares becoming `split_to` shares, so a two-for-one forward split
+/// is `1 -> 2` and a one-for-three reverse split is `3 -> 1`. Both sides are real rather than whole
+/// numbers, because a fifth of the live feed is fractional mutual-fund reallocations.
 ///
-/// Both sides are real rather than whole numbers. Nineteen percent of the live feed is fractional —
-/// mutual-fund reallocations like `1 -> 1.0056` — and a whole-number type rejects every one of them.
+/// `execution_date` may be in the future: the feed publishes splits once announced, and can later
+/// revise or cancel one.
 #[derive(Debug, Clone, PartialEq)]
 pub struct EquitySplit {
     id: String,

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -868,6 +868,78 @@ impl EquityTrade {
     }
 }
 
+/// One stock split as the corporate-actions feed reported it.
+///
+/// `execution_date` is the session the ratio takes effect on, and the feed publishes splits once
+/// they are announced, so a date in the future is ordinary here rather than a fault. The ratio reads
+/// `split_from` shares becoming `split_to` shares: a two-for-one forward split is `1 -> 2`, and a
+/// one-for-three reverse split is `3 -> 1`.
+///
+/// Both sides are real rather than whole numbers. Nineteen percent of the live feed is fractional —
+/// mutual-fund reallocations like `1 -> 1.0056` — and a whole-number type rejects every one of them.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EquitySplit {
+    id: String,
+    ticker: Ticker,
+    execution_date: SessionDate,
+    split_from: f64,
+    split_to: f64,
+}
+
+impl EquitySplit {
+    /// Constructs an `EquitySplit`, rejecting a ratio that cannot describe one.
+    ///
+    /// A non-positive or non-finite side would make the adjustment factor a division by zero, a
+    /// sign flip, or a `NaN` that silently poisons every price it touches. An unidentified row
+    /// cannot be merged against a later fetch of the same split.
+    pub fn new(
+        id: String,
+        ticker: Ticker,
+        execution_date: SessionDate,
+        split_from: f64,
+        split_to: f64,
+    ) -> Result<Self, InconsistentRecordError> {
+        if id.trim().is_empty() {
+            return Err(reject("split identifier is empty"));
+        }
+        for (name, side) in [("from", split_from), ("to", split_to)] {
+            if !side.is_finite() || side <= 0.0 {
+                return Err(reject(format!(
+                    "split {name} side {side} is not a positive number"
+                )));
+            }
+        }
+
+        Ok(Self {
+            id,
+            ticker,
+            execution_date,
+            split_from,
+            split_to,
+        })
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    pub fn execution_date(&self) -> SessionDate {
+        self.execution_date
+    }
+
+    pub fn split_from(&self) -> f64 {
+        self.split_from
+    }
+
+    pub fn split_to(&self) -> f64 {
+        self.split_to
+    }
+}
+
 /// Ticker metadata used to constrain pair selection to cross-sector matches.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EquityDetail {
@@ -1340,6 +1412,41 @@ mod tests {
             EquityTrade::new(ticker("AAPL"), at, f64::NAN).is_err(),
             "non-finite"
         );
+    }
+
+    fn split(id: &str, from: f64, to: f64) -> Result<EquitySplit, InconsistentRecordError> {
+        EquitySplit::new(
+            id.to_string(),
+            ticker("MNST"),
+            SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 7, 6).unwrap()),
+            from,
+            to,
+        )
+    }
+
+    /// A non-positive side makes the adjustment factor a division by zero or a sign flip, and a
+    /// `NaN` poisons every price it reaches. An unidentified row cannot be merged against a later
+    /// fetch of the same split.
+    #[test]
+    fn test_split_rejects_a_ratio_or_identifier_it_cannot_use() {
+        let forward = split("E1", 1.0, 2.0).expect("a two-for-one must construct");
+        assert_eq!((forward.split_from(), forward.split_to()), (1.0, 2.0));
+        assert!(split("E1", 3.0, 1.0).is_ok(), "a reverse split is ordinary");
+
+        assert!(split("E1", 0.0, 2.0).is_err(), "zero from");
+        assert!(split("E1", 1.0, 0.0).is_err(), "zero to");
+        assert!(split("E1", -1.0, 2.0).is_err(), "negative from");
+        assert!(split("E1", 1.0, f64::NAN).is_err(), "non-finite to");
+        assert!(split("", 1.0, 2.0).is_err(), "empty identifier");
+        assert!(split("   ", 1.0, 2.0).is_err(), "blank identifier");
+    }
+
+    /// Nineteen percent of the live feed is fractional, so a whole-number ratio would silently
+    /// discard every mutual-fund reallocation in it.
+    #[test]
+    fn test_split_accepts_a_fractional_ratio() {
+        let reallocation = split("E1", 1.0, 1.0056).expect("a fractional ratio must construct");
+        assert_eq!(reallocation.split_to(), 1.0056);
     }
 
     fn prediction(

--- a/src/data.rs
+++ b/src/data.rs
@@ -18,4 +18,5 @@ pub mod calendar;
 pub mod details;
 pub mod export;
 pub mod purge;
+pub mod splits;
 pub mod universe;

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -27,13 +27,14 @@ use std::io::Cursor;
 use aws_sdk_s3::operation::get_object::GetObjectError;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client as S3Client;
+use chrono::{DateTime, Utc};
 use polars::prelude::*;
 use tracing::{info, warn};
 
 use crate::common::aws::{date_from_partitioned_key, date_partitioned_key};
 use crate::common::massive::MassiveClient;
 use crate::common::types::SessionDate;
-use crate::data::bars;
+use crate::data::{bars, splits};
 
 /// S3 prefix for the bar archive.
 ///
@@ -48,6 +49,16 @@ pub const BAR_ARCHIVE_PREFIX: &str = "data/equity/bars";
 /// read it: the trainer parses the CSV compiled into its own binary, so this copy can be absent
 /// without a model run noticing.
 pub const DETAILS_ARCHIVE_KEY: &str = "data/equity/details/details.csv";
+
+/// S3 key for the stock splits the bars are adjusted against.
+///
+/// One object rather than a partition per session, unlike the bars beside it. A split belongs to
+/// its execution date, but the feed revises and cancels announced ones, so a per-date layout would
+/// leave a cancelled split sitting in a partition nothing revisits.
+///
+/// Under `corporate_actions/` rather than a directory of its own, because spinoffs and symbol
+/// changes are the same kind of fact read the same way and belong beside it as sibling files.
+pub const SPLITS_ARCHIVE_KEY: &str = "data/equity/corporate_actions/splits.parquet";
 
 /// Trailing sessions re-fetched even when a partition already exists.
 ///
@@ -372,7 +383,26 @@ async fn write_partition(
     fetched: DataFrame,
 ) -> Result<(), ArchiveError> {
     let key = date_partitioned_key(BAR_ARCHIVE_PREFIX, session.date());
+    write_merged(s3_client, bucket, key, fetched, |existing, fetched, key| {
+        merge_or_replace(existing, fetched, key)
+    })
+    .await
+}
 
+/// The read-merge-write cycle itself, over any key and any way of combining the two frames.
+///
+/// Shared because the bar partitions and the splits table differ only in how they merge — the
+/// compare-and-swap around it, and the reasoning for it, are the same either way.
+async fn write_merged<F>(
+    s3_client: &S3Client,
+    bucket: &str,
+    key: String,
+    fetched: DataFrame,
+    merge: F,
+) -> Result<(), ArchiveError>
+where
+    F: Fn(DataFrame, DataFrame, &str) -> Result<DataFrame, ArchiveError>,
+{
     for attempt in 1..=CONTENDED_WRITE_ATTEMPTS {
         // Merged with whatever the partition already holds rather than written over it. A plain
         // overwrite would discard anything a later response happens to omit, and merging costs one
@@ -380,7 +410,7 @@ async fn write_partition(
         let existing = read_partition_with_etag(s3_client, bucket, &key).await?;
         let (mut frame, precondition) = match existing {
             Some((existing_frame, etag)) => (
-                merge_or_replace(existing_frame, fetched.clone(), &key)?,
+                merge(existing_frame, fetched.clone(), &key)?,
                 Precondition::Match(etag),
             ),
             None => (fetched.clone(), Precondition::Absent),
@@ -438,6 +468,45 @@ fn merge_or_replace(
             Ok(fetched)
         }
     }
+}
+
+/// Fetches the whole splits table and writes it, keeping each row's earliest `first_seen`.
+///
+/// Not a gap scan like [`archive_missing_sessions`], because there are no gaps to find: the feed
+/// answers with its entire current opinion in a few seconds, and that opinion is the answer. Rows
+/// it has stopped reporting are dropped rather than kept, which is the case a per-session layout
+/// could not express.
+pub async fn archive_splits(
+    s3_client: &S3Client,
+    massive: &MassiveClient,
+    bucket: &str,
+    fetched_at: DateTime<Utc>,
+) -> Result<usize, ArchiveError> {
+    let splits = massive
+        .fetch_splits()
+        .await
+        .map_err(|error| ArchiveError::Read {
+            bucket: bucket.to_string(),
+            key: SPLITS_ARCHIVE_KEY.to_string(),
+            message: error.to_string(),
+        })?;
+
+    let frame = splits::splits_to_dataframe(&splits, fetched_at)?;
+    write_merged(
+        s3_client,
+        bucket,
+        SPLITS_ARCHIVE_KEY.to_string(),
+        frame,
+        |existing, fetched, _key| Ok(splits::merge_splits(existing, fetched)?),
+    )
+    .await?;
+
+    info!(
+        key = SPLITS_ARCHIVE_KEY,
+        splits = splits.len(),
+        "Splits table archived"
+    );
+    Ok(splits.len())
 }
 
 /// Writes the ticker metadata that accompanies the archive.

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -114,6 +114,9 @@ pub enum ArchiveError {
     },
     #[error("gave up on {key} after {attempts} concurrent writes by another pass")]
     Contended { key: String, attempts: usize },
+    /// The upstream feed failed, before any bucket was touched.
+    #[error("failed to fetch from Massive: {0}")]
+    Feed(String),
     #[error("failed to build a bar frame: {0}")]
     Frame(#[from] PolarsError),
 }
@@ -488,11 +491,7 @@ pub async fn archive_splits(
     let splits = massive
         .fetch_splits()
         .await
-        .map_err(|error| ArchiveError::Read {
-            bucket: bucket.to_string(),
-            key: SPLITS_ARCHIVE_KEY.to_string(),
-            message: error.to_string(),
-        })?;
+        .map_err(|error| ArchiveError::Feed(error.to_string()))?;
 
     // Refused before the write rather than merged away inside it, so a cold bucket does not get an
     // empty object either. A feed that answers success with nothing is an outage, not an emptied
@@ -511,7 +510,19 @@ pub async fn archive_splits(
         bucket,
         SPLITS_ARCHIVE_KEY.to_string(),
         frame,
-        |existing, fetched, _key| Ok(splits::merge_splits(existing, fetched)?),
+        // Falls back rather than propagating, for the reason `merge_or_replace` does: a stored
+        // object whose schema stopped matching would otherwise fail every future refresh too.
+        |existing, fetched, key| match splits::merge_splits(existing, fetched.clone()) {
+            Ok(merged) => Ok(merged),
+            Err(error) => {
+                warn!(
+                    key,
+                    %error,
+                    "Could not merge the stored splits table; replacing it with the fetched rows"
+                );
+                Ok(fetched)
+            }
+        },
     )
     .await?;
 

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -50,7 +50,7 @@ pub const BAR_ARCHIVE_PREFIX: &str = "data/equity/bars";
 /// without a model run noticing.
 pub const DETAILS_ARCHIVE_KEY: &str = "data/equity/details/details.csv";
 
-/// S3 key for the stock splits the bars are adjusted against.
+/// S3 key for the stock splits the bars will be adjusted against; nothing reads it yet.
 ///
 /// One object rather than a partition per session, unlike the bars beside it. A split belongs to
 /// its execution date, but the feed revises and cancels announced ones, so a per-date layout would
@@ -472,6 +472,9 @@ fn merge_or_replace(
 
 /// Fetches the whole splits table and writes it, keeping each row's earliest `first_seen`.
 ///
+/// Accumulates the history that makes the switch to unadjusted bars possible; nothing reads the
+/// result yet.
+///
 /// Not a gap scan like [`archive_missing_sessions`], because there are no gaps to find: the feed
 /// answers with its entire current opinion in a few seconds, and that opinion is the answer. Rows
 /// it has stopped reporting are dropped rather than kept, which is the case a per-session layout
@@ -490,6 +493,17 @@ pub async fn archive_splits(
             key: SPLITS_ARCHIVE_KEY.to_string(),
             message: error.to_string(),
         })?;
+
+    // Refused before the write rather than merged away inside it, so a cold bucket does not get an
+    // empty object either. A feed that answers success with nothing is an outage, not an emptied
+    // table.
+    if splits.is_empty() {
+        warn!(
+            key = SPLITS_ARCHIVE_KEY,
+            "Splits fetch returned nothing; keeping the stored table"
+        );
+        return Ok(0);
+    }
 
     let frame = splits::splits_to_dataframe(&splits, fetched_at)?;
     write_merged(

--- a/src/data/splits.rs
+++ b/src/data/splits.rs
@@ -22,10 +22,12 @@ pub fn splits_to_dataframe(
     let mut splits_from: Vec<f64> = Vec::with_capacity(splits.len());
     let mut splits_to: Vec<f64> = Vec::with_capacity(splits.len());
 
+    // Through the stored-form accessors rather than `Display`, which is a presentation concern and
+    // would silently change these columns if it were ever reformatted.
     for split in splits {
         identifiers.push(split.id().to_string());
-        tickers.push(split.ticker().to_string());
-        execution_dates.push(split.execution_date().to_string());
+        tickers.push(split.ticker().as_str().to_string());
+        execution_dates.push(split.execution_date().date().format("%Y-%m-%d").to_string());
         splits_from.push(split.split_from());
         splits_to.push(split.split_to());
     }

--- a/src/data/splits.rs
+++ b/src/data/splits.rs
@@ -1,4 +1,4 @@
-//! The corporate-actions table the bar archive is adjusted against.
+//! The stock splits the bar archive will be adjusted against; nothing reads them yet.
 //!
 //! One S3 object rather than a partition per session: a split belongs to its execution date, but
 //! the feed revises and cancels announced ones, so only the whole table is ever authoritative.
@@ -47,7 +47,15 @@ pub fn splits_to_dataframe(
 /// keeping it would adjust prices across a split that never happened. Only `first_seen` survives
 /// from the stored copy, taking the earlier of the two so a row keeps the date we first saw it
 /// rather than the date of the latest fetch.
+///
+/// An empty fetch is the exception, and keeps the stored table. Replacing means an upstream answering
+/// success with nothing would erase every corporate action we hold, and the feed has never held
+/// nothing — it goes back to 1978.
 pub fn merge_splits(existing: DataFrame, fetched: DataFrame) -> Result<DataFrame, PolarsError> {
+    if fetched.height() == 0 {
+        return Ok(existing);
+    }
+
     let previously_seen = existing
         .lazy()
         .select([col("id"), col("first_seen").alias("previous_first_seen")])
@@ -199,6 +207,26 @@ mod tests {
             first_seen_by_id(&merged, "S2"),
             Some(instant("2026-08-14T02:00:00Z").timestamp_millis()),
             "a split seen for the first time is stamped with this fetch"
+        );
+    }
+
+    /// The replace-the-row-set rule inverted: an upstream answering success with an empty page
+    /// would otherwise erase every corporate action we hold, and log it as a refresh.
+    #[test]
+    fn test_an_empty_fetch_keeps_the_stored_table() {
+        let stored = splits_to_dataframe(
+            &[split("S1", "MNST", "2026-07-06", 1.0, 2.0)],
+            instant("2026-08-01T02:00:00Z"),
+        )
+        .unwrap();
+        let nothing = splits_to_dataframe(&[], instant("2026-08-14T02:00:00Z")).unwrap();
+
+        let merged = merge_splits(stored, nothing).expect("the merge must succeed");
+
+        assert_eq!(merged.height(), 1, "the stored table survives");
+        assert_eq!(
+            merged.column("id").unwrap().str().unwrap().get(0),
+            Some("S1")
         );
     }
 

--- a/src/data/splits.rs
+++ b/src/data/splits.rs
@@ -1,0 +1,223 @@
+//! The corporate-actions table the bar archive is adjusted against.
+//!
+//! One S3 object rather than a partition per session: a split belongs to its execution date, but
+//! the feed revises and cancels announced ones, so only the whole table is ever authoritative.
+
+use chrono::{DateTime, Utc};
+use polars::prelude::*;
+
+use crate::common::types::EquitySplit;
+
+/// Builds the frame written to the archive, stamping every row with when this pass saw it.
+///
+/// `first_seen` is provenance rather than input: it answers whether a split was known to us when a
+/// given bar partition was written, which is the question an adjustment disagreement turns into.
+pub fn splits_to_dataframe(
+    splits: &[EquitySplit],
+    fetched_at: DateTime<Utc>,
+) -> Result<DataFrame, PolarsError> {
+    let mut identifiers: Vec<String> = Vec::with_capacity(splits.len());
+    let mut tickers: Vec<String> = Vec::with_capacity(splits.len());
+    let mut execution_dates: Vec<String> = Vec::with_capacity(splits.len());
+    let mut splits_from: Vec<f64> = Vec::with_capacity(splits.len());
+    let mut splits_to: Vec<f64> = Vec::with_capacity(splits.len());
+
+    for split in splits {
+        identifiers.push(split.id().to_string());
+        tickers.push(split.ticker().to_string());
+        execution_dates.push(split.execution_date().to_string());
+        splits_from.push(split.split_from());
+        splits_to.push(split.split_to());
+    }
+    let first_seen = vec![fetched_at.timestamp_millis(); splits.len()];
+
+    DataFrame::new(vec![
+        Column::new("id".into(), identifiers),
+        Column::new("ticker".into(), tickers),
+        Column::new("execution_date".into(), execution_dates),
+        Column::new("split_from".into(), splits_from),
+        Column::new("split_to".into(), splits_to),
+        Column::new("first_seen".into(), first_seen),
+    ])
+}
+
+/// Merges a stored splits table with a freshly fetched one.
+///
+/// The fetched rows are the row set: a split the feed no longer reports has been cancelled, and
+/// keeping it would adjust prices across a split that never happened. Only `first_seen` survives
+/// from the stored copy, taking the earlier of the two so a row keeps the date we first saw it
+/// rather than the date of the latest fetch.
+pub fn merge_splits(existing: DataFrame, fetched: DataFrame) -> Result<DataFrame, PolarsError> {
+    let previously_seen = existing
+        .lazy()
+        .select([col("id"), col("first_seen").alias("previous_first_seen")])
+        .group_by([col("id")])
+        .agg([col("previous_first_seen").min()]);
+
+    fetched
+        .lazy()
+        .join(
+            previously_seen,
+            [col("id")],
+            [col("id")],
+            JoinArgs::new(JoinType::Left),
+        )
+        // Defaulted before it is compared, because a row absent from the stored table joins to null
+        // and a null comparison would propagate rather than choose a branch.
+        .with_column(
+            coalesce(&[col("previous_first_seen"), col("first_seen")]).alias("previous_first_seen"),
+        )
+        .with_column(
+            when(col("previous_first_seen").lt(col("first_seen")))
+                .then(col("previous_first_seen"))
+                .otherwise(col("first_seen"))
+                .alias("first_seen"),
+        )
+        // Named rather than dropped, so the merged frame is written back with the same schema
+        // `splits_to_dataframe` produces and the next read finds what it expects.
+        .select([
+            col("id"),
+            col("ticker"),
+            col("execution_date"),
+            col("split_from"),
+            col("split_to"),
+            col("first_seen"),
+        ])
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::types::{SessionDate, Ticker};
+
+    fn instant(value: &str) -> DateTime<Utc> {
+        value.parse().expect("a valid test instant")
+    }
+
+    fn split(id: &str, ticker: &str, execution_date: &str, from: f64, to: f64) -> EquitySplit {
+        EquitySplit::new(
+            id.to_string(),
+            Ticker::new(ticker).expect("a valid ticker"),
+            SessionDate::from_date(execution_date.parse().expect("a valid execution date")),
+            from,
+            to,
+        )
+        .expect("a valid split")
+    }
+
+    fn first_seen_by_id(frame: &DataFrame, id: &str) -> Option<i64> {
+        let identifiers = frame.column("id").unwrap().str().unwrap();
+        let seen = frame.column("first_seen").unwrap().i64().unwrap();
+        (0..frame.height()).find_map(|row| (identifiers.get(row)? == id).then(|| seen.get(row))?)
+    }
+
+    #[test]
+    fn test_the_frame_carries_every_field_a_split_has() {
+        let frame = splits_to_dataframe(
+            &[split("S1", "MNST", "2026-07-06", 1.0, 2.0)],
+            instant("2026-08-14T02:00:00Z"),
+        )
+        .expect("a frame must build");
+
+        assert_eq!(frame.height(), 1);
+        assert_eq!(
+            frame.column("ticker").unwrap().str().unwrap().get(0),
+            Some("MNST")
+        );
+        assert_eq!(
+            frame
+                .column("execution_date")
+                .unwrap()
+                .str()
+                .unwrap()
+                .get(0),
+            Some("2026-07-06")
+        );
+        assert_eq!(
+            frame.column("split_from").unwrap().f64().unwrap().get(0),
+            Some(1.0)
+        );
+        assert_eq!(
+            frame.column("split_to").unwrap().f64().unwrap().get(0),
+            Some(2.0)
+        );
+    }
+
+    /// The reason the merge is not a union. A cancelled split disappears from the feed, and a table
+    /// that only ever grew would keep adjusting prices across one that never executed.
+    #[test]
+    fn test_a_split_the_feed_no_longer_reports_is_dropped() {
+        let stored = splits_to_dataframe(
+            &[
+                split("S1", "MNST", "2026-07-06", 1.0, 2.0),
+                split("S2", "GONE", "2026-09-01", 1.0, 3.0),
+            ],
+            instant("2026-08-01T02:00:00Z"),
+        )
+        .unwrap();
+        let fetched = splits_to_dataframe(
+            &[split("S1", "MNST", "2026-07-06", 1.0, 2.0)],
+            instant("2026-08-14T02:00:00Z"),
+        )
+        .unwrap();
+
+        let merged = merge_splits(stored, fetched).expect("the merge must succeed");
+
+        assert_eq!(merged.height(), 1);
+        assert_eq!(
+            merged.column("id").unwrap().str().unwrap().get(0),
+            Some("S1")
+        );
+    }
+
+    /// A row that survives keeps the date we first saw it, not the date of the latest fetch, so the
+    /// column stays an answer about when a split became known rather than when this job last ran.
+    #[test]
+    fn test_a_surviving_split_keeps_the_earlier_first_seen() {
+        let first = instant("2026-08-01T02:00:00Z");
+        let stored =
+            splits_to_dataframe(&[split("S1", "MNST", "2026-07-06", 1.0, 2.0)], first).unwrap();
+        let fetched = splits_to_dataframe(
+            &[
+                split("S1", "MNST", "2026-07-06", 1.0, 2.0),
+                split("S2", "NEW", "2026-12-17", 50.0, 1.0),
+            ],
+            instant("2026-08-14T02:00:00Z"),
+        )
+        .unwrap();
+
+        let merged = merge_splits(stored, fetched).expect("the merge must succeed");
+
+        assert_eq!(merged.height(), 2);
+        assert_eq!(
+            first_seen_by_id(&merged, "S1"),
+            Some(first.timestamp_millis()),
+            "a split already stored keeps when it was first seen"
+        );
+        assert_eq!(
+            first_seen_by_id(&merged, "S2"),
+            Some(instant("2026-08-14T02:00:00Z").timestamp_millis()),
+            "a split seen for the first time is stamped with this fetch"
+        );
+    }
+
+    /// The cold-bucket case: nothing stored, so every row is new and none of them lose their stamp
+    /// to a null from the join.
+    #[test]
+    fn test_merging_into_an_empty_table_keeps_every_row_stamped() {
+        let fetched_at = instant("2026-08-14T02:00:00Z");
+        let empty = splits_to_dataframe(&[], fetched_at).unwrap();
+        let fetched =
+            splits_to_dataframe(&[split("S1", "MNST", "2026-07-06", 1.0, 2.0)], fetched_at)
+                .unwrap();
+
+        let merged = merge_splits(empty, fetched).expect("the merge must succeed");
+
+        assert_eq!(merged.height(), 1);
+        assert_eq!(
+            first_seen_by_id(&merged, "S1"),
+            Some(fetched_at.timestamp_millis())
+        );
+    }
+}

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -55,6 +55,29 @@ FROM read_csv(
     auto_detect = true
 );
 
+-- Every stock split Massive reports, historical and announced, refreshed whole each night. Named
+-- in full because "split" alone collides with the train/validation split the trainer beside it
+-- means by the word. One object
+-- rather than a partition per date: the feed revises and cancels announced splits, so a row that
+-- disappears is a cancellation and the current table is the only authoritative answer.
+--
+-- split_from shares become split_to shares -- a two-for-one forward split is 1 -> 2 and a
+-- one-for-three reverse split is 3 -> 1. execution_date is an Eastern calendar date and may be in
+-- the future. first_seen is when this job first saw the row, not when the split was announced.
+.print 'Loading training_stock_splits...'
+DROP VIEW IF EXISTS training_stock_splits;
+CREATE OR REPLACE VIEW training_stock_splits AS
+SELECT
+    id,
+    ticker,
+    CAST(execution_date AS DATE) AS execution_date,
+    split_from,
+    split_to,
+    to_timestamp(first_seen / 1000.0) AS first_seen
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/data/equity/corporate_actions/splits.parquet'
+);
+
 -- ---------------------------------------------------------------------------
 -- Nightly exports (exports/) -- one view per exported table
 -- ---------------------------------------------------------------------------

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -64,6 +64,10 @@ FROM read_csv(
 -- split_from shares become split_to shares -- a two-for-one forward split is 1 -> 2 and a
 -- one-for-three reverse split is 3 -> 1. execution_date is an Eastern calendar date and may be in
 -- the future. first_seen is when this job first saw the row, not when the split was announced.
+--
+-- On a bucket where the trainer has not yet run, the object does not exist and this one CREATE
+-- prints an IO error and is skipped; every other view still loads, and this one appears after the
+-- first refresh. training_details has the same fixed-key exposure.
 .print 'Loading training_stock_splits...'
 DROP VIEW IF EXISTS training_stock_splits;
 CREATE OR REPLACE VIEW training_stock_splits AS


### PR DESCRIPTION
# Overview

## Changes

- Add `MassiveClient::fetch_splits`, following the `next_url` cursor to the last page and refusing
  one that points off-host
- Add a validated `EquitySplit` type and `data::splits`, which builds the frame and merges it
- Add `archive::archive_splits`, writing one object at `data/equity/corporate_actions/splits.parquet`
  under the same compare-and-swap the bar partitions use; `write_partition`'s read-merge-write loop
  is generalised into `write_merged` rather than copied
- Refresh the table nightly from the trainer, beside the archive repair and stepped over on failure
  the same way
- Expose it to DuckDB as `training_stock_splits`
- Send the Massive API key as a bearer token instead of a query parameter, on both endpoints

**Nothing reads the table yet.** This accumulates the history that makes the switch to unadjusted
bars possible; that is the next task.

## Context

Massive's `adjusted=true` is splits-only and applies whatever was known at fetch time. Partitions
freeze after `CORRECTION_WINDOW_SESSIONS = 2` and nothing re-fetches an old date, so each partition
keeps the adjustment epoch it was written in. `MNST` closed 96.38 on 2026-07-02 in S3 and 48.19 in
Postgres — a two-for-one split landing on the seam between two write blocks, which is why the
trainer and the application are on different histories for that name.

The defect is decay rather than damage: nothing resets the epoch, so the drift grows until a human
re-seeds. Owning the splits is what makes the fix possible — adjustment becomes a pure fold over
(raw bars, splits), and a raw close is immutable, so there is no epoch left to drift.

**Why one object and not a partition per session.** A split belongs to its execution date, but the
feed revises and cancels announced ones. The whole table is 29 pages and three seconds, so each run
replaces the row set outright and only `first_seen` survives the merge, taking the earlier of the
two. A row the feed stops reporting is therefore dropped rather than kept and applied forever — the
case a per-date layout cannot express, since nothing revisits an old partition.

## Naming

"Split" alone collides with the train/validation split, which is settled vocabulary in the trainer
that owns this same archive — `split_by_timestamp` and `TrainingFraction` sit a module away, and
`TrainingFraction`'s own docstring already refuses to name a type after an ambiguous reading of the
word. So the view is `training_stock_splits` rather than `training_splits`, which would have read as
the training half of a split, and the type is `EquitySplit`, matching `EquityBar`, `EquityQuote`,
`EquityTrade`, and `EquityDetail` beside it. The object sits under `data/equity/corporate_actions/`
so task #7's spinoffs and symbol changes land as sibling files; nothing had been written to the old
path in any bucket, so the layout was still free to choose.

## Two findings from probing the live endpoint

Both were invisible to a mocked test, and the first made the feature completely non-functional.

**Nineteen percent of the feed carries fractional ratios.** 5,344 of 28,135 rows are mutual-fund
reallocations like `1 -> 1.0056`. Serde fails the entire page on one such row rather than just that
row, and those rows appear on most pages — so with a whole-number ratio, `fetch_splits` returned a
parse error against every real response. Both sides are now `f64`, validated finite and positive.

**The API key was travelling in the query string.** `reqwest` puts the full URL into the `Display`
of a decode failure, so the key appeared in plaintext in the error the first probe printed — and
would have appeared in any log line reporting one. Massive accepts `Authorization: Bearer`, and a
control request confirms auth is genuinely required, so both endpoints now use it.

## Two P1s from review, fixed in `ba120f9e`

**The cursor could redirect the credential.** `next_url` is response-controlled, and the request
following it carries the bearer token, so a compromised or hostile upstream could name any reachable
host and receive the API key. Pagination now refuses a cursor whose scheme, host, or port differs
from the configured base. This predates the switch to bearer auth — the query-string form appended
the key to the same cursor — so it is a fix rather than a regression from it.

**An empty response would have erased the table.** Replacing the row set is what lets a cancelled
split disappear, and it is also what makes an empty answer destructive: HTTP 200 with no results
would have written an empty table over every corporate action held, and logged a successful refresh.
Refused in two places for two reasons — `archive_splits` skips the write entirely, which also stops
a cold bucket gaining an empty object, and `merge_splits` returns the stored frame, which is the
pure surface a test can reach.

## Verification

Unit tests cover the cursor and its off-host refusal, the drop-don't-fail path, ratio validation,
and the merge's four cases including the empty fetch. Beyond those, a throwaway probe ran the whole
path against the live feed and a scratch key in the development bucket, then deleted it:

| | |
| --- | --- |
| splits parsed | 28,077 of 28,135 |
| dropped | 58, all lowercase preferred and warrant symbols |
| execution dates | 1978-10-25 → 2026-12-17 |
| fractional ratios retained | 4,794 |
| Parquet written | 1.23 MB |
| read back | 28,077 rows, expected schema |
| second merge | 28,077 rows, every one holding the earlier `first_seen` |

`devenv tasks run checks:rust` exits 0; 546 library tests pass.

Task 3 of the nine-task data-correctness plan; follows #1062. Blocks the switch to unadjusted bars.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stock-split data retrieval with pagination, validation, fractional ratios, and secure authorization.
  * Added split archiving with merging, timestamp preservation, and protection against empty fetches.
  * Added a training data view exposing stock split details.
* **Bug Fixes**
  * Archived split data now refreshes after missing sessions are repaired, with failures handled without interrupting training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->