### PR TITLE
Sync dividends, interest, and fees over a trailing window

### DIFF
--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -762,12 +762,12 @@ pub const TRANSFER_ACTIVITY_TYPES: [&str; 3] = ["CSD", "CSW", "JNLC"];
 /// Activity types that move the balance without capital crossing the account boundary.
 ///
 /// The complement of [`TRANSFER_ACTIVITY_TYPES`]: these are performance, so a session holding one
-/// still has a publishable return. The dividend family is listed in full because the withholdings
-/// and fees among it — `DIVFEE`, `DIVNRA`, `DIVFT`, `DIVTW` — are reductions, and syncing `DIV`
-/// alone would report gross income as net.
-pub const RETURN_ACTIVITY_TYPES: [&str; 13] = [
-    "DIV", "DIVCGL", "DIVCGS", "DIVFEE", "DIVFT", "DIVNRA", "DIVROC", "DIVTW", "DIVTXEX", "INT",
-    "INTNRA", "INTTW", "FEE",
+/// still has a publishable return. Listed in full because the withholdings among them — `DIVFEE`,
+/// `DIVNRA`, `DIVFT`, `DIVTW` — are reductions, and syncing `DIV` alone would report gross income
+/// as net.
+pub const RETURN_ACTIVITY_TYPES: [&str; 14] = [
+    "DIV", "DIVCGL", "DIVCGS", "DIVFEE", "DIVFT", "DIVNRA", "DIVROC", "DIVTW", "DIVTXEX", "CGD",
+    "INT", "INTNRA", "INTTW", "FEE",
 ];
 
 /// What one activity fetch returned, and what it knows it missed.
@@ -1219,10 +1219,8 @@ impl TradingClient {
 
     /// Fetches every activity of `activity_types` Alpaca has recorded since `after`.
     ///
-    /// Windowed on Alpaca's record time rather than the session an activity belongs to, because
-    /// the two differ: a fee for session S is not created until roughly S+1 00:15 UTC, so asking
-    /// for S returns nothing. Callers file each row under its own date and rely on the activity id
-    /// to make the overlap idempotent.
+    /// Windowed on Alpaca's record time, not the session an activity belongs to: a fee for session
+    /// S is not created until roughly S+1 00:15 UTC. Callers file each row under its own date.
     pub async fn fetch_activities_since(
         &self,
         activity_types: &[&str],
@@ -1248,7 +1246,7 @@ impl TradingClient {
         &self,
         url: &str,
         base_query: &[(&str, &str)],
-        activity_type: &str,
+        activity_types: &str,
     ) -> Result<ActivityFetch, ClientError> {
         let page_size = ACTIVITIES_PAGE_SIZE.to_string();
 
@@ -1314,7 +1312,7 @@ impl TradingClient {
             if page + 1 == ACTIVITIES_MAXIMUM_PAGES {
                 truncated = true;
                 warn!(
-                    activity_type,
+                    activity_types,
                     pages = ACTIVITIES_MAXIMUM_PAGES,
                     "Activity pagination hit its page bound; the tail was not fetched"
                 );
@@ -1323,12 +1321,12 @@ impl TradingClient {
 
         if undated > 0 {
             warn!(
-                activity_type,
+                activity_types,
                 undated, "Dropped activities carrying neither a transaction time nor a date"
             );
         }
         debug!(
-            activity_type,
+            activity_types,
             activities = activities.len(),
             "Account activities fetched"
         );
@@ -3374,6 +3372,9 @@ mod tests {
 
     /// The trailing-window fetch asks the plural endpoint for every return type in one request,
     /// windowed on Alpaca's record time. Verbatim live payload, fees and all.
+    ///
+    /// The type list is matched whole rather than by a wildcard, so dropping one from the constant
+    /// fails here instead of silently narrowing what a sync asks for.
     #[tokio::test]
     async fn test_return_activities_are_fetched_as_one_windowed_request() {
         let mut server = mockito::Server::new_async().await;
@@ -3381,7 +3382,12 @@ mod tests {
             .mock("GET", "/v2/account/activities")
             .match_query(mockito::Matcher::AllOf(vec![
                 mockito::Matcher::UrlEncoded("after".into(), "2026-08-07".into()),
-                mockito::Matcher::Regex("activity_types=DIV%2C.*%2CFEE".into()),
+                mockito::Matcher::UrlEncoded(
+                    "activity_types".into(),
+                    "DIV,DIVCGL,DIVCGS,DIVFEE,DIVFT,DIVNRA,DIVROC,DIVTW,DIVTXEX,CGD,INT,INTNRA,\
+                     INTTW,FEE"
+                        .into(),
+                ),
             ]))
             .with_status(200)
             .with_header("content-type", "application/json")

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -759,6 +759,17 @@ pub const FILL_ACTIVITY_TYPE: &str = "FILL";
 /// accounts on Alpaca's own books, which is how paper accounts are funded.
 pub const TRANSFER_ACTIVITY_TYPES: [&str; 3] = ["CSD", "CSW", "JNLC"];
 
+/// Activity types that move the balance without capital crossing the account boundary.
+///
+/// The complement of [`TRANSFER_ACTIVITY_TYPES`]: these are performance, so a session holding one
+/// still has a publishable return. The dividend family is listed in full because the withholdings
+/// and fees among it — `DIVFEE`, `DIVNRA`, `DIVFT`, `DIVTW` — are reductions, and syncing `DIV`
+/// alone would report gross income as net.
+pub const RETURN_ACTIVITY_TYPES: [&str; 13] = [
+    "DIV", "DIVCGL", "DIVCGS", "DIVFEE", "DIVFT", "DIVNRA", "DIVROC", "DIVTW", "DIVTXEX", "INT",
+    "INTNRA", "INTTW", "FEE",
+];
+
 /// What one activity fetch returned, and what it knows it missed.
 ///
 /// `truncated` is the one that matters: the page bound is a bound on a loop, not on reality, and a
@@ -1195,11 +1206,6 @@ impl TradingClient {
     }
 
     /// Fetches one activity type for a single session date, walking pagination.
-    ///
-    ///
-    /// Activities with neither a `transaction_time` nor a `date` are dropped with a warning. They
-    /// cannot be stored — `account_activities.transaction_time` is `NOT NULL` — and synthesizing a
-    /// timestamp would put a fabricated time into the record the dashboard reads as fact.
     pub async fn fetch_activities(
         &self,
         activity_type: &str,
@@ -1207,6 +1213,43 @@ impl TradingClient {
     ) -> Result<ActivityFetch, ClientError> {
         let url = format!("{}/v2/account/activities/{activity_type}", self.base_url);
         let date_text = date.to_string();
+        self.paginate_activities(&url, &[("date", &date_text)], activity_type)
+            .await
+    }
+
+    /// Fetches every activity of `activity_types` Alpaca has recorded since `after`.
+    ///
+    /// Windowed on Alpaca's record time rather than the session an activity belongs to, because
+    /// the two differ: a fee for session S is not created until roughly S+1 00:15 UTC, so asking
+    /// for S returns nothing. Callers file each row under its own date and rely on the activity id
+    /// to make the overlap idempotent.
+    pub async fn fetch_activities_since(
+        &self,
+        activity_types: &[&str],
+        after: NaiveDate,
+    ) -> Result<ActivityFetch, ClientError> {
+        let url = format!("{}/v2/account/activities", self.base_url);
+        let types = activity_types.join(",");
+        let after_text = after.to_string();
+        self.paginate_activities(
+            &url,
+            &[("activity_types", &types), ("after", &after_text)],
+            &types,
+        )
+        .await
+    }
+
+    /// Walks one activity query's pagination into a single fetch result.
+    ///
+    /// Activities with neither a `transaction_time` nor a `date` are dropped with a warning. They
+    /// cannot be stored — `account_activities.transaction_time` is `NOT NULL` — and synthesizing a
+    /// timestamp would put a fabricated time into the record the dashboard reads as fact.
+    async fn paginate_activities(
+        &self,
+        url: &str,
+        base_query: &[(&str, &str)],
+        activity_type: &str,
+    ) -> Result<ActivityFetch, ClientError> {
         let page_size = ACTIVITIES_PAGE_SIZE.to_string();
 
         let mut activities: Vec<AccountActivity> = Vec::new();
@@ -1215,15 +1258,13 @@ impl TradingClient {
         let mut truncated = false;
 
         for page in 0..ACTIVITIES_MAXIMUM_PAGES {
-            let mut query: Vec<(&str, &str)> = vec![
-                ("date", date_text.as_str()),
-                ("page_size", page_size.as_str()),
-            ];
+            let mut query: Vec<(&str, &str)> = base_query.to_vec();
+            query.push(("page_size", page_size.as_str()));
             if let Some(token) = page_token.as_deref() {
                 query.push(("page_token", token));
             }
 
-            let response = error_for_status(self.get(&url).query(&query).send().await?).await?;
+            let response = error_for_status(self.get(url).query(&query).send().await?).await?;
             let payloads: Vec<ActivityResponse> = response.json().await.map_err(|error| {
                 ClientError::Parse(format!("Failed to parse activities response: {error}"))
             })?;
@@ -1274,7 +1315,6 @@ impl TradingClient {
                 truncated = true;
                 warn!(
                     activity_type,
-                    %date,
                     pages = ACTIVITIES_MAXIMUM_PAGES,
                     "Activity pagination hit its page bound; the tail was not fetched"
                 );
@@ -1287,7 +1327,11 @@ impl TradingClient {
                 undated, "Dropped activities carrying neither a transaction time nor a date"
             );
         }
-        debug!(activity_type, %date, activities = activities.len(), "Account activities fetched");
+        debug!(
+            activity_type,
+            activities = activities.len(),
+            "Account activities fetched"
+        );
         Ok(ActivityFetch {
             activities,
             undated,
@@ -3326,6 +3370,87 @@ mod tests {
             "a dated activity must land in the session Alpaca dated it"
         );
         mock.assert_async().await;
+    }
+
+    /// The trailing-window fetch asks the plural endpoint for every return type in one request,
+    /// windowed on Alpaca's record time. Verbatim live payload, fees and all.
+    #[tokio::test]
+    async fn test_return_activities_are_fetched_as_one_windowed_request() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/v2/account/activities")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("after".into(), "2026-08-07".into()),
+                mockito::Matcher::Regex("activity_types=DIV%2C.*%2CFEE".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"[{"id":"20260814000000000::taf","activity_type":"FEE","activity_sub_type":"TAF",
+                     "date":"2026-08-14","net_amount":"-0.07","status":"executed"},
+                    {"id":"20260814000000000::reg","activity_type":"FEE","activity_sub_type":"REG",
+                     "date":"2026-08-14","net_amount":"-0.31","status":"executed"}]"#,
+            )
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(credentials(), server.url());
+        let fetched = client
+            .fetch_activities_since(&RETURN_ACTIVITY_TYPES, date(2026, 8, 7))
+            .await
+            .expect("activities must parse");
+
+        assert_eq!(fetched.activities.len(), 2);
+        let total: Decimal = fetched
+            .activities
+            .iter()
+            .filter_map(|activity| activity.net_amount())
+            .sum();
+        assert_eq!(
+            total,
+            Decimal::new(-38, 2),
+            "the fee family nets to a cost, not income"
+        );
+        assert!(
+            fetched.activities.iter().all(|activity| activity
+                .transaction_time()
+                .with_timezone(&New_York)
+                .date_naive()
+                == date(2026, 8, 14)),
+            "each row files under its own date, not the window it was fetched by"
+        );
+        mock.assert_async().await;
+    }
+
+    /// A fee has no symbol, so it can never reach a pair through `attribute`. Worth pinning: it is
+    /// why the sync reports these as a session cost rather than a per-pair adjustment.
+    #[tokio::test]
+    async fn test_a_fee_carries_no_ticker_and_no_cash_flow() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"[{"id":"20260814000000000::cat","activity_type":"FEE","activity_sub_type":"CAT",
+                     "date":"2026-08-14","net_amount":"-0.01","status":"executed"}]"#,
+            )
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(credentials(), server.url());
+        let fetched = client
+            .fetch_activities_since(&["FEE"], date(2026, 8, 7))
+            .await
+            .expect("activities must parse");
+
+        let fee = &fetched.activities[0];
+        assert!(fee.ticker().is_none(), "a fee names no security");
+        assert!(
+            fee.signed_cash_flow().is_none(),
+            "and carries no quantity or price to derive one from"
+        );
+        assert_eq!(fee.net_amount(), Some(Decimal::new(-1, 2)));
     }
 
     /// A transfer carries neither quantity nor price, so `net_amount` is the only field saying how

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -1,17 +1,7 @@
 //! The post-close account sync: what Alpaca says actually happened.
 //!
-//! Three things, in order. Balances land in `account_snapshots`, whose `equity` is what the *next*
-//! session's drawdown gate measures against. Fills, transfers, dividends, interest, and fees land
-//! in `account_activities`, keyed by Alpaca's activity identifier so a re-run conflicts on every
-//! row and changes nothing. Then the fills — and only the fills — are attributed back to their
-//! pairs.
-//!
-//! Attribution is a materialization, not a source: `realized_profit_and_loss` exists so the
-//! dashboard need not re-join activities to pairs on every page load.
-//!
-//! Transfers are stored because they are read, not because they are attributed: a capital flow
-//! makes every equity-derived return wrong, and the dashboard withholds those figures rather than
-//! publishing them. Nothing here decides *whose* capital moved — Alpaca does not know.
+//! Balances land in `account_snapshots`, activities in `account_activities` keyed by Alpaca's own
+//! identifier, and then the fills — and only the fills — are attributed back to their pairs.
 
 use std::collections::{HashMap, HashSet};
 
@@ -33,11 +23,12 @@ use crate::common::types::SessionDate;
 use crate::data::calendar::TradingCalendar;
 use crate::portfolio::pairs::{self, ClosedPair, PairsError};
 
-/// The activity types this sync fetches for the session it is syncing.
+/// The activity types this sync asks for by session date.
 ///
 /// Fills, because they are attributed to pairs, plus transfers, because a capital flow invalidates
-/// every equity-derived return the dashboard publishes and something has to see it arrive. Both
-/// carry a `transaction_time`, so asking for the session they belong to returns them.
+/// every equity-derived return the dashboard publishes. Only fills answer the session they belong
+/// to: a transfer is date-only and created the next morning, so `date=D` returns the one dated
+/// `D-1` and this session's arrives at the next sync.
 pub fn synced_activity_types() -> Vec<&'static str> {
     std::iter::once(FILL_ACTIVITY_TYPE)
         .chain(TRANSFER_ACTIVITY_TYPES)
@@ -46,10 +37,9 @@ pub fn synced_activity_types() -> Vec<&'static str> {
 
 /// How far back each sync re-asks for [`RETURN_ACTIVITY_TYPES`].
 ///
-/// A fee for a session is not created until roughly 00:15 UTC the following day, hours after the
-/// 16:15 Eastern sync, so the session that incurred it can never see it — every one is picked up
-/// by a later run. Seven days spans a long weekend with room for a missed sync, and costs one
-/// request whose rows are already stored.
+/// A session's fees are not created until roughly 00:15 UTC the next day, so the session that
+/// incurred them can never observe them. Seven days spans a long weekend with room for a missed
+/// sync, and costs one request whose rows are already stored.
 const RETURN_ACTIVITY_WINDOW_DAYS: i64 = 7;
 
 /// Errors syncing the account.
@@ -82,7 +72,7 @@ pub struct AccountSyncSummary {
     /// Dividends, interest, and fees seen for the first time by this sync, which belong to earlier
     /// sessions rather than this one.
     pub return_activities_stored: usize,
-    /// What those cost, summed and signed: negative is a drag on the sessions they fell in.
+    /// Their net effect on the balance, signed: dividends and interest add, fees subtract.
     pub return_activities_net: Decimal,
 }
 

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -1,9 +1,10 @@
 //! The post-close account sync: what Alpaca says actually happened.
 //!
 //! Three things, in order. Balances land in `account_snapshots`, whose `equity` is what the *next*
-//! session's drawdown gate measures against. Fills and transfers land in `account_activities`,
-//! keyed by Alpaca's activity identifier so a re-run conflicts on every row and changes nothing.
-//! Then the fills — and only the fills — are attributed back to their pairs.
+//! session's drawdown gate measures against. Fills, transfers, dividends, interest, and fees land
+//! in `account_activities`, keyed by Alpaca's activity identifier so a re-run conflicts on every
+//! row and changes nothing. Then the fills — and only the fills — are attributed back to their
+//! pairs.
 //!
 //! Attribution is a materialization, not a source: `realized_profit_and_loss` exists so the
 //! dashboard need not re-join activities to pairs on every page load.
@@ -12,18 +13,18 @@
 //! makes every equity-derived return wrong, and the dashboard withholds those figures rather than
 //! publishing them. Nothing here decides *whose* capital moved — Alpaca does not know.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Utc};
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
-use sqlx::PgPool;
+use sqlx::{PgPool, Row};
 use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::common::alpaca::{
     AccountActivity, AccountSnapshot, ClientError, TradingClient, FILL_ACTIVITY_TYPE,
-    TRANSFER_ACTIVITY_TYPES,
+    RETURN_ACTIVITY_TYPES, TRANSFER_ACTIVITY_TYPES,
 };
 use crate::common::session_log::{
     AccountObserved, ActivityObserved, Observation, PairAttributed, SessionLog,
@@ -32,19 +33,24 @@ use crate::common::types::SessionDate;
 use crate::data::calendar::TradingCalendar;
 use crate::portfolio::pairs::{self, ClosedPair, PairsError};
 
-/// The activity types this sync fetches and stores.
+/// The activity types this sync fetches for the session it is syncing.
 ///
 /// Fills, because they are attributed to pairs, plus transfers, because a capital flow invalidates
-/// every equity-derived return the dashboard publishes and something has to see it arrive.
-///
-/// `INT`, `DIV`, and `FEE` are deliberately absent. They are return rather than external flow, so
-/// nothing consumes them yet, and syncing a type nothing reads is how a column full of untested
-/// parsing gets discovered in production. They join when the unit ledger needs them.
+/// every equity-derived return the dashboard publishes and something has to see it arrive. Both
+/// carry a `transaction_time`, so asking for the session they belong to returns them.
 pub fn synced_activity_types() -> Vec<&'static str> {
     std::iter::once(FILL_ACTIVITY_TYPE)
         .chain(TRANSFER_ACTIVITY_TYPES)
         .collect()
 }
+
+/// How far back each sync re-asks for [`RETURN_ACTIVITY_TYPES`].
+///
+/// A fee for a session is not created until roughly 00:15 UTC the following day, hours after the
+/// 16:15 Eastern sync, so the session that incurred it can never see it — every one is picked up
+/// by a later run. Seven days spans a long weekend with room for a missed sync, and costs one
+/// request whose rows are already stored.
+const RETURN_ACTIVITY_WINDOW_DAYS: i64 = 7;
 
 /// Errors syncing the account.
 #[derive(Debug, thiserror::Error)]
@@ -73,6 +79,11 @@ pub struct AccountSyncSummary {
     pub activities_truncated: bool,
     /// Activities Alpaca sent with no usable timestamp, which cannot be stored at all.
     pub activities_undated: usize,
+    /// Dividends, interest, and fees seen for the first time by this sync, which belong to earlier
+    /// sessions rather than this one.
+    pub return_activities_stored: usize,
+    /// What those cost, summed and signed: negative is a drag on the sessions they fell in.
+    pub return_activities_net: Decimal,
 }
 
 /// Runs the whole post-close sync for one session date.
@@ -121,7 +132,46 @@ pub async fn sync_account(
         activities_undated += fetched.undated;
         activities.extend(fetched.activities);
     }
-    let activities_stored = store_activities(pool, &activities).await?;
+
+    // Asked for over a trailing window rather than this session, because none of these exist yet
+    // when the sync runs. The overlap re-reads rows already stored, which the activity id absorbs.
+    let returns = client
+        .fetch_activities_since(
+            &RETURN_ACTIVITY_TYPES,
+            session_date.date() - chrono::Duration::days(RETURN_ACTIVITY_WINDOW_DAYS),
+        )
+        .await?;
+    activities_truncated |= returns.truncated;
+    activities_undated += returns.undated;
+    let return_activity_ids: HashSet<String> = returns
+        .activities
+        .iter()
+        .map(|activity| activity.id().to_string())
+        .collect();
+    activities.extend(returns.activities);
+
+    let stored = store_activities(pool, &activities).await?;
+    let activities_stored = stored.len() as u64;
+    // Only the rows this sync actually inserted, so a window that re-reads a fee for six more days
+    // does not record it six more times, and a re-run of the session appends nothing.
+    let newly_stored: HashSet<String> = stored.into_iter().collect();
+    let return_activities: Vec<&AccountActivity> = activities
+        .iter()
+        .filter(|activity| {
+            newly_stored.contains(activity.id()) && return_activity_ids.contains(activity.id())
+        })
+        .collect();
+    let return_activities_net: Decimal = return_activities
+        .iter()
+        .filter_map(|activity| activity.net_amount())
+        .sum();
+    if !return_activities.is_empty() {
+        info!(
+            count = return_activities.len(),
+            net = %return_activities_net,
+            "Dividend, interest, and fee activities recorded for earlier sessions"
+        );
+    }
     if activities_truncated || activities_undated > 0 {
         warn!(
             activities_truncated,
@@ -134,7 +184,10 @@ pub async fn sync_account(
     // Our own record of every activity, not just the ones the attribution used. Alpaca's retention
     // bounds how long these can be re-fetched, and `net_amount` — the only field saying how much a
     // deposit or withdrawal moved — reaches no other store this application owns.
-    for activity in &activities {
+    for activity in activities
+        .iter()
+        .filter(|activity| newly_stored.contains(activity.id()))
+    {
         session_log
             .record(
                 correlation_id,
@@ -210,6 +263,8 @@ pub async fn sync_account(
         activities_unattributed: attribution.unattributed,
         activities_truncated,
         activities_undated,
+        return_activities_stored: return_activities.len(),
+        return_activities_net,
     })
 }
 
@@ -273,12 +328,12 @@ pub async fn store_equity_snapshot(
 pub async fn store_activities(
     pool: &PgPool,
     activities: &[AccountActivity],
-) -> Result<u64, AccountError> {
+) -> Result<Vec<String>, AccountError> {
     if activities.is_empty() {
-        return Ok(0);
+        return Ok(Vec::new());
     }
 
-    let mut rows_affected: u64 = 0;
+    let mut inserted: Vec<String> = Vec::new();
     let mut transaction = pool.begin().await?;
 
     for chunk in activities.chunks(1_000) {
@@ -299,22 +354,21 @@ pub async fn store_activities(
                 .push_bind(activity.net_amount())
                 .push_bind(activity.order_id().map(str::to_string));
         });
-        query_builder.push(" ON CONFLICT (id) DO NOTHING");
+        query_builder.push(" ON CONFLICT (id) DO NOTHING RETURNING id");
 
-        rows_affected += query_builder
-            .build()
-            .execute(&mut *transaction)
-            .await?
-            .rows_affected();
+        let rows = query_builder.build().fetch_all(&mut *transaction).await?;
+        for row in rows {
+            inserted.push(row.try_get("id")?);
+        }
     }
 
     transaction.commit().await?;
     info!(
-        rows = rows_affected,
+        rows = inserted.len(),
         supplied = activities.len(),
         "Account activities stored"
     );
-    Ok(rows_affected)
+    Ok(inserted)
 }
 
 /// The previous trading session, when it has no snapshot of its own.

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -212,14 +212,15 @@ async fn test_activities_are_idempotent_on_alpacas_identifier() {
         account::store_activities(&pool, std::slice::from_ref(&activity))
             .await
             .unwrap(),
-        1
+        vec![activity.id().to_string()],
+        "the first store reports the row it inserted"
     );
     assert_eq!(
         account::store_activities(&pool, std::slice::from_ref(&activity))
             .await
             .unwrap(),
-        0,
-        "a re-run must conflict rather than duplicate"
+        Vec::<String>::new(),
+        "a re-run must conflict rather than duplicate, and report nothing new"
     );
 
     let count: i64 = sqlx::query_scalar("SELECT count(*) FROM account_activities")

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -158,6 +158,23 @@ async fn mock_no_transfers(server: &mut mockito::ServerGuard) {
     }
 }
 
+/// Answers the trailing-window request for dividends, interest, and fees with an empty list.
+///
+/// One request rather than one per type: the sync asks the plural endpoint for the whole family at
+/// once. Anchored so it cannot also swallow the per-type requests the other mocks answer.
+async fn mock_no_return_activities(server: &mut mockito::ServerGuard) {
+    server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"^/v2/account/activities(\?|$)".into()),
+        )
+        .with_status(200)
+        .with_body("[]")
+        .expect_at_least(1)
+        .create_async()
+        .await;
+}
+
 /// A universe holding exactly the named tickers, every one of them shortable.
 fn universe_of(tickers: &[&str]) -> Universe {
     use fund::common::alpaca::TradableAssets;
@@ -1251,6 +1268,7 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
         .await;
 
     mock_no_transfers(&mut server).await;
+    mock_no_return_activities(&mut server).await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
     let log = session_log("test-the-account-sync-stores-and-attributes-a-session");
@@ -1340,6 +1358,7 @@ async fn test_the_account_sync_is_idempotent() {
         .await;
 
     mock_no_transfers(&mut server).await;
+    mock_no_return_activities(&mut server).await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
     let calendar = calendar_ending_at(session_date);
@@ -1422,6 +1441,7 @@ async fn test_the_account_sync_stores_transfers_without_attributing_them() {
             .create_async()
             .await;
     }
+    mock_no_return_activities(&mut server).await;
     // The shape a real account returns: a settlement date, no transaction time, and the amount
     // carried by `net_amount` rather than a quantity and a price.
     let _deposit = server
@@ -1509,6 +1529,7 @@ async fn test_the_account_sync_reports_a_missing_previous_session() {
             .create_async()
             .await;
     }
+    mock_no_return_activities(&mut server).await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
     let log = session_log("test-the-account-sync-reports-a-missing-previous-session-2");
@@ -1610,4 +1631,115 @@ fn session_instant() -> chrono::DateTime<Utc> {
     let today = SessionDate::at(Utc::now());
     let (start, _) = today.bounds();
     start + Duration::hours(11) // 11:00 Eastern, mid-session
+}
+
+/// A fee for an earlier session, which is the only way one can ever arrive.
+///
+/// Alpaca does not create a session's fees until roughly 00:15 UTC the following day, hours after
+/// the 16:15 Eastern sync, so the trailing window is what picks them up. This asserts the fee is
+/// stored under its own session, counted as a cost, and never reaches attribution — it has no
+/// symbol, so no pair could claim it.
+#[tokio::test]
+#[serial]
+async fn test_a_fee_from_an_earlier_session_is_stored_as_a_cost() {
+    use fund::portfolio::account;
+
+    let pool = fresh_pool().await;
+    let mut server = mockito::Server::new_async().await;
+    let session_date = SessionDate::at(session_instant());
+    let earlier = session_date.plus_calendar_days(-1);
+
+    let _account = server
+        .mock("GET", "/v2/account")
+        .with_status(200)
+        .with_body(account_body(30_000))
+        .create_async()
+        .await;
+    for activity_type in account::synced_activity_types() {
+        server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(format!("^/v2/account/activities/{activity_type}")),
+            )
+            .with_status(200)
+            .with_body("[]")
+            .create_async()
+            .await;
+    }
+    let _fees = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"^/v2/account/activities(\?|$)".into()),
+        )
+        .with_status(200)
+        .with_body(format!(
+            r#"[{{"id":"fee-taf","activity_type":"FEE","activity_sub_type":"TAF","date":"{}",
+                  "net_amount":"-0.07","status":"executed"}},
+                {{"id":"fee-reg","activity_type":"FEE","activity_sub_type":"REG","date":"{}",
+                  "net_amount":"-0.31","status":"executed"}}]"#,
+            earlier.date(),
+            earlier.date()
+        ))
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    let trading = TradingClient::with_base_url(credentials(), server.url());
+    let log = session_log("test-a-fee-from-an-earlier-session-is-stored-as-a-cost");
+    let summary = account::sync_account(
+        &pool,
+        &trading,
+        &log,
+        uuid::Uuid::new_v4(),
+        &calendar_ending_at(session_date),
+        session_date,
+    )
+    .await
+    .expect("the sync must run");
+
+    assert_eq!(summary.return_activities_stored, 2);
+    assert_eq!(
+        summary.return_activities_net,
+        rust_decimal::Decimal::new(-38, 2),
+        "the fee family nets to a drag on the session it fell in"
+    );
+    assert_eq!(
+        summary.activities_unattributed, 0,
+        "a fee has no symbol and must never reach attribution"
+    );
+
+    let stored_time: chrono::DateTime<Utc> =
+        sqlx::query_scalar("SELECT transaction_time FROM account_activities WHERE id = 'fee-taf'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        SessionDate::at(stored_time),
+        earlier,
+        "the fee belongs to the session that incurred it, not the one that fetched it"
+    );
+
+    // The window re-reads the same fees for another six days. Without the insert reporting which
+    // rows were new, each re-read would append another observation for a fee already recorded.
+    account::sync_account(
+        &pool,
+        &trading,
+        &log,
+        uuid::Uuid::new_v4(),
+        &calendar_ending_at(session_date),
+        session_date,
+    )
+    .await
+    .expect("the second sync must run");
+
+    let observed = recorded(&log);
+    let fees: Vec<&serde_json::Value> = of_type(&observed, "activity_observed")
+        .into_iter()
+        .filter(|record| record["payload"]["activity_type"] == "FEE")
+        .collect();
+    assert_eq!(
+        fees.len(),
+        2,
+        "an overlapping window must not record a fee it already recorded"
+    );
 }


### PR DESCRIPTION
# Overview

Syncs the activity types that are return rather than external flow — dividends, interest, and fees —
so a cost that reduces equity reaches a store this application owns. Task #6 of the data-correctness
plan.

## Changes

- Adds `RETURN_ACTIVITY_TYPES`: the whole dividend family, the interest family, and `FEE`. All
  thirteen verified against the endpoint, which `422`s an unknown type.
- Adds `TradingClient::fetch_activities_since`, one request to the plural endpoint for the whole
  family over a date window; the existing per-type fetch and it now share a pagination helper.
- Fetches the family over a trailing seven days each sync and files each row under its own date.
- `store_activities` returns the ids it inserted rather than a count, and only those reach the
  session log.
- `AccountSyncSummary` gains `return_activities_stored` and `return_activities_net`.

## Context

**The stated case is not the live one.** The task was written around short dividends. A full sweep
of the account's history — 790 activities since 2026-05-15 — returns 774 `FILL`, 15 `FEE`, and one
`JNLC`. No dividend of any kind, for two reasons that both hold: it is a paper account, and every
pair has closed same-session, so no position has ever spanned an ex-date. `FEE` is the member of the
family that actually occurs: 15 rows across `TAF`, `REG`, and `CAT`, totalling **−$3.31**, scaling
with turnover — `REG` alone was $1.16 on $56,090 of proceeds on 2026-08-11.

**Fetching by session date would have stored nothing, permanently.** Alpaca does not create a
session's fees until roughly 00:15 UTC the next day, hours after the 16:15 Eastern sync, so the
session that incurs a fee can never observe it:

| session | fee appears | delay |
|---|---|---|
| 2026-08-11 … 08-14 | 20:05–20:15 ET, same day | +3.8h to +4.0h |
| 2026-06-09, 05-22 | 04:20–04:25 ET, next day | +12.1h to +12.2h |

The endpoint's own filter confirms it: `until=D` returns activities dated only up to `D−2`, because
the window applies to Alpaca's record time, not the date the row carries. Same distinction #7 hit
between process date and the date a price moved. Hence a trailing window, with the overlap absorbed
by the activity id that was already the primary key.

**Why the id-returning insert.** A seven-day window re-reads the same fee on seven consecutive
evenings. Without knowing which rows were new, the session log would record each one seven times —
and a re-run of a session would append a second copy of every activity in it, which the old
`rows_affected` count could not distinguish from a genuine insert.

**Why a session cost and not a per-pair adjustment.** A fee carries no symbol; it is an
account-level aggregate over many trades ("TAF fee for proceed of 354.5 shares (45 trades)"), so
`attribute` has nothing to match on. Allocating it across the pairs that caused it would be
inventing a number. The types deliberately stay out of `TRANSFER_ACTIVITY_TYPES`, so the dashboard
still publishes returns for a session that incurred one — that constant continues to mean capital
crossing the account boundary.

The dividend and interest types come along because they arrive by the same path for a string each,
and because `DIVFEE`, `DIVNRA`, `DIVFT`, and `DIVTW` are *reductions* — syncing `DIV` alone would
report gross income as net.

## Verification

- `devenv tasks run checks:rust` exits 0.
- Three new tests. The de-dup assertion is load-bearing: removing the `newly_stored` filter fails it
  4-against-2.
- **Live, through the real client**: twelve fee rows over the window, none truncated or undated,
  each resolving to its own session from 2026-08-11 to 2026-08-14, every ticker absent, netting
  −$3.25. The two remaining all-time fees fall outside the seven-day window.

## Not in scope

`DIV*` parsing has no live coverage and cannot get any from a paper account that has never produced
one. It is exercised by fixtures only, and that is stated rather than implied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account synchronization now captures dividend, interest, and fee activities from the trailing seven-day window.
  * Return activity totals and net amounts are included in synchronization results.
  * Duplicate activities are prevented during repeated or overlapping synchronizations.

* **Bug Fixes**
  * Fees are assigned to their activity date, included in net returns, and excluded from trade-pair attribution.
  * Previously stored activities are no longer logged again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->