### PR TITLE
Fetch and store the dates a symbol's series may not be read across

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -982,9 +982,11 @@ in {
     # downtime cost the same nothing -- then trains against that window and uploads a model.tar.gz
     # the service loads directly. A gap older than the window is `data:seed:s3`, which floors at two
     # years.
-    # Needs no Alpaca credentials: the grouped endpoint answers by date, so there is no symbol list
-    # to build and therefore no broker to ask for one. That is also why the archive scan decides
-    # which sessions to request from weekends rather than from the published trading calendar.
+    # The bars need no Alpaca credentials: the grouped endpoint answers by date, so there is no
+    # symbol list to build and therefore no broker to ask for one. That is also why the archive scan
+    # decides which sessions to request from weekends rather than from the published trading
+    # calendar. The series-boundary table does need them, because Massive reports splits and nothing
+    # else -- but it warns and skips when they are absent rather than failing the run.
     # The former Python/tinygrad workflow and its Prefect block registration are retired.
     "models:tide:train".exec = ''
       set -euo pipefail

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -18,6 +18,7 @@ use chrono::Utc;
 use polars::prelude::*;
 use tracing::{error, info, warn};
 
+use fund::common::alpaca::{AlpacaCredentials, MarketDataClient};
 use fund::common::aws::date_partitioned_key;
 use fund::common::massive::MassiveClient;
 use fund::common::observability::init_tracing;
@@ -154,6 +155,36 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     if let Err(error) = archive::archive_details(&s3_client, &bucket, details::embedded_csv()).await
     {
         warn!(%error, "Ticker metadata upload failed; the archive keeps the previous copy");
+    }
+
+    // The one thing here that needs a broker rather than a data vendor: Massive reports splits and
+    // nothing else, so renames, spinoffs, rights and unit separations come from Alpaca. Refreshed
+    // over the training window only — rows outside it survive the merge, so a nightly pass costs
+    // one windowed request rather than a full history.
+    //
+    // Absent credentials warn and continue, like the Massive arm above. The boundary table is not
+    // read yet, and a trainer that refused to run without a broker key would be a worse trade than
+    // one whose boundary table is a night stale.
+    match AlpacaCredentials::from_env() {
+        Ok(credentials) => {
+            let market_data = MarketDataClient::from_env(credentials);
+            match archive::archive_boundaries(
+                &s3_client,
+                &market_data,
+                &bucket,
+                window_start,
+                session,
+                now,
+            )
+            .await
+            {
+                Ok(boundaries) => info!(boundaries, "Boundary table refreshed"),
+                Err(error) => {
+                    warn!(%error, "Boundary refresh failed; the archive keeps its copy")
+                }
+            }
+        }
+        Err(error) => warn!(%error, "No Alpaca credentials; the boundary table is not refreshed"),
     }
 
     // --- stage two: load the accumulated window ---

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -1928,6 +1928,7 @@ struct SpinOffPayload {
     source_symbol: String,
     new_symbol: String,
     ex_date: Option<NaiveDate>,
+    process_date: Option<NaiveDate>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1935,6 +1936,7 @@ struct RightsDistributionPayload {
     id: String,
     source_symbol: String,
     ex_date: Option<NaiveDate>,
+    process_date: Option<NaiveDate>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1942,6 +1944,7 @@ struct UnitSplitPayload {
     id: String,
     old_symbol: String,
     effective_date: Option<NaiveDate>,
+    process_date: Option<NaiveDate>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1949,6 +1952,7 @@ struct ReorganizationPayload {
     id: String,
     symbol: String,
     effective_date: Option<NaiveDate>,
+    process_date: Option<NaiveDate>,
 }
 
 /// Turns one page's categories into boundaries, dropping rows that cannot be one.
@@ -1958,12 +1962,25 @@ struct ReorganizationPayload {
 /// is dropped by [`SeriesBoundary::new`], and it is the single most common row in the feed.
 fn parse_boundaries(categories: CorporateActionCategories) -> Vec<SeriesBoundary> {
     let mut boundaries: Vec<SeriesBoundary> = Vec::new();
-    let mut push = |id: String, symbol: &str, date: Option<NaiveDate>, reason: BoundaryReason| {
-        let (Some(ticker), Some(date)) = (Ticker::new(symbol), date) else {
+    let mut push = |id: String,
+                    symbol: &str,
+                    date: Option<NaiveDate>,
+                    process_date: Option<NaiveDate>,
+                    reason: BoundaryReason| {
+        // The process date is required rather than defaulted: it is what a refresh matches its own
+        // window against, and a row without one could never be recognised as cancelled.
+        let (Some(ticker), Some(date), Some(process_date)) =
+            (Ticker::new(symbol), date, process_date)
+        else {
             return;
         };
-        if let Ok(boundary) = SeriesBoundary::new(id, ticker, SessionDate::from_date(date), reason)
-        {
+        if let Ok(boundary) = SeriesBoundary::new(
+            id,
+            ticker,
+            SessionDate::from_date(date),
+            SessionDate::from_date(process_date),
+            reason,
+        ) {
             boundaries.push(boundary);
         }
     };
@@ -1978,6 +1995,7 @@ fn parse_boundaries(categories: CorporateActionCategories) -> Vec<SeriesBoundary
             payload.id,
             &payload.old_symbol,
             payload.process_date,
+            payload.process_date,
             BoundaryReason::Renamed { to },
         );
     }
@@ -1989,6 +2007,7 @@ fn parse_boundaries(categories: CorporateActionCategories) -> Vec<SeriesBoundary
             payload.id,
             &payload.source_symbol,
             payload.ex_date,
+            payload.process_date,
             BoundaryReason::SpunOff { spin_off_company },
         );
     }
@@ -1997,6 +2016,7 @@ fn parse_boundaries(categories: CorporateActionCategories) -> Vec<SeriesBoundary
             payload.id,
             &payload.source_symbol,
             payload.ex_date,
+            payload.process_date,
             BoundaryReason::RightsDistributed,
         );
     }
@@ -2005,6 +2025,7 @@ fn parse_boundaries(categories: CorporateActionCategories) -> Vec<SeriesBoundary
             payload.id,
             &payload.old_symbol,
             payload.effective_date,
+            payload.process_date,
             BoundaryReason::UnitSeparated,
         );
     }
@@ -2013,6 +2034,7 @@ fn parse_boundaries(categories: CorporateActionCategories) -> Vec<SeriesBoundary
             payload.id,
             &payload.symbol,
             payload.effective_date,
+            payload.process_date,
             BoundaryReason::Reorganized,
         );
     }
@@ -3784,7 +3806,9 @@ mod tests {
                  "process_date":"2026-04-10"}
             ],
             "reorganizations": [
-                {"cash_rate":0.1,"cusip":"004ESC018","effective_date":"2026-05-06","id":"o1",
+                {"cash_rate":0.1,"cusip":"89531P105","effective_date":"2026-05-29","id":"o1",
+                 "payable_date":"2026-06-02","process_date":"2026-06-02","symbol":"TRXO"},
+                {"cash_rate":0.1,"cusip":"004ESC018","effective_date":"2026-05-06","id":"o2",
                  "payable_date":"2026-05-11","process_date":"2026-05-11","symbol":"004ESC018"}
             ]
         }
@@ -3843,6 +3867,10 @@ mod tests {
             Some(&BoundaryReason::UnitSeparated),
             "a unit separation names no successor: its price steps, so history cannot follow it"
         );
+        assert_eq!(
+            boundary_for(&boundaries, "TRXO").map(SeriesBoundary::reason),
+            Some(&BoundaryReason::Reorganized)
+        );
     }
 
     /// A spinoff bounds the session its price steps in, which is the ex-date rather than the date
@@ -3878,8 +3906,8 @@ mod tests {
 
         assert_eq!(
             boundaries.len(),
-            4,
-            "RNA, FDX, AIM and ACAAU survive; the three placeholder rows and INDV do not"
+            5,
+            "RNA, FDX, AIM, ACAAU and TRXO survive; the three placeholder rows and INDV do not"
         );
         assert!(boundaries
             .iter()

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -19,7 +19,10 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 use tracing::{debug, info, warn};
 
-use crate::common::types::{BarInterval, Dollars, EquityBar, EquityQuote, EquityTrade, Ticker};
+use crate::common::types::{
+    BarInterval, BoundaryReason, Dollars, EquityBar, EquityQuote, EquityTrade, SeriesBoundary,
+    SessionDate, Ticker,
+};
 
 // --------------------------------------------------------------------------
 // Shared configuration and errors
@@ -1874,6 +1877,149 @@ impl std::fmt::Display for PriceSource {
     }
 }
 
+/// Rows per corporate-actions page. The endpoint's maximum.
+const CORPORATE_ACTIONS_PAGE_SIZE: usize = 1_000;
+
+/// Page bound for the corporate-actions cursor, so a token that never clears cannot loop forever.
+const CORPORATE_ACTIONS_PAGE_LIMIT: usize = 200;
+
+/// The action types that bound a price series.
+///
+/// Splits are absent deliberately: they come from Massive and are folded rather than bounded.
+/// Mergers and worthless removals are absent because a terminated symbol stops appearing in the bar
+/// feed, so a recent window excludes it without being told to.
+const BOUNDARY_ACTION_TYPES: &str =
+    "name_change,spin_off,rights_distribution,unit_split,reorganization";
+
+/// The corporate-actions envelope: categories keyed by name, plus the cursor.
+#[derive(Debug, Deserialize)]
+struct CorporateActionsResponse {
+    #[serde(default)]
+    corporate_actions: CorporateActionCategories,
+    next_page_token: Option<String>,
+}
+
+/// Every category is optional: the endpoint omits one entirely when a page has none of it.
+#[derive(Debug, Default, Deserialize)]
+struct CorporateActionCategories {
+    #[serde(default)]
+    name_changes: Vec<NameChangePayload>,
+    #[serde(default)]
+    spin_offs: Vec<SpinOffPayload>,
+    #[serde(default)]
+    rights_distributions: Vec<RightsDistributionPayload>,
+    #[serde(default)]
+    unit_splits: Vec<UnitSplitPayload>,
+    #[serde(default)]
+    reorganizations: Vec<ReorganizationPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NameChangePayload {
+    id: String,
+    old_symbol: String,
+    new_symbol: String,
+    process_date: Option<NaiveDate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpinOffPayload {
+    id: String,
+    source_symbol: String,
+    new_symbol: String,
+    ex_date: Option<NaiveDate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RightsDistributionPayload {
+    id: String,
+    source_symbol: String,
+    ex_date: Option<NaiveDate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UnitSplitPayload {
+    id: String,
+    old_symbol: String,
+    effective_date: Option<NaiveDate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReorganizationPayload {
+    id: String,
+    symbol: String,
+    effective_date: Option<NaiveDate>,
+}
+
+/// Turns one page's categories into boundaries, dropping rows that cannot be one.
+///
+/// Most dropped rows are the feed's CUSIP placeholders in symbol fields — `038CVR031` and the like
+/// — which [`Ticker::new`] rejects for containing digits. A name change whose symbol did not change
+/// is dropped by [`SeriesBoundary::new`], and it is the single most common row in the feed.
+fn parse_boundaries(categories: CorporateActionCategories) -> Vec<SeriesBoundary> {
+    let mut boundaries: Vec<SeriesBoundary> = Vec::new();
+    let mut push = |id: String, symbol: &str, date: Option<NaiveDate>, reason: BoundaryReason| {
+        let (Some(ticker), Some(date)) = (Ticker::new(symbol), date) else {
+            return;
+        };
+        if let Ok(boundary) = SeriesBoundary::new(id, ticker, SessionDate::from_date(date), reason)
+        {
+            boundaries.push(boundary);
+        }
+    };
+
+    for payload in categories.name_changes {
+        // The successor has to parse for the row to say anything: a rename onto a CUSIP placeholder
+        // records that the symbol stopped, but not where to follow it.
+        let Some(to) = Ticker::new(&payload.new_symbol) else {
+            continue;
+        };
+        push(
+            payload.id,
+            &payload.old_symbol,
+            payload.process_date,
+            BoundaryReason::Renamed { to },
+        );
+    }
+    for payload in categories.spin_offs {
+        let Some(spin_off_company) = Ticker::new(&payload.new_symbol) else {
+            continue;
+        };
+        push(
+            payload.id,
+            &payload.source_symbol,
+            payload.ex_date,
+            BoundaryReason::SpunOff { spin_off_company },
+        );
+    }
+    for payload in categories.rights_distributions {
+        push(
+            payload.id,
+            &payload.source_symbol,
+            payload.ex_date,
+            BoundaryReason::RightsDistributed,
+        );
+    }
+    for payload in categories.unit_splits {
+        push(
+            payload.id,
+            &payload.old_symbol,
+            payload.effective_date,
+            BoundaryReason::UnitSeparated,
+        );
+    }
+    for payload in categories.reorganizations {
+        push(
+            payload.id,
+            &payload.symbol,
+            payload.effective_date,
+            BoundaryReason::Reorganized,
+        );
+    }
+
+    boundaries
+}
+
 /// REST client for the Alpaca market data API.
 #[derive(Clone)]
 pub struct MarketDataClient {
@@ -1929,6 +2075,78 @@ impl MarketDataClient {
             .get(url)
             .header(HEADER_KEY_ID, self.credentials.key_id())
             .header(HEADER_SECRET_KEY, self.credentials.secret())
+    }
+
+    /// Fetches the corporate actions that bound a price series, between `start` and `end`.
+    ///
+    /// Bounded by a date range rather than fetched whole, unlike the splits table: this endpoint
+    /// has no all-time form, so the caller decides how far back the archive should reach.
+    ///
+    /// Rows the feed reports but this cannot use are dropped and counted rather than failing the
+    /// page, because most of them are expected — the feed puts CUSIP placeholders in symbol fields
+    /// and reports far more unchanged-symbol renames than real ones.
+    pub async fn fetch_corporate_actions(
+        &self,
+        start: NaiveDate,
+        end: NaiveDate,
+    ) -> Result<Vec<SeriesBoundary>, ClientError> {
+        let url = format!("{}/v1/corporate-actions", self.base_url);
+        let start_text = start.to_string();
+        let end_text = end.to_string();
+        let page_size = CORPORATE_ACTIONS_PAGE_SIZE.to_string();
+
+        let mut boundaries: Vec<SeriesBoundary> = Vec::new();
+        let mut page_token: Option<String> = None;
+        let mut received: usize = 0;
+
+        for page in 1..=CORPORATE_ACTIONS_PAGE_LIMIT {
+            let mut query: Vec<(&str, &str)> = vec![
+                ("start", start_text.as_str()),
+                ("end", end_text.as_str()),
+                ("types", BOUNDARY_ACTION_TYPES),
+                ("limit", page_size.as_str()),
+            ];
+            if let Some(token) = page_token.as_deref() {
+                query.push(("page_token", token));
+            }
+
+            let response = error_for_status(self.get(&url).query(&query).send().await?).await?;
+            let payload: CorporateActionsResponse = response.json().await.map_err(|error| {
+                ClientError::Parse(format!("Failed to parse corporate actions: {error}"))
+            })?;
+
+            let categories = payload.corporate_actions;
+            received += categories.name_changes.len()
+                + categories.spin_offs.len()
+                + categories.rights_distributions.len()
+                + categories.unit_splits.len()
+                + categories.reorganizations.len();
+            boundaries.extend(parse_boundaries(categories));
+
+            let Some(token) = payload.next_page_token else {
+                let dropped = received.saturating_sub(boundaries.len());
+                if dropped > 0 {
+                    // Routine, and the majority: placeholders and renames that changed no symbol.
+                    warn!(
+                        dropped,
+                        received, "Dropped corporate action rows that bound nothing"
+                    );
+                }
+                info!(
+                    boundaries = boundaries.len(),
+                    pages = page,
+                    %start,
+                    %end,
+                    "Corporate actions fetched"
+                );
+                return Ok(boundaries);
+            };
+            page_token = Some(token);
+        }
+
+        Err(ClientError::Parse(format!(
+            "corporate action pagination did not end within {CORPORATE_ACTIONS_PAGE_LIMIT} pages"
+        )))
     }
 
     /// Fetches point-in-time snapshots for `symbols`, in bounded chunks.
@@ -3528,5 +3746,194 @@ mod tests {
         let server = mockito::Server::new_async().await;
         let snapshots = client(server.url()).fetch_snapshots(&[]).await.unwrap();
         assert!(snapshots.snapshots.is_empty());
+    }
+
+    // --- corporate actions ---
+
+    /// Field names and row shapes copied from live responses, including the placeholder rows. The
+    /// splits feed taught that a payload which parses in a test and not against the feed is the
+    /// failure mode worth spending a fixture on.
+    const CORPORATE_ACTIONS_PAGE: &str = r#"{
+        "corporate_actions": {
+            "name_changes": [
+                {"id":"n1","old_cusip":"03209R103","old_symbol":"RNA",
+                 "new_cusip":"05370B107","new_symbol":"RNAM","process_date":"2026-02-26"},
+                {"id":"n2","old_cusip":"185CNT011","old_symbol":"185CNT011",
+                 "new_cusip":"18506U302","new_symbol":"18506U302","process_date":"2026-02-05"},
+                {"id":"n3","old_cusip":"00846U101","old_symbol":"INDV",
+                 "new_cusip":"00846U101","new_symbol":"INDV","process_date":"2026-01-26"}
+            ],
+            "spin_offs": [
+                {"ex_date":"2026-06-01","id":"s1","new_cusip":"31428X106","new_rate":0.5,
+                 "new_symbol":"FDXF","process_date":"2026-06-01","source_cusip":"31428X106",
+                 "source_rate":1,"source_symbol":"FDX"},
+                {"ex_date":"2026-01-27","id":"s2","new_cusip":"898920103","new_rate":0.072996,
+                 "new_symbol":"HURA","process_date":"2026-01-27","source_cusip":"494ESC015",
+                 "source_rate":1,"source_symbol":"494ESC015"}
+            ],
+            "rights_distributions": [
+                {"ex_date":"2026-02-10","expiration_date":"2026-02-27","id":"r1",
+                 "new_cusip":"009RGT010","new_symbol":"009RGT010","payable_date":"2026-02-19",
+                 "process_date":"2026-02-19","rate":1,"record_date":"2026-02-10",
+                 "source_cusip":"00901B303","source_symbol":"AIM"}
+            ],
+            "unit_splits": [
+                {"alternate_cusip":"G0679A118","alternate_rate":0.1667,"alternate_symbol":"ACAAW",
+                 "effective_date":"2026-04-10","id":"u1","new_cusip":"G0679A100","new_rate":1,
+                 "new_symbol":"ACAA","old_cusip":"G0679A126","old_rate":1,"old_symbol":"ACAAU",
+                 "process_date":"2026-04-10"}
+            ],
+            "reorganizations": [
+                {"cash_rate":0.1,"cusip":"004ESC018","effective_date":"2026-05-06","id":"o1",
+                 "payable_date":"2026-05-11","process_date":"2026-05-11","symbol":"004ESC018"}
+            ]
+        }
+    }"#;
+
+    async fn boundaries_from(body: &str) -> Vec<SeriesBoundary> {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let fetched = client(server.url())
+            .fetch_corporate_actions(date(2026, 1, 1), date(2026, 8, 14))
+            .await
+            .expect("the page must parse");
+        mock.assert_async().await;
+        fetched
+    }
+
+    fn boundary_for<'a>(
+        boundaries: &'a [SeriesBoundary],
+        ticker: &str,
+    ) -> Option<&'a SeriesBoundary> {
+        boundaries
+            .iter()
+            .find(|boundary| boundary.ticker().as_str() == ticker)
+    }
+
+    #[tokio::test]
+    async fn test_each_category_becomes_the_boundary_it_describes() {
+        let boundaries = boundaries_from(CORPORATE_ACTIONS_PAGE).await;
+
+        assert_eq!(
+            boundary_for(&boundaries, "RNA").map(SeriesBoundary::reason),
+            Some(&BoundaryReason::Renamed {
+                to: Ticker::new("RNAM").unwrap()
+            })
+        );
+        assert_eq!(
+            boundary_for(&boundaries, "FDX").map(SeriesBoundary::reason),
+            Some(&BoundaryReason::SpunOff {
+                spin_off_company: Ticker::new("FDXF").unwrap()
+            }),
+            "a spinoff names the company whose shares were distributed"
+        );
+        assert_eq!(
+            boundary_for(&boundaries, "AIM").map(SeriesBoundary::reason),
+            Some(&BoundaryReason::RightsDistributed)
+        );
+        assert_eq!(
+            boundary_for(&boundaries, "ACAAU").map(SeriesBoundary::reason),
+            Some(&BoundaryReason::UnitSeparated),
+            "a unit separation names no successor: its price steps, so history cannot follow it"
+        );
+    }
+
+    /// A spinoff bounds the session its price steps in, which is the ex-date rather than the date
+    /// the transfer agent processed it.
+    #[tokio::test]
+    async fn test_a_spinoff_is_bounded_at_its_ex_date() {
+        let boundaries = boundaries_from(CORPORATE_ACTIONS_PAGE).await;
+
+        assert_eq!(
+            boundary_for(&boundaries, "FDX").map(SeriesBoundary::date),
+            Some(SessionDate::from_date(date(2026, 6, 1)))
+        );
+    }
+
+    /// The single most common row in the feed, and one that bounds nothing: the company's name or
+    /// CUSIP changed under an unchanged ticker. Admitting it would truncate every window spanning
+    /// a date on which nothing happened to the price.
+    #[tokio::test]
+    async fn test_a_rename_that_changes_no_symbol_is_not_a_boundary() {
+        let boundaries = boundaries_from(CORPORATE_ACTIONS_PAGE).await;
+
+        assert!(
+            boundary_for(&boundaries, "INDV").is_none(),
+            "INDV renamed to itself, so its series is continuous"
+        );
+    }
+
+    /// The feed puts CUSIPs in symbol fields for entities that never traded under a ticker. They
+    /// parse as JSON and mean nothing to a bar archive keyed by symbol.
+    #[tokio::test]
+    async fn test_placeholder_symbols_are_dropped() {
+        let boundaries = boundaries_from(CORPORATE_ACTIONS_PAGE).await;
+
+        assert_eq!(
+            boundaries.len(),
+            4,
+            "RNA, FDX, AIM and ACAAU survive; the three placeholder rows and INDV do not"
+        );
+        assert!(boundaries
+            .iter()
+            .all(|boundary| !boundary.ticker().as_str().contains(char::is_numeric)));
+    }
+
+    /// A page carrying only some categories is the normal case, not a malformed response.
+    #[tokio::test]
+    async fn test_a_page_missing_every_category_is_empty_rather_than_an_error() {
+        assert!(boundaries_from(r#"{"corporate_actions":{}}"#)
+            .await
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_pagination_follows_the_token_to_the_last_page() {
+        let mut server = mockito::Server::new_async().await;
+        // Registered before the tokenless page, because mockito serves the first mock whose
+        // matchers accept the request and the fallback below accepts any query at all.
+        let second = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_query(mockito::Matcher::UrlEncoded(
+                "page_token".into(),
+                "page-two".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"corporate_actions":{"name_changes":[
+                    {"id":"n2","old_symbol":"SPCX","new_symbol":"SPCK","process_date":"2026-04-07"}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+        let first = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"corporate_actions":{"name_changes":[
+                    {"id":"n1","old_symbol":"RNA","new_symbol":"RNAM","process_date":"2026-02-26"}
+                ]},"next_page_token":"page-two"}"#,
+            )
+            .create_async()
+            .await;
+
+        let boundaries = client(server.url())
+            .fetch_corporate_actions(date(2026, 1, 1), date(2026, 8, 14))
+            .await
+            .expect("both pages must parse");
+
+        assert_eq!(boundaries.len(), 2, "rows from both pages are kept");
+        assert!(boundary_for(&boundaries, "SPCX").is_some());
+        first.assert_async().await;
+        second.assert_async().await;
     }
 }

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -996,6 +996,7 @@ pub struct SeriesBoundary {
     id: String,
     ticker: Ticker,
     date: SessionDate,
+    process_date: SessionDate,
     reason: BoundaryReason,
 }
 
@@ -1005,13 +1006,18 @@ impl SeriesBoundary {
     /// A rename onto the same symbol is the case this exists for: the feed reports a company's name
     /// or CUSIP changing under an unchanged ticker far more often than a real symbol change, and
     /// such a row bounds nothing while truncating every window that spans it.
+    ///
+    /// The identifier is stored trimmed, because it is the key a refresh matches stored rows on and
+    /// whitespace either side would make one boundary look like two.
     pub fn new(
         id: String,
         ticker: Ticker,
         date: SessionDate,
+        process_date: SessionDate,
         reason: BoundaryReason,
     ) -> Result<Self, InconsistentRecordError> {
-        if id.trim().is_empty() {
+        let id = id.trim().to_string();
+        if id.is_empty() {
             return Err(reject("boundary identifier is empty"));
         }
         if reason.successor() == Some(&ticker) {
@@ -1024,6 +1030,7 @@ impl SeriesBoundary {
             id,
             ticker,
             date,
+            process_date,
             reason,
         })
     }
@@ -1036,8 +1043,17 @@ impl SeriesBoundary {
         &self.ticker
     }
 
+    /// The session the price moved: an ex-date, or an effective date.
     pub fn date(&self) -> SessionDate {
         self.date
+    }
+
+    /// The session the feed processed the action, which is what its date filter selects on.
+    ///
+    /// Carried because it is the only way a refresh can tell which stored rows it was in a position
+    /// to re-report, and therefore which absences mean an action was cancelled.
+    pub fn process_date(&self) -> SessionDate {
+        self.process_date
     }
 
     pub fn reason(&self) -> &BoundaryReason {

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -939,6 +939,112 @@ impl EquitySplit {
     }
 }
 
+/// Why a symbol's price series must not be read across a date.
+///
+/// Only `Renamed` carries history forward. The rest mean the symbol still denotes the same company
+/// but its price stepped for a reason no return should be computed across, so their bars before the
+/// date are unusable rather than relocatable.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BoundaryReason {
+    /// The company kept trading under `to`, which is where its history continues.
+    ///
+    /// This one row also ends the old symbol's series: whatever trades under it afterwards is a
+    /// different company, so reuse needs no variant of its own.
+    Renamed { to: Ticker },
+    /// The company distributed shares of `spin_off_company`; its price fell by their value.
+    SpunOff { spin_off_company: Ticker },
+    /// Rights were distributed. The price falls by their value and the bar feed never carries a
+    /// price for them, so the step cannot be measured, only avoided.
+    RightsDistributed,
+    /// A unit separated into its components — a rename and a distribution at once, so unlike a
+    /// rename the price steps and the history does not follow.
+    UnitSeparated,
+    /// A reorganization the feed does not classify further; truncating is the conservative reading.
+    Reorganized,
+}
+
+impl BoundaryReason {
+    /// The stored form, and the discriminant a reader matches on.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BoundaryReason::Renamed { .. } => "renamed",
+            BoundaryReason::SpunOff { .. } => "spun_off",
+            BoundaryReason::RightsDistributed => "rights_distributed",
+            BoundaryReason::UnitSeparated => "unit_separated",
+            BoundaryReason::Reorganized => "reorganized",
+        }
+    }
+
+    /// The symbol this one's history continues under, when it continues at all.
+    pub fn successor(&self) -> Option<&Ticker> {
+        match self {
+            BoundaryReason::Renamed { to } => Some(to),
+            BoundaryReason::SpunOff { .. }
+            | BoundaryReason::RightsDistributed
+            | BoundaryReason::UnitSeparated
+            | BoundaryReason::Reorganized => None,
+        }
+    }
+}
+
+/// A date a symbol's series may not be read across.
+///
+/// Held per symbol rather than per company on purpose: no identifier shared by our two providers
+/// survives a rename, so a symbol bounded in time is the strongest identity available.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SeriesBoundary {
+    id: String,
+    ticker: Ticker,
+    date: SessionDate,
+    reason: BoundaryReason,
+}
+
+impl SeriesBoundary {
+    /// Constructs a `SeriesBoundary`, rejecting one that does not divide anything.
+    ///
+    /// A rename onto the same symbol is the case this exists for: the feed reports a company's name
+    /// or CUSIP changing under an unchanged ticker far more often than a real symbol change, and
+    /// such a row bounds nothing while truncating every window that spans it.
+    pub fn new(
+        id: String,
+        ticker: Ticker,
+        date: SessionDate,
+        reason: BoundaryReason,
+    ) -> Result<Self, InconsistentRecordError> {
+        if id.trim().is_empty() {
+            return Err(reject("boundary identifier is empty"));
+        }
+        if reason.successor() == Some(&ticker) {
+            return Err(reject(format!(
+                "boundary for {ticker} names itself as its successor"
+            )));
+        }
+
+        Ok(Self {
+            id,
+            ticker,
+            date,
+            reason,
+        })
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    pub fn date(&self) -> SessionDate {
+        self.date
+    }
+
+    pub fn reason(&self) -> &BoundaryReason {
+        &self.reason
+    }
+}
+
 /// Ticker metadata used to constrain pair selection to cross-sector matches.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EquityDetail {

--- a/src/data.rs
+++ b/src/data.rs
@@ -15,6 +15,7 @@
 pub mod adjust;
 pub mod archive;
 pub mod bars;
+pub mod boundaries;
 pub mod calendar;
 pub mod details;
 pub mod export;

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -122,8 +122,14 @@ pub enum ArchiveError {
     #[error("gave up on {key} after {attempts} concurrent writes by another pass")]
     Contended { key: String, attempts: usize },
     /// The upstream feed failed, before any bucket was touched.
-    #[error("failed to fetch from Massive: {0}")]
-    Feed(String),
+    ///
+    /// The vendor is carried because two of them supply this archive, and an operator reading the
+    /// message during an incident needs to know which one to look at.
+    #[error("failed to fetch from {vendor}: {message}")]
+    Feed {
+        vendor: &'static str,
+        message: String,
+    },
     #[error("failed to build a bar frame: {0}")]
     Frame(#[from] PolarsError),
 }
@@ -498,7 +504,10 @@ pub async fn archive_splits(
     let splits = massive
         .fetch_splits()
         .await
-        .map_err(|error| ArchiveError::Feed(error.to_string()))?;
+        .map_err(|error| ArchiveError::Feed {
+            vendor: "Massive",
+            message: error.to_string(),
+        })?;
 
     // Refused before the write rather than merged away inside it, so a cold bucket does not get an
     // empty object either. A feed that answers success with nothing is an outage, not an emptied
@@ -543,13 +552,9 @@ pub async fn archive_splits(
 
 /// Refreshes the series-boundary table over `start..=end`, merging it with what is stored.
 ///
-/// Windowed rather than whole, unlike [`archive_splits`]: the corporate-actions endpoint has no
-/// all-time form, so the caller says how far back to refresh and rows outside that range are left
-/// as they were.
-///
-/// An empty fetch is written rather than refused, again unlike the splits table. A date range
-/// containing no corporate action is an ordinary answer, so treating it as an outage would leave a
-/// cancelled action in the table forever.
+/// Windowed rather than whole, unlike [`archive_splits`]: the endpoint has no all-time form, so
+/// rows outside the range are left as they were. An empty fetch is written rather than refused,
+/// because a range with no corporate action in it is an ordinary answer here.
 pub async fn archive_boundaries(
     s3_client: &S3Client,
     market_data: &MarketDataClient,
@@ -561,7 +566,10 @@ pub async fn archive_boundaries(
     let fetched = market_data
         .fetch_corporate_actions(start.date(), end.date())
         .await
-        .map_err(|error| ArchiveError::Feed(error.to_string()))?;
+        .map_err(|error| ArchiveError::Feed {
+            vendor: "Alpaca",
+            message: error.to_string(),
+        })?;
 
     let frame = boundaries::boundaries_to_dataframe(&fetched, fetched_at)?;
     write_merged(
@@ -569,23 +577,16 @@ pub async fn archive_boundaries(
         bucket,
         BOUNDARIES_ARCHIVE_KEY.to_string(),
         frame,
-        // Falls back rather than propagating, for the reason `archive_splits` does: a stored object
-        // whose schema stopped matching would otherwise fail every future refresh too.
-        |existing, fetched, key| match boundaries::merge_boundaries(
-            existing,
-            fetched.clone(),
-            start,
-            end,
-        ) {
-            Ok(merged) => Ok(merged),
-            Err(error) => {
-                warn!(
-                    key,
-                    %error,
-                    "Could not merge the stored boundary table; replacing it with the fetched rows"
-                );
-                Ok(fetched)
-            }
+        // Fails rather than falling back, which is the opposite of `archive_splits`. Replacing with
+        // the fetch would drop every boundary outside the window, and quietly keeping the stored
+        // table would report a refresh that did not happen — a schema mismatch would then look like
+        // success on every run forever. Nothing is written, so the stored table survives either way.
+        |existing, fetched, key| {
+            boundaries::merge_boundaries(existing, fetched, start, end).map_err(|error| {
+                ArchiveError::Frame(PolarsError::ComputeError(
+                    format!("could not merge the stored boundary table at {key}: {error}").into(),
+                ))
+            })
         },
     )
     .await?;

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -31,10 +31,11 @@ use chrono::{DateTime, Utc};
 use polars::prelude::*;
 use tracing::{info, warn};
 
+use crate::common::alpaca::MarketDataClient;
 use crate::common::aws::{date_from_partitioned_key, date_partitioned_key};
 use crate::common::massive::MassiveClient;
 use crate::common::types::SessionDate;
-use crate::data::{bars, splits};
+use crate::data::{bars, boundaries, splits};
 
 /// S3 prefix for the bar archive.
 ///
@@ -59,6 +60,12 @@ pub const DETAILS_ARCHIVE_KEY: &str = "data/equity/details/details.csv";
 /// Under `corporate_actions/` rather than a directory of its own, because spinoffs and symbol
 /// changes are the same kind of fact read the same way and belong beside it as sibling files.
 pub const SPLITS_ARCHIVE_KEY: &str = "data/equity/corporate_actions/splits.parquet";
+
+/// Object holding every date a symbol's price series may not be read across.
+///
+/// Beside the splits table rather than merged into it, because the two are read for opposite
+/// purposes: a split says how to restate a price across a date, a boundary says not to.
+pub const BOUNDARIES_ARCHIVE_KEY: &str = "data/equity/corporate_actions/boundaries.parquet";
 
 /// Trailing sessions re-fetched even when a partition already exists.
 ///
@@ -532,6 +539,65 @@ pub async fn archive_splits(
         "Splits table archived"
     );
     Ok(splits.len())
+}
+
+/// Refreshes the series-boundary table over `start..=end`, merging it with what is stored.
+///
+/// Windowed rather than whole, unlike [`archive_splits`]: the corporate-actions endpoint has no
+/// all-time form, so the caller says how far back to refresh and rows outside that range are left
+/// as they were.
+///
+/// An empty fetch is written rather than refused, again unlike the splits table. A date range
+/// containing no corporate action is an ordinary answer, so treating it as an outage would leave a
+/// cancelled action in the table forever.
+pub async fn archive_boundaries(
+    s3_client: &S3Client,
+    market_data: &MarketDataClient,
+    bucket: &str,
+    start: SessionDate,
+    end: SessionDate,
+    fetched_at: DateTime<Utc>,
+) -> Result<usize, ArchiveError> {
+    let fetched = market_data
+        .fetch_corporate_actions(start.date(), end.date())
+        .await
+        .map_err(|error| ArchiveError::Feed(error.to_string()))?;
+
+    let frame = boundaries::boundaries_to_dataframe(&fetched, fetched_at)?;
+    write_merged(
+        s3_client,
+        bucket,
+        BOUNDARIES_ARCHIVE_KEY.to_string(),
+        frame,
+        // Falls back rather than propagating, for the reason `archive_splits` does: a stored object
+        // whose schema stopped matching would otherwise fail every future refresh too.
+        |existing, fetched, key| match boundaries::merge_boundaries(
+            existing,
+            fetched.clone(),
+            start,
+            end,
+        ) {
+            Ok(merged) => Ok(merged),
+            Err(error) => {
+                warn!(
+                    key,
+                    %error,
+                    "Could not merge the stored boundary table; replacing it with the fetched rows"
+                );
+                Ok(fetched)
+            }
+        },
+    )
+    .await?;
+
+    info!(
+        key = BOUNDARIES_ARCHIVE_KEY,
+        boundaries = fetched.len(),
+        %start,
+        %end,
+        "Boundary table archived"
+    );
+    Ok(fetched.len())
 }
 
 /// Writes the ticker metadata that accompanies the archive.

--- a/src/data/boundaries.rs
+++ b/src/data/boundaries.rs
@@ -1,0 +1,346 @@
+//! The dates a symbol's price series may not be read across; nothing reads them yet.
+//!
+//! One S3 object rather than a partition per session, for the reason the splits table is one: a
+//! boundary belongs to its date, but the feed revises what it reports, so only the whole table is
+//! ever authoritative.
+
+use chrono::{DateTime, Utc};
+use polars::prelude::*;
+
+use crate::common::types::{BoundaryReason, SeriesBoundary, SessionDate};
+
+/// Builds the frame written to the archive, stamping every row with when this pass saw it.
+///
+/// `related_ticker` holds whichever symbol the reason names — where a rename continues, or which
+/// company a spinoff distributed — and is null for the reasons that name none. One nullable column
+/// rather than one per variant keeps the frame flat and the schema stable as variants are added.
+pub fn boundaries_to_dataframe(
+    boundaries: &[SeriesBoundary],
+    fetched_at: DateTime<Utc>,
+) -> Result<DataFrame, PolarsError> {
+    let mut identifiers: Vec<String> = Vec::with_capacity(boundaries.len());
+    let mut tickers: Vec<String> = Vec::with_capacity(boundaries.len());
+    let mut dates: Vec<String> = Vec::with_capacity(boundaries.len());
+    let mut reasons: Vec<String> = Vec::with_capacity(boundaries.len());
+    let mut related: Vec<Option<String>> = Vec::with_capacity(boundaries.len());
+
+    for boundary in boundaries {
+        identifiers.push(boundary.id().to_string());
+        tickers.push(boundary.ticker().as_str().to_string());
+        dates.push(boundary.date().date().format("%Y-%m-%d").to_string());
+        reasons.push(boundary.reason().as_str().to_string());
+        related.push(match boundary.reason() {
+            BoundaryReason::Renamed { to } => Some(to.as_str().to_string()),
+            BoundaryReason::SpunOff { spin_off_company } => {
+                Some(spin_off_company.as_str().to_string())
+            }
+            BoundaryReason::RightsDistributed
+            | BoundaryReason::UnitSeparated
+            | BoundaryReason::Reorganized => None,
+        });
+    }
+    let first_seen = vec![fetched_at.timestamp_millis(); boundaries.len()];
+
+    DataFrame::new(vec![
+        Column::new("id".into(), identifiers),
+        Column::new("ticker".into(), tickers),
+        Column::new("date".into(), dates),
+        Column::new("reason".into(), reasons),
+        Column::new("related_ticker".into(), related),
+        Column::new("first_seen".into(), first_seen),
+    ])
+}
+
+/// Merges a stored boundary table with one fetched over `start..=end`.
+///
+/// Deliberately unlike [`crate::data::splits::merge_splits`], which replaces the row set outright.
+/// That is safe there because the splits feed answers with its entire history; this feed answers
+/// only for a date range, so replacing would erase every boundary outside the window that was
+/// asked for. Stored rows outside it therefore survive untouched, and only rows dated inside it are
+/// replaced — which is what lets a revised or cancelled action disappear.
+///
+/// An empty fetch still replaces inside the window: a range genuinely containing no corporate
+/// action is ordinary, unlike an empty all-time splits response, which is an outage.
+///
+/// The window and the stored date are not the same date. Alpaca filters a request by when it
+/// processed an action, while the boundary is stamped with when the price moved — its ex or
+/// effective date — so a June request returns rows stamped 2017. Surviving stored rows are
+/// therefore anti-joined on `id` as well as filtered by date, or a row outside the window that came
+/// back anyway would be kept twice.
+pub fn merge_boundaries(
+    existing: DataFrame,
+    fetched: DataFrame,
+    start: SessionDate,
+    end: SessionDate,
+) -> Result<DataFrame, PolarsError> {
+    let start_text = start.date().format("%Y-%m-%d").to_string();
+    let end_text = end.date().format("%Y-%m-%d").to_string();
+
+    // Compared as text rather than parsed dates: the column is written `%Y-%m-%d`, which orders
+    // lexicographically exactly as it orders chronologically, and parsing would import a failure
+    // mode for no gain.
+    let outside_window = existing
+        .clone()
+        .lazy()
+        .join(
+            fetched.clone().lazy().select([col("id")]),
+            [col("id")],
+            [col("id")],
+            JoinArgs::new(JoinType::Anti),
+        )
+        .filter(
+            col("date")
+                .lt(lit(start_text.clone()))
+                .or(col("date").gt(lit(end_text.clone()))),
+        );
+
+    let previously_seen = existing
+        .lazy()
+        .select([col("id"), col("first_seen").alias("previous_first_seen")])
+        .group_by([col("id")])
+        .agg([col("previous_first_seen").min()]);
+
+    let refreshed = fetched
+        .lazy()
+        .join(
+            previously_seen,
+            [col("id")],
+            [col("id")],
+            JoinArgs::new(JoinType::Left),
+        )
+        // Defaulted before it is compared, because a row absent from the stored table joins to null
+        // and a null comparison would propagate rather than choose a branch.
+        .with_column(
+            coalesce(&[col("previous_first_seen"), col("first_seen")]).alias("previous_first_seen"),
+        )
+        .with_column(
+            when(col("previous_first_seen").lt(col("first_seen")))
+                .then(col("previous_first_seen"))
+                .otherwise(col("first_seen"))
+                .alias("first_seen"),
+        )
+        .select([
+            col("id"),
+            col("ticker"),
+            col("date"),
+            col("reason"),
+            col("related_ticker"),
+            col("first_seen"),
+        ]);
+
+    concat(
+        [outside_window, refreshed],
+        UnionArgs {
+            rechunk: true,
+            ..Default::default()
+        },
+    )?
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::types::Ticker;
+
+    fn instant(value: &str) -> DateTime<Utc> {
+        value.parse().expect("a valid test instant")
+    }
+
+    fn session(value: &str) -> SessionDate {
+        SessionDate::from_date(value.parse().expect("a valid session date"))
+    }
+
+    fn renamed(id: &str, ticker: &str, date: &str, to: &str) -> SeriesBoundary {
+        SeriesBoundary::new(
+            id.to_string(),
+            Ticker::new(ticker).expect("a valid ticker"),
+            session(date),
+            BoundaryReason::Renamed {
+                to: Ticker::new(to).expect("a valid ticker"),
+            },
+        )
+        .expect("a valid boundary")
+    }
+
+    fn rights(id: &str, ticker: &str, date: &str) -> SeriesBoundary {
+        SeriesBoundary::new(
+            id.to_string(),
+            Ticker::new(ticker).expect("a valid ticker"),
+            session(date),
+            BoundaryReason::RightsDistributed,
+        )
+        .expect("a valid boundary")
+    }
+
+    fn identifiers(frame: &DataFrame) -> Vec<String> {
+        let column = frame.column("id").unwrap().str().unwrap();
+        let mut found: Vec<String> = (0..frame.height())
+            .filter_map(|row| column.get(row).map(str::to_string))
+            .collect();
+        found.sort();
+        found
+    }
+
+    #[test]
+    fn test_the_frame_carries_the_reason_and_the_symbol_it_names() {
+        let frame = boundaries_to_dataframe(
+            &[
+                renamed("n1", "RNA", "2026-02-26", "RNAM"),
+                rights("r1", "AIM", "2026-02-10"),
+            ],
+            instant("2026-08-15T02:00:00Z"),
+        )
+        .expect("a frame must build");
+
+        let reasons = frame.column("reason").unwrap().str().unwrap();
+        let related = frame.column("related_ticker").unwrap().str().unwrap();
+
+        assert_eq!(reasons.get(0), Some("renamed"));
+        assert_eq!(related.get(0), Some("RNAM"));
+        assert_eq!(reasons.get(1), Some("rights_distributed"));
+        assert_eq!(
+            related.get(1),
+            None,
+            "a reason that names no symbol stores none"
+        );
+    }
+
+    /// The request window filters a different date than the one stored, so the feed returns rows
+    /// stamped well outside it — four of them on the first live refresh. Splitting the stored table
+    /// on date alone put those in both halves and wrote them twice.
+    #[test]
+    fn test_a_row_returned_from_outside_the_window_is_kept_once() {
+        let stored = boundaries_to_dataframe(
+            &[renamed("old", "FB", "2022-06-09", "META")],
+            instant("2026-08-01T02:00:00Z"),
+        )
+        .unwrap();
+        let fetched = boundaries_to_dataframe(
+            &[renamed("old", "FB", "2022-06-09", "META")],
+            instant("2026-08-15T02:00:00Z"),
+        )
+        .unwrap();
+
+        let merged = merge_boundaries(
+            stored,
+            fetched,
+            session("2026-06-01"),
+            session("2026-06-30"),
+        )
+        .expect("the merge must succeed");
+
+        assert_eq!(
+            identifiers(&merged),
+            vec!["old"],
+            "a stored row the fetch returned again is replaced, not duplicated"
+        );
+    }
+
+    /// The difference from the splits merge, and the reason this one takes a window at all. A
+    /// refresh covering this year must not erase a boundary recorded for a previous one.
+    #[test]
+    fn test_a_boundary_outside_the_refreshed_window_survives() {
+        let stored = boundaries_to_dataframe(
+            &[
+                renamed("old", "FB", "2022-06-09", "META"),
+                renamed("n1", "RNA", "2026-02-26", "RNAM"),
+            ],
+            instant("2026-08-01T02:00:00Z"),
+        )
+        .unwrap();
+        let fetched = boundaries_to_dataframe(
+            &[renamed("n1", "RNA", "2026-02-26", "RNAM")],
+            instant("2026-08-15T02:00:00Z"),
+        )
+        .unwrap();
+
+        let merged = merge_boundaries(
+            stored,
+            fetched,
+            session("2026-01-01"),
+            session("2026-08-14"),
+        )
+        .expect("the merge must succeed");
+
+        assert_eq!(identifiers(&merged), vec!["n1", "old"]);
+    }
+
+    /// Inside the window the fetch is authoritative, so an action the feed stopped reporting is
+    /// dropped rather than kept — the same rule the splits table applies to its whole history.
+    #[test]
+    fn test_a_boundary_the_feed_no_longer_reports_inside_the_window_is_dropped() {
+        let stored = boundaries_to_dataframe(
+            &[
+                renamed("n1", "RNA", "2026-02-26", "RNAM"),
+                renamed("gone", "CNCL", "2026-03-01", "OTHR"),
+            ],
+            instant("2026-08-01T02:00:00Z"),
+        )
+        .unwrap();
+        let fetched = boundaries_to_dataframe(
+            &[renamed("n1", "RNA", "2026-02-26", "RNAM")],
+            instant("2026-08-15T02:00:00Z"),
+        )
+        .unwrap();
+
+        let merged = merge_boundaries(
+            stored,
+            fetched,
+            session("2026-01-01"),
+            session("2026-08-14"),
+        )
+        .expect("the merge must succeed");
+
+        assert_eq!(identifiers(&merged), vec!["n1"]);
+    }
+
+    #[test]
+    fn test_a_surviving_boundary_keeps_the_earlier_first_seen() {
+        let first = instant("2026-08-01T02:00:00Z");
+        let stored =
+            boundaries_to_dataframe(&[renamed("n1", "RNA", "2026-02-26", "RNAM")], first).unwrap();
+        let fetched = boundaries_to_dataframe(
+            &[renamed("n1", "RNA", "2026-02-26", "RNAM")],
+            instant("2026-08-15T02:00:00Z"),
+        )
+        .unwrap();
+
+        let merged = merge_boundaries(
+            stored,
+            fetched,
+            session("2026-01-01"),
+            session("2026-08-14"),
+        )
+        .expect("the merge must succeed");
+
+        assert_eq!(
+            merged.column("first_seen").unwrap().i64().unwrap().get(0),
+            Some(first.timestamp_millis())
+        );
+    }
+
+    /// A window with no corporate actions in it is ordinary, and clears what the window held.
+    #[test]
+    fn test_an_empty_window_clears_only_that_window() {
+        let stored = boundaries_to_dataframe(
+            &[
+                renamed("old", "FB", "2022-06-09", "META"),
+                renamed("n1", "RNA", "2026-02-26", "RNAM"),
+            ],
+            instant("2026-08-01T02:00:00Z"),
+        )
+        .unwrap();
+        let nothing = boundaries_to_dataframe(&[], instant("2026-08-15T02:00:00Z")).unwrap();
+
+        let merged = merge_boundaries(
+            stored,
+            nothing,
+            session("2026-01-01"),
+            session("2026-08-14"),
+        )
+        .expect("the merge must succeed");
+
+        assert_eq!(identifiers(&merged), vec!["old"]);
+    }
+}

--- a/src/data/boundaries.rs
+++ b/src/data/boundaries.rs
@@ -1,8 +1,6 @@
 //! The dates a symbol's price series may not be read across; nothing reads them yet.
 //!
-//! One S3 object rather than a partition per session, for the reason the splits table is one: a
-//! boundary belongs to its date, but the feed revises what it reports, so only the whole table is
-//! ever authoritative.
+//! One S3 object, refreshed over a date range and merged with what is stored.
 
 use chrono::{DateTime, Utc};
 use polars::prelude::*;
@@ -12,8 +10,7 @@ use crate::common::types::{BoundaryReason, SeriesBoundary, SessionDate};
 /// Builds the frame written to the archive, stamping every row with when this pass saw it.
 ///
 /// `related_ticker` holds whichever symbol the reason names — where a rename continues, or which
-/// company a spinoff distributed — and is null for the reasons that name none. One nullable column
-/// rather than one per variant keeps the frame flat and the schema stable as variants are added.
+/// company a spinoff distributed — and is null for the reasons that name neither.
 pub fn boundaries_to_dataframe(
     boundaries: &[SeriesBoundary],
     fetched_at: DateTime<Utc>,
@@ -21,6 +18,7 @@ pub fn boundaries_to_dataframe(
     let mut identifiers: Vec<String> = Vec::with_capacity(boundaries.len());
     let mut tickers: Vec<String> = Vec::with_capacity(boundaries.len());
     let mut dates: Vec<String> = Vec::with_capacity(boundaries.len());
+    let mut process_dates: Vec<String> = Vec::with_capacity(boundaries.len());
     let mut reasons: Vec<String> = Vec::with_capacity(boundaries.len());
     let mut related: Vec<Option<String>> = Vec::with_capacity(boundaries.len());
 
@@ -28,6 +26,13 @@ pub fn boundaries_to_dataframe(
         identifiers.push(boundary.id().to_string());
         tickers.push(boundary.ticker().as_str().to_string());
         dates.push(boundary.date().date().format("%Y-%m-%d").to_string());
+        process_dates.push(
+            boundary
+                .process_date()
+                .date()
+                .format("%Y-%m-%d")
+                .to_string(),
+        );
         reasons.push(boundary.reason().as_str().to_string());
         related.push(match boundary.reason() {
             BoundaryReason::Renamed { to } => Some(to.as_str().to_string()),
@@ -45,6 +50,7 @@ pub fn boundaries_to_dataframe(
         Column::new("id".into(), identifiers),
         Column::new("ticker".into(), tickers),
         Column::new("date".into(), dates),
+        Column::new("process_date".into(), process_dates),
         Column::new("reason".into(), reasons),
         Column::new("related_ticker".into(), related),
         Column::new("first_seen".into(), first_seen),
@@ -53,20 +59,13 @@ pub fn boundaries_to_dataframe(
 
 /// Merges a stored boundary table with one fetched over `start..=end`.
 ///
-/// Deliberately unlike [`crate::data::splits::merge_splits`], which replaces the row set outright.
-/// That is safe there because the splits feed answers with its entire history; this feed answers
-/// only for a date range, so replacing would erase every boundary outside the window that was
-/// asked for. Stored rows outside it therefore survive untouched, and only rows dated inside it are
-/// replaced — which is what lets a revised or cancelled action disappear.
+/// Unlike [`crate::data::splits::merge_splits`], which replaces the row set outright because that
+/// feed answers with its whole history, this one answers only for a range — so stored rows the
+/// refresh could not have re-reported survive, and absence within it means cancelled.
 ///
-/// An empty fetch still replaces inside the window: a range genuinely containing no corporate
-/// action is ordinary, unlike an empty all-time splits response, which is an outage.
-///
-/// The window and the stored date are not the same date. Alpaca filters a request by when it
-/// processed an action, while the boundary is stamped with when the price moved — its ex or
-/// effective date — so a June request returns rows stamped 2017. Surviving stored rows are
-/// therefore anti-joined on `id` as well as filtered by date, or a row outside the window that came
-/// back anyway would be kept twice.
+/// The range is matched on `process_date`, never on `date`. Alpaca filters a request by when it
+/// processed an action, while the boundary is stamped with when the price moved, and those differ
+/// by years: filtering survivors on the wrong one leaves a cancelled action archived forever.
 pub fn merge_boundaries(
     existing: DataFrame,
     fetched: DataFrame,
@@ -76,9 +75,8 @@ pub fn merge_boundaries(
     let start_text = start.date().format("%Y-%m-%d").to_string();
     let end_text = end.date().format("%Y-%m-%d").to_string();
 
-    // Compared as text rather than parsed dates: the column is written `%Y-%m-%d`, which orders
-    // lexicographically exactly as it orders chronologically, and parsing would import a failure
-    // mode for no gain.
+    // Compared as text: the column is written `%Y-%m-%d`, which orders lexicographically exactly as
+    // it orders chronologically.
     let outside_window = existing
         .clone()
         .lazy()
@@ -89,9 +87,9 @@ pub fn merge_boundaries(
             JoinArgs::new(JoinType::Anti),
         )
         .filter(
-            col("date")
+            col("process_date")
                 .lt(lit(start_text.clone()))
-                .or(col("date").gt(lit(end_text.clone()))),
+                .or(col("process_date").gt(lit(end_text.clone()))),
         );
 
     let previously_seen = existing
@@ -102,6 +100,14 @@ pub fn merge_boundaries(
 
     let refreshed = fetched
         .lazy()
+        // One row per identifier before the join, so a repeat across pages cannot become two rows.
+        .unique_stable(
+            Some(polars::prelude::Selector::ByName {
+                names: vec![PlSmallStr::from("id")].into(),
+                strict: false,
+            }),
+            UniqueKeepStrategy::First,
+        )
         .join(
             previously_seen,
             [col("id")],
@@ -123,6 +129,7 @@ pub fn merge_boundaries(
             col("id"),
             col("ticker"),
             col("date"),
+            col("process_date"),
             col("reason"),
             col("related_ticker"),
             col("first_seen"),
@@ -151,11 +158,24 @@ mod tests {
         SessionDate::from_date(value.parse().expect("a valid session date"))
     }
 
+    /// Processed on the day the price moved, which is the ordinary case. The tests that turn on the
+    /// two dates differing use `renamed_processed` instead.
     fn renamed(id: &str, ticker: &str, date: &str, to: &str) -> SeriesBoundary {
+        renamed_processed(id, ticker, date, date, to)
+    }
+
+    fn renamed_processed(
+        id: &str,
+        ticker: &str,
+        date: &str,
+        process_date: &str,
+        to: &str,
+    ) -> SeriesBoundary {
         SeriesBoundary::new(
             id.to_string(),
             Ticker::new(ticker).expect("a valid ticker"),
             session(date),
+            session(process_date),
             BoundaryReason::Renamed {
                 to: Ticker::new(to).expect("a valid ticker"),
             },
@@ -167,6 +187,7 @@ mod tests {
         SeriesBoundary::new(
             id.to_string(),
             Ticker::new(ticker).expect("a valid ticker"),
+            session(date),
             session(date),
             BoundaryReason::RightsDistributed,
         )
@@ -203,6 +224,37 @@ mod tests {
             related.get(1),
             None,
             "a reason that names no symbol stores none"
+        );
+    }
+
+    /// The cancellation this table exists to record, in the shape that is easiest to miss. The
+    /// action was processed inside the refreshed window but is stamped years outside it, so
+    /// matching survivors on the stored date would keep it forever and truncate real history at a
+    /// date nothing happened on.
+    #[test]
+    fn test_a_cancelled_action_processed_inside_the_window_is_dropped() {
+        let stored = boundaries_to_dataframe(
+            &[
+                renamed_processed("cancelled", "CNCL", "2017-03-01", "2026-06-10", "OTHR"),
+                renamed_processed("kept", "FB", "2022-06-09", "2022-06-09", "META"),
+            ],
+            instant("2026-08-01T02:00:00Z"),
+        )
+        .unwrap();
+        let nothing = boundaries_to_dataframe(&[], instant("2026-08-15T02:00:00Z")).unwrap();
+
+        let merged = merge_boundaries(
+            stored,
+            nothing,
+            session("2026-06-01"),
+            session("2026-06-30"),
+        )
+        .expect("the merge must succeed");
+
+        assert_eq!(
+            identifiers(&merged),
+            vec!["kept"],
+            "the refresh covered the cancelled action's processing, so its absence is authoritative"
         );
     }
 

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -91,6 +91,7 @@ SELECT
     id,
     ticker,
     CAST(date AS DATE) AS boundary_date,
+    CAST(process_date AS DATE) AS process_date,
     reason,
     related_ticker,
     to_timestamp(first_seen / 1000.0) AS first_seen

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -82,6 +82,22 @@ FROM read_parquet(
     's3://' || getvariable('bucket') || '/data/equity/corporate_actions/splits.parquet'
 );
 
+-- The dates a symbol's series may not be read across. `related_ticker` is where a rename continues
+-- or which company a spinoff distributed, and is null for the reasons that name neither.
+.print 'Loading training_series_boundaries...'
+DROP VIEW IF EXISTS training_series_boundaries;
+CREATE OR REPLACE VIEW training_series_boundaries AS
+SELECT
+    id,
+    ticker,
+    CAST(date AS DATE) AS boundary_date,
+    reason,
+    related_ticker,
+    to_timestamp(first_seen / 1000.0) AS first_seen
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/data/equity/corporate_actions/boundaries.parquet'
+);
+
 -- ---------------------------------------------------------------------------
 -- Nightly exports (exports/) -- one view per exported table
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
# Overview

## Changes

- Add `MarketDataClient::fetch_corporate_actions`, reading Alpaca's corporate-actions endpoint over
  a date window with cursor pagination
- Add `SeriesBoundary` and `BoundaryReason` to `common::types`, with a validated constructor that
  rejects a rename naming itself as its successor
- Add `data::boundaries`, mirroring `data::splits` except for the merge, which is windowed
- Archive to `data/equity/corporate_actions/boundaries.parquet` beside the splits table, refreshed
  by the trainer over its training window
- Expose the table to DuckDB as `training_series_boundaries`
- Correct the `devenv.nix` comment claiming the trainer needs no Alpaca credentials

Nothing reads the table yet. Wiring it into the loaders is the follow-up.

## Context

Massive's `adjusted` parameter is splits-only, so every other corporate action reaches the archive
from Alpaca. Measured over 2026 to date, the table holds 492 boundaries: 330 renames, 25 spinoffs,
60 unit separations, 58 reorganizations, 19 rights distributions.

**Against the liquidity-screened set rather than the whole archive, that is 15 events, not 492.**
Intersecting with the ~1,963 tickers clearing the $10 and 1,000,000-share floors leaves 8 renames, 7
spinoffs, and zero of the other three kinds. Two a month. The counts above are the full archive
universe of 13,533 tickers, most of which the screen never considers, and are quoted only to size
the feed.

That makes spinoffs the load-bearing case: 7 of 25 reach the eligible set — 28%, against 2.4% for
renames — because spinoffs happen to large liquid companies. `FDX`, `BDX` and `CMCSA` are names this
strategy would pair. `unit_separated`, `reorganized` and `rights_distributed` have no measured
effect on tradable names and are carried as cheap insurance, not as justification.

(The eligible-set figure applies the two floors over 90 sessions rather than invoking the screen,
which also applies sector rules, so treat 1,963 as an upper bound on the denominator.)

### Why a boundary and not an adjustment

A split has an exact factor. Nothing else here does. Reconciling each spinoff's parent drop against
its distributed value leaves FedEx 2% unexplained, Becton Dickinson 19%, Aptiv 21%, and Honeywell
off by a factor of twenty-five. The residual is real market movement on ex-day mixed with a spinco
price discovered on its first session. Rights distributions have no priced instrument at all — the
feed names them with a CUSIP placeholder.

So the table records only that a return must not be computed across a date. That claim is exact,
needs no external price, and degrades gracefully on the rows where the arithmetic is nonsense. The
screen's existing insufficient-history rejection then does the work, with no new rejection surface.

Spinoffs matter more than their count suggests: FedEx fell 17.8% in one session, Becton Dickinson
17.2%, Middleby 22.3%. Those are not price moves — shareholders received the spinco — and they sit
below the 0.40 threshold the structural-break guard from #1 rejects at, so nothing currently sees
them.

### Two variants that are not there

`BoundaryReason` has no `SymbolReassigned`. A rename on the old symbol already ends its series, and
whatever trades under it afterwards is a different company, so reuse needs no variant — `RNA`
renaming to `RNAM` is what makes `RNA`'s later bars, now Atrium Therapeutics rather than Avidity
Biosciences, unreadable against its earlier ones.

`UnitSeparated` names no successor, unlike `Renamed`. A unit's price steps when it separates, so its
history must not be carried forward the way a rename's is.

### Why the merge differs from the splits merge

The splits feed answers with its entire history, which is what makes replacing the row set safe
there. This endpoint answers only for a date range, so replacing would erase every boundary outside
the window that was asked for.

The first live refresh then wrote four rows twice. Alpaca filters a request by when it *processed*
an action, while a boundary is stamped with when the price *moved*, so a June request returns rows
stamped 2017 and 2025 — and splitting the stored table on date alone put those in both halves.
Surviving rows are now anti-joined on `id` as well as filtered by date. No test predicted this and
no reasoning would have; it took running the thing.

### Dropped from scope

Stock dividends were planned as a fold, since the rate is exact and needs no external price. They
are dropped: **26 of the 28** Alpaca reports for 2026 already appear in Massive's splits table, so
folding them would double-adjust 26 names in order to cover 2.

The two that remain are not reachable. `FBYDP` is a preferred share outside our universe. `HERZ` is
a genuine gap — Massive holds only a later 1-for-10 reverse split, not the 2025-12-31 stock dividend
— and it is in our universe, but its mean daily volume is 28,188 against the screen's 1,000,000
floor, so it fails on liquidity long before adjustment matters.

Where a boundary and a Massive split coincide on the same ticker within three days, which happens 14
times, the two do not fight: truncation means every session read sits after the boundary, which puts
the split's execution date outside the fold's `(session, as_of]` range.

Mergers are also absent, and belong in #5 rather than here. A merged ticker stops appearing in the
bar feed at the effective date — `ACLX`'s last bar is 2026-04-27 against a 04-29 effective date — so
a recent window excludes it without being told to. What merger data cannot do is warn us *before*
one: the feed carries no announcement date and publishes no future-dated cash mergers at all, so it
cannot stop us entering a pair whose leg is already pinned to an offer. That needs a source we do
not have.

## Verification

- `devenv tasks run checks:rust` exits 0; 571 lib tests, 27 database, 13 handler
- Live: 492 boundaries archived to the development bucket — `RNA` renamed to `RNAM`, `FDX` spun off
  `FDXF`, `AIM` rights distributed
- Live: a June-only refresh over that table left 492 rows and 492 distinct identifiers, which is the
  regression the anti-join fixes
- The self-reference guard is load-bearing: removing it fails two tests, because a rename onto an
  unchanged symbol is the single most common row the feed reports
