### PR TITLE
Stop reading a price series across a boundary

### DIFF
--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -204,9 +204,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
         };
 
-    // Not fatal where the splits table is, and the asymmetry is deliberate: an absent splits table
-    // makes every price wrong by whole factors, an absent boundary table costs a guard that fires on
-    // a handful of names a year.
+    // Not fatal where the splits table is: an absent boundary table costs a guard on a handful of
+    // names, where an absent splits table makes every price wrong by whole factors.
     let boundaries = match archive::read_partition(
         &s3_client,
         &bucket,

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -27,6 +27,7 @@ use fund::data::adjust;
 use fund::data::archive;
 use fund::data::bars;
 use fund::data::details;
+use fund::data::truncate;
 use fund::models::tide::artifact::{
     candidate_folders_descending, list_run_folders, package_dir_to_tar_gz, upload_artifact,
 };
@@ -203,8 +204,35 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
         };
 
-    let equity_bars =
-        load_archived_bars(&s3_client, &bucket, lookback_days, session, &splits).await?;
+    // Not fatal where the splits table is, and the asymmetry is deliberate: an absent splits table
+    // makes every price wrong by whole factors, an absent boundary table costs a guard that fires on
+    // a handful of names a year.
+    let boundaries = match archive::read_partition(
+        &s3_client,
+        &bucket,
+        archive::BOUNDARIES_ARCHIVE_KEY,
+    )
+    .await?
+    {
+        Some(frame) => truncate::BoundaryTable::from_dataframe(&frame)?,
+        None => {
+            warn!(
+                key = archive::BOUNDARIES_ARCHIVE_KEY,
+                "No boundary table in the archive; training on unbounded series"
+            );
+            truncate::BoundaryTable::default()
+        }
+    };
+
+    let equity_bars = load_archived_bars(
+        &s3_client,
+        &bucket,
+        lookback_days,
+        session,
+        &splits,
+        &boundaries,
+    )
+    .await?;
     info!(rows = equity_bars.height(), "Loaded equity bars from S3");
 
     let equity_details = details::details_to_dataframe(&details::parse_embedded_details()?)?;
@@ -528,6 +556,7 @@ async fn load_archived_bars(
     lookback_days: i64,
     session: SessionDate,
     splits: &adjust::SplitTable,
+    boundaries: &truncate::BoundaryTable,
 ) -> Result<DataFrame, Box<dyn std::error::Error>> {
     let end_date = session;
     let start_date = end_date.plus_calendar_days(-lookback_days);
@@ -577,11 +606,14 @@ async fn load_archived_bars(
     }
     // Folded once over the concatenated window rather than per partition: the factor depends on
     // where a bar sits relative to today, not on which file it came out of.
-    Ok(adjust::adjust_bars(
+    // Bounded before it is folded, for the reason the PostgreSQL loader does it in that order: a
+    // bar the boundary drops should not have a factor applied to it first.
+    let bounded = truncate::truncate_bars(
         concat(frames, UnionArgs::default())?.collect()?,
-        splits,
+        boundaries,
         session,
-    )?)
+    )?;
+    Ok(adjust::adjust_bars(bounded, splits, session)?)
 }
 
 /// The bar columns training consumes, in the types [`fund::data::bars::bars_to_dataframe`] writes.

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -606,14 +606,17 @@ async fn load_archived_bars(
     }
     // Folded once over the concatenated window rather than per partition: the factor depends on
     // where a bar sits relative to today, not on which file it came out of.
-    // Bounded before it is folded, for the reason the PostgreSQL loader does it in that order: a
-    // bar the boundary drops should not have a factor applied to it first.
-    let bounded = truncate::truncate_bars(
-        concat(frames, UnionArgs::default())?.collect()?,
-        boundaries,
+    // Stitched, bounded, then folded, in the order the PostgreSQL loader uses and for the same
+    // reasons: the stitch rescues the bars truncation would drop, and the fold keys on the symbol a
+    // bar carries after both.
+    let stitched =
+        truncate::stitch_bars(concat(frames, UnionArgs::default())?.collect()?, boundaries)?;
+    let bounded = truncate::truncate_bars(stitched, boundaries, session)?;
+    Ok(adjust::adjust_bars(
+        bounded,
+        &splits.following_renames(boundaries),
         session,
-    )?;
-    Ok(adjust::adjust_bars(bounded, splits, session)?)
+    )?)
 }
 
 /// The bar columns training consumes, in the types [`fund::data::bars::bars_to_dataframe`] writes.

--- a/src/data.rs
+++ b/src/data.rs
@@ -21,4 +21,5 @@ pub mod details;
 pub mod export;
 pub mod purge;
 pub mod splits;
+pub mod truncate;
 pub mod universe;

--- a/src/data/adjust.rs
+++ b/src/data/adjust.rs
@@ -11,6 +11,7 @@ use tracing::warn;
 
 use crate::common::types::SessionDate;
 use crate::data::archive::{read_partition, ArchiveError, SPLITS_ARCHIVE_KEY};
+use crate::data::truncate::BoundaryTable;
 
 /// The splits table indexed for lookup, as read from the archive.
 ///
@@ -99,6 +100,33 @@ impl SplitTable {
         } else {
             1.0
         }
+    }
+
+    /// Re-files each split under the symbol its company trades as now.
+    ///
+    /// Needed because [`crate::data::truncate::stitch_bars`] moves a bar to its company's current
+    /// symbol while the split stays filed under the one in force when it executed. Left unresolved,
+    /// a stitched bar would take the successor's splits and miss its own — and 18 of 330 renames in
+    /// a year have a split on one side of them, so this is not a theoretical gap.
+    pub fn following_renames(&self, boundaries: &BoundaryTable) -> Self {
+        if boundaries.is_empty() {
+            return self.clone();
+        }
+
+        let mut by_ticker: HashMap<String, Vec<(SessionDate, f64)>> = HashMap::new();
+        for (ticker, splits) in &self.by_ticker {
+            for (execution_date, ratio) in splits {
+                let symbol = boundaries
+                    .current_symbol(ticker, *execution_date)
+                    .unwrap_or_else(|| ticker.clone());
+                by_ticker
+                    .entry(symbol)
+                    .or_default()
+                    .push((*execution_date, *ratio));
+            }
+        }
+
+        Self { by_ticker }
     }
 
     /// Whether any split is known, which is what makes skipping the whole fold safe.

--- a/src/data/bars.rs
+++ b/src/data/bars.rs
@@ -18,6 +18,7 @@ use tracing::{info, warn};
 use crate::common::massive::{MassiveClient, MassiveError};
 use crate::common::types::{BarInterval, EquityBar, SessionDate, Ticker};
 use crate::data::adjust::{self, SplitTable};
+use crate::data::truncate::{self, BoundaryTable};
 
 /// Rows per insert chunk.
 ///
@@ -250,6 +251,7 @@ pub async fn load_bars_dataframe(
     bar_interval: BarInterval,
     lookback_days: i64,
     splits: &SplitTable,
+    boundaries: &BoundaryTable,
     as_of: SessionDate,
 ) -> Result<DataFrame, BarsError> {
     // Anchored to `as_of` rather than the clock. `bounds` is half-open, so the upper comparison is
@@ -312,6 +314,9 @@ pub async fn load_bars_dataframe(
         Column::new("volume_weighted_average_price".into(), volume_weighted),
     ])?;
 
+    // Truncated before it is adjusted: a bar the boundary drops must not have a factor
+    // applied to it, and the fold is the more expensive of the two.
+    let dataframe = truncate::truncate_bars(dataframe, boundaries, as_of)?;
     let dataframe = adjust::adjust_bars(dataframe, splits, as_of)?;
 
     info!(
@@ -342,6 +347,7 @@ pub async fn load_aligned_closes(
     bar_interval: BarInterval,
     sessions: usize,
     splits: &SplitTable,
+    boundaries: &BoundaryTable,
     as_of: SessionDate,
 ) -> Result<HashMap<Ticker, Vec<f64>>, BarsError> {
     if sessions == 0 {
@@ -386,11 +392,21 @@ pub async fn load_aligned_closes(
         .len();
 
     let mut closes_by_ticker: HashMap<Ticker, Vec<f64>> = HashMap::new();
+    let mut bounded: HashSet<Ticker> = HashSet::new();
     for row in rows {
         let Some(ticker) = Ticker::new(&row.ticker) else {
             continue;
         };
-        let factor = splits.factor_at(ticker.as_str(), SessionDate::at(row.timestamp), as_of);
+        let session = SessionDate::at(row.timestamp);
+        // Dropped rather than kept short: the retain below needs a full-length series, so a ticker
+        // whose boundary falls inside this window loses its alignment and with it its candidacy.
+        if let Some(earliest) = boundaries.earliest_usable_session(ticker.as_str(), as_of) {
+            if session < earliest {
+                bounded.insert(ticker);
+                continue;
+            }
+        }
+        let factor = splits.factor_at(ticker.as_str(), session, as_of);
         closes_by_ticker
             .entry(ticker)
             .or_default()
@@ -399,10 +415,17 @@ pub async fn load_aligned_closes(
 
     let before = closes_by_ticker.len();
     closes_by_ticker.retain(|_, closes| closes.len() == session_count);
+    // Reported apart from the gap count, because the two are different facts about a ticker: one
+    // has a hole in its history, the other has history belonging to a different company.
+    let dropped_at_a_boundary = bounded
+        .iter()
+        .filter(|ticker| !closes_by_ticker.contains_key(*ticker))
+        .count();
 
     info!(
         tickers = closes_by_ticker.len(),
         dropped_for_gaps = before - closes_by_ticker.len(),
+        dropped_at_a_boundary,
         sessions = session_count,
         "Aligned close history loaded"
     );
@@ -440,6 +463,7 @@ impl CloseHistoryCache {
         bar_interval: BarInterval,
         sessions: usize,
         splits: &SplitTable,
+        boundaries: &BoundaryTable,
         now: DateTime<Utc>,
     ) -> Result<AlignedCloses, BarsError> {
         let today = SessionDate::at(now);
@@ -452,8 +476,9 @@ impl CloseHistoryCache {
 
         // Keyed by the Eastern date, which is also what the closes were restated onto, so a cache
         // hit can never hand back a series adjusted for a different day than it is asked about.
-        let closes =
-            Arc::new(load_aligned_closes(pool, bar_interval, sessions, splits, today).await?);
+        let closes = Arc::new(
+            load_aligned_closes(pool, bar_interval, sessions, splits, boundaries, today).await?,
+        );
         if !closes.is_empty() {
             *self.inner.lock().await = Some((today, Arc::clone(&closes)));
         }

--- a/src/data/bars.rs
+++ b/src/data/bars.rs
@@ -446,18 +446,29 @@ pub async fn load_aligned_closes(
         );
     }
 
-    let before = closes_by_ticker.len();
+    // Partitioned by membership rather than counted by subtraction: a ticker truncated away
+    // entirely never reached the map, so it is missing from one count and present in the other.
+    let short: Vec<Ticker> = closes_by_ticker
+        .iter()
+        .filter(|(_, closes)| closes.len() != session_count)
+        .map(|(ticker, _)| ticker.clone())
+        .collect();
     closes_by_ticker.retain(|_, closes| closes.len() == session_count);
-    // Reported apart from the gap count, because the two are different facts about a ticker: one
-    // has a hole in its history, the other has history belonging to a different company.
+
     let dropped_at_a_boundary = bounded
         .iter()
         .filter(|ticker| !closes_by_ticker.contains_key(*ticker))
         .count();
+    // A hole in a history and a history belonging to a different company are different facts, and
+    // a ticker with both is reported as the second: it is the more specific cause.
+    let dropped_for_gaps = short
+        .iter()
+        .filter(|ticker| !bounded.contains(*ticker))
+        .count();
 
     info!(
         tickers = closes_by_ticker.len(),
-        dropped_for_gaps = before - closes_by_ticker.len(),
+        dropped_for_gaps,
         dropped_at_a_boundary,
         sessions = session_count,
         "Aligned close history loaded"

--- a/src/data/bars.rs
+++ b/src/data/bars.rs
@@ -314,10 +314,12 @@ pub async fn load_bars_dataframe(
         Column::new("volume_weighted_average_price".into(), volume_weighted),
     ])?;
 
-    // Truncated before it is adjusted: a bar the boundary drops must not have a factor
-    // applied to it, and the fold is the more expensive of the two.
+    // Stitched, then truncated, then folded. The stitch moves a renamed company's bars onto the
+    // symbol it trades as now — which are exactly the bars truncation would otherwise drop — and the
+    // fold runs last because it keys on the symbol a bar carries after both.
+    let dataframe = truncate::stitch_bars(dataframe, boundaries)?;
     let dataframe = truncate::truncate_bars(dataframe, boundaries, as_of)?;
-    let dataframe = adjust::adjust_bars(dataframe, splits, as_of)?;
+    let dataframe = adjust::adjust_bars(dataframe, &splits.following_renames(boundaries), as_of)?;
 
     info!(
         rows = dataframe.height(),
@@ -391,13 +393,29 @@ pub async fn load_aligned_closes(
         .collect::<HashSet<_>>()
         .len();
 
-    let mut closes_by_ticker: HashMap<Ticker, Vec<f64>> = HashMap::new();
+    // Splits are re-filed through the same renames the bars are, so a stitched close takes its own
+    // company's factor rather than the one belonging to whoever holds its old symbol now.
+    let splits = splits.following_renames(boundaries);
+
+    // The third element records whether the bar was already filed under this symbol, which decides
+    // the overlap: a predecessor and its successor can both trade for a stretch — BK and BNY share
+    // two dozen sessions — and the symbol still trading is the one whose price is authoritative.
+    let mut dated_closes: HashMap<Ticker, Vec<(SessionDate, f64, bool)>> = HashMap::new();
     let mut bounded: HashSet<Ticker> = HashSet::new();
     for row in rows {
-        let Some(ticker) = Ticker::new(&row.ticker) else {
+        let Some(stored) = Ticker::new(&row.ticker) else {
             continue;
         };
         let session = SessionDate::at(row.timestamp);
+        // Resolved before it is bounded, so a bar moved onto its successor is judged against that
+        // symbol's boundaries rather than against the ones that sent it there.
+        let (ticker, own) = match boundaries.current_symbol(stored.as_str(), session) {
+            Some(successor) => match Ticker::new(&successor) {
+                Some(ticker) => (ticker, false),
+                None => (stored, true),
+            },
+            None => (stored, true),
+        };
         // Dropped rather than kept short: the retain below needs a full-length series, so a ticker
         // whose boundary falls inside this window loses its alignment and with it its candidacy.
         if let Some(earliest) = boundaries.earliest_usable_session(ticker.as_str(), as_of) {
@@ -407,10 +425,25 @@ pub async fn load_aligned_closes(
             }
         }
         let factor = splits.factor_at(ticker.as_str(), session, as_of);
-        closes_by_ticker
+        dated_closes
             .entry(ticker)
             .or_default()
-            .push(row.close_price * factor);
+            .push((session, row.close_price * factor, own));
+    }
+
+    // Sorted because a stitched series arrives in two runs — the successor's rows and the
+    // predecessor's — and the query orders within a symbol, not across a rename.
+    let mut closes_by_ticker: HashMap<Ticker, Vec<f64>> =
+        HashMap::with_capacity(dated_closes.len());
+    for (ticker, mut dated) in dated_closes {
+        // Ordered by session, and within a session the symbol's own bar first, so the deduplication
+        // below keeps it and discards the inherited one.
+        dated.sort_by(|left, right| left.0.cmp(&right.0).then(right.2.cmp(&left.2)));
+        dated.dedup_by_key(|(session, _, _)| *session);
+        closes_by_ticker.insert(
+            ticker,
+            dated.into_iter().map(|(_, close, _)| close).collect(),
+        );
     }
 
     let before = closes_by_ticker.len();

--- a/src/data/truncate.rs
+++ b/src/data/truncate.rs
@@ -2,7 +2,7 @@
 //!
 //! Applied by the loaders, so a series spanning two companies is not something a caller can hold.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use chrono::{DateTime, NaiveDate, Utc};
@@ -15,13 +15,20 @@ use crate::data::archive::{read_partition, ArchiveError, BOUNDARIES_ARCHIVE_KEY}
 /// Column the join threshold is carried on, dropped before the frame is returned.
 const THRESHOLD_COLUMN: &str = "earliest_usable_millis";
 
+/// Renames followed before a chain is declared circular.
+///
+/// A symbol changing hands eight times inside one lookback is not something the feed describes; a
+/// table that pointed a symbol back at itself is, and would otherwise loop forever.
+const RENAME_CHAIN_LIMIT: usize = 8;
+
 /// The boundary dates indexed for lookup, as read from the archive.
 ///
-/// Holds only ticker and date: the reason explains a boundary but does not change what a reader
-/// does with one, which is to stop.
+/// Renames are held separately from the rest because only they answer a second question: every
+/// boundary says where a series stops, and a rename also says where it continues.
 #[derive(Debug, Clone, Default)]
 pub struct BoundaryTable {
     by_ticker: HashMap<String, Vec<SessionDate>>,
+    renames: HashMap<String, Vec<(SessionDate, String)>>,
 }
 
 impl BoundaryTable {
@@ -33,8 +40,11 @@ impl BoundaryTable {
     pub fn from_dataframe(frame: &DataFrame) -> Result<Self, PolarsError> {
         let tickers = frame.column("ticker")?.str()?;
         let dates = frame.column("date")?.str()?;
+        let reasons = frame.column("reason")?.str()?;
+        let related = frame.column("related_ticker")?.str()?;
 
         let mut by_ticker: HashMap<String, Vec<SessionDate>> = HashMap::new();
+        let mut renames: HashMap<String, Vec<(SessionDate, String)>> = HashMap::new();
         for row in 0..frame.height() {
             let (Some(ticker), Some(date)) = (tickers.get(row), dates.get(row)) else {
                 continue;
@@ -42,13 +52,20 @@ impl BoundaryTable {
             let Ok(date) = NaiveDate::parse_from_str(date, "%Y-%m-%d") else {
                 continue;
             };
-            by_ticker
-                .entry(ticker.to_string())
-                .or_default()
-                .push(SessionDate::from_date(date));
+            let date = SessionDate::from_date(date);
+            by_ticker.entry(ticker.to_string()).or_default().push(date);
+
+            if reasons.get(row) == Some("renamed") {
+                if let Some(successor) = related.get(row) {
+                    renames
+                        .entry(ticker.to_string())
+                        .or_default()
+                        .push((date, successor.to_string()));
+                }
+            }
         }
 
-        Ok(Self { by_ticker })
+        Ok(Self { by_ticker, renames })
     }
 
     /// The earliest session of `ticker` describing the same company as `as_of` does.
@@ -63,6 +80,43 @@ impl BoundaryTable {
             .filter(|date| **date <= as_of)
             .max()
             .copied()
+    }
+
+    /// The symbol a fact about `ticker` dated `session` belongs to now, if it moved.
+    ///
+    /// Follows every rename dated after the session, so a company renamed twice is reached in two
+    /// steps. A rename dated at or before the session is somebody else's: the symbol was free by
+    /// then, and whoever took it is who `ticker` means from that date on.
+    ///
+    /// Used for splits as well as bars, which is what keeps the fold correct across a rename —
+    /// otherwise a stitched bar takes the successor's splits and misses its own, or the reverse.
+    /// A chain that revisits a symbol stops there rather than going round again, keeping the last
+    /// symbol reached: the table is malformed at that point, and the walk so far is still the best
+    /// answer available.
+    pub fn current_symbol(&self, ticker: &str, session: SessionDate) -> Option<String> {
+        let mut symbol = ticker.to_string();
+        let mut visited: HashSet<String> = HashSet::from([symbol.clone()]);
+        for _ in 0..RENAME_CHAIN_LIMIT {
+            let Some(successor) = self
+                .renames
+                .get(&symbol)
+                .and_then(|renames| {
+                    renames
+                        .iter()
+                        .filter(|(date, _)| *date > session)
+                        .min_by_key(|(date, _)| *date)
+                })
+                .map(|(_, successor)| successor.clone())
+            else {
+                break;
+            };
+            if !visited.insert(successor.clone()) {
+                break;
+            }
+            symbol = successor;
+        }
+
+        (symbol != ticker).then_some(symbol)
     }
 
     /// Whether any boundary is known, which is what makes skipping the whole filter safe.
@@ -116,6 +170,47 @@ impl BoundaryTableCache {
         *self.inner.lock().await = Some((today, Arc::clone(&table)));
         Ok(Some(table))
     }
+}
+
+/// Re-files each bar under the symbol its company trades as now.
+///
+/// A renamed company's history sits under a symbol that stopped trading, which leaves the successor
+/// too short to screen while the predecessor is unusable. Relabelling joins them into one series.
+///
+/// Runs before [`truncate_bars`], because the bars it moves are exactly the ones truncation would
+/// otherwise drop, and before the fold, because the fold keys on the symbol a bar now carries.
+pub fn stitch_bars(frame: DataFrame, boundaries: &BoundaryTable) -> Result<DataFrame, PolarsError> {
+    if boundaries.is_empty() || frame.height() == 0 {
+        return Ok(frame);
+    }
+
+    let tickers = frame.column("ticker")?.str()?;
+    let timestamps = frame.column("timestamp")?.i64()?;
+    let mut relabelled: Vec<String> = Vec::with_capacity(frame.height());
+    let mut moved = 0usize;
+    for row in 0..frame.height() {
+        let (Some(ticker), Some(timestamp)) = (tickers.get(row), timestamps.get(row)) else {
+            relabelled.push(String::new());
+            continue;
+        };
+        let session =
+            SessionDate::at(DateTime::from_timestamp_millis(timestamp).unwrap_or_default());
+        match boundaries.current_symbol(ticker, session) {
+            Some(successor) => {
+                moved += 1;
+                relabelled.push(successor);
+            }
+            None => relabelled.push(ticker.to_string()),
+        }
+    }
+
+    if moved == 0 {
+        return Ok(frame);
+    }
+
+    let mut frame = frame;
+    frame.with_column(Column::new("ticker".into(), relabelled))?;
+    Ok(frame)
 }
 
 /// Drops the bars of each ticker that predate its most recent boundary.
@@ -186,12 +281,38 @@ mod tests {
         SessionDate::from_date(value.parse().expect("a valid session date"))
     }
 
+    /// Boundaries that stop a series without continuing it, like a spinoff.
     fn table(rows: &[(&str, &str)]) -> BoundaryTable {
-        let tickers: Vec<String> = rows.iter().map(|(ticker, _)| ticker.to_string()).collect();
-        let dates: Vec<String> = rows.iter().map(|(_, date)| date.to_string()).collect();
+        let renames: Vec<(&str, &str, Option<&str>)> = rows
+            .iter()
+            .map(|(ticker, date)| (*ticker, *date, None))
+            .collect();
+        renamed_table(&renames)
+    }
+
+    /// `None` in the third position is a spinoff; `Some` is a rename onto that symbol.
+    fn renamed_table(rows: &[(&str, &str, Option<&str>)]) -> BoundaryTable {
+        let tickers: Vec<String> = rows
+            .iter()
+            .map(|(ticker, _, _)| ticker.to_string())
+            .collect();
+        let dates: Vec<String> = rows.iter().map(|(_, date, _)| date.to_string()).collect();
+        let reasons: Vec<String> = rows
+            .iter()
+            .map(|(_, _, to)| match to {
+                Some(_) => "renamed".to_string(),
+                None => "spun_off".to_string(),
+            })
+            .collect();
+        let related: Vec<Option<String>> = rows
+            .iter()
+            .map(|(_, _, to)| to.map(str::to_string))
+            .collect();
         let frame = DataFrame::new(vec![
             Column::new("ticker".into(), tickers),
             Column::new("date".into(), dates),
+            Column::new("reason".into(), reasons),
+            Column::new("related_ticker".into(), related),
         ])
         .expect("a frame must build");
         BoundaryTable::from_dataframe(&frame).expect("the table must build")
@@ -289,6 +410,104 @@ mod tests {
             .filter_map(|row| tickers.get(row))
             .collect();
         assert_eq!(kept, vec!["AAPL", "AAPL"], "RNA loses its pre-boundary bar");
+    }
+
+    /// A bar predating a rename belongs to the symbol the company trades as now; one from after it
+    /// belongs to whoever took the vacated symbol.
+    #[test]
+    fn test_a_session_resolves_to_the_symbol_its_company_trades_as_now() {
+        let table = renamed_table(&[("RNA", "2026-02-26", Some("RNAM"))]);
+
+        assert_eq!(
+            table.current_symbol("RNA", session("2026-02-24")),
+            Some("RNAM".to_string())
+        );
+        assert_eq!(table.current_symbol("RNA", session("2026-02-26")), None);
+        assert_eq!(table.current_symbol("RNA", session("2026-03-10")), None);
+    }
+
+    #[test]
+    fn test_a_chain_of_renames_is_followed_to_the_end() {
+        let table = renamed_table(&[
+            ("AAA", "2026-03-01", Some("BBB")),
+            ("BBB", "2026-05-01", Some("CCC")),
+        ]);
+
+        assert_eq!(
+            table.current_symbol("AAA", session("2026-01-05")),
+            Some("CCC".to_string())
+        );
+        assert_eq!(
+            table.current_symbol("AAA", session("2026-04-01")),
+            None,
+            "the symbol was already free, so a later bar under it is somebody else's"
+        );
+    }
+
+    /// A table pointing a symbol back at itself is malformed rather than impossible, and would
+    /// otherwise be followed forever.
+    #[test]
+    fn test_a_circular_rename_terminates() {
+        let table = renamed_table(&[
+            ("AAA", "2026-03-01", Some("BBB")),
+            ("BBB", "2026-05-01", Some("AAA")),
+        ]);
+
+        assert_eq!(
+            table.current_symbol("AAA", session("2026-01-05")),
+            Some("BBB".to_string()),
+            "the walk stops where the cycle closes rather than going round again"
+        );
+    }
+
+    #[test]
+    fn test_bars_from_before_a_rename_move_to_the_successor() {
+        let frame = bars(&[("RNA", "2026-02-24", 72.87), ("RNAM", "2026-02-26", 73.10)]);
+
+        let stitched = stitch_bars(
+            frame,
+            &renamed_table(&[("RNA", "2026-02-26", Some("RNAM"))]),
+        )
+        .unwrap();
+
+        let tickers = stitched.column("ticker").unwrap().str().unwrap();
+        let labels: Vec<&str> = (0..stitched.height())
+            .filter_map(|row| tickers.get(row))
+            .collect();
+        assert_eq!(labels, vec!["RNAM", "RNAM"], "one company, one symbol");
+    }
+
+    /// The reason the fold has to follow renames too. Without it a stitched bar takes whatever
+    /// splits are filed under its new symbol and misses the ones filed under its old one.
+    #[test]
+    fn test_a_split_moves_with_the_company_that_declared_it() {
+        let boundaries = renamed_table(&[("RNA", "2026-02-26", Some("RNAM"))]);
+        let splits = crate::data::adjust::SplitTable::from_dataframe(
+            &DataFrame::new(vec![
+                Column::new("ticker".into(), vec!["RNA".to_string(), "RNA".to_string()]),
+                Column::new(
+                    "execution_date".into(),
+                    vec!["2026-02-10".to_string(), "2026-04-01".to_string()],
+                ),
+                Column::new("split_from".into(), vec![1.0, 1.0]),
+                Column::new("split_to".into(), vec![2.0, 4.0]),
+            ])
+            .unwrap(),
+        )
+        .unwrap();
+
+        let followed = splits.following_renames(&boundaries);
+
+        assert_eq!(
+            followed.factor_at("RNAM", session("2026-02-01"), session("2026-08-15")),
+            0.5,
+            "the pre-rename split follows the company onto its new symbol"
+        );
+        assert_eq!(
+            followed.factor_at("RNA", session("2026-03-01"), session("2026-08-15")),
+            0.25,
+            "the post-rename split stays with whoever holds the old symbol now"
+        );
     }
 
     #[test]

--- a/src/data/truncate.rs
+++ b/src/data/truncate.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, NaiveDate, Utc};
 use polars::prelude::*;
 use tracing::warn;
 
-use crate::common::types::SessionDate;
+use crate::common::types::{SessionDate, Ticker};
 use crate::data::archive::{read_partition, ArchiveError, BOUNDARIES_ARCHIVE_KEY};
 
 /// Column the join threshold is carried on, dropped before the frame is returned.
@@ -49,6 +49,12 @@ impl BoundaryTable {
             let (Some(ticker), Some(date)) = (tickers.get(row), dates.get(row)) else {
                 continue;
             };
+            // Validated here rather than on every lookup: the index is keyed by string because
+            // `current_symbol` runs per row over millions of them, as `SplitTable` is for the fold.
+            let Some(ticker) = Ticker::new(ticker) else {
+                continue;
+            };
+            let ticker = ticker.as_str();
             let Ok(date) = NaiveDate::parse_from_str(date, "%Y-%m-%d") else {
                 continue;
             };

--- a/src/data/truncate.rs
+++ b/src/data/truncate.rs
@@ -1,0 +1,303 @@
+//! Series truncation as a read-time filter over raw bars and the boundary table.
+//!
+//! Applied by the loaders, so a series spanning two companies is not something a caller can hold.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::{DateTime, NaiveDate, Utc};
+use polars::prelude::*;
+use tracing::warn;
+
+use crate::common::types::SessionDate;
+use crate::data::archive::{read_partition, ArchiveError, BOUNDARIES_ARCHIVE_KEY};
+
+/// Column the join threshold is carried on, dropped before the frame is returned.
+const THRESHOLD_COLUMN: &str = "earliest_usable_millis";
+
+/// The boundary dates indexed for lookup, as read from the archive.
+///
+/// Holds only ticker and date: the reason explains a boundary but does not change what a reader
+/// does with one, which is to stop.
+#[derive(Debug, Clone, Default)]
+pub struct BoundaryTable {
+    by_ticker: HashMap<String, Vec<SessionDate>>,
+}
+
+impl BoundaryTable {
+    /// Builds the index from the stored frame, ignoring rows it cannot read.
+    ///
+    /// A row that fails to parse is skipped rather than fatal, for the reason
+    /// [`crate::data::adjust::SplitTable::from_dataframe`] skips one: the table covers the whole
+    /// market, and one unreadable row should not cost every other ticker its guard.
+    pub fn from_dataframe(frame: &DataFrame) -> Result<Self, PolarsError> {
+        let tickers = frame.column("ticker")?.str()?;
+        let dates = frame.column("date")?.str()?;
+
+        let mut by_ticker: HashMap<String, Vec<SessionDate>> = HashMap::new();
+        for row in 0..frame.height() {
+            let (Some(ticker), Some(date)) = (tickers.get(row), dates.get(row)) else {
+                continue;
+            };
+            let Ok(date) = NaiveDate::parse_from_str(date, "%Y-%m-%d") else {
+                continue;
+            };
+            by_ticker
+                .entry(ticker.to_string())
+                .or_default()
+                .push(SessionDate::from_date(date));
+        }
+
+        Ok(Self { by_ticker })
+    }
+
+    /// The earliest session of `ticker` describing the same company as `as_of` does.
+    ///
+    /// The latest boundary at or before `as_of`, because that is where the current run of sessions
+    /// begins. A boundary dated after `as_of` has not happened yet from this read's point of view,
+    /// and one long before it constrains nothing a lookback would reach.
+    pub fn earliest_usable_session(&self, ticker: &str, as_of: SessionDate) -> Option<SessionDate> {
+        self.by_ticker
+            .get(ticker)?
+            .iter()
+            .filter(|date| **date <= as_of)
+            .max()
+            .copied()
+    }
+
+    /// Whether any boundary is known, which is what makes skipping the whole filter safe.
+    pub fn is_empty(&self) -> bool {
+        self.by_ticker.is_empty()
+    }
+}
+
+/// The boundary table, reloaded when the cached copy is from an earlier Eastern date.
+///
+/// A daily table behind a daily cache, like [`crate::data::adjust::SplitTableCache`]: a boundary
+/// falls on a session, so it cannot start applying part-way through one.
+#[derive(Default)]
+pub struct BoundaryTableCache {
+    inner: tokio::sync::Mutex<Option<(SessionDate, Arc<BoundaryTable>)>>,
+}
+
+impl BoundaryTableCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns today's table, or `None` when the archive holds none.
+    ///
+    /// Absent is reported rather than flattened to an empty table, because the two mean opposite
+    /// things: empty says no symbol changed hands, missing says nothing is known about whether one
+    /// did. An absent object is not cached, so the next pass retries it.
+    pub async fn get(
+        &self,
+        s3_client: &aws_sdk_s3::Client,
+        bucket: &str,
+        now: DateTime<Utc>,
+    ) -> Result<Option<Arc<BoundaryTable>>, ArchiveError> {
+        let today = SessionDate::at(now);
+
+        if let Some((cached_date, table)) = self.inner.lock().await.as_ref() {
+            if *cached_date == today {
+                return Ok(Some(Arc::clone(table)));
+            }
+        }
+
+        let Some(frame) = read_partition(s3_client, bucket, BOUNDARIES_ARCHIVE_KEY).await? else {
+            warn!(
+                key = BOUNDARIES_ARCHIVE_KEY,
+                "No boundary table in the archive; series cannot be bounded"
+            );
+            return Ok(None);
+        };
+
+        let table = Arc::new(BoundaryTable::from_dataframe(&frame)?);
+        *self.inner.lock().await = Some((today, Arc::clone(&table)));
+        Ok(Some(table))
+    }
+}
+
+/// Drops the bars of each ticker that predate its most recent boundary.
+///
+/// Returns the frame untouched when no boundary is known, which is the ordinary case: fifteen of
+/// the market's liquid names carry one in a year.
+pub fn truncate_bars(
+    frame: DataFrame,
+    boundaries: &BoundaryTable,
+    as_of: SessionDate,
+) -> Result<DataFrame, PolarsError> {
+    if boundaries.is_empty() || frame.height() == 0 {
+        return Ok(frame);
+    }
+
+    let tickers = frame.column("ticker")?.str()?;
+    let mut bounded: Vec<String> = Vec::new();
+    let mut thresholds: Vec<i64> = Vec::new();
+    let mut seen: HashMap<&str, ()> = HashMap::new();
+    for row in 0..frame.height() {
+        let Some(ticker) = tickers.get(row) else {
+            continue;
+        };
+        if seen.insert(ticker, ()).is_some() {
+            continue;
+        }
+        if let Some(earliest) = boundaries.earliest_usable_session(ticker, as_of) {
+            bounded.push(ticker.to_string());
+            thresholds.push(earliest.midnight().timestamp_millis());
+        }
+    }
+    if bounded.is_empty() {
+        return Ok(frame);
+    }
+
+    let cuts = DataFrame::new(vec![
+        Column::new("ticker".into(), bounded),
+        Column::new(THRESHOLD_COLUMN.into(), thresholds),
+    ])?;
+
+    frame
+        .lazy()
+        .join(
+            cuts.lazy(),
+            [col("ticker")],
+            [col("ticker")],
+            JoinArgs::new(JoinType::Left),
+        )
+        // A ticker with no boundary joins to null and keeps every bar; one with a boundary keeps the
+        // sessions from it onward, the run that describes the company trading under the symbol now.
+        .filter(
+            col(THRESHOLD_COLUMN)
+                .is_null()
+                .or(col("timestamp").gt_eq(col(THRESHOLD_COLUMN))),
+        )
+        .drop(Selector::ByName {
+            names: vec![PlSmallStr::from(THRESHOLD_COLUMN)].into(),
+            strict: false,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(value: &str) -> SessionDate {
+        SessionDate::from_date(value.parse().expect("a valid session date"))
+    }
+
+    fn table(rows: &[(&str, &str)]) -> BoundaryTable {
+        let tickers: Vec<String> = rows.iter().map(|(ticker, _)| ticker.to_string()).collect();
+        let dates: Vec<String> = rows.iter().map(|(_, date)| date.to_string()).collect();
+        let frame = DataFrame::new(vec![
+            Column::new("ticker".into(), tickers),
+            Column::new("date".into(), dates),
+        ])
+        .expect("a frame must build");
+        BoundaryTable::from_dataframe(&frame).expect("the table must build")
+    }
+
+    fn bars(rows: &[(&str, &str, f64)]) -> DataFrame {
+        let tickers: Vec<String> = rows
+            .iter()
+            .map(|(ticker, _, _)| ticker.to_string())
+            .collect();
+        let timestamps: Vec<i64> = rows
+            .iter()
+            .map(|(_, date, _)| session(date).midnight().timestamp_millis())
+            .collect();
+        let closes: Vec<f64> = rows.iter().map(|(_, _, close)| *close).collect();
+        DataFrame::new(vec![
+            Column::new("ticker".into(), tickers),
+            Column::new("timestamp".into(), timestamps),
+            Column::new("close_price".into(), closes),
+        ])
+        .expect("a frame must build")
+    }
+
+    #[test]
+    fn test_the_latest_boundary_at_or_before_as_of_is_the_one_that_applies() {
+        let table = table(&[("RNA", "2022-06-09"), ("RNA", "2026-02-26")]);
+
+        assert_eq!(
+            table.earliest_usable_session("RNA", session("2026-08-15")),
+            Some(session("2026-02-26"))
+        );
+    }
+
+    /// The feed carries actions ahead of their date, exactly as the splits table does. One that has
+    /// not happened yet must not shorten a window that ends before it.
+    #[test]
+    fn test_a_boundary_after_as_of_does_not_apply() {
+        let table = table(&[("RNA", "2026-02-26")]);
+
+        assert_eq!(
+            table.earliest_usable_session("RNA", session("2026-01-05")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_a_ticker_with_no_boundary_is_unconstrained() {
+        let table = table(&[("RNA", "2026-02-26")]);
+
+        assert_eq!(
+            table.earliest_usable_session("AAPL", session("2026-08-15")),
+            None
+        );
+    }
+
+    /// The case the table exists for. `RNA` was Avidity Biosciences until 2026-02-26 and Atrium
+    /// Therapeutics after it, so a window spanning that date holds two companies' prices.
+    #[test]
+    fn test_bars_before_a_boundary_are_dropped() {
+        let frame = bars(&[
+            ("RNA", "2026-02-24", 72.87),
+            ("RNA", "2026-02-26", 14.10),
+            ("RNA", "2026-02-27", 14.35),
+        ]);
+
+        let truncated = truncate_bars(
+            frame,
+            &table(&[("RNA", "2026-02-26")]),
+            session("2026-08-15"),
+        )
+        .expect("the truncation must succeed");
+
+        assert_eq!(truncated.height(), 2, "only the sessions from the boundary");
+        let closes = truncated.column("close_price").unwrap().f64().unwrap();
+        assert_eq!(closes.get(0), Some(14.10));
+    }
+
+    #[test]
+    fn test_a_ticker_without_a_boundary_keeps_every_bar() {
+        let frame = bars(&[
+            ("AAPL", "2026-02-24", 190.0),
+            ("AAPL", "2026-02-26", 191.0),
+            ("RNA", "2026-02-24", 72.87),
+        ]);
+
+        let truncated = truncate_bars(
+            frame,
+            &table(&[("RNA", "2026-02-26")]),
+            session("2026-08-15"),
+        )
+        .expect("the truncation must succeed");
+
+        let tickers = truncated.column("ticker").unwrap().str().unwrap();
+        let kept: Vec<&str> = (0..truncated.height())
+            .filter_map(|row| tickers.get(row))
+            .collect();
+        assert_eq!(kept, vec!["AAPL", "AAPL"], "RNA loses its pre-boundary bar");
+    }
+
+    #[test]
+    fn test_an_empty_table_leaves_the_frame_alone() {
+        let frame = bars(&[("RNA", "2026-02-24", 72.87)]);
+
+        let truncated =
+            truncate_bars(frame, &BoundaryTable::default(), session("2026-08-15")).unwrap();
+
+        assert_eq!(truncated.height(), 1);
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -30,6 +30,7 @@ use crate::data::calendar::{CalendarCache, TradingCalendar};
 use crate::data::details;
 use crate::data::export;
 use crate::data::purge;
+use crate::data::truncate::{BoundaryTable, BoundaryTableCache};
 use crate::data::universe::{UniverseCache, UniverseError};
 use crate::models::tide::{artifact, predict};
 use crate::portfolio::account;
@@ -101,6 +102,7 @@ pub struct ServiceState {
     close_history_cache: CloseHistoryCache,
     /// The splits every stored price is restated against, read once per Eastern date.
     split_table_cache: SplitTableCache,
+    boundary_table_cache: BoundaryTableCache,
     sizing: SizingParameters,
     execution: ExecutionSettings,
     /// The append-only record of what this process observed before it acted.
@@ -145,6 +147,7 @@ impl ServiceState {
             universe_cache: UniverseCache::new(),
             close_history_cache: CloseHistoryCache::new(),
             split_table_cache: SplitTableCache::new(),
+            boundary_table_cache: BoundaryTableCache::new(),
             sizing: SizingParameters::from_env(),
             execution: ExecutionSettings::default(),
             session_log: SessionLog::from_env()?,
@@ -357,6 +360,14 @@ async fn handle_predictions(
         .get(&state.s3_client, &state.bucket, now)
         .await?;
     let unadjustable = SplitTable::default();
+    // Absent boundaries do not block the way absent splits do. A missing splits table makes every
+    // price wrong by whole factors; a missing boundary table costs a guard that fires on fifteen
+    // liquid names a year, and refusing to trade without it would be the larger failure.
+    let boundaries = state
+        .boundary_table_cache
+        .get(&state.s3_client, &state.bucket, now)
+        .await?;
+    let unbounded = BoundaryTable::default();
     let close_history = state
         .close_history_cache
         .get(
@@ -364,6 +375,7 @@ async fn handle_predictions(
             BarInterval::OneDay,
             CORRELATION_WINDOW_SESSIONS,
             splits.as_deref().unwrap_or(&unadjustable),
+            boundaries.as_deref().unwrap_or(&unbounded),
             now,
         )
         .await?;
@@ -461,11 +473,18 @@ async fn run_inference(
         .await
         .map_err(|error| at("load_splits")(error.to_string()))?
         .ok_or_else(|| at("load_splits")("no splits table in the archive".to_string()))?;
+    let boundaries = state
+        .boundary_table_cache
+        .get(&state.s3_client, &state.bucket, now)
+        .await
+        .map_err(|error| at("load_boundaries")(error.to_string()))?;
+    let unbounded = BoundaryTable::default();
     let equity_bars = bars::load_bars_dataframe(
         &state.pool,
         BarInterval::OneDay,
         HISTORY_LOOKBACK_DAYS,
         &splits,
+        boundaries.as_deref().unwrap_or(&unbounded),
         SessionDate::at(now),
     )
     .await
@@ -532,6 +551,14 @@ async fn handle_portfolio_evaluation(
         .get(&state.s3_client, &state.bucket, now)
         .await?;
     let unadjustable = SplitTable::default();
+    // Absent boundaries do not block the way absent splits do. A missing splits table makes every
+    // price wrong by whole factors; a missing boundary table costs a guard that fires on fifteen
+    // liquid names a year, and refusing to trade without it would be the larger failure.
+    let boundaries = state
+        .boundary_table_cache
+        .get(&state.s3_client, &state.bucket, now)
+        .await?;
+    let unbounded = BoundaryTable::default();
     let close_history = state
         .close_history_cache
         .get(
@@ -539,6 +566,7 @@ async fn handle_portfolio_evaluation(
             BarInterval::OneDay,
             CORRELATION_WINDOW_SESSIONS,
             splits.as_deref().unwrap_or(&unadjustable),
+            boundaries.as_deref().unwrap_or(&unbounded),
             now,
         )
         .await?;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -360,9 +360,8 @@ async fn handle_predictions(
         .get(&state.s3_client, &state.bucket, now)
         .await?;
     let unadjustable = SplitTable::default();
-    // Absent boundaries do not block the way absent splits do. A missing splits table makes every
-    // price wrong by whole factors; a missing boundary table costs a guard that fires on fifteen
-    // liquid names a year, and refusing to trade without it would be the larger failure.
+    // Absent boundaries do not block the way absent splits do: the guard they provide is worth far
+    // less than the trading refusing to run without it would cost.
     let boundaries = state
         .boundary_table_cache
         .get(&state.s3_client, &state.bucket, now)
@@ -551,9 +550,8 @@ async fn handle_portfolio_evaluation(
         .get(&state.s3_client, &state.bucket, now)
         .await?;
     let unadjustable = SplitTable::default();
-    // Absent boundaries do not block the way absent splits do. A missing splits table makes every
-    // price wrong by whole factors; a missing boundary table costs a guard that fires on fifteen
-    // liquid names a year, and refusing to trade without it would be the larger failure.
+    // Absent boundaries do not block the way absent splits do: the guard they provide is worth far
+    // less than the trading refusing to run without it would cost.
     let boundaries = state
         .boundary_table_cache
         .get(&state.s3_client, &state.bucket, now)

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -947,6 +947,48 @@ async fn test_a_renamed_company_keeps_its_history_under_the_new_symbol() {
     );
 }
 
+/// Both ways a ticker leaves the aligned set, exercised together: a hole in its history, and a
+/// boundary that takes every session it has.
+///
+/// The two are reported as separate counts, which this cannot assert — they are log fields, not
+/// return values — so it covers the exclusions themselves rather than the tally.
+#[tokio::test]
+#[serial]
+async fn test_a_gap_and_a_boundary_both_exclude_a_ticker() {
+    let pool = fresh_pool().await;
+    let today = SessionDate::at(Utc::now());
+
+    // Complete: three consecutive sessions, no boundary.
+    for offset in 1..=3 {
+        common::seed_bar(&pool, "GOOD", today.plus_calendar_days(-offset), 10.0).await;
+    }
+    // A hole in the middle, no boundary.
+    common::seed_bar(&pool, "GAPY", today.plus_calendar_days(-1), 10.0).await;
+    common::seed_bar(&pool, "GAPY", today.plus_calendar_days(-3), 10.0).await;
+    // Every session precedes its boundary, so nothing of it survives.
+    for offset in 1..=3 {
+        common::seed_bar(&pool, "BNDY", today.plus_calendar_days(-offset), 10.0).await;
+    }
+
+    let boundaries = boundary_table(&[("BNDY", today, None)]);
+    let closes = bars::load_aligned_closes(
+        &pool,
+        BarInterval::OneDay,
+        3,
+        &SplitTable::default(),
+        &boundaries,
+        today,
+    )
+    .await
+    .expect("the load must succeed");
+
+    assert_eq!(
+        closes.keys().collect::<Vec<_>>(),
+        vec![&ticker("GOOD")],
+        "only the complete unbounded series survives"
+    );
+}
+
 /// A predecessor and its successor can trade at the same time — `BK` and `BNY` share about two
 /// dozen sessions — and on those the symbol still trading is the one whose price counts.
 #[tokio::test]

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -870,19 +870,115 @@ async fn test_the_loaded_window_follows_as_of_rather_than_the_clock() {
     );
 }
 
-fn boundary_table(rows: &[(&str, SessionDate)]) -> BoundaryTable {
+/// `None` in the third position is a boundary that stops a series; `Some` renames it onto that
+/// symbol, which is what lets the successor inherit the history.
+fn boundary_table(rows: &[(&str, SessionDate, Option<&str>)]) -> BoundaryTable {
     use polars::prelude::*;
-    let tickers: Vec<String> = rows.iter().map(|(ticker, _)| ticker.to_string()).collect();
+    let tickers: Vec<String> = rows
+        .iter()
+        .map(|(ticker, _, _)| ticker.to_string())
+        .collect();
     let dates: Vec<String> = rows
         .iter()
-        .map(|(_, date)| date.date().format("%Y-%m-%d").to_string())
+        .map(|(_, date, _)| date.date().format("%Y-%m-%d").to_string())
+        .collect();
+    let reasons: Vec<String> = rows
+        .iter()
+        .map(|(_, _, to)| match to {
+            Some(_) => "renamed".to_string(),
+            None => "spun_off".to_string(),
+        })
+        .collect();
+    let related: Vec<Option<String>> = rows
+        .iter()
+        .map(|(_, _, to)| to.map(str::to_string))
         .collect();
     let frame = DataFrame::new(vec![
         Column::new("ticker".into(), tickers),
         Column::new("date".into(), dates),
+        Column::new("reason".into(), reasons),
+        Column::new("related_ticker".into(), related),
     ])
     .expect("a frame must build");
     BoundaryTable::from_dataframe(&frame).expect("the table must build")
+}
+
+/// The other half of a rename. `AAAA` stops trading and `BBBB` continues it, so neither symbol has
+/// a full window on its own and the screen would see two unusable series where there is one company.
+#[tokio::test]
+#[serial]
+async fn test_a_renamed_company_keeps_its_history_under_the_new_symbol() {
+    let pool = fresh_pool().await;
+    let today = SessionDate::at(Utc::now());
+    let renamed_on = today.plus_calendar_days(-3);
+
+    for offset in 4..=6 {
+        common::seed_bar(&pool, "AAAA", today.plus_calendar_days(-offset), 10.0).await;
+    }
+    for offset in 1..=3 {
+        common::seed_bar(&pool, "BBBB", today.plus_calendar_days(-offset), 20.0).await;
+    }
+
+    let boundaries = boundary_table(&[("AAAA", renamed_on, Some("BBBB"))]);
+    let closes = bars::load_aligned_closes(
+        &pool,
+        BarInterval::OneDay,
+        6,
+        &SplitTable::default(),
+        &boundaries,
+        today,
+    )
+    .await
+    .expect("the load must succeed");
+
+    assert_eq!(
+        closes.get(&ticker("BBBB")).map(Vec::len),
+        Some(6),
+        "the successor carries both runs, so it fills the window"
+    );
+    assert_eq!(
+        closes[&ticker("BBBB")],
+        vec![10.0, 10.0, 10.0, 20.0, 20.0, 20.0],
+        "and they arrive in session order, not in the order the query returned them"
+    );
+    assert!(
+        !closes.contains_key(&ticker("AAAA")),
+        "the symbol that stopped trading is not a candidate of its own"
+    );
+}
+
+/// A predecessor and its successor can trade at the same time — `BK` and `BNY` share about two
+/// dozen sessions — and on those the symbol still trading is the one whose price counts.
+#[tokio::test]
+#[serial]
+async fn test_an_overlapping_session_keeps_the_successors_own_price() {
+    let pool = fresh_pool().await;
+    let today = SessionDate::at(Utc::now());
+    let renamed_on = today.plus_calendar_days(-2);
+    let shared = today.plus_calendar_days(-3);
+
+    common::seed_bar(&pool, "AAAA", today.plus_calendar_days(-4), 10.0).await;
+    common::seed_bar(&pool, "AAAA", shared, 11.0).await;
+    common::seed_bar(&pool, "BBBB", shared, 99.0).await;
+    common::seed_bar(&pool, "BBBB", today.plus_calendar_days(-2), 20.0).await;
+
+    let boundaries = boundary_table(&[("AAAA", renamed_on, Some("BBBB"))]);
+    let closes = bars::load_aligned_closes(
+        &pool,
+        BarInterval::OneDay,
+        3,
+        &SplitTable::default(),
+        &boundaries,
+        today,
+    )
+    .await
+    .expect("the load must succeed");
+
+    assert_eq!(
+        closes[&ticker("BBBB")],
+        vec![10.0, 99.0, 20.0],
+        "the shared session takes BBBB's own close, not the one inherited from AAAA"
+    );
 }
 
 /// The case the boundary table exists for, in the shape it really occurred. `RNA` was Avidity
@@ -905,7 +1001,7 @@ async fn test_a_window_is_not_read_across_a_boundary() {
         .await;
     }
 
-    let boundaries = boundary_table(&[("AAAA", boundary)]);
+    let boundaries = boundary_table(&[("AAAA", boundary, None)]);
     let frame = bars::load_bars_dataframe(
         &pool,
         BarInterval::OneDay,

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -18,6 +18,7 @@ use fund::common::events::{self, Command, EventType, Outcome};
 use fund::common::types::{BarInterval, PairID, SessionDate, Ticker};
 use fund::data::adjust::SplitTable;
 use fund::data::bars;
+use fund::data::truncate::BoundaryTable;
 
 use fund::models::tide::predict;
 use fund::portfolio::account;
@@ -388,6 +389,7 @@ async fn test_aligned_closes_drops_a_ticker_with_a_gap() {
         BarInterval::OneDay,
         5,
         &SplitTable::default(),
+        &BoundaryTable::default(),
         SessionDate::at(Utc::now()),
     )
     .await
@@ -428,6 +430,7 @@ async fn test_aligned_closes_reads_only_the_requested_interval() {
         BarInterval::OneDay,
         1,
         &SplitTable::default(),
+        &BoundaryTable::default(),
         SessionDate::at(Utc::now()),
     )
     .await
@@ -750,9 +753,16 @@ async fn test_aligned_closes_are_restated_onto_todays_share_basis() {
     )
     .unwrap();
 
-    let closes = bars::load_aligned_closes(&pool, BarInterval::OneDay, 5, &splits, today)
-        .await
-        .expect("the load must succeed");
+    let closes = bars::load_aligned_closes(
+        &pool,
+        BarInterval::OneDay,
+        5,
+        &splits,
+        &BoundaryTable::default(),
+        today,
+    )
+    .await
+    .expect("the load must succeed");
 
     // Ordered oldest first, so the two halved entries lead.
     assert_eq!(
@@ -787,9 +797,16 @@ async fn test_the_bar_frame_is_restated_onto_todays_share_basis() {
     )
     .unwrap();
 
-    let frame = bars::load_bars_dataframe(&pool, BarInterval::OneDay, 10, &splits, today)
-        .await
-        .expect("the load must succeed");
+    let frame = bars::load_bars_dataframe(
+        &pool,
+        BarInterval::OneDay,
+        10,
+        &splits,
+        &BoundaryTable::default(),
+        today,
+    )
+    .await
+    .expect("the load must succeed");
 
     assert_eq!(
         frame.column("close_price").unwrap().f64().unwrap().get(0),
@@ -814,10 +831,16 @@ async fn test_the_loaded_window_follows_as_of_rather_than_the_clock() {
     common::seed_bar(&pool, "AAAA", as_of.plus_calendar_days(1), 55.0).await;
     common::seed_bar(&pool, "AAAA", today, 99.0).await;
 
-    let frame =
-        bars::load_bars_dataframe(&pool, BarInterval::OneDay, 5, &SplitTable::default(), as_of)
-            .await
-            .expect("the load must succeed");
+    let frame = bars::load_bars_dataframe(
+        &pool,
+        BarInterval::OneDay,
+        5,
+        &SplitTable::default(),
+        &BoundaryTable::default(),
+        as_of,
+    )
+    .await
+    .expect("the load must succeed");
 
     assert_eq!(
         frame.height(),
@@ -829,15 +852,91 @@ async fn test_the_loaded_window_follows_as_of_rather_than_the_clock() {
         Some(10.0)
     );
 
-    let closes =
-        bars::load_aligned_closes(&pool, BarInterval::OneDay, 5, &SplitTable::default(), as_of)
-            .await
-            .expect("the load must succeed");
+    let closes = bars::load_aligned_closes(
+        &pool,
+        BarInterval::OneDay,
+        5,
+        &SplitTable::default(),
+        &BoundaryTable::default(),
+        as_of,
+    )
+    .await
+    .expect("the load must succeed");
 
     assert_eq!(
         closes[&ticker("AAAA")],
         vec![10.0],
         "the aligned window is bounded above by `as_of` too, not by the latest session stored"
+    );
+}
+
+fn boundary_table(rows: &[(&str, SessionDate)]) -> BoundaryTable {
+    use polars::prelude::*;
+    let tickers: Vec<String> = rows.iter().map(|(ticker, _)| ticker.to_string()).collect();
+    let dates: Vec<String> = rows
+        .iter()
+        .map(|(_, date)| date.date().format("%Y-%m-%d").to_string())
+        .collect();
+    let frame = DataFrame::new(vec![
+        Column::new("ticker".into(), tickers),
+        Column::new("date".into(), dates),
+    ])
+    .expect("a frame must build");
+    BoundaryTable::from_dataframe(&frame).expect("the table must build")
+}
+
+/// The case the boundary table exists for, in the shape it really occurred. `RNA` was Avidity
+/// Biosciences until 2026-02-26 and Atrium Therapeutics after it, so a window spanning that date
+/// fits a hedge ratio across two companies' prices and reports nothing unusual.
+#[tokio::test]
+#[serial]
+async fn test_a_window_is_not_read_across_a_boundary() {
+    let pool = fresh_pool().await;
+    let today = SessionDate::at(Utc::now());
+    let boundary = today.plus_calendar_days(-3);
+
+    for offset in 1..=6 {
+        common::seed_bar(
+            &pool,
+            "AAAA",
+            today.plus_calendar_days(-offset),
+            10.0 * offset as f64,
+        )
+        .await;
+    }
+
+    let boundaries = boundary_table(&[("AAAA", boundary)]);
+    let frame = bars::load_bars_dataframe(
+        &pool,
+        BarInterval::OneDay,
+        10,
+        &SplitTable::default(),
+        &boundaries,
+        today,
+    )
+    .await
+    .expect("the load must succeed");
+
+    assert_eq!(
+        frame.height(),
+        3,
+        "only the sessions from the boundary onward describe the company trading now"
+    );
+
+    let closes = bars::load_aligned_closes(
+        &pool,
+        BarInterval::OneDay,
+        6,
+        &SplitTable::default(),
+        &boundaries,
+        today,
+    )
+    .await
+    .expect("the load must succeed");
+
+    assert!(
+        !closes.contains_key(&ticker("AAAA")),
+        "a truncated series cannot fill a six-session window, so it is not a candidate"
     );
 }
 
@@ -864,10 +963,16 @@ async fn test_a_bar_on_the_upper_bound_belongs_to_the_next_session() {
     .await
     .expect("Failed to seed the boundary bar");
 
-    let frame =
-        bars::load_bars_dataframe(&pool, BarInterval::OneDay, 5, &SplitTable::default(), as_of)
-            .await
-            .expect("the load must succeed");
+    let frame = bars::load_bars_dataframe(
+        &pool,
+        BarInterval::OneDay,
+        5,
+        &SplitTable::default(),
+        &BoundaryTable::default(),
+        as_of,
+    )
+    .await
+    .expect("the load must succeed");
 
     assert_eq!(
         frame.height(),
@@ -875,10 +980,16 @@ async fn test_a_bar_on_the_upper_bound_belongs_to_the_next_session() {
         "the upper bound is exclusive, so the next session's opening instant is outside it"
     );
 
-    let closes =
-        bars::load_aligned_closes(&pool, BarInterval::OneDay, 5, &SplitTable::default(), as_of)
-            .await
-            .expect("the load must succeed");
+    let closes = bars::load_aligned_closes(
+        &pool,
+        BarInterval::OneDay,
+        5,
+        &SplitTable::default(),
+        &BoundaryTable::default(),
+        as_of,
+    )
+    .await
+    .expect("the load must succeed");
 
     assert_eq!(
         closes[&ticker("AAAA")],

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -19,6 +19,7 @@ use fund::common::types::{BarInterval, SessionDate, Ticker};
 use fund::data::adjust::SplitTable;
 use fund::data::bars;
 use fund::data::calendar::TradingCalendar;
+use fund::data::truncate::BoundaryTable;
 use fund::data::universe::{LiquidityRow, Universe};
 use fund::portfolio::evaluate::{self, EvaluationContext};
 use fund::portfolio::execute::ExecutionSettings;
@@ -200,6 +201,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
         BarInterval::OneDay,
         60,
         &SplitTable::default(),
+        &BoundaryTable::default(),
         SessionDate::at(Utc::now()),
     )
     .await
@@ -485,6 +487,7 @@ async fn test_a_pass_opens_nothing_once_shutdown_is_requested() {
         BarInterval::OneDay,
         60,
         &SplitTable::default(),
+        &BoundaryTable::default(),
         SessionDate::at(Utc::now()),
     )
     .await
@@ -579,6 +582,7 @@ async fn test_a_pass_closes_a_converged_pair_from_a_full_book() {
         BarInterval::OneDay,
         60,
         &SplitTable::default(),
+        &BoundaryTable::default(),
         SessionDate::at(Utc::now()),
     )
     .await
@@ -741,6 +745,7 @@ async fn test_a_failed_pass_records_what_it_had_already_observed() {
         BarInterval::OneDay,
         60,
         &SplitTable::default(),
+        &BoundaryTable::default(),
         SessionDate::at(Utc::now()),
     )
     .await
@@ -842,6 +847,7 @@ async fn test_a_pair_that_cannot_be_priced_is_held_and_counted() {
         BarInterval::OneDay,
         60,
         &SplitTable::default(),
+        &BoundaryTable::default(),
         SessionDate::at(Utc::now()),
     )
     .await
@@ -920,6 +926,7 @@ async fn test_a_refused_book_with_no_trade_records_what_was_refused() {
         BarInterval::OneDay,
         60,
         &SplitTable::default(),
+        &BoundaryTable::default(),
         SessionDate::at(Utc::now()),
     )
     .await


### PR DESCRIPTION
# Overview

## Changes

- Add `data::truncate` — `BoundaryTable`, its per-Eastern-date cache, and `truncate_bars` — as the
  read-side sibling of `data::adjust`: `adjust` folds, `truncate` cuts
- Both PostgreSQL loaders and the trainer's S3 loader now drop each ticker's bars from before its
  most recent boundary
- `handle_evaluate_pass` and `handle_predictions` carry the boundary table alongside the splits table
- Add `stitch_bars` and `BoundaryTable::current_symbol`, resolving each bar to the symbol its
  company trades as now, and `SplitTable::following_renames` doing the same for the splits table
- Add database tests for the truncation, the stitch, and the overlap between a symbol and its
  successor

## Context

The boundary table landed in #1068 with nothing reading it. This is the read side.

`RNA` is the case it exists for. It was Avidity Biosciences until 2026-02-26 and Atrium Therapeutics
after it, so a 60-session window spanning that date fits a hedge ratio across two companies and
reports nothing unusual — no gap, no error, just a regression on concatenated strangers.

Truncation happens **before** adjustment in both paths: a bar the boundary drops should not have a
split factor applied to it first.

`load_aligned_closes` needs no new rejection surface. It already drops any ticker without a
full-length series, so a truncated one loses its alignment and with it its candidacy. The count is
logged separately from the gap count, because a hole in a history and a history belonging to someone
else are different facts about a ticker.

### An absent table does not block

An absent *splits* table blocks entries through the risk gate; an absent *boundary* table does not.
The asymmetry is deliberate: a missing splits table makes every price wrong by whole factors, while a
missing boundary table costs a guard that fires on fifteen liquid names a year. Refusing to trade
without it would be the larger failure. The trainer takes the same view — fatal on splits, a warning
on boundaries.

### Measured impact

Against the development archive and the ~1,963 tickers clearing the screen's price and volume floors:

| | |
|---|---|
| eligible tickers carrying a boundary | 15 |
| **newly excluded until 60 sessions accumulate** | **5** — REZI, SPGI, HON, SPCX, FDX |
| already excluded (series ends at the boundary) | 7 — including BK, which stops trading 2026-05-20 and is renamed 05-21 |
| unaffected (60+ sessions since) | 3 — APTV, BDX, CMCSA |

Four of the five newly excluded are large-cap spinoffs. That is the intended behaviour: FedEx fell
17.8% in a session on its spinoff, and pairing it on a window containing that step is exactly what
this prevents.

### Stitching, and why the splits table had to move with it

Truncation alone was net-negative: five names lost, none recovered, because a renamed company's
history stayed under a symbol that had stopped trading. Both halves were unusable — the predecessor
has no recent bars, the successor no depth.

Every bar **and every split** is now resolved to the symbol its company trades as today, by
following the renames dated after it. One rule covers both directions: a bar from before the rename
moves to the successor, a bar from after it stays with whoever took the vacated symbol.

Resolving the splits table is not defensive coding. **18 of the year's 330 renames have a split on
the successor after the rename, and 52 have one on the predecessor before it**, so a stitch that
left splits alone would take the wrong company's factors in one direction or miss them in the other.

Recovered, measured against the development archive:

| Successor | Own sessions | Inherited | Total |
|---|---|---|---|
| HAPN (from LC) | 39 | 116 | **155** |
| VSXY (from VSCO) | 52 | 103 | **155** |
| ECHO (from SATS) | 37 | 118 | **155** |
| BNY (from BK) | 84 | 96 | 180 — already eligible |
| SKHY (from SKHYV) | 25 | 1 | 26 — still short |

Three names cross the sixty-session floor against the five truncation costs. `SKHY` does not: its
predecessor has a single session in the archive.

### Two cases the live data forced

A predecessor and its successor can **trade at the same time** — `BK` and `BNY` overlap by about two
dozen sessions — so an overlapping session keeps the successor's own close. Before this it kept
whichever row sorted first, which was non-deterministic between two different companies' prices.

A stitched series arrives as **two runs**, because the query orders within a symbol and not across a
rename, so closes are sorted by session before being returned. The database test asserts the order,
not just the length.

A rename chain that revisits a symbol stops where the cycle closes. The first version iterated a
fixed eight times, landed back where it started, and reported no change at all.

## Verification

- `devenv tasks run checks:rust` exits 0; 578 lib tests, 28 database, 13 handler
- The new database test fails 6-against-3 with an empty boundary table and passes with a populated
  one, so it is testing the guard rather than the fixture
- Impact figures above are measured against the live development archive and boundary table
