### PR TITLE
Fetch transfers on the trailing window, not by session date

### DIFF
--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -23,24 +23,33 @@ use crate::common::types::SessionDate;
 use crate::data::calendar::TradingCalendar;
 use crate::portfolio::pairs::{self, ClosedPair, PairsError};
 
-/// The activity types this sync asks for by session date.
+/// The activity types a session date can be asked for directly.
 ///
-/// Fills, because they are attributed to pairs, plus transfers, because a capital flow invalidates
-/// every equity-derived return the dashboard publishes. Only fills answer the session they belong
-/// to: a transfer is date-only and created the next morning, so `date=D` returns the one dated
-/// `D-1` and this session's arrives at the next sync.
+/// Fills alone, because they are the only type that answers such a query: they carry a real
+/// `transaction_time`, where every other type is date-only and created the following morning, so
+/// `date=D` returns the row dated `D-1`. The rest come through [`windowed_activity_types`].
 pub fn synced_activity_types() -> Vec<&'static str> {
-    std::iter::once(FILL_ACTIVITY_TYPE)
+    vec![FILL_ACTIVITY_TYPE]
+}
+
+/// The activity types asked for over a trailing window instead.
+///
+/// Everything Alpaca stamps with a date rather than a time. A session cannot observe its own fees
+/// or its own transfers — both are created hours after the 16:15 Eastern sync — so asking by
+/// session date would miss each one on the only run that looks for it.
+pub fn windowed_activity_types() -> Vec<&'static str> {
+    RETURN_ACTIVITY_TYPES
+        .iter()
+        .copied()
         .chain(TRANSFER_ACTIVITY_TYPES)
         .collect()
 }
 
-/// How far back each sync re-asks for [`RETURN_ACTIVITY_TYPES`].
+/// How far back each sync re-asks for [`windowed_activity_types`].
 ///
-/// A session's fees are not created until roughly 00:15 UTC the next day, so the session that
-/// incurred them can never observe them. Seven days spans a long weekend with room for a missed
-/// sync, and costs one request whose rows are already stored.
-const RETURN_ACTIVITY_WINDOW_DAYS: i64 = 7;
+/// Seven days spans a long weekend with room for a missed sync, and costs one request whose rows
+/// are already stored.
+const ACTIVITY_WINDOW_DAYS: i64 = 7;
 
 /// Errors syncing the account.
 #[derive(Debug, thiserror::Error)]
@@ -123,22 +132,17 @@ pub async fn sync_account(
         activities.extend(fetched.activities);
     }
 
-    // Asked for over a trailing window rather than this session, because none of these exist yet
-    // when the sync runs. The overlap re-reads rows already stored, which the activity id absorbs.
-    let returns = client
+    // Over a trailing window rather than this session, because none of these exist yet when the
+    // sync runs. The overlap re-reads stored rows, which the activity id absorbs.
+    let windowed = client
         .fetch_activities_since(
-            &RETURN_ACTIVITY_TYPES,
-            session_date.date() - chrono::Duration::days(RETURN_ACTIVITY_WINDOW_DAYS),
+            &windowed_activity_types(),
+            session_date.date() - chrono::Duration::days(ACTIVITY_WINDOW_DAYS),
         )
         .await?;
-    activities_truncated |= returns.truncated;
-    activities_undated += returns.undated;
-    let return_activity_ids: HashSet<String> = returns
-        .activities
-        .iter()
-        .map(|activity| activity.id().to_string())
-        .collect();
-    activities.extend(returns.activities);
+    activities_truncated |= windowed.truncated;
+    activities_undated += windowed.undated;
+    activities.extend(windowed.activities);
 
     let stored = store_activities(pool, &activities).await?;
     let activities_stored = stored.len() as u64;
@@ -148,7 +152,8 @@ pub async fn sync_account(
     let return_activities: Vec<&AccountActivity> = activities
         .iter()
         .filter(|activity| {
-            newly_stored.contains(activity.id()) && return_activity_ids.contains(activity.id())
+            newly_stored.contains(activity.id())
+                && RETURN_ACTIVITY_TYPES.contains(&activity.activity_type())
         })
         .collect();
     let return_activities_net: Decimal = return_activities

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -1416,10 +1416,21 @@ async fn test_the_account_sync_stores_transfers_without_attributing_them() {
     // On the trailing window, which is the only request that can reach it: a transfer is dated and
     // created the morning after, so this session's own `date=` query returns the previous one's.
     let _deposit = server
-        .mock(
-            "GET",
-            mockito::Matcher::Regex(r"^/v2/account/activities(\?|$)".into()),
-        )
+        .mock("GET", "/v2/account/activities")
+        .match_query(mockito::Matcher::AllOf(vec![
+            // Pinned to literals, not to the production constants: building the expectation from
+            // the list under test would move both sides together and assert nothing.
+            mockito::Matcher::UrlEncoded(
+                "activity_types".into(),
+                "DIV,DIVCGL,DIVCGS,DIVFEE,DIVFT,DIVNRA,DIVROC,DIVTW,DIVTXEX,CGD,INT,INTNRA,INTTW,\
+                 FEE,CSD,CSW,JNLC"
+                    .into(),
+            ),
+            mockito::Matcher::UrlEncoded(
+                "after".into(),
+                (session_date.date() - Duration::days(7)).to_string(),
+            ),
+        ]))
         .with_status(200)
         .with_body(format!(
             r#"[{{"id":"deposit-1","activity_type":"{DEPOSIT_ACTIVITY_TYPE}","date":"{}",

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 use chrono::{Duration, NaiveTime, Utc};
 use fund::common::alpaca::{
     AlpacaCredentials, CalendarDay, DataFeed, MarketDataClient, TradingClient,
-    TRANSFER_ACTIVITY_TYPES,
 };
 use fund::common::session_log::SessionLog;
 use fund::common::types::{BarInterval, SessionDate, Ticker};
@@ -136,26 +135,6 @@ fn calendar_ending_at(session_date: SessionDate) -> TradingCalendar {
         })
         .collect();
     TradingCalendar::from_days(days)
-}
-
-/// Answers every transfer activity endpoint with an empty list.
-///
-/// The sync asks for each synced type in turn, so a test mocking only `FILL` would have its
-/// remaining requests go unmatched. Driven by the production constant so a new transfer type cannot
-/// leave these tests quietly mocking the wrong set.
-async fn mock_no_transfers(server: &mut mockito::ServerGuard) {
-    for activity_type in TRANSFER_ACTIVITY_TYPES {
-        server
-            .mock(
-                "GET",
-                mockito::Matcher::Regex(format!("^/v2/account/activities/{activity_type}")),
-            )
-            .with_status(200)
-            .with_body("[]")
-            .expect_at_least(1)
-            .create_async()
-            .await;
-    }
 }
 
 /// Answers the trailing-window request for dividends, interest, and fees with an empty list.
@@ -1267,7 +1246,6 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
         .create_async()
         .await;
 
-    mock_no_transfers(&mut server).await;
     mock_no_return_activities(&mut server).await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
@@ -1357,7 +1335,6 @@ async fn test_the_account_sync_is_idempotent() {
         .create_async()
         .await;
 
-    mock_no_transfers(&mut server).await;
     mock_no_return_activities(&mut server).await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
@@ -1425,12 +1402,7 @@ async fn test_the_account_sync_stores_transfers_without_attributing_them() {
         .with_body(account_body(30_000))
         .create_async()
         .await;
-    // Every type the sync actually asks for answers empty, except the deposit under test. Driven by
-    // the production list so an added type cannot leave a request unmatched here.
-    for activity_type in account::synced_activity_types()
-        .into_iter()
-        .filter(|activity_type| *activity_type != DEPOSIT_ACTIVITY_TYPE)
-    {
+    for activity_type in account::synced_activity_types() {
         server
             .mock(
                 "GET",
@@ -1441,13 +1413,12 @@ async fn test_the_account_sync_stores_transfers_without_attributing_them() {
             .create_async()
             .await;
     }
-    mock_no_return_activities(&mut server).await;
-    // The shape a real account returns: a settlement date, no transaction time, and the amount
-    // carried by `net_amount` rather than a quantity and a price.
+    // On the trailing window, which is the only request that can reach it: a transfer is dated and
+    // created the morning after, so this session's own `date=` query returns the previous one's.
     let _deposit = server
         .mock(
             "GET",
-            mockito::Matcher::Regex(format!("^/v2/account/activities/{DEPOSIT_ACTIVITY_TYPE}")),
+            mockito::Matcher::Regex(r"^/v2/account/activities(\?|$)".into()),
         )
         .with_status(200)
         .with_body(format!(
@@ -1455,6 +1426,7 @@ async fn test_the_account_sync_stores_transfers_without_attributing_them() {
                   "net_amount":"10000.00","status":"executed"}}]"#,
             session_date.date()
         ))
+        .expect_at_least(1)
         .create_async()
         .await;
 


### PR DESCRIPTION
# Overview

Closes the window where the dashboard could publish a return for a session that had received capital. Task #11, found while addressing review on #1071.

## Changes

- `synced_activity_types` is now fills alone — the only type a `date=` query answers correctly.
- Adds `windowed_activity_types`: everything Alpaca stamps with a date, transfers included, fetched with the same `after=` window the return family already used. One request covers both.
- `return_activities_net` selects on activity type rather than on which fetch supplied the row, so a transfer cannot be counted as return.
- Removes `mock_no_transfers`, which mocked endpoints nothing requests any more.

## Context

Same record-time skew #1071 documented for fees. Transfers are date-only, and Alpaca's `date=` filter runs on its own record time while creating date-only rows the following morning — so `date=D` returns the row dated `D-1`. Measured: the JNLC dated 2026-05-15 is returned by `date=2026-05-16` and by no other date. Fills are unaffected.

The consequence was narrow but real: `fetch_transfer_sessions` reads `account_activities` to find sessions with a capital flow, and the dashboard withholds equity-derived returns for those. A transfer on session D was absent from that table until D+1's sync, so D's return was publishable in between. Data was never wrong — it arrived one sync later with the correct timestamp — so this is a visibility window, not corruption, and it cannot bite while flows are zero.

The split is now by **what a query can answer**, not by what the row means. Transfers stay in `TRANSFER_ACTIVITY_TYPES`, which is what gates whether a return is publishable; only their fetch route changed.

## Verification

- `devenv tasks run checks:rust` exits 0; 14 handler tests pass.
- The existing transfer test is the regression. It previously mocked the deposit on the per-type endpoint and so passed against the bug; with the deposit dated the session under sync it fails against the old code and passes against the new.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity retrieval to display fills for the selected session date.
  * Return and transfer activities are now retrieved from the previous seven days.
  * Improved classification of return activities for more accurate account activity results.
  * Updated account synchronization to correctly include deposits and transfers from the trailing activity window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->