### PR TITLE
Stamp bar fixtures at the session close, where bars actually land

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,10 @@ This is a collection of guidelines and references.
 - `SessionDate::from_date` is for dates already expressed in Eastern terms — a parsed argument, a `DATE`
   column, an exchange calendar entry — so transport modules (`common::alpaca`, `common::massive`,
   `common::aws`) keep `NaiveDate` and the wrap happens at the domain boundary; render Eastern only at the
-  display boundary, and stamp test fixtures with `.midnight()` so they match how bars really arrive
+  display boundary; `.midnight()` is for genuinely date-only values, such as an Alpaca transfer that
+  arrives with a date and no time, and never for a daily bar — those are stamped at the session
+  close (16:00 Eastern, so 20:00 UTC under daylight saving and 21:00 outside it), and a fixture
+  stamped at midnight sits on the edge of `bounds()` in a way ingestion never produces
 - `SessionDate` guarantees the timezone, not tradability: weekends and holidays are representable and
   `plus_calendar_days` will land on them, so only `TradingCalendar::is_trading_day` answers whether a date
   trades — never infer it from the type

--- a/src/data/bars.rs
+++ b/src/data/bars.rs
@@ -253,8 +253,8 @@ pub async fn load_bars_dataframe(
     as_of: SessionDate,
 ) -> Result<DataFrame, BarsError> {
     // Anchored to `as_of` rather than the clock, so the window loaded and the basis it is restated
-    // onto are the same day. `bounds` is half-open and a daily bar is stamped at its own session's
-    // midnight, so the upper comparison has to be exclusive or the next session lands inside it.
+    // onto are the same day. `bounds` is half-open, so the upper comparison is exclusive: its end
+    // is the next session's opening instant and belongs to that session, not this one.
     let (_, end) = as_of.bounds();
     let start = as_of.plus_calendar_days(-lookback_days).midnight();
 

--- a/src/data/bars.rs
+++ b/src/data/bars.rs
@@ -252,9 +252,8 @@ pub async fn load_bars_dataframe(
     splits: &SplitTable,
     as_of: SessionDate,
 ) -> Result<DataFrame, BarsError> {
-    // Anchored to `as_of` rather than the clock, so the window loaded and the basis it is restated
-    // onto are the same day. `bounds` is half-open, so the upper comparison is exclusive: its end
-    // is the next session's opening instant and belongs to that session, not this one.
+    // Anchored to `as_of` rather than the clock. `bounds` is half-open, so the upper comparison is
+    // exclusive: its end is the next session's opening instant, which belongs to that session.
     let (_, end) = as_of.bounds();
     let start = as_of.plus_calendar_days(-lookback_days).midnight();
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,8 +7,8 @@
 
 #![allow(dead_code)]
 
-use chrono::{DateTime, Utc};
-
+use chrono::{DateTime, TimeZone, Utc};
+use chrono_tz::America::New_York;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -207,6 +207,23 @@ pub async fn reset_tables(pool: &PgPool) {
     .expect("Failed to reset the test tables");
 }
 
+/// The instant a daily bar for `date` actually carries: 16:00 Eastern, the regular-session close.
+///
+/// Not `SessionDate::midnight`, which sits on the edge of `bounds()` rather than inside it and is a
+/// shape ingestion never produces. Resolved through the zone rather than by adding sixteen hours,
+/// because the two differ on the days the clocks move and `seed_correlated_bars` walks onto them.
+pub fn session_close(date: SessionDate) -> DateTime<Utc> {
+    let local_close = date
+        .date()
+        .and_hms_opt(16, 0, 0)
+        .expect("16:00 is a valid wall-clock time");
+    New_York
+        .from_local_datetime(&local_close)
+        .earliest()
+        .map(|zoned| zoned.with_timezone(&Utc))
+        .expect("16:00 Eastern exists on every date")
+}
+
 /// Inserts daily bars for each ticker over `sessions` consecutive **calendar** days ending today.
 ///
 /// Calendar days, not trading sessions: the loop applies no weekday filter, so the series includes
@@ -230,7 +247,7 @@ pub async fn seed_correlated_bars(pool: &PgPool, tickers: &[&str], sessions: i64
             let idiosyncratic = 0.012 * (step as f64 * 1.9 + index as f64).sin();
             price *= (0.8 * common + 0.6 * idiosyncratic).exp();
 
-            let timestamp = session_date.midnight();
+            let timestamp = session_close(session_date);
 
             sqlx::query(
                 "INSERT INTO equity_bars \
@@ -258,7 +275,7 @@ pub async fn seed_correlated_bars(pool: &PgPool, tickers: &[&str], sessions: i64
 
 /// Inserts one daily bar for a ticker at a specific date, for gap and alignment tests.
 pub async fn seed_bar(pool: &PgPool, ticker: &str, date: SessionDate, close: f64) {
-    let timestamp = date.midnight();
+    let timestamp = session_close(date);
     sqlx::query(
         "INSERT INTO equity_bars \
          (ticker, bar_interval, timestamp, open_price, high_price, low_price, close_price, volume) \

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -844,11 +844,8 @@ async fn test_the_loaded_window_follows_as_of_rather_than_the_clock() {
 /// `SessionDate::bounds` is half-open, so a row landing exactly on its upper edge belongs to the
 /// next session and must not load.
 ///
-/// Deliberately stamped at Eastern midnight, which is a shape the ingestion path does not produce —
-/// daily bars arrive at the session close, sixteen hours inside the interval, where an inclusive
-/// and an exclusive upper bound agree. This guards the predicate itself rather than reproducing
-/// observed data, so that a provider stamping daily bars at the session start cannot silently widen
-/// every window by a day.
+/// Stamped at midnight deliberately: real bars arrive sixteen hours inside the interval, where both
+/// bound forms agree, so this guards the predicate rather than reproducing observed data.
 #[tokio::test]
 #[serial]
 async fn test_a_bar_on_the_upper_bound_belongs_to_the_next_session() {

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -410,7 +410,9 @@ async fn test_aligned_closes_reads_only_the_requested_interval() {
     let today = SessionDate::at(Utc::now());
     common::seed_bar(&pool, "AAAA", today, 100.0).await;
 
-    let timestamp = today.midnight();
+    // Inside the session, like the daily bar above and unlike Eastern midnight — the interval is
+    // what the loader must discriminate on here, not the hour.
+    let timestamp = common::session_close(today);
     sqlx::query(
         "INSERT INTO equity_bars \
          (ticker, bar_interval, timestamp, open_price, high_price, low_price, close_price, volume) \
@@ -806,10 +808,8 @@ async fn test_the_loaded_window_follows_as_of_rather_than_the_clock() {
     let today = SessionDate::at(Utc::now());
     let as_of = today.plus_calendar_days(-10);
 
-    // Inside the requested window, on the first session outside it, and well past it. A daily bar
-    // is stamped at its own session's Eastern midnight, so the middle one sits exactly on the
-    // half-open interval's upper edge — which an inclusive bound admits and an exclusive one does
-    // not. Only the first belongs to an `as_of` ten days back.
+    // Inside the requested window, on the first session outside it, and well past it. Only the
+    // first belongs to an `as_of` ten days back.
     common::seed_bar(&pool, "AAAA", as_of.plus_calendar_days(-1), 10.0).await;
     common::seed_bar(&pool, "AAAA", as_of.plus_calendar_days(1), 55.0).await;
     common::seed_bar(&pool, "AAAA", today, 99.0).await;
@@ -838,5 +838,54 @@ async fn test_the_loaded_window_follows_as_of_rather_than_the_clock() {
         closes[&ticker("AAAA")],
         vec![10.0],
         "the aligned window is bounded above by `as_of` too, not by the latest session stored"
+    );
+}
+
+/// `SessionDate::bounds` is half-open, so a row landing exactly on its upper edge belongs to the
+/// next session and must not load.
+///
+/// Deliberately stamped at Eastern midnight, which is a shape the ingestion path does not produce —
+/// daily bars arrive at the session close, sixteen hours inside the interval, where an inclusive
+/// and an exclusive upper bound agree. This guards the predicate itself rather than reproducing
+/// observed data, so that a provider stamping daily bars at the session start cannot silently widen
+/// every window by a day.
+#[tokio::test]
+#[serial]
+async fn test_a_bar_on_the_upper_bound_belongs_to_the_next_session() {
+    let pool = fresh_pool().await;
+    let as_of = SessionDate::at(Utc::now()).plus_calendar_days(-10);
+
+    common::seed_bar(&pool, "AAAA", as_of.plus_calendar_days(-1), 10.0).await;
+
+    sqlx::query(
+        "INSERT INTO equity_bars \
+         (ticker, bar_interval, timestamp, open_price, high_price, low_price, close_price, volume) \
+         VALUES ('AAAA', 'one_day', $1, 55, 55, 55, 55, 5000000)",
+    )
+    .bind(as_of.plus_calendar_days(1).midnight())
+    .execute(&pool)
+    .await
+    .expect("Failed to seed the boundary bar");
+
+    let frame =
+        bars::load_bars_dataframe(&pool, BarInterval::OneDay, 5, &SplitTable::default(), as_of)
+            .await
+            .expect("the load must succeed");
+
+    assert_eq!(
+        frame.height(),
+        1,
+        "the upper bound is exclusive, so the next session's opening instant is outside it"
+    );
+
+    let closes =
+        bars::load_aligned_closes(&pool, BarInterval::OneDay, 5, &SplitTable::default(), as_of)
+            .await
+            .expect("the load must succeed");
+
+    assert_eq!(
+        closes[&ticker("AAAA")],
+        vec![10.0],
+        "both loaders have to agree about where the window stops"
     );
 }


### PR DESCRIPTION
# Overview

## Changes

- Stamp daily-bar fixtures at 16:00 Eastern via a new `common::session_close`, rather than at Eastern
  midnight, so `seed_bar` and `seed_correlated_bars` produce the timestamp ingestion actually writes
- Correct the comment on `load_bars_dataframe`'s upper bound, which asserted bars are stamped at
  their session's midnight
- Add `test_a_bar_on_the_upper_bound_belongs_to_the_next_session`, which stamps midnight on purpose
  and is documented as guarding the half-open predicate rather than reproducing observed data
- Drop the same wrong claim from the comment on
  `test_the_loaded_window_follows_as_of_rather_than_the_clock`
- Correct the `CLAUDE.md` guidance that told fixtures to use `.midnight()` "so they match how bars
  really arrive"

## Context

Daily bars are stamped at the regular-session close, not at midnight. The archive holds 21:00 UTC
for January and February and 20:00 UTC for July and August — one Eastern wall-clock time, 16:00,
moving with daylight saving.

This matters because #1066 added an exclusive upper bound on the strength of the opposite claim. The
argument was that a bar for the session after `as_of` lands exactly on the half-open interval's
upper edge, so an inclusive bound would admit it; the accompanying test appeared to confirm it. Both
held only because `seed_bar` produced that timestamp. A real bar for that session lands sixteen
hours past the edge and is excluded either way, so no production read was ever widened by the
inclusive form. Reverting to `<=` on this branch leaves
`test_the_loaded_window_follows_as_of_rather_than_the_clock` green, which is the demonstration.

The operator stays exclusive — that is what a half-open interval means — but the coverage backing it
should be honest about what it exercises. The new test manufactures the midnight-stamped bar
explicitly and says why: a provider that stamped daily bars at the session start would otherwise
widen every window by a day, silently. It fails 2-against-1 under `<=`.

`session_close` resolves through `America/New_York` rather than adding sixteen hours to midnight.
The two disagree on the two days a year the clocks move, and `seed_correlated_bars` walks calendar
days, so it steps onto the Sundays they fall on.

The `CLAUDE.md` line is where the belief came from, so it is corrected here too. Midnight remains
right for genuinely date-only values — an Alpaca transfer arrives with a date and no time — and
wrong for a bar.

Found while verifying the unadjusted-bar migration against the live archive, which is what exposed
the real stamping convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of daily bar timestamps by aligning them with the market session close and accounting for daylight-saving time.
  * Corrected session-window boundary behavior so bars at the next session’s opening time are excluded as expected.

* **Tests**
  * Expanded coverage for session-close timestamps and upper-bound exclusion behavior.

* **Documentation**
  * Clarified guidance for date-only values, session-close timestamps, and window boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->