### PR TITLE
Let an operator rebuild the archive, not only repair its gaps

### DIFF
--- a/src/bin/seed_equity_bars_s3.rs
+++ b/src/bin/seed_equity_bars_s3.rs
@@ -4,12 +4,14 @@
 //! window every night, but only the window it reads — so this exists for the two cases that window
 //! cannot cover: a bucket with nothing in it, and an outage older than the training lookback.
 //!
-//! Usage: `seed_equity_bars_s3 [start YYYY-MM-DD] [end YYYY-MM-DD]`
+//! Usage: `seed_equity_bars_s3 [start YYYY-MM-DD] [end YYYY-MM-DD] [--rebuild]`
 //! With no arguments the window is the last [`DEFAULT_ARCHIVE_LOOKBACK_DAYS`] days ending today
-//! (US/Eastern), which is the answer to "just make the archive right".
+//! (US/Eastern), which is the answer to "just make the archive right". `--rebuild` re-fetches every
+//! session in the window and replaces what is there, for when the stored bars stopped meaning what
+//! they meant when written.
 //!
 //! Needs Massive and AWS credentials and no database, so it runs from either VM or a laptop. The
-//! work itself is [`fund::data::archive::archive_missing_sessions`] — the same call the trainer
+//! work itself is [`fund::data::archive::archive_sessions`] — the same call the trainer
 //! makes, because a second implementation of the gap scan would drift from this one and the
 //! symptom would be a model quietly trained across a hole.
 
@@ -21,7 +23,7 @@ use fund::common::observability::init_tracing;
 use fund::common::types::SessionDate;
 use fund::data::archive;
 
-const USAGE: &str = "Usage: seed_equity_bars_s3 [start YYYY-MM-DD] [end YYYY-MM-DD]";
+const USAGE: &str = "Usage: seed_equity_bars_s3 [start YYYY-MM-DD] [end YYYY-MM-DD] [--rebuild]";
 
 /// Calendar days the archive covers when no start date is given.
 ///
@@ -55,12 +57,30 @@ fn parse_date(value: &str) -> Result<SessionDate, String> {
         .map_err(|error| format!("Invalid date '{value}': expected YYYY-MM-DD ({error})"))
 }
 
-/// Parses the optional positional date arguments.
+/// What a run was asked to do: a window, and whether to re-fetch what is already there.
+#[derive(Debug, PartialEq, Eq)]
+struct SeedRequest {
+    range: ArchiveRange,
+    coverage: archive::Coverage,
+}
+
+/// Parses the optional positional date arguments and the `--rebuild` flag.
 ///
-/// `today` is a parameter rather than read from the clock here, because a function that reads the
-/// wall clock cannot be tested across the hours where the Eastern date and the UTC date disagree.
-fn parse_arguments(arguments: &[String], today: SessionDate) -> Result<ArchiveRange, String> {
-    match arguments {
+/// The flag is extracted before the positions are matched, so it may appear anywhere. `today` is a
+/// parameter rather than read from the clock here, because a function that reads the wall clock
+/// cannot be tested across the hours where the Eastern date and the UTC date disagree.
+fn parse_arguments(arguments: &[String], today: SessionDate) -> Result<SeedRequest, String> {
+    let coverage = if arguments.iter().any(|argument| argument == "--rebuild") {
+        archive::Coverage::Rebuild
+    } else {
+        archive::Coverage::Gaps
+    };
+    let dates: Vec<&String> = arguments
+        .iter()
+        .filter(|argument| *argument != "--rebuild")
+        .collect();
+
+    let range = match dates.as_slice() {
         [] => ArchiveRange::new(
             today.plus_calendar_days(-DEFAULT_ARCHIVE_LOOKBACK_DAYS),
             today,
@@ -68,7 +88,9 @@ fn parse_arguments(arguments: &[String], today: SessionDate) -> Result<ArchiveRa
         [start] => ArchiveRange::new(parse_date(start)?, today),
         [start, end] => ArchiveRange::new(parse_date(start)?, parse_date(end)?),
         _ => Err(format!("Too many arguments\n{USAGE}")),
-    }
+    }?;
+
+    Ok(SeedRequest { range, coverage })
 }
 
 #[tokio::main]
@@ -81,8 +103,8 @@ async fn main() {
     );
 
     let arguments: Vec<String> = std::env::args().skip(1).collect();
-    let range = match parse_arguments(&arguments, SessionDate::at(Utc::now())) {
-        Ok(range) => range,
+    let request = match parse_arguments(&arguments, SessionDate::at(Utc::now())) {
+        Ok(request) => request,
         Err(message) => {
             eprintln!("{message}");
             drop(tracing_guard);
@@ -90,7 +112,7 @@ async fn main() {
         }
     };
 
-    let code = match run(&range).await {
+    let code = match run(&request).await {
         Ok(summary) => {
             info!(
                 sessions_requested = summary.sessions_requested,
@@ -122,13 +144,13 @@ async fn main() {
     std::process::exit(code);
 }
 
-/// Repairs the archive over `range` and returns what the pass accomplished.
+/// Archives the requested window and returns what the pass accomplished.
 ///
 /// Reads `AWS_S3_BUCKET_NAME` and the Massive credentials from the environment, and writes bar
-/// partitions under `data/equity/bars/`. No database is touched. Only the sessions the bucket is
-/// missing are fetched, so the cost of a run is the size of the gap rather than the size of the
-/// range, and re-running over a repaired range is close to free.
-async fn run(range: &ArchiveRange) -> Result<archive::ArchiveSummary, Box<dyn std::error::Error>> {
+/// partitions under `data/equity/bars/`. No database is touched. Under `Coverage::Gaps` only the
+/// sessions the bucket is missing are fetched, so re-running over a repaired range is close to
+/// free; a rebuild deliberately pays for the whole window.
+async fn run(request: &SeedRequest) -> Result<archive::ArchiveSummary, Box<dyn std::error::Error>> {
     let bucket = std::env::var("AWS_S3_BUCKET_NAME")
         .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
     let massive = MassiveClient::from_env()?;
@@ -136,15 +158,21 @@ async fn run(range: &ArchiveRange) -> Result<archive::ArchiveSummary, Box<dyn st
 
     info!(
         bucket,
-        start = %range.start,
-        end = %range.end,
+        start = %request.range.start,
+        end = %request.range.end,
+        coverage = ?request.coverage,
         "Seeding the equity bar archive from Massive"
     );
 
-    Ok(
-        archive::archive_missing_sessions(&s3_client, &massive, &bucket, range.start, range.end)
-            .await?,
+    Ok(archive::archive_sessions(
+        &s3_client,
+        &massive,
+        &bucket,
+        request.range.start,
+        request.range.end,
+        request.coverage,
     )
+    .await?)
 }
 
 #[cfg(test)]
@@ -160,10 +188,10 @@ mod tests {
     #[test]
     fn test_no_arguments_covers_the_default_lookback_ending_today() {
         let today = session(2026, 8, 6);
-        let range = parse_arguments(&[], today).unwrap();
-        assert_eq!(range.end, today);
+        let request = parse_arguments(&[], today).unwrap();
+        assert_eq!(request.range.end, today);
         assert_eq!(
-            range.start,
+            request.range.start,
             today.plus_calendar_days(-DEFAULT_ARCHIVE_LOOKBACK_DAYS)
         );
     }
@@ -171,20 +199,20 @@ mod tests {
     #[test]
     fn test_one_argument_runs_from_that_date_to_today() {
         let today = session(2026, 8, 6);
-        let range = parse_arguments(&["2026-01-02".to_string()], today).unwrap();
-        assert_eq!(range.start, session(2026, 1, 2));
-        assert_eq!(range.end, today);
+        let request = parse_arguments(&["2026-01-02".to_string()], today).unwrap();
+        assert_eq!(request.range.start, session(2026, 1, 2));
+        assert_eq!(request.range.end, today);
     }
 
     #[test]
     fn test_two_arguments_bound_both_ends() {
-        let range = parse_arguments(
+        let request = parse_arguments(
             &["2026-01-02".to_string(), "2026-02-03".to_string()],
             session(2026, 8, 6),
         )
         .unwrap();
-        assert_eq!(range.start, session(2026, 1, 2));
-        assert_eq!(range.end, session(2026, 2, 3));
+        assert_eq!(request.range.start, session(2026, 1, 2));
+        assert_eq!(request.range.end, session(2026, 2, 3));
     }
 
     #[test]

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -115,12 +115,13 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let window_start = session.plus_calendar_days(-lookback_days);
     match MassiveClient::from_env() {
         Ok(massive) => {
-            match archive::archive_missing_sessions(
+            match archive::archive_sessions(
                 &s3_client,
                 &massive,
                 &bucket,
                 window_start,
                 session,
+                archive::Coverage::Gaps,
             )
             .await
             {

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -2,7 +2,7 @@
 //!
 //! One partition per session under `data/equity/bars/year=/month=/day=/data.parquet`, written by
 //! whoever holds Massive credentials — the seeder on a cold bucket, the trainer every night. Both
-//! call [`archive_missing_sessions`], because two implementations of this would drift the way the
+//! call [`archive_sessions`], because two implementations of this would drift the way the
 //! trainer's fetch and load stages once did over Eastern versus UTC dates.
 //!
 //! **What gets fetched is a set difference, not a lookback.** The archive is asked what it already
@@ -164,6 +164,19 @@ pub struct ArchiveSummary {
     pub bars_written: usize,
 }
 
+/// Which sessions in the window a pass asks Massive for.
+///
+/// A rebuild exists because the archive's whole design is that a written partition is left alone,
+/// which is right while the stored bars mean what they meant when written and wrong the moment that
+/// changes. Nothing infers it: re-fetching the market for two years is an operator's decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Coverage {
+    /// Sessions with no partition, plus the correction window. What a nightly repair wants.
+    Gaps,
+    /// Every session in the window, whatever the archive already holds.
+    Rebuild,
+}
+
 /// Every weekday in `[start, end]` that the archive should be able to answer for.
 ///
 /// Weekends are excluded because they are never sessions anywhere; holidays are not, because
@@ -186,7 +199,12 @@ fn expected_sessions(start: SessionDate, end: SessionDate) -> Vec<SessionDate> {
 fn sessions_to_request(
     expected: &[SessionDate],
     present: &BTreeSet<SessionDate>,
+    coverage: Coverage,
 ) -> Vec<SessionDate> {
+    if coverage == Coverage::Rebuild {
+        return expected.to_vec();
+    }
+
     // The trailing entries of `expected`, which already excludes weekends, so the window is
     // measured in sessions rather than in calendar days that a weekend can swallow.
     let correction_window: BTreeSet<SessionDate> = expected
@@ -246,24 +264,26 @@ async fn present_sessions(
 /// Safe to run concurrently with another pass over the same bucket, which the trainer's nightly
 /// repair and an operator's seed can be. Each partition is written under a precondition on what was
 /// read, so a racing writer is detected rather than overwritten; see [`write_partition`].
-pub async fn archive_missing_sessions(
+pub async fn archive_sessions(
     s3_client: &S3Client,
     massive: &MassiveClient,
     bucket: &str,
     window_start: SessionDate,
     window_end: SessionDate,
+    coverage: Coverage,
 ) -> Result<ArchiveSummary, ArchiveError> {
     let expected = expected_sessions(window_start, window_end);
     let present = present_sessions(s3_client, bucket, window_start, window_end).await?;
-    let requested = sessions_to_request(&expected, &present);
+    let requested = sessions_to_request(&expected, &present, coverage);
 
     info!(
         %window_start,
         %window_end,
+        ?coverage,
         expected = expected.len(),
         present = present.len(),
         requested = requested.len(),
-        "Scanned the bar archive for gaps"
+        "Scanned the bar archive"
     );
 
     let mut summary = ArchiveSummary {
@@ -276,7 +296,7 @@ pub async fn archive_missing_sessions(
     // weekdays held every bar for all of them in memory before the first write. The same reasoning
     // and the same size as `seed_equity_bars_postgres`, whose chunking predates this.
     for chunk in requested.chunks(CHUNK_SESSIONS) {
-        archive_chunk(s3_client, massive, bucket, chunk, &mut summary).await?;
+        archive_chunk(s3_client, massive, bucket, chunk, coverage, &mut summary).await?;
     }
 
     if !summary.sessions_failed.is_empty() {
@@ -324,6 +344,7 @@ async fn archive_chunk(
     massive: &MassiveClient,
     bucket: &str,
     chunk: &[SessionDate],
+    coverage: Coverage,
     summary: &mut ArchiveSummary,
 ) -> Result<(), ArchiveError> {
     let fetched = bars::fetch_daily_bars(massive, chunk).await;
@@ -349,7 +370,7 @@ async fn archive_chunk(
         let fetched_frame = bars::bars_to_dataframe(&bars_for_session)?;
         let fetched_rows = fetched_frame.height();
 
-        match write_partition(s3_client, bucket, session, fetched_frame).await {
+        match write_partition(s3_client, bucket, session, fetched_frame, coverage).await {
             Ok(()) => {
                 // The rows this pass contributed, not the partition's height. Counting the merged
                 // total reported the archive's size as though every pass had just written it.
@@ -384,12 +405,31 @@ async fn write_partition(
     bucket: &str,
     session: SessionDate,
     fetched: DataFrame,
+    coverage: Coverage,
 ) -> Result<(), ArchiveError> {
     let key = date_partitioned_key(BAR_ARCHIVE_PREFIX, session.date());
     write_merged(s3_client, bucket, key, fetched, |existing, fetched, key| {
-        merge_or_replace(existing, fetched, key)
+        combine(existing, fetched, key, coverage)
     })
     .await
+}
+
+/// How a written partition combines with whatever was already at the key.
+///
+/// A rebuild discards what it read rather than merging into it. Merging keeps any ticker the fresh
+/// response omits, which is the point when filling a gap and exactly wrong when the reason for
+/// rebuilding is that the stored values no longer mean what they used to — that ticker would keep
+/// its old meaning forever, in a partition nothing revisits.
+fn combine(
+    existing: DataFrame,
+    fetched: DataFrame,
+    key: &str,
+    coverage: Coverage,
+) -> Result<DataFrame, ArchiveError> {
+    match coverage {
+        Coverage::Gaps => merge_or_replace(existing, fetched, key),
+        Coverage::Rebuild => Ok(fetched),
+    }
 }
 
 /// The read-merge-write cycle itself, over any key and any way of combining the two frames.
@@ -478,7 +518,7 @@ fn merge_or_replace(
 /// Accumulates the history that makes the switch to unadjusted bars possible; nothing reads the
 /// result yet.
 ///
-/// Not a gap scan like [`archive_missing_sessions`], because there are no gaps to find: the feed
+/// Not a gap scan like [`archive_sessions`], because there are no gaps to find: the feed
 /// answers with its entire current opinion in a few seconds, and that opinion is the answer. Rows
 /// it has stopped reporting are dropped rather than kept, which is the case a per-session layout
 /// could not express.
@@ -740,7 +780,7 @@ mod tests {
     #[test]
     fn test_an_empty_archive_requests_the_whole_window() {
         let expected = expected_sessions(session(2026, 6, 1), session(2026, 6, 5));
-        let requested = sessions_to_request(&expected, &BTreeSet::new());
+        let requested = sessions_to_request(&expected, &BTreeSet::new(), Coverage::Gaps);
         assert_eq!(requested, expected);
     }
 
@@ -756,7 +796,7 @@ mod tests {
             .filter(|date| *date != session(2026, 6, 3))
             .collect();
 
-        let requested = sessions_to_request(&expected, &present);
+        let requested = sessions_to_request(&expected, &present, Coverage::Gaps);
 
         // The hole, plus the trailing sessions after the correction floor (2026-06-17).
         assert_eq!(
@@ -777,7 +817,7 @@ mod tests {
         let expected = expected_sessions(session(2026, 6, 1), end);
         let present: BTreeSet<SessionDate> = expected.iter().copied().collect();
 
-        let requested = sessions_to_request(&expected, &present);
+        let requested = sessions_to_request(&expected, &present, Coverage::Gaps);
 
         assert_eq!(requested, vec![session(2026, 6, 18), session(2026, 6, 19)]);
     }
@@ -796,7 +836,7 @@ mod tests {
         let expected = expected_sessions(session(2026, 6, 1), end);
         let present: BTreeSet<SessionDate> = expected.iter().copied().collect();
 
-        let requested = sessions_to_request(&expected, &present);
+        let requested = sessions_to_request(&expected, &present, Coverage::Gaps);
 
         assert_eq!(
             requested,
@@ -812,7 +852,7 @@ mod tests {
         let present: BTreeSet<SessionDate> = expected.iter().copied().collect();
 
         assert_eq!(
-            sessions_to_request(&expected, &present),
+            sessions_to_request(&expected, &present, Coverage::Gaps),
             vec![session(2026, 6, 1)]
         );
     }
@@ -820,7 +860,28 @@ mod tests {
     /// An empty window requests nothing rather than panicking on the trailing take.
     #[test]
     fn test_an_empty_window_requests_nothing() {
-        assert!(sessions_to_request(&[], &BTreeSet::new()).is_empty());
+        assert!(sessions_to_request(&[], &BTreeSet::new(), Coverage::Gaps).is_empty());
+        assert!(sessions_to_request(&[], &BTreeSet::new(), Coverage::Rebuild).is_empty());
+    }
+
+    /// A rebuild ignores what the archive holds entirely, which is the whole point: the gap scan
+    /// is an optimisation over "fetch the window", and it is the wrong one when the stored bars
+    /// stopped meaning what they meant when written.
+    #[test]
+    fn test_a_rebuild_requests_every_session_however_complete_the_archive_is() {
+        let expected = expected_sessions(session(2026, 6, 1), session(2026, 6, 19));
+        let present: BTreeSet<SessionDate> = expected.iter().copied().collect();
+
+        assert_eq!(
+            sessions_to_request(&expected, &present, Coverage::Rebuild),
+            expected,
+            "a full archive is still fetched in full"
+        );
+        assert_eq!(
+            sessions_to_request(&expected, &BTreeSet::new(), Coverage::Rebuild),
+            expected,
+            "and so is an empty one"
+        );
     }
 
     /// A session Massive has no data for is never written, so the next scan finds it absent and
@@ -838,7 +899,7 @@ mod tests {
             .filter(|date| *date != holiday)
             .collect();
 
-        assert!(sessions_to_request(&expected, &present).contains(&holiday));
+        assert!(sessions_to_request(&expected, &present, Coverage::Gaps).contains(&holiday));
     }
 
     /// The three counts partition the requested set, which is what makes the summary readable as
@@ -958,6 +1019,50 @@ mod tests {
             merged.height(),
             2,
             "a symbol absent from a later response must survive the merge"
+        );
+    }
+
+    /// The behaviour that makes a rebuild worth having, stated against the behaviour it replaces.
+    ///
+    /// Surviving a merge is right when filling a gap and wrong when rebuilding: the reason to
+    /// rebuild is that the stored values stopped meaning what they used to, and a ticker the fresh
+    /// response omits would otherwise keep the old meaning forever, in a partition nothing revisits.
+    #[test]
+    fn test_a_rebuild_replaces_the_partition_where_a_gap_fill_merges_into_it() {
+        let existing = df![
+            "ticker" => ["AAPL", "DELISTED"],
+            "bar_interval" => ["one_day", "one_day"],
+            "timestamp" => [1_i64, 1_i64],
+            "close_price" => [100.0_f64, 200.0_f64],
+        ]
+        .unwrap();
+        let fetched = df![
+            "ticker" => ["AAPL"],
+            "bar_interval" => ["one_day"],
+            "timestamp" => [1_i64],
+            "close_price" => [50.0_f64],
+        ]
+        .unwrap();
+
+        let gap_filled = combine(
+            existing.clone(),
+            fetched.clone(),
+            "some/key",
+            Coverage::Gaps,
+        )
+        .unwrap();
+        assert_eq!(
+            gap_filled.height(),
+            2,
+            "a gap fill keeps what it did not see"
+        );
+
+        let rebuilt = combine(existing, fetched, "some/key", Coverage::Rebuild).unwrap();
+        assert_eq!(rebuilt.height(), 1, "a rebuild keeps only what it fetched");
+        assert_eq!(
+            rebuilt.column("close_price").unwrap().f64().unwrap().get(0),
+            Some(50.0),
+            "and the fetched value, not the stored one"
         );
     }
 }


### PR DESCRIPTION
# Overview

## Changes

- Add `archive::Coverage` — `Gaps` (the nightly behaviour) or `Rebuild` (the whole window, whatever
  the archive holds)
- Rename `archive_missing_sessions` to `archive_sessions`, since a function that can rebuild is not
  fetching what is missing
- A rebuild **replaces** the partition rather than merging into it; `combine` names that decision so
  the divergence between the two is testable
- Add `seed_equity_bars_s3 --rebuild`, accepted in any argument position
- Log `?coverage` on the scan line, so a run says which of the two it was

No behaviour change to any existing path: the trainer passes `Gaps`, and the seeder defaults to it.

## Context

The archive is built on the rule that a written partition is left alone. The scan asks the bucket
what it has and fetches the difference, and `CORRECTION_WINDOW_SESSIONS = 2` is the only thing that
ever revisits a session. That is the right rule while a stored bar means what it meant when written.

Switching the fetch to `adjusted=false` is precisely the event that breaks it — every partition
written before the switch holds prices on a different basis from every partition written after. The
fix is to re-fetch the window, and there was no way to ask for that: `sessions_to_request` skips
anything already present. So the migration had no tool, and this is that tool, landed on its own so
it is deployed and exercised before the switch needs it.

## The half that is easy to miss

A rebuild must replace rather than merge. `merge_partitions` keeps any ticker the fresh response
omits — which is correct when filling a gap, and the opposite of what a rebuild is for: that ticker
would keep its old meaning forever, in a partition nothing revisits. Since the whole reason to
rebuild is that the stored values stopped meaning what they used to, merging would leave behind
exactly the rows the rebuild exists to correct.

`test_a_rebuild_replaces_the_partition_where_a_gap_fill_merges_into_it` states both behaviours
against each other so neither can drift into the other.

## Verification

Unit tests cover the request set under both coverages and the replace-versus-merge divergence.
Beyond those, both paths were run against the development bucket over a populated three-session
window:

| run | expected | present | requested | sessions written | bars written |
| --- | --- | --- | --- | --- | --- |
| gap scan | 3 | 3 | 2 — the correction window | 2 | 24,094 |
| `--rebuild` | 3 | 3 | 3 — everything | 3 | 36,110 |

Roughly 12,000 bars a session, which is the whole market. The fetch still asks for adjusted prices,
so that run rewrote the values it had just read.

`devenv tasks run checks:rust` exits 0; 560 library tests and 6 seeder tests pass.

## What follows

The switch itself: `adjusted=false`, the fold wired into the trainer's S3 read and the
application's two Postgres reads, and then a rebuild of both stores. That has to land as one change,
because bars and readers must move together — and it is why this went first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a rebuild option to fully regenerate archived session data for a selected date range.
  * The default archive process continues to update only missing or incomplete sessions.
* **Bug Fixes**
  * Improved archive repair handling to consistently restore expected session data across supported workflows.
* **Tests**
  * Updated date-range and archive coverage tests to validate both gap repair and full rebuild modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->