### PR TITLE
Type the common module and rename the session log to the journal

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -11,16 +11,21 @@
     export AWS_S3_BUCKET_NAME="oscm-fund-$(echo ''${FUND_PROFILE} | tr '/.' '--')"
     export SECRETSPEC_PROFILE="''${FUND_PROFILE}"
     export AWS_S3_MODEL_ARTIFACT_PATH="models/tide/"
-    if [[ ! -w "''${FUND_LOG_DIR:-/var/log/fund}" ]]; then
-      export FUND_LOG_DIR="$HOME/.local/state/fund/log"
+    if [[ ! -w "''${FUND_LOG_DIRECTORY:-/var/log/fund}" ]]; then
+      export FUND_LOG_DIRECTORY="$HOME/.local/state/fund/log"
     else
-      export FUND_LOG_DIR="''${FUND_LOG_DIR:-/var/log/fund}"
+      export FUND_LOG_DIRECTORY="''${FUND_LOG_DIRECTORY:-/var/log/fund}"
     fi
-    mkdir -p "$FUND_LOG_DIR" 2>/dev/null || true
-    # The session log is data rather than logs, but it inherits FUND_LOG_DIR's writability
-    # fallback so it needs no provisioning of its own. Point it elsewhere to separate them.
-    export FUND_SESSION_LOG_DIR="''${FUND_SESSION_LOG_DIR:-$FUND_LOG_DIR/sessions}"
-    mkdir -p "$FUND_SESSION_LOG_DIR" 2>/dev/null || true
+    mkdir -p "$FUND_LOG_DIRECTORY" 2>/dev/null || true
+    # Its own tree, not a subdirectory of the logs. The journal is the only original this
+    # application owns, and the retention and rotation a log directory gets are the wrong ones for
+    # it. Falls back beside the logs on a machine bootstrap has not reached.
+    if [[ ! -w "''${FUND_JOURNAL_DIRECTORY:-/var/journal/fund}" ]]; then
+      export FUND_JOURNAL_DIRECTORY="$HOME/.local/state/fund/journal"
+    else
+      export FUND_JOURNAL_DIRECTORY="''${FUND_JOURNAL_DIRECTORY:-/var/journal/fund}"
+    fi
+    mkdir -p "$FUND_JOURNAL_DIRECTORY" 2>/dev/null || true
   '';
 
   applySchema = ''
@@ -65,10 +70,11 @@
     export PGUSER="''${PGUSER:-$(id -un)}"
   '';
 
-  # Log directory. VMs use /var/log/fund (provisioned by bootstrap-machine).
-  # The runtimeEnv block above detects when that path is not writable (e.g.
+  # Log and journal directories. VMs use /var/log/fund and /var/journal/fund, both provisioned by
+  # bootstrap-machine. The runtimeEnv block above detects when either path is not writable (e.g. a
   # local laptop without bootstrap) and falls back to an XDG state path.
-  fundLogDir = "/var/log/fund";
+  fundLogDirectory = "/var/log/fund";
+  fundJournalDirectory = "/var/journal/fund";
 
   # S3-compatible object store for the integration test suite. Defined here so
   # the process definition and the environment handed to the tests cannot drift
@@ -174,8 +180,9 @@ in {
     AWS_REGION = awsRegion;
     AWS_DEFAULT_REGION = awsRegion;
 
-    # Writable log directory for local file logging (see fundLogDir above)
-    FUND_LOG_DIR = fundLogDir;
+    # Writable directories for the service logs and the journal (see above)
+    FUND_LOG_DIRECTORY = fundLogDirectory;
+    FUND_JOURNAL_DIRECTORY = fundJournalDirectory;
 
     # PostgreSQL
     DATABASE_URL = "postgresql://localhost:5432/fund";

--- a/src/bin/backfill_account_snapshots.rs
+++ b/src/bin/backfill_account_snapshots.rs
@@ -16,7 +16,7 @@ use tracing::{error, info, warn};
 
 use fund::common::alpaca::{AlpacaCredentials, TradingClient};
 use fund::common::database::connect_pool;
-use fund::common::observability::init_tracing;
+use fund::common::log::init_tracing;
 use fund::common::types::SessionDate;
 use fund::data::calendar::TradingCalendar;
 use fund::portfolio::account;
@@ -209,7 +209,7 @@ async fn run(request: &BackfillRequest) -> Result<BackfillSummary, Box<dyn std::
         .fetch_portfolio_history(request.start.date(), request.end.date())
         .await?
         .into_iter()
-        .map(|point| (SessionDate::at(point.measured_at()), point.equity()))
+        .map(|point| (SessionDate::at(point.timestamp()), point.equity()))
         .collect();
 
     let (fills, mut summary) = plan(&trading_days, &stored, &reported);

--- a/src/bin/fund.rs
+++ b/src/bin/fund.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use fund::common::events::{self, Notification, Outcome};
-use fund::common::{crypto, database, observability};
+use fund::common::{crypto, database, log};
 use fund::handlers::{self, ServiceState};
 use sqlx::postgres::PgListener;
 use tokio::signal::unix::{signal, SignalKind};
@@ -47,7 +47,7 @@ const HANDLER_DRAIN_TIMEOUT: Duration = Duration::from_secs(75);
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     crypto::install_default_crypto_provider();
-    let _log_guard = observability::init_tracing("fund.log", None, "fund");
+    let _log_guard = log::init_tracing("fund.log", None, "fund");
 
     let pool = database::connect_pool().await?;
 

--- a/src/bin/seed_equity_bars_postgres.rs
+++ b/src/bin/seed_equity_bars_postgres.rs
@@ -16,8 +16,8 @@ use chrono::{NaiveDate, Utc};
 use tracing::{error, info, warn};
 
 use fund::common::database::connect_pool;
+use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
-use fund::common::observability::init_tracing;
 use fund::common::types::SessionDate;
 use fund::data::bars;
 

--- a/src/bin/seed_equity_bars_s3.rs
+++ b/src/bin/seed_equity_bars_s3.rs
@@ -16,8 +16,8 @@
 use chrono::{NaiveDate, Utc};
 use tracing::{error, info};
 
+use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
-use fund::common::observability::init_tracing;
 use fund::common::types::SessionDate;
 use fund::data::archive;
 

--- a/src/bin/seed_equity_details_postgres.rs
+++ b/src/bin/seed_equity_details_postgres.rs
@@ -11,7 +11,7 @@
 //! a bucket, so PostgreSQL is the only target.
 
 use fund::common::database::connect_pool;
-use fund::common::observability::init_tracing;
+use fund::common::log::init_tracing;
 use fund::data::details;
 use tracing::{error, info};
 

--- a/src/bin/seed_equity_details_s3.rs
+++ b/src/bin/seed_equity_details_s3.rs
@@ -12,7 +12,7 @@
 
 use tracing::{error, info};
 
-use fund::common::observability::init_tracing;
+use fund::common::log::init_tracing;
 use fund::data::archive;
 use fund::data::details;
 

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -20,8 +20,8 @@ use tracing::{error, info, warn};
 
 use fund::common::alpaca::{AlpacaCredentials, MarketDataClient};
 use fund::common::aws::date_partitioned_key;
+use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
-use fund::common::observability::init_tracing;
 use fund::common::types::{SessionDate, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
 use fund::data::adjust;
 use fund::data::archive;
@@ -105,7 +105,6 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // network round trips first and reports the failure as a sample count.
     validate_lookback_window(lookback_days, session)?;
 
-    // --- stage one: repair the archive ---
     //
     // Scanned rather than topped up: every weekday in the window with no partition is fetched, so a
     // night this did not run, a week of downtime, and an empty bucket are one case. The window is
@@ -188,8 +187,6 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         Err(error) => warn!(%error, "No Alpaca credentials; the boundary table is not refreshed"),
     }
 
-    // --- stage two: load the accumulated window ---
-
     // Fatal where the archive repair above was not: the stored bars are raw, so training without
     // this table fits a two-for-one split as a genuine fifty percent fall.
     let splits =
@@ -240,8 +237,6 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let consolidated = consolidate_data(equity_bars, equity_details)?;
     let filtered = filter_training_bars(consolidated, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME)?;
     info!(rows = filtered.height(), "Consolidated and filtered");
-
-    // --- stage three: train and evaluate ---
 
     // The same fraction reaches preprocessing and windowing, because the scaler is fitted on the
     // rows at or before its cutoff. Passing one value here and another below would fit statistics
@@ -316,8 +311,6 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         quantile_coverage = metrics.quantile_coverage,
         "Evaluation metrics"
     );
-
-    // --- stage four: publish ---
 
     let staging = tempfile::tempdir()?;
     write_artifact_json(

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,18 +1,11 @@
 //! Shared vocabulary and service infrastructure.
-//!
-//! Two market data providers, split by question rather than preference. [`alpaca`] is the venue,
-//! so it answers everything about our account and the current moment. [`massive`] answers only what
-//! the whole market did on a given date — its grouped endpoint takes no symbol list, which is what
-//! keeps historical bars free of survivorship bias.
-//!
-//! [`session_log`] lives here rather than under `data` because every module writes to it.
 
 pub mod alpaca;
 pub mod aws;
 pub mod crypto;
 pub mod database;
 pub mod events;
+pub mod journal;
+pub mod log;
 pub mod massive;
-pub mod observability;
-pub mod session_log;
 pub mod types;

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -1,14 +1,4 @@
 //! The Alpaca integration: credentials, the trading API, and the market data API.
-//!
-//! Two services behind one set of credentials: the trading API answers what the market *is* — the
-//! clock, calendar, assets, orders, positions — and the market data API what things *cost*. They
-//! share authentication and an error type and nothing else, which is why one file holds both.
-//!
-//! Deliberately thin, since Alpaca is the source of truth for fills and balances. Deserialization
-//! surfaces ambiguity rather than defaulting it — a snapshot with no quote, a calendar day with no
-//! duration — because a missing value and a zero one are indistinguishable after the fact. What to
-//! do about a missing value is left to the consumer: [`Snapshot::reference_price`], for one,
-//! deliberately falls back to the last trade.
 
 use std::collections::HashSet;
 use std::num::NonZeroU32;
@@ -16,31 +6,22 @@ use std::num::NonZeroU32;
 use chrono::{DateTime, NaiveDate, NaiveTime, TimeZone, Utc};
 use chrono_tz::America::New_York;
 use rust_decimal::Decimal;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
+use uuid::Uuid;
 
 use crate::common::types::{
-    BarInterval, BoundaryReason, Dollars, EquityBar, EquityQuote, EquityTrade, SeriesBoundary,
-    SessionDate, Ticker,
+    BoundaryReason, Dollars, EquityQuote, EquityTrade, SeriesBoundary, SessionDate, Ticker,
 };
 
-// --------------------------------------------------------------------------
-// Shared configuration and errors
-// --------------------------------------------------------------------------
-
-/// Base URL for paper trading (sandbox environment).
 const PAPER_BASE_URL: &str = "https://paper-api.alpaca.markets";
 
-/// Base URL for live trading.
 const LIVE_BASE_URL: &str = "https://api.alpaca.markets";
 
-/// Base URL for the Alpaca market data API.
 const DATA_BASE_URL: &str = "https://data.alpaca.markets";
 
-/// Header name for the Alpaca API key ID.
 const HEADER_KEY_ID: &str = "APCA-API-KEY-ID";
 
-/// Header name for the Alpaca API secret key.
 const HEADER_SECRET_KEY: &str = "APCA-API-SECRET-KEY";
 
 /// Failures reaching or interpreting an Alpaca endpoint.
@@ -80,10 +61,6 @@ async fn error_for_status(response: reqwest::Response) -> Result<reqwest::Respon
     Err(ClientError::Api { status, body })
 }
 
-// --------------------------------------------------------------------------
-// Credentials
-// --------------------------------------------------------------------------
-
 /// Why credentials could not be constructed.
 ///
 /// Typed rather than a `String` so a caller can tell an absent variable from an empty one without
@@ -103,78 +80,39 @@ pub enum CredentialsError {
 #[derive(Clone)]
 pub struct AlpacaCredentials {
     key_id: String,
-    secret: String,
+    secret_key: String,
 }
 
 impl AlpacaCredentials {
-    /// Constructs `AlpacaCredentials` from explicit field values.
-    ///
-    /// Rejects empty values: an empty key reaches Alpaca as a 403, which reads like a permissions
-    /// problem rather than the configuration one it is.
-    pub fn new(key_id: String, secret: String) -> Result<Self, CredentialsError> {
+    pub fn new(key_id: String, secret_key: String) -> Result<Self, CredentialsError> {
         if key_id.is_empty() {
             return Err(CredentialsError::Empty { field: "key_id" });
         }
-        if secret.is_empty() {
-            return Err(CredentialsError::Empty { field: "secret" });
+        if secret_key.is_empty() {
+            return Err(CredentialsError::Empty {
+                field: "secret_key",
+            });
         }
-        Ok(Self { key_id, secret })
+        Ok(Self { key_id, secret_key })
     }
 
-    /// Reads `ALPACA_API_KEY_ID` and `ALPACA_API_SECRET` from the environment.
     pub fn from_env() -> Result<Self, CredentialsError> {
         let key_id = std::env::var("ALPACA_API_KEY_ID").map_err(|_| CredentialsError::Missing {
             variable: "ALPACA_API_KEY_ID",
         })?;
-        let secret = std::env::var("ALPACA_API_SECRET").map_err(|_| CredentialsError::Missing {
-            variable: "ALPACA_API_SECRET",
-        })?;
-        Self::new(key_id, secret)
+        let secret_key =
+            std::env::var("ALPACA_API_SECRET").map_err(|_| CredentialsError::Missing {
+                variable: "ALPACA_API_SECRET",
+            })?;
+        Self::new(key_id, secret_key)
     }
 
     pub fn key_id(&self) -> &str {
         &self.key_id
     }
 
-    pub fn secret(&self) -> &str {
-        &self.secret
-    }
-}
-
-// --------------------------------------------------------------------------
-// Trading API: clock, calendar, asset universe
-// --------------------------------------------------------------------------
-
-/// The trading session as Alpaca's clock reports it right now.
-///
-/// `next_close` reflects early-close days, so a caller gets the real session end without consulting
-/// a local holiday table.
-#[derive(Debug, Clone, PartialEq)]
-pub struct ClockSnapshot {
-    is_open: bool,
-    next_open: DateTime<Utc>,
-    next_close: DateTime<Utc>,
-}
-
-impl ClockSnapshot {
-    pub fn new(is_open: bool, next_open: DateTime<Utc>, next_close: DateTime<Utc>) -> Self {
-        Self {
-            is_open,
-            next_open,
-            next_close,
-        }
-    }
-
-    pub fn is_open(&self) -> bool {
-        self.is_open
-    }
-
-    pub fn next_open(&self) -> DateTime<Utc> {
-        self.next_open
-    }
-
-    pub fn next_close(&self) -> DateTime<Utc> {
-        self.next_close
+    pub fn secret_key(&self) -> &str {
+        &self.secret_key
     }
 }
 
@@ -227,25 +165,24 @@ impl CalendarDay {
 /// the short leg of a pair needs.
 #[derive(Debug, Clone, Default)]
 pub struct TradableAssets {
-    tradable: HashSet<String>,
-    shortable: HashSet<String>,
+    tradable: HashSet<Ticker>,
+    shortable: HashSet<Ticker>,
 }
 
 impl TradableAssets {
-    /// Constructs from explicit sets, for tests and for the cache warm path.
-    pub fn from_sets(tradable: HashSet<String>, shortable: HashSet<String>) -> Self {
+    pub fn from_sets(tradable: HashSet<Ticker>, shortable: HashSet<Ticker>) -> Self {
         Self {
             tradable,
             shortable,
         }
     }
 
-    pub fn is_tradable(&self, symbol: &str) -> bool {
-        self.tradable.contains(symbol)
+    pub fn is_tradable(&self, ticker: &Ticker) -> bool {
+        self.tradable.contains(ticker)
     }
 
-    pub fn is_shortable(&self, symbol: &str) -> bool {
-        self.shortable.contains(symbol)
+    pub fn is_shortable(&self, ticker: &Ticker) -> bool {
+        self.shortable.contains(ticker)
     }
 
     pub fn tradable_count(&self) -> usize {
@@ -254,13 +191,6 @@ impl TradableAssets {
 
     pub fn shortable_count(&self) -> usize {
         self.shortable.len()
-    }
-
-    /// Every symbol that can be traded, sorted so callers get a stable universe order.
-    pub fn tradable_symbols(&self) -> Vec<String> {
-        let mut symbols: Vec<String> = self.tradable.iter().cloned().collect();
-        symbols.sort();
-        symbols
     }
 }
 
@@ -313,22 +243,7 @@ impl TradingClient {
         self.http_client
             .get(url)
             .header(HEADER_KEY_ID, self.credentials.key_id())
-            .header(HEADER_SECRET_KEY, self.credentials.secret())
-    }
-
-    /// Fetches the current trading session from the clock endpoint.
-    pub async fn fetch_clock(&self) -> Result<ClockSnapshot, ClientError> {
-        let url = format!("{}/v2/clock", self.base_url);
-        let response = error_for_status(self.get(&url).send().await?).await?;
-        let clock: ClockResponse = response.json().await.map_err(|error| {
-            ClientError::Parse(format!("Failed to parse clock response: {error}"))
-        })?;
-
-        Ok(ClockSnapshot::new(
-            clock.is_open,
-            clock.next_open,
-            clock.next_close,
-        ))
+            .header(HEADER_SECRET_KEY, self.credentials.secret_key())
     }
 
     /// Fetches published trading days over an inclusive date range.
@@ -395,6 +310,7 @@ impl TradingClient {
         let mut tradable = HashSet::new();
         let mut shortable = HashSet::new();
         let mut inactive_rejected: usize = 0;
+        let mut unparsable_rejected: usize = 0;
 
         for asset in assets {
             // Checked here as well as in the query string. The `status=active` parameter already
@@ -404,11 +320,15 @@ impl TradingClient {
                 inactive_rejected += 1;
                 continue;
             }
+            let Some(ticker) = Ticker::new(&asset.symbol) else {
+                unparsable_rejected += 1;
+                continue;
+            };
             if asset.tradable.unwrap_or(false) {
-                tradable.insert(asset.symbol.clone());
                 if asset.shortable.unwrap_or(false) && asset.easy_to_borrow.unwrap_or(false) {
-                    shortable.insert(asset.symbol);
+                    shortable.insert(ticker.clone());
                 }
+                tradable.insert(ticker);
             }
         }
 
@@ -416,6 +336,7 @@ impl TradingClient {
             tradable = tradable.len(),
             shortable = shortable.len(),
             inactive_rejected,
+            unparsable_rejected,
             "Tradable asset universe fetched"
         );
         Ok(TradableAssets {
@@ -423,13 +344,6 @@ impl TradingClient {
             shortable,
         })
     }
-}
-
-#[derive(Deserialize)]
-struct ClockResponse {
-    is_open: bool,
-    next_open: DateTime<Utc>,
-    next_close: DateTime<Utc>,
 }
 
 #[derive(Deserialize)]
@@ -448,10 +362,6 @@ struct AssetResponse {
     easy_to_borrow: Option<bool>,
 }
 
-// --------------------------------------------------------------------------
-// Trading API: orders, positions, account, activities
-// --------------------------------------------------------------------------
-
 /// Activities requested per page. 100 is the endpoint's documented maximum.
 const ACTIVITIES_PAGE_SIZE: usize = 100;
 
@@ -467,6 +377,45 @@ const ACTIVITIES_MAXIMUM_PAGES: usize = 100;
 /// intraday timeframe would return several points per session with no rule for picking one.
 const PORTFOLIO_HISTORY_TIMEFRAME: &str = "1D";
 
+/// Which way an order or fill runs, in Alpaca's vocabulary.
+///
+/// `SellShort` is a report and never a request: a short leg is submitted as `Sell` carrying a
+/// `sell_to_open` position intent, and Alpaca names the resulting fill `sell_short`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OrderSide {
+    Buy,
+    Sell,
+    SellShort,
+}
+
+impl OrderSide {
+    pub const ALL: [OrderSide; 3] = [OrderSide::Buy, OrderSide::Sell, OrderSide::SellShort];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OrderSide::Buy => "buy",
+            OrderSide::Sell => "sell",
+            OrderSide::SellShort => "sell_short",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        OrderSide::ALL.into_iter().find(|side| side.as_str() == raw)
+    }
+}
+
+impl std::fmt::Display for OrderSide {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl Serialize for OrderSide {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
 /// What an order is meant to do, carrying the sizing form that side actually accepts.
 ///
 /// The two variants differ in more than direction. A long leg is submitted as a dollar notional and
@@ -479,22 +428,23 @@ pub enum OrderIntent {
     /// Buy to open the long leg, sized in dollars.
     OpenLong { ticker: Ticker, notional: Dollars },
     /// Sell to open the short leg, sized in whole shares.
-    OpenShort { ticker: Ticker, shares: NonZeroU32 },
+    OpenShort {
+        ticker: Ticker,
+        quantity: NonZeroU32,
+    },
 }
 
 impl OrderIntent {
-    /// The symbol the order is for.
     pub fn ticker(&self) -> &Ticker {
         match self {
             OrderIntent::OpenLong { ticker, .. } | OrderIntent::OpenShort { ticker, .. } => ticker,
         }
     }
 
-    /// Which side of the book this order takes, as Alpaca names it.
-    pub fn side(&self) -> &'static str {
+    pub fn side(&self) -> OrderSide {
         match self {
-            OrderIntent::OpenLong { .. } => "buy",
-            OrderIntent::OpenShort { .. } => "sell",
+            OrderIntent::OpenLong { .. } => OrderSide::Buy,
+            OrderIntent::OpenShort { .. } => OrderSide::Sell,
         }
     }
 
@@ -503,11 +453,11 @@ impl OrderIntent {
     /// `position_intent` is sent explicitly rather than left to Alpaca's inference. Without it a
     /// sell against an existing long is read as a close rather than a short, which for a strategy
     /// that holds both sides of a pair is the difference between opening a hedge and unwinding one.
-    fn to_request(&self, client_order_id: &str) -> OrderRequest {
+    fn to_request(&self, client_order_id: Uuid) -> OrderRequest {
         match self {
             OrderIntent::OpenLong { ticker, notional } => OrderRequest {
                 symbol: ticker.as_str().to_string(),
-                side: "buy",
+                side: OrderSide::Buy.as_str(),
                 order_type: "market",
                 time_in_force: "day",
                 notional: Some(format!("{:.2}", notional.value())),
@@ -515,13 +465,13 @@ impl OrderIntent {
                 position_intent: "buy_to_open",
                 client_order_id: client_order_id.to_string(),
             },
-            OrderIntent::OpenShort { ticker, shares } => OrderRequest {
+            OrderIntent::OpenShort { ticker, quantity } => OrderRequest {
                 symbol: ticker.as_str().to_string(),
-                side: "sell",
+                side: OrderSide::Sell.as_str(),
                 order_type: "market",
                 time_in_force: "day",
                 notional: None,
-                qty: Some(shares.get()),
+                qty: Some(quantity.get()),
                 position_intent: "sell_to_open",
                 client_order_id: client_order_id.to_string(),
             },
@@ -542,18 +492,24 @@ impl OrderIntent {
 #[derive(Debug, Clone, PartialEq)]
 pub enum OrderState {
     /// Alpaca still has it: accepted, queued, or partially filled. Ask again.
-    Working { status: String, filled_shares: f64 },
+    Working {
+        status: String,
+        filled_quantity: Decimal,
+    },
     /// Terminal and completely filled.
     Filled {
         status: String,
-        filled_shares: f64,
-        average_price: f64,
+        filled_quantity: Decimal,
+        average_price: Decimal,
     },
     /// Terminal without a complete fill: canceled, expired, rejected, or done for the day.
     ///
-    /// `filled_shares` is non-zero when a partial fill was terminated, which is the case that makes
-    /// this more than a failure flag — those shares are held and have to be unwound.
-    Abandoned { status: String, filled_shares: f64 },
+    /// `filled_quantity` is non-zero when a partial fill was terminated, which is the case that
+    /// makes this more than a failure flag — those shares are held and have to be unwound.
+    Abandoned {
+        status: String,
+        filled_quantity: Decimal,
+    },
 }
 
 impl OrderState {
@@ -575,11 +531,17 @@ impl OrderState {
     }
 
     /// Shares Alpaca reports as filled, whatever state the order reached.
-    pub fn filled_shares(&self) -> f64 {
+    pub fn filled_quantity(&self) -> Decimal {
         match self {
-            OrderState::Working { filled_shares, .. }
-            | OrderState::Filled { filled_shares, .. }
-            | OrderState::Abandoned { filled_shares, .. } => *filled_shares,
+            OrderState::Working {
+                filled_quantity, ..
+            }
+            | OrderState::Filled {
+                filled_quantity, ..
+            }
+            | OrderState::Abandoned {
+                filled_quantity, ..
+            } => *filled_quantity,
         }
     }
 }
@@ -592,13 +554,12 @@ pub enum PositionSide {
 }
 
 impl PositionSide {
-    /// Parses Alpaca's `side` field. Returns `None` for anything else.
-    fn parse(raw: &str) -> Option<Self> {
-        match raw {
-            "long" => Some(PositionSide::Long),
-            "short" => Some(PositionSide::Short),
-            _ => None,
-        }
+    pub const ALL: [PositionSide; 2] = [PositionSide::Long, PositionSide::Short];
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        PositionSide::ALL
+            .into_iter()
+            .find(|side| side.as_str() == raw)
     }
 
     pub fn as_str(self) -> &'static str {
@@ -609,32 +570,54 @@ impl PositionSide {
     }
 }
 
+impl std::fmt::Display for PositionSide {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl Serialize for PositionSide {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+/// What one position fetch returned, and what it could not read.
+///
+/// `unreadable` separates a flat book from one whose rows could not be interpreted, which are the
+/// same empty list and opposite situations.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct PositionFetch {
+    pub positions: Vec<Position>,
+    pub unreadable: usize,
+}
+
 /// One open position as Alpaca reports it.
 ///
-/// `shares` is the absolute count; the direction lives in `side`. Alpaca signs the quantity for
+/// `quantity` is the absolute count; the direction lives in `side`. Alpaca signs the quantity for
 /// shorts, and carrying a signed count alongside a side means two representations of the same fact
 /// that can disagree.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Position {
     ticker: Ticker,
     side: PositionSide,
-    shares: f64,
-    market_value: f64,
-    unrealized_profit_and_loss: f64,
+    quantity: Decimal,
+    market_value: Decimal,
+    unrealized_profit_and_loss: Decimal,
 }
 
 impl Position {
     pub fn new(
         ticker: Ticker,
         side: PositionSide,
-        shares: f64,
-        market_value: f64,
-        unrealized_profit_and_loss: f64,
+        quantity: Decimal,
+        market_value: Decimal,
+        unrealized_profit_and_loss: Decimal,
     ) -> Self {
         Self {
             ticker,
             side,
-            shares: shares.abs(),
+            quantity: quantity.abs(),
             market_value,
             unrealized_profit_and_loss,
         }
@@ -648,15 +631,15 @@ impl Position {
         self.side
     }
 
-    pub fn shares(&self) -> f64 {
-        self.shares
+    pub fn quantity(&self) -> Decimal {
+        self.quantity
     }
 
-    pub fn market_value(&self) -> f64 {
+    pub fn market_value(&self) -> Decimal {
         self.market_value
     }
 
-    pub fn unrealized_profit_and_loss(&self) -> f64 {
+    pub fn unrealized_profit_and_loss(&self) -> Decimal {
         self.unrealized_profit_and_loss
     }
 }
@@ -727,20 +710,17 @@ impl AccountSnapshot {
 /// terms — the caller wraps it with `SessionDate::at`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EquityPoint {
-    measured_at: DateTime<Utc>,
+    timestamp: DateTime<Utc>,
     equity: Decimal,
 }
 
 impl EquityPoint {
-    pub fn new(measured_at: DateTime<Utc>, equity: Decimal) -> Self {
-        Self {
-            measured_at,
-            equity,
-        }
+    pub fn new(timestamp: DateTime<Utc>, equity: Decimal) -> Self {
+        Self { timestamp, equity }
     }
 
-    pub fn measured_at(&self) -> DateTime<Utc> {
-        self.measured_at
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
     }
 
     pub fn equity(&self) -> Decimal {
@@ -748,27 +728,129 @@ impl EquityPoint {
     }
 }
 
-/// The activity type carrying trade fills.
-pub const FILL_ACTIVITY_TYPE: &str = "FILL";
-
-/// Activity types that move capital into or out of the account from outside it.
+/// One of Alpaca's dividend, interest, and fee codes.
 ///
-/// The distinction that matters is external flow versus return, not cash versus non-cash: `INT`,
-/// `DIV`, and `FEE` also move the balance, but they are performance and must never be netted out of
-/// a return. `CSD` and `CSW` are bank deposits and withdrawals; `JNLC` is cash journalled between
-/// accounts on Alpaca's own books, which is how paper accounts are funded.
-pub const TRANSFER_ACTIVITY_TYPES: [&str; 3] = ["CSD", "CSW", "JNLC"];
+/// Held in the broker's own spelling rather than expanded into named variants: the fourteen differ
+/// in tax treatment rather than in anything this application does with one, and the withholdings
+/// among them — `DIVFEE`, `DIVNRA`, `DIVFT`, `DIVTW` — are reductions, so syncing `DIV` alone would
+/// report gross income as net.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ReturnCode(&'static str);
 
-/// Activity types that move the balance without capital crossing the account boundary.
+impl ReturnCode {
+    pub const ALL: [ReturnCode; 14] = [
+        ReturnCode("DIV"),
+        ReturnCode("DIVCGL"),
+        ReturnCode("DIVCGS"),
+        ReturnCode("DIVFEE"),
+        ReturnCode("DIVFT"),
+        ReturnCode("DIVNRA"),
+        ReturnCode("DIVROC"),
+        ReturnCode("DIVTW"),
+        ReturnCode("DIVTXEX"),
+        ReturnCode("CGD"),
+        ReturnCode("INT"),
+        ReturnCode("INTNRA"),
+        ReturnCode("INTTW"),
+        ReturnCode("FEE"),
+    ];
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        ReturnCode::ALL.into_iter().find(|code| code.0 == raw)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+/// One of Alpaca's account activity types.
 ///
-/// The complement of [`TRANSFER_ACTIVITY_TYPES`]: these are performance, so a session holding one
-/// still has a publishable return. Listed in full because the withholdings among them — `DIVFEE`,
-/// `DIVNRA`, `DIVFT`, `DIVTW` — are reductions, and syncing `DIV` alone would report gross income
-/// as net.
-pub const RETURN_ACTIVITY_TYPES: [&str; 14] = [
-    "DIV", "DIVCGL", "DIVCGS", "DIVFEE", "DIVFT", "DIVNRA", "DIVROC", "DIVTW", "DIVTXEX", "CGD",
-    "INT", "INTNRA", "INTTW", "FEE",
-];
+/// The distinction the named variants draw is external flow versus return, not cash versus
+/// non-cash: `INT`, `DIV`, and `FEE` also move the balance, but they are performance and must never
+/// be netted out of a return. `Other` holds anything this build does not recognize, so a type
+/// Alpaca adds is stored unclassified rather than dropped.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ActivityType {
+    /// A trade fill: `FILL`.
+    Fill,
+    /// A bank deposit: `CSD`.
+    CashDeposit,
+    /// A bank withdrawal: `CSW`.
+    CashWithdrawal,
+    /// Cash journalled between accounts on Alpaca's own books, which is how paper accounts are
+    /// funded: `JNLC`.
+    CashJournal,
+    /// A dividend, interest, or fee.
+    Return(ReturnCode),
+    /// A type this build does not classify.
+    Other(String),
+}
+
+impl ActivityType {
+    /// Every type moving capital into or out of the account from outside it.
+    pub const TRANSFERS: [ActivityType; 3] = [
+        ActivityType::CashDeposit,
+        ActivityType::CashWithdrawal,
+        ActivityType::CashJournal,
+    ];
+
+    pub fn parse(raw: &str) -> Self {
+        match raw {
+            "FILL" => ActivityType::Fill,
+            "CSD" => ActivityType::CashDeposit,
+            "CSW" => ActivityType::CashWithdrawal,
+            "JNLC" => ActivityType::CashJournal,
+            other => match ReturnCode::parse(other) {
+                Some(code) => ActivityType::Return(code),
+                None => ActivityType::Other(other.to_string()),
+            },
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            ActivityType::Fill => "FILL",
+            ActivityType::CashDeposit => "CSD",
+            ActivityType::CashWithdrawal => "CSW",
+            ActivityType::CashJournal => "JNLC",
+            ActivityType::Return(code) => code.as_str(),
+            ActivityType::Other(raw) => raw,
+        }
+    }
+
+    /// Whether capital crossed the account boundary, which is what a return must never net out.
+    pub fn is_transfer(&self) -> bool {
+        ActivityType::TRANSFERS.contains(self)
+    }
+
+    /// Whether the balance moved as performance rather than as flow.
+    pub fn is_return(&self) -> bool {
+        matches!(self, ActivityType::Return(_))
+    }
+
+    /// Every type asked for over the trailing window, which is everything Alpaca stamps with a date
+    /// rather than a time.
+    pub fn windowed() -> Vec<ActivityType> {
+        ReturnCode::ALL
+            .into_iter()
+            .map(ActivityType::Return)
+            .chain(ActivityType::TRANSFERS)
+            .collect()
+    }
+}
+
+impl std::fmt::Display for ActivityType {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl Serialize for ActivityType {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
 
 /// What one activity fetch returned, and what it knows it missed.
 ///
@@ -790,49 +872,49 @@ pub struct ActivityFetch {
 /// a `FEE` carries none of them; a transfer carries only `net_amount`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AccountActivity {
-    id: String,
-    activity_type: String,
+    activity_id: String,
+    activity_type: ActivityType,
     transaction_time: DateTime<Utc>,
     ticker: Option<Ticker>,
-    side: Option<String>,
-    shares: Option<Decimal>,
+    side: Option<OrderSide>,
+    quantity: Option<Decimal>,
     price: Option<Decimal>,
     net_amount: Option<Decimal>,
-    order_id: Option<String>,
+    alpaca_order_id: Option<String>,
 }
 
 impl AccountActivity {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        id: String,
-        activity_type: String,
+        activity_id: String,
+        activity_type: ActivityType,
         transaction_time: DateTime<Utc>,
         ticker: Option<Ticker>,
-        side: Option<String>,
-        shares: Option<Decimal>,
+        side: Option<OrderSide>,
+        quantity: Option<Decimal>,
         price: Option<Decimal>,
         net_amount: Option<Decimal>,
-        order_id: Option<String>,
+        alpaca_order_id: Option<String>,
     ) -> Self {
         Self {
-            id,
+            activity_id,
             activity_type,
             transaction_time,
             ticker,
             side,
-            shares,
+            quantity,
             price,
             net_amount,
-            order_id,
+            alpaca_order_id,
         }
     }
 
     /// Alpaca's own activity identifier, and the primary key of `account_activities`.
-    pub fn id(&self) -> &str {
-        &self.id
+    pub fn activity_id(&self) -> &str {
+        &self.activity_id
     }
 
-    pub fn activity_type(&self) -> &str {
+    pub fn activity_type(&self) -> &ActivityType {
         &self.activity_type
     }
 
@@ -844,12 +926,12 @@ impl AccountActivity {
         self.ticker.as_ref()
     }
 
-    pub fn side(&self) -> Option<&str> {
-        self.side.as_deref()
+    pub fn side(&self) -> Option<OrderSide> {
+        self.side
     }
 
-    pub fn shares(&self) -> Option<Decimal> {
-        self.shares
+    pub fn quantity(&self) -> Option<Decimal> {
+        self.quantity
     }
 
     pub fn price(&self) -> Option<Decimal> {
@@ -864,8 +946,8 @@ impl AccountActivity {
         self.net_amount
     }
 
-    pub fn order_id(&self) -> Option<&str> {
-        self.order_id.as_deref()
+    pub fn alpaca_order_id(&self) -> Option<&str> {
+        self.alpaca_order_id.as_deref()
     }
 
     /// Signed cash effect of a fill: negative when shares were bought, positive when sold.
@@ -873,12 +955,11 @@ impl AccountActivity {
     /// `None` for any activity that is not a two-sided trade, which is what keeps a fee or a
     /// dividend from being attributed to a pair as though it were a leg.
     pub fn signed_cash_flow(&self) -> Option<Decimal> {
-        let shares = self.shares?;
+        let quantity = self.quantity?;
         let price = self.price?;
-        match self.side.as_deref()? {
-            "buy" => Some(-(shares * price)),
-            "sell" | "sell_short" => Some(shares * price),
-            _ => None,
+        match self.side? {
+            OrderSide::Buy => Some(-(quantity * price)),
+            OrderSide::Sell | OrderSide::SellShort => Some(quantity * price),
         }
     }
 }
@@ -892,8 +973,8 @@ pub struct PositionClose {
     ticker: Ticker,
     /// Absent when Alpaca accepted the close but returned a body this client could not read.
     alpaca_order_id: Option<String>,
-    side: Option<String>,
-    quantity: Option<f64>,
+    side: Option<OrderSide>,
+    quantity: Option<Decimal>,
 }
 
 impl PositionClose {
@@ -905,11 +986,11 @@ impl PositionClose {
         self.alpaca_order_id.as_deref()
     }
 
-    pub fn side(&self) -> Option<&str> {
-        self.side.as_deref()
+    pub fn side(&self) -> Option<OrderSide> {
+        self.side
     }
 
-    pub fn quantity(&self) -> Option<f64> {
+    pub fn quantity(&self) -> Option<Decimal> {
         self.quantity
     }
 }
@@ -925,7 +1006,7 @@ pub struct LiquidationOutcome {
     status: u16,
     /// The order Alpaca raised, absent when it refused the close.
     alpaca_order_id: Option<String>,
-    quantity: Option<f64>,
+    quantity: Option<Decimal>,
 }
 
 impl LiquidationOutcome {
@@ -943,7 +1024,7 @@ impl LiquidationOutcome {
         ticker: Ticker,
         status: u16,
         alpaca_order_id: Option<String>,
-        quantity: Option<f64>,
+        quantity: Option<Decimal>,
     ) -> Self {
         Self {
             ticker,
@@ -965,7 +1046,7 @@ impl LiquidationOutcome {
         self.alpaca_order_id.as_deref()
     }
 
-    pub fn quantity(&self) -> Option<f64> {
+    pub fn quantity(&self) -> Option<Decimal> {
         self.quantity
     }
 
@@ -980,14 +1061,14 @@ impl TradingClient {
         self.http_client
             .post(url)
             .header(HEADER_KEY_ID, self.credentials.key_id())
-            .header(HEADER_SECRET_KEY, self.credentials.secret())
+            .header(HEADER_SECRET_KEY, self.credentials.secret_key())
     }
 
     fn delete(&self, url: &str) -> reqwest::RequestBuilder {
         self.http_client
             .delete(url)
             .header(HEADER_KEY_ID, self.credentials.key_id())
-            .header(HEADER_SECRET_KEY, self.credentials.secret())
+            .header(HEADER_SECRET_KEY, self.credentials.secret_key())
     }
 
     /// Fetches current account balances.
@@ -1012,7 +1093,7 @@ impl TradingClient {
     /// Positions whose symbol or side cannot be interpreted are dropped with a warning rather than
     /// failing the call. The caller uses this to decide what to close, and one unrecognizable row
     /// must not stop the rest of the book from being flattened.
-    pub async fn fetch_positions(&self) -> Result<Vec<Position>, ClientError> {
+    pub async fn fetch_positions(&self) -> Result<PositionFetch, ClientError> {
         let url = format!("{}/v2/positions", self.base_url);
         let response = error_for_status(self.get(&url).send().await?).await?;
         let payloads: Vec<PositionResponse> = response.json().await.map_err(|error| {
@@ -1021,6 +1102,7 @@ impl TradingClient {
 
         let reported = payloads.len();
         let mut positions = Vec::with_capacity(reported);
+        let mut unreadable = 0;
         for payload in payloads {
             let (Some(ticker), Some(side)) = (
                 Ticker::new(&payload.symbol),
@@ -1031,25 +1113,28 @@ impl TradingClient {
                     side = %payload.side,
                     "Dropped an Alpaca position with an unrecognized symbol or side"
                 );
+                unreadable += 1;
                 continue;
             };
             positions.push(Position::new(
                 ticker,
                 side,
-                parse_f64(&payload.qty, "qty")?,
-                parse_f64(&payload.market_value, "market_value")?,
-                parse_f64(&payload.unrealized_pl, "unrealized_pl")?,
+                parse_decimal(&payload.qty, "qty")?,
+                parse_decimal(&payload.market_value, "market_value")?,
+                parse_decimal(&payload.unrealized_pl, "unrealized_pl")?,
             ));
         }
 
         debug!(
             positions = positions.len(),
-            reported, "Alpaca positions fetched"
+            reported, unreadable, "Alpaca positions fetched"
         );
-        Ok(positions)
+        Ok(PositionFetch {
+            positions,
+            unreadable,
+        })
     }
 
-    /// Submits an order and returns Alpaca's order identifier.
     /// Sends an order under a caller-chosen `client_order_id`.
     ///
     /// The identifier is the caller's because it must exist before the request does, so a crash
@@ -1057,7 +1142,7 @@ impl TradingClient {
     pub async fn submit_order(
         &self,
         intent: &OrderIntent,
-        client_order_id: &str,
+        client_order_id: Uuid,
     ) -> Result<String, ClientError> {
         let url = format!("{}/v2/orders", self.base_url);
         let response = error_for_status(
@@ -1073,8 +1158,8 @@ impl TradingClient {
 
         info!(
             ticker = %intent.ticker(),
-            order_id = %order.id,
-            client_order_id,
+            alpaca_order_id = %order.id,
+            %client_order_id,
             "Order submitted"
         );
         Ok(order.id)
@@ -1106,11 +1191,6 @@ impl TradingClient {
         Ok(true)
     }
 
-    /// Closes the whole position in one symbol.
-    ///
-    /// Returns `false` when there was no position to close (`404`). That is the expected answer
-    /// when a pair is being closed for the second time — after a retry, or after Alpaca liquidated
-    /// the leg itself — and treating it as an error would turn a no-op into an incident.
     /// Closes one position, returning the order Alpaca raised to do it.
     ///
     /// `None` means there was no position, the expected answer on a retry. The order identifier is
@@ -1139,17 +1219,20 @@ impl TradingClient {
         let alpaca_order_id = order.as_ref().and_then(|order| order.id.clone());
         info!(
             ticker = %ticker,
-            order_id = alpaca_order_id.as_deref().unwrap_or("unknown"),
+            alpaca_order_id = alpaca_order_id.as_deref().unwrap_or("unknown"),
             "Position close submitted"
         );
         Ok(Some(PositionClose {
             ticker: ticker.clone(),
             alpaca_order_id,
-            side: order.as_ref().and_then(|order| order.side.clone()),
+            side: order
+                .as_ref()
+                .and_then(|order| order.side.as_deref())
+                .and_then(OrderSide::parse),
             quantity: order
                 .as_ref()
-                .and_then(|order| order.qty.as_ref())
-                .and_then(|quantity| quantity.parse().ok()),
+                .and_then(|order| order.qty.as_deref())
+                .and_then(decimal_or_none),
         }))
     }
 
@@ -1192,8 +1275,8 @@ impl TradingClient {
                 payload
                     .body
                     .as_ref()
-                    .and_then(|order| order.qty.as_ref())
-                    .and_then(|quantity| quantity.parse().ok()),
+                    .and_then(|order| order.qty.as_deref())
+                    .and_then(decimal_or_none),
             ));
         }
 
@@ -1208,12 +1291,16 @@ impl TradingClient {
     /// Fetches one activity type for a single session date, walking pagination.
     pub async fn fetch_activities(
         &self,
-        activity_type: &str,
+        activity_type: &ActivityType,
         date: NaiveDate,
     ) -> Result<ActivityFetch, ClientError> {
-        let url = format!("{}/v2/account/activities/{activity_type}", self.base_url);
+        let url = format!(
+            "{}/v2/account/activities/{}",
+            self.base_url,
+            activity_type.as_str()
+        );
         let date_text = date.to_string();
-        self.paginate_activities(&url, &[("date", &date_text)], activity_type)
+        self.paginate_activities(&url, &[("date", &date_text)], activity_type.as_str())
             .await
     }
 
@@ -1223,11 +1310,15 @@ impl TradingClient {
     /// S is not created until roughly S+1 00:15 UTC. Callers file each row under its own date.
     pub async fn fetch_activities_since(
         &self,
-        activity_types: &[&str],
+        activity_types: &[ActivityType],
         after: NaiveDate,
     ) -> Result<ActivityFetch, ClientError> {
         let url = format!("{}/v2/account/activities", self.base_url);
-        let types = activity_types.join(",");
+        let types = activity_types
+            .iter()
+            .map(ActivityType::as_str)
+            .collect::<Vec<_>>()
+            .join(",");
         let after_text = after.to_string();
         self.paginate_activities(
             &url,
@@ -1280,10 +1371,10 @@ impl TradingClient {
                 };
                 activities.push(AccountActivity::new(
                     payload.id,
-                    payload.activity_type,
+                    ActivityType::parse(&payload.activity_type),
                     transaction_time,
                     payload.symbol.as_deref().and_then(Ticker::new),
-                    payload.side,
+                    payload.side.as_deref().and_then(OrderSide::parse),
                     payload
                         .qty
                         .as_deref()
@@ -1432,11 +1523,12 @@ fn eastern_midnight(date: NaiveDate) -> DateTime<Utc> {
 /// waiting on an order that is in fact dead times out and unwinds, whereas one that treats an
 /// unfamiliar working status as terminal abandons a live position.
 fn order_state_from(order: OrderResponse) -> Result<OrderState, ClientError> {
-    let filled_shares = order
+    let filled_quantity = order
         .filled_qty
         .as_deref()
-        .and_then(|raw| raw.parse::<f64>().ok())
-        .unwrap_or(0.0);
+        .map(str::trim)
+        .and_then(decimal_or_none)
+        .unwrap_or_default();
 
     let status = order.status.clone();
     match status.as_str() {
@@ -1444,7 +1536,8 @@ fn order_state_from(order: OrderResponse) -> Result<OrderState, ClientError> {
             let average_price = order
                 .filled_avg_price
                 .as_deref()
-                .and_then(|raw| raw.parse::<f64>().ok())
+                .map(str::trim)
+                .and_then(decimal_or_none)
                 .ok_or_else(|| {
                     ClientError::Parse(format!(
                         "Alpaca reported order {} filled with no average fill price",
@@ -1453,19 +1546,19 @@ fn order_state_from(order: OrderResponse) -> Result<OrderState, ClientError> {
                 })?;
             Ok(OrderState::Filled {
                 status: order.status,
-                filled_shares,
+                filled_quantity,
                 average_price,
             })
         }
         "canceled" | "expired" | "rejected" | "done_for_day" | "stopped" | "suspended" => {
             Ok(OrderState::Abandoned {
                 status: order.status,
-                filled_shares,
+                filled_quantity,
             })
         }
         _ => Ok(OrderState::Working {
             status: order.status,
-            filled_shares,
+            filled_quantity,
         }),
     }
 }
@@ -1473,12 +1566,6 @@ fn order_state_from(order: OrderResponse) -> Result<OrderState, ClientError> {
 fn parse_decimal(raw: &str, field: &'static str) -> Result<Decimal, ClientError> {
     raw.trim()
         .parse::<Decimal>()
-        .map_err(|error| ClientError::Parse(format!("Failed to parse {field} '{raw}': {error}")))
-}
-
-fn parse_f64(raw: &str, field: &'static str) -> Result<f64, ClientError> {
-    raw.trim()
-        .parse::<f64>()
         .map_err(|error| ClientError::Parse(format!("Failed to parse {field} '{raw}': {error}")))
 }
 
@@ -1585,10 +1672,6 @@ struct ActivityResponse {
     order_id: Option<String>,
 }
 
-// --------------------------------------------------------------------------
-// Market data API: snapshots and bars
-// --------------------------------------------------------------------------
-
 /// Symbols requested per snapshot call.
 ///
 /// Not the API's limit — the endpoint has been measured accepting 2,000 symbols in a
@@ -1638,27 +1721,24 @@ impl std::fmt::Display for DataFeed {
 /// What one snapshot fetch returned, and what it could not ask about.
 ///
 /// A symbol is absent from `snapshots` either because Alpaca had no usable price for it or because
-/// the request carrying it failed. `failed_symbols` is what separates the two.
+/// the request carrying it failed. `failed_tickers` is what separates the two.
 #[derive(Debug, Clone, Default)]
 pub struct SnapshotFetch {
     pub snapshots: Vec<Snapshot>,
-    pub failed_symbols: Vec<String>,
+    pub failed_tickers: Vec<Ticker>,
 }
 
 /// One symbol's point-in-time market state.
 ///
-/// Every field is optional because Alpaca omits rather than zeroes: a symbol that has not traded
-/// today has no daily bar, and one that is halted may have no quote. A missing value and a zero one
-/// are indistinguishable after the fact, so the distinction is preserved here and resolved by the
+/// Both readings are optional because Alpaca omits rather than zeroes: a symbol that is halted may
+/// have no quote, and one that has not traded today no trade. A missing value and a zero one are
+/// indistinguishable after the fact, so the distinction is preserved here and resolved by the
 /// caller.
 #[derive(Debug, Clone)]
 pub struct Snapshot {
     ticker: Ticker,
     latest_quote: Option<EquityQuote>,
     latest_trade: Option<EquityTrade>,
-    minute_bar: Option<EquityBar>,
-    daily_bar: Option<EquityBar>,
-    previous_daily_bar: Option<EquityBar>,
 }
 
 impl Snapshot {
@@ -1674,46 +1754,7 @@ impl Snapshot {
         self.latest_trade.as_ref()
     }
 
-    pub fn minute_bar(&self) -> Option<&EquityBar> {
-        self.minute_bar.as_ref()
-    }
-
-    pub fn daily_bar(&self) -> Option<&EquityBar> {
-        self.daily_bar.as_ref()
-    }
-
-    pub fn previous_daily_bar(&self) -> Option<&EquityBar> {
-        self.previous_daily_bar.as_ref()
-    }
-
-    /// The most defensible current price, preferring the quote midpoint and falling back to the
-    /// last trade.
-    ///
-    /// The midpoint leads because it reflects where the market currently is willing to transact,
-    /// while the last trade reports where someone already did — possibly a long time ago in a thin
-    /// name. It takes any book at all, though, including one too wide or too stale to be a price:
-    /// anything deciding on the number wants [`Snapshot::reference_price_checked`]. This is the
-    /// convenience path, not the careful one.
-    pub fn reference_price(&self) -> Option<f64> {
-        self.reference_price_with_source().map(|(price, _)| price)
-    }
-
-    /// [`Snapshot::reference_price`] together with the field it came from.
-    ///
-    /// A midpoint and a last trade are not interchangeable readings, so a price without its source
-    /// cannot be compared against the same symbol on the next pass.
-    pub fn reference_price_with_source(&self) -> Option<(f64, PriceSource)> {
-        self.latest_quote
-            .as_ref()
-            .map(|quote| (quote.mid_price(), PriceSource::QuoteMidpoint))
-            .or_else(|| {
-                self.latest_trade
-                    .as_ref()
-                    .map(|trade| (trade.price(), PriceSource::LastTrade))
-            })
-    }
-
-    /// The careful path: the reference price, with a book that fails `limits` refused.
+    /// The reference price, with a book that fails `limits` refused.
     ///
     /// A refused midpoint falls through to the last trade, and a refusal with no last trade behind
     /// it yields `None` so the symbol goes unpriced rather than silently mispriced. The refusal
@@ -1848,6 +1889,12 @@ impl QuoteRejection {
     }
 }
 
+impl Serialize for QuoteRejection {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
 impl std::fmt::Display for QuoteRejection {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -1909,8 +1956,7 @@ impl CheckedPrice {
 }
 
 /// Which field of a [`Snapshot`] a reference price was read from.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PriceSource {
     QuoteMidpoint,
     LastTrade,
@@ -1923,6 +1969,12 @@ impl PriceSource {
             PriceSource::QuoteMidpoint => "quote_midpoint",
             PriceSource::LastTrade => "last_trade",
         }
+    }
+}
+
+impl Serialize for PriceSource {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
     }
 }
 
@@ -2151,7 +2203,7 @@ impl MarketDataClient {
         self.http_client
             .get(url)
             .header(HEADER_KEY_ID, self.credentials.key_id())
-            .header(HEADER_SECRET_KEY, self.credentials.secret())
+            .header(HEADER_SECRET_KEY, self.credentials.secret_key())
     }
 
     /// Fetches the corporate actions that bound a price series, between `start` and `end`.
@@ -2226,7 +2278,7 @@ impl MarketDataClient {
         )))
     }
 
-    /// Fetches point-in-time snapshots for `symbols`, in bounded chunks.
+    /// Fetches point-in-time snapshots for `tickers`, in bounded chunks.
     ///
     /// A chunk that fails is logged and skipped; its symbols simply go unpriced. Partial pricing
     /// narrows the entry set and holds the exits it cannot price, both of which beat pricing
@@ -2235,18 +2287,18 @@ impl MarketDataClient {
     ///
     /// The failed chunk's symbols come back named. Downstream, a symbol Alpaca had no quote for and
     /// one whose request never completed are the same absence, and they are not the same problem.
-    pub async fn fetch_snapshots(&self, symbols: &[String]) -> Result<SnapshotFetch, ClientError> {
-        if symbols.is_empty() {
+    pub async fn fetch_snapshots(&self, tickers: &[Ticker]) -> Result<SnapshotFetch, ClientError> {
+        if tickers.is_empty() {
             return Ok(SnapshotFetch::default());
         }
 
         let mut snapshots: Vec<Snapshot> = Vec::new();
-        let mut failed_symbols: Vec<String> = Vec::new();
+        let mut failed_tickers: Vec<Ticker> = Vec::new();
         let mut failed_chunks: usize = 0;
         let mut requests: usize = 0;
         let mut last_error: Option<ClientError> = None;
 
-        for chunk in symbols.chunks(SNAPSHOT_SYMBOLS_PER_REQUEST) {
+        for chunk in tickers.chunks(SNAPSHOT_SYMBOLS_PER_REQUEST) {
             requests += 1;
             match self.fetch_snapshot_chunk(chunk).await {
                 Ok(chunk_snapshots) => snapshots.extend(chunk_snapshots),
@@ -2257,7 +2309,7 @@ impl MarketDataClient {
                         "Snapshot chunk failed; its symbols stay unpriced"
                     );
                     failed_chunks += 1;
-                    failed_symbols.extend(chunk.iter().cloned());
+                    failed_tickers.extend(chunk.iter().cloned());
                     last_error = Some(error);
                 }
             }
@@ -2268,7 +2320,7 @@ impl MarketDataClient {
         }
 
         info!(
-            requested = symbols.len(),
+            requested = tickers.len(),
             returned = snapshots.len(),
             requests,
             failed_chunks,
@@ -2276,18 +2328,20 @@ impl MarketDataClient {
         );
         Ok(SnapshotFetch {
             snapshots,
-            failed_symbols,
+            failed_tickers,
         })
     }
 
-    async fn fetch_snapshot_chunk(&self, symbols: &[String]) -> Result<Vec<Snapshot>, ClientError> {
+    async fn fetch_snapshot_chunk(&self, tickers: &[Ticker]) -> Result<Vec<Snapshot>, ClientError> {
         let url = format!("{}/v2/stocks/snapshots", self.base_url);
+        let symbols = tickers
+            .iter()
+            .map(Ticker::as_str)
+            .collect::<Vec<_>>()
+            .join(",");
         let response = error_for_status(
             self.get(&url)
-                .query(&[
-                    ("symbols", symbols.join(",").as_str()),
-                    ("feed", self.feed.as_str()),
-                ])
+                .query(&[("symbols", symbols.as_str()), ("feed", self.feed.as_str())])
                 .send()
                 .await?,
         )
@@ -2308,15 +2362,6 @@ impl MarketDataClient {
                     latest_trade: snapshot
                         .latest_trade
                         .and_then(|trade| trade.into_equity_trade(&ticker)),
-                    minute_bar: snapshot
-                        .minute_bar
-                        .and_then(|bar| bar.into_equity_bar(&ticker, BarInterval::OneMinute)),
-                    daily_bar: snapshot
-                        .daily_bar
-                        .and_then(|bar| bar.into_equity_bar(&ticker, BarInterval::OneDay)),
-                    previous_daily_bar: snapshot
-                        .previous_daily_bar
-                        .and_then(|bar| bar.into_equity_bar(&ticker, BarInterval::OneDay)),
                     ticker,
                 })
             })
@@ -2332,12 +2377,6 @@ struct SnapshotResponse {
     latest_quote: Option<QuotePayload>,
     #[serde(rename = "latestTrade")]
     latest_trade: Option<TradePayload>,
-    #[serde(rename = "minuteBar")]
-    minute_bar: Option<BarPayload>,
-    #[serde(rename = "dailyBar")]
-    daily_bar: Option<BarPayload>,
-    #[serde(rename = "prevDailyBar")]
-    previous_daily_bar: Option<BarPayload>,
 }
 
 #[derive(Deserialize)]
@@ -2397,57 +2436,10 @@ impl TradePayload {
     }
 }
 
-#[derive(Deserialize)]
-struct BarPayload {
-    #[serde(rename = "t")]
-    timestamp: Option<DateTime<Utc>>,
-    #[serde(rename = "o")]
-    open_price: Option<f64>,
-    #[serde(rename = "h")]
-    high_price: Option<f64>,
-    #[serde(rename = "l")]
-    low_price: Option<f64>,
-    #[serde(rename = "c")]
-    close_price: Option<f64>,
-    #[serde(rename = "v")]
-    volume: Option<f64>,
-    #[serde(rename = "vw")]
-    vw: Option<f64>,
-    #[serde(rename = "n")]
-    transactions: Option<i64>,
-}
-
-impl BarPayload {
-    /// Volume arrives as a float and is rounded to whole shares. Alpaca reports fractional volume
-    /// for some feeds; the column is a `BIGINT` and a partial share is not a meaningful unit here.
-    ///
-    /// A bar whose prices do not form a coherent candle is dropped by the constructor, with the
-    /// reason logged, rather than being stored for the screen to trip over later.
-    fn into_equity_bar(self, ticker: &Ticker, bar_interval: BarInterval) -> Option<EquityBar> {
-        EquityBar::new(
-            ticker.clone(),
-            bar_interval,
-            self.timestamp?,
-            self.open_price?,
-            self.high_price?,
-            self.low_price?,
-            self.close_price?,
-            self.volume?.round() as i64,
-            self.vw,
-            self.transactions,
-        )
-        .inspect_err(|error| {
-            debug!(ticker = %ticker, error = %error, "Dropped an incoherent bar");
-        })
-        .ok()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // --- credentials ---
     use serial_test::serial;
 
     #[test]
@@ -2455,7 +2447,7 @@ mod tests {
         let credentials =
             AlpacaCredentials::new("key123".to_string(), "secret456".to_string()).unwrap();
         assert_eq!(credentials.key_id(), "key123");
-        assert_eq!(credentials.secret(), "secret456");
+        assert_eq!(credentials.secret_key(), "secret456");
     }
 
     #[test]
@@ -2470,10 +2462,12 @@ mod tests {
     }
 
     #[test]
-    fn test_new_rejects_empty_secret() {
+    fn test_new_rejects_empty_secret_key() {
         assert!(matches!(
             AlpacaCredentials::new("key123".to_string(), String::new()),
-            Err(CredentialsError::Empty { field: "secret" })
+            Err(CredentialsError::Empty {
+                field: "secret_key"
+            })
         ));
     }
 
@@ -2483,7 +2477,7 @@ mod tests {
             AlpacaCredentials::new("key123".to_string(), "secret456".to_string()).unwrap();
         let cloned = credentials.clone();
         assert_eq!(cloned.key_id(), "key123");
-        assert_eq!(cloned.secret(), "secret456");
+        assert_eq!(cloned.secret_key(), "secret456");
     }
 
     /// RAII guard restoring one environment variable on drop, so an assertion failure cannot leave
@@ -2544,8 +2538,6 @@ mod tests {
         assert_eq!(DataFeed::parse(""), None);
     }
 
-    // --- trading API ---
-
     fn credentials() -> AlpacaCredentials {
         AlpacaCredentials::new("key".to_string(), "secret".to_string()).unwrap()
     }
@@ -2570,39 +2562,16 @@ mod tests {
     #[test]
     fn test_tradable_assets_partitions_membership() {
         let assets = TradableAssets::from_sets(
-            HashSet::from(["AAPL".to_string(), "MSFT".to_string()]),
-            HashSet::from(["AAPL".to_string()]),
+            HashSet::from([ticker("AAPL"), ticker("MSFT")]),
+            HashSet::from([ticker("AAPL")]),
         );
-        assert!(assets.is_tradable("AAPL"));
-        assert!(assets.is_tradable("MSFT"));
-        assert!(assets.is_shortable("AAPL"));
-        assert!(!assets.is_shortable("MSFT"));
-        assert!(!assets.is_tradable("NVDA"));
+        assert!(assets.is_tradable(&ticker("AAPL")));
+        assert!(assets.is_tradable(&ticker("MSFT")));
+        assert!(assets.is_shortable(&ticker("AAPL")));
+        assert!(!assets.is_shortable(&ticker("MSFT")));
+        assert!(!assets.is_tradable(&ticker("NVDA")));
         assert_eq!(assets.tradable_count(), 2);
         assert_eq!(assets.shortable_count(), 1);
-        assert_eq!(assets.tradable_symbols(), vec!["AAPL", "MSFT"]);
-    }
-
-    #[tokio::test]
-    async fn test_fetch_clock_reads_session_boundaries() {
-        let mut server = mockito::Server::new_async().await;
-        let mock = server
-            .mock("GET", "/v2/clock")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                r#"{"timestamp":"2026-06-10T14:00:00Z","is_open":true,
-                    "next_open":"2026-06-11T13:30:00Z","next_close":"2026-06-10T20:00:00Z"}"#,
-            )
-            .create_async()
-            .await;
-
-        let client = TradingClient::with_base_url(credentials(), server.url());
-        let clock = client.fetch_clock().await.expect("clock must parse");
-
-        assert!(clock.is_open());
-        assert_eq!(clock.next_close().to_rfc3339(), "2026-06-10T20:00:00+00:00");
-        mock.assert_async().await;
     }
 
     /// A half-day must survive with its real close. Dropping the published hours in favour of an
@@ -2685,9 +2654,9 @@ mod tests {
 
         assert_eq!(points.len(), 2);
         // Both halves: asserting equities alone would pass with the timestamps transposed.
-        assert_eq!(points[0].measured_at().timestamp(), 1_778_788_800);
+        assert_eq!(points[0].timestamp().timestamp(), 1_778_788_800);
         assert_eq!(points[0].equity(), Decimal::new(2010050, 2));
-        assert_eq!(points[1].measured_at().timestamp(), 1_778_875_200);
+        assert_eq!(points[1].timestamp().timestamp(), 1_778_875_200);
         assert_eq!(points[1].equity(), Decimal::new(2055916, 2));
         mock.assert_async().await;
     }
@@ -2717,10 +2686,7 @@ mod tests {
             .await
             .expect("portfolio history must parse");
 
-        let eastern = points[0]
-            .measured_at()
-            .with_timezone(&New_York)
-            .date_naive();
+        let eastern = points[0].timestamp().with_timezone(&New_York).date_naive();
         assert_eq!(
             eastern,
             NaiveDate::from_ymd_opt(2026, 5, 15).expect("a valid date")
@@ -2839,15 +2805,18 @@ mod tests {
             .await
             .expect("assets must parse");
 
-        assert!(assets.is_shortable("AAPL"));
-        assert!(assets.is_tradable("MSFT"));
+        assert!(assets.is_shortable(&ticker("AAPL")));
+        assert!(assets.is_tradable(&ticker("MSFT")));
         assert!(
-            !assets.is_shortable("MSFT"),
+            !assets.is_shortable(&ticker("MSFT")),
             "hard to borrow is not shortable"
         );
-        assert!(!assets.is_tradable("XYZ"), "inactive assets are excluded");
         assert!(
-            !assets.is_tradable("NOPE"),
+            !assets.is_tradable(&ticker("XYZ")),
+            "inactive assets are excluded"
+        );
+        assert!(
+            !assets.is_tradable(&ticker("NOPE")),
             "non-tradable assets are excluded"
         );
         mock.assert_async().await;
@@ -2857,7 +2826,7 @@ mod tests {
     async fn test_api_error_carries_status_and_body() {
         let mut server = mockito::Server::new_async().await;
         let mock = server
-            .mock("GET", "/v2/clock")
+            .mock("GET", mockito::Matcher::Any)
             .with_status(403)
             .with_body("forbidden")
             .create_async()
@@ -2865,7 +2834,7 @@ mod tests {
 
         let client = TradingClient::with_base_url(credentials(), server.url());
         let error = client
-            .fetch_clock()
+            .fetch_calendar(date(2026, 6, 10), date(2026, 6, 10))
             .await
             .expect_err("403 must be an error");
 
@@ -2878,8 +2847,6 @@ mod tests {
         }
         mock.assert_async().await;
     }
-
-    // --- trading API: orders, positions, account, activities ---
 
     fn ticker(raw: &str) -> Ticker {
         Ticker::new(raw).expect("the test ticker must be valid")
@@ -2907,7 +2874,7 @@ mod tests {
             ticker: ticker("AAPL"),
             notional: Dollars::new(Decimal::new(123456, 2)).unwrap(),
         }
-        .to_request("client-long");
+        .to_request(Uuid::nil());
         assert_eq!(long.side, "buy");
         assert_eq!(long.notional.as_deref(), Some("1234.56"));
         assert_eq!(long.qty, None);
@@ -2915,9 +2882,9 @@ mod tests {
 
         let short = OrderIntent::OpenShort {
             ticker: ticker("MSFT"),
-            shares: shares(40),
+            quantity: shares(40),
         }
-        .to_request("client-short");
+        .to_request(Uuid::nil());
         assert_eq!(short.side, "sell");
         assert_eq!(short.notional, None);
         assert_eq!(short.qty, Some(40));
@@ -2932,9 +2899,9 @@ mod tests {
         let body = serde_json::to_value(
             OrderIntent::OpenShort {
                 ticker: ticker("MSFT"),
-                shares: shares(10),
+                quantity: shares(10),
             }
-            .to_request("client-short"),
+            .to_request(Uuid::nil()),
         )
         .unwrap();
         assert_eq!(body["position_intent"], "sell_to_open");
@@ -2949,17 +2916,17 @@ mod tests {
             order_state_from(order_response("filled", "12", "101.25")).unwrap(),
             OrderState::Filled {
                 status: "filled".to_string(),
-                filled_shares: 12.0,
-                average_price: 101.25,
+                filled_quantity: Decimal::new(12, 0),
+                average_price: Decimal::new(10125, 2),
             }
         );
         for status in ["canceled", "expired", "rejected", "done_for_day"] {
             assert!(matches!(
                 order_state_from(order_response(status, "3", "100")).unwrap(),
                 OrderState::Abandoned {
-                    filled_shares,
+                    filled_quantity,
                     ..
-                } if filled_shares == 3.0
+                } if filled_quantity == Decimal::new(3, 0)
             ));
         }
         for status in ["new", "accepted", "partially_filled", "pending_cancel"] {
@@ -2986,7 +2953,7 @@ mod tests {
     #[test]
     fn test_abandoned_order_retains_its_partial_fill() {
         let state = order_state_from(order_response("canceled", "7.5", "0")).unwrap();
-        assert_eq!(state.filled_shares(), 7.5);
+        assert_eq!(state.filled_quantity(), Decimal::new(75, 1));
         assert!(state.is_terminal());
     }
 
@@ -3068,10 +3035,13 @@ mod tests {
             .await
             .expect("positions must parse");
 
-        assert_eq!(positions.len(), 2);
-        assert_eq!(positions[1].side(), PositionSide::Short);
-        assert_eq!(positions[1].shares(), 4.0);
-        assert_eq!(positions[1].market_value(), -1480.0);
+        assert_eq!(positions.positions.len(), 2);
+        assert_eq!(positions.positions[1].side(), PositionSide::Short);
+        assert_eq!(positions.positions[1].quantity(), Decimal::new(4, 0));
+        assert_eq!(
+            positions.positions[1].market_value(),
+            Decimal::new(-1480, 0)
+        );
         mock.assert_async().await;
     }
 
@@ -3099,8 +3069,12 @@ mod tests {
             .await
             .expect("positions must parse");
 
-        assert_eq!(positions.len(), 1);
-        assert_eq!(positions[0].ticker(), &ticker("MSFT"));
+        assert_eq!(positions.positions.len(), 1);
+        assert_eq!(
+            positions.unreadable, 1,
+            "the unreadable row is counted, not silently dropped"
+        );
+        assert_eq!(positions.positions[0].ticker(), &ticker("MSFT"));
         mock.assert_async().await;
     }
 
@@ -3127,7 +3101,7 @@ mod tests {
                     ticker: ticker("AAPL"),
                     notional: Dollars::new(Decimal::new(5000, 0)).unwrap(),
                 },
-                "client-long",
+                Uuid::nil(),
             )
             .await
             .expect("order must submit");
@@ -3254,12 +3228,15 @@ mod tests {
 
         let client = TradingClient::with_base_url(credentials(), server.url());
         let activities = client
-            .fetch_activities("FILL", date(2026, 7, 30))
+            .fetch_activities(&ActivityType::Fill, date(2026, 7, 30))
             .await
             .expect("activities must parse");
 
         assert_eq!(activities.activities.len(), ACTIVITIES_PAGE_SIZE + 1);
-        assert_eq!(activities.activities.last().unwrap().id(), "activity-tail");
+        assert_eq!(
+            activities.activities.last().unwrap().activity_id(),
+            "activity-tail"
+        );
         assert!(
             !activities.truncated,
             "this fetch finished inside the page bound"
@@ -3272,13 +3249,13 @@ mod tests {
     /// realized profit and loss, which is a number that looks entirely plausible either way.
     #[test]
     fn test_signed_cash_flow_follows_the_side() {
-        let build = |side: &str| {
+        let build = |side: OrderSide| {
             AccountActivity::new(
                 "a".to_string(),
-                "FILL".to_string(),
+                ActivityType::Fill,
                 Utc::now(),
                 Some(ticker("AAPL")),
-                Some(side.to_string()),
+                Some(side),
                 Some(Decimal::new(10, 0)),
                 Some(Decimal::new(15050, 2)),
                 None,
@@ -3286,15 +3263,15 @@ mod tests {
             )
         };
         assert_eq!(
-            build("buy").signed_cash_flow(),
+            build(OrderSide::Buy).signed_cash_flow(),
             Some(Decimal::new(-150500, 2))
         );
         assert_eq!(
-            build("sell").signed_cash_flow(),
+            build(OrderSide::Sell).signed_cash_flow(),
             Some(Decimal::new(150500, 2))
         );
         assert_eq!(
-            build("sell_short").signed_cash_flow(),
+            build(OrderSide::SellShort).signed_cash_flow(),
             Some(Decimal::new(150500, 2))
         );
     }
@@ -3305,7 +3282,7 @@ mod tests {
     fn test_non_trade_activity_has_no_cash_flow() {
         let fee = AccountActivity::new(
             "f".to_string(),
-            "FEE".to_string(),
+            ActivityType::parse("FEE"),
             Utc::now(),
             None,
             None,
@@ -3336,12 +3313,12 @@ mod tests {
 
         let client = TradingClient::with_base_url(credentials(), server.url());
         let activities = client
-            .fetch_activities("FEE", date(2026, 7, 30))
+            .fetch_activities(&ActivityType::parse("FEE"), date(2026, 7, 30))
             .await
             .expect("activities must parse");
 
         assert_eq!(activities.activities.len(), 1);
-        assert_eq!(activities.activities[0].id(), "dated");
+        assert_eq!(activities.activities[0].activity_id(), "dated");
         assert_eq!(
             activities.undated, 1,
             "the dropped record is counted, not silently absent"
@@ -3368,7 +3345,7 @@ mod tests {
 
         let client = TradingClient::with_base_url(credentials(), server.url());
         let activities = client
-            .fetch_activities("JNLC", date(2026, 5, 15))
+            .fetch_activities(&ActivityType::CashJournal, date(2026, 5, 15))
             .await
             .expect("activities must parse");
 
@@ -3398,7 +3375,7 @@ mod tests {
                 mockito::Matcher::UrlEncoded(
                     "activity_types".into(),
                     "DIV,DIVCGL,DIVCGS,DIVFEE,DIVFT,DIVNRA,DIVROC,DIVTW,DIVTXEX,CGD,INT,INTNRA,\
-                     INTTW,FEE"
+                     INTTW,FEE,CSD,CSW,JNLC"
                         .into(),
                 ),
             ]))
@@ -3415,7 +3392,7 @@ mod tests {
 
         let client = TradingClient::with_base_url(credentials(), server.url());
         let fetched = client
-            .fetch_activities_since(&RETURN_ACTIVITY_TYPES, date(2026, 8, 7))
+            .fetch_activities_since(&ActivityType::windowed(), date(2026, 8, 7))
             .await
             .expect("activities must parse");
 
@@ -3459,7 +3436,7 @@ mod tests {
 
         let client = TradingClient::with_base_url(credentials(), server.url());
         let fetched = client
-            .fetch_activities_since(&["FEE"], date(2026, 8, 7))
+            .fetch_activities_since(&[ActivityType::parse("FEE")], date(2026, 8, 7))
             .await
             .expect("activities must parse");
 
@@ -3498,7 +3475,7 @@ mod tests {
 
         let client = TradingClient::with_base_url(credentials(), server.url());
         let activities = client
-            .fetch_activities("JNLC", date(2026, 5, 15))
+            .fetch_activities(&ActivityType::CashJournal, date(2026, 5, 15))
             .await
             .expect("activities must parse");
 
@@ -3543,7 +3520,7 @@ mod tests {
 
         let client = TradingClient::with_base_url(credentials(), server.url());
         let activities = client
-            .fetch_activities("FILL", date(2026, 5, 15))
+            .fetch_activities(&ActivityType::Fill, date(2026, 5, 15))
             .await
             .expect("activities must parse");
 
@@ -3553,8 +3530,6 @@ mod tests {
         );
         mock.assert_async().await;
     }
-
-    // --- market data API ---
 
     fn client(base_url: String) -> MarketDataClient {
         MarketDataClient::with_base_url(credentials(), base_url, DataFeed::Iex)
@@ -3584,7 +3559,7 @@ mod tests {
             .await;
 
         let snapshots = client(server.url())
-            .fetch_snapshots(&["AAPL".to_string()])
+            .fetch_snapshots(&[ticker("AAPL")])
             .await
             .expect("snapshot must parse");
 
@@ -3593,13 +3568,6 @@ mod tests {
         assert_eq!(snapshot.ticker().as_str(), "AAPL");
         assert_eq!(snapshot.latest_trade().unwrap().price(), 201.5);
         assert_eq!(snapshot.latest_quote().unwrap().bid_price(), 201.0);
-        assert_eq!(snapshot.minute_bar().unwrap().close_price(), 201.5);
-        assert_eq!(snapshot.daily_bar().unwrap().volume(), 2_500_000);
-        assert_eq!(snapshot.previous_daily_bar().unwrap().close_price(), 199.0);
-        assert_eq!(
-            snapshot.previous_daily_bar().unwrap().bar_interval(),
-            BarInterval::OneDay
-        );
         mock.assert_async().await;
     }
 
@@ -3616,12 +3584,25 @@ mod tests {
             .await;
 
         let snapshots = client(server.url())
-            .fetch_snapshots(&["AAPL".to_string()])
+            .fetch_snapshots(&[ticker("AAPL")])
             .await
             .unwrap();
 
-        assert_eq!(snapshots.snapshots[0].reference_price(), Some(201.5));
+        assert_eq!(
+            snapshots.snapshots[0]
+                .reference_price_checked(snapshot_read_at(), QuoteLimits::default())
+                .map(|checked| checked.price()),
+            Some(201.5)
+        );
         mock.assert_async().await;
+    }
+
+    /// The instant the snapshot fixtures are read at, a few seconds after the quotes they carry so
+    /// the staleness guard does not refuse them.
+    fn snapshot_read_at() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-10T16:00:05Z")
+            .expect("valid instant")
+            .with_timezone(&Utc)
     }
 
     /// A quote missing a side must be dropped, not defaulted to zero. The fallback to the last
@@ -3640,7 +3621,7 @@ mod tests {
             .await;
 
         let snapshots = client(server.url())
-            .fetch_snapshots(&["AAPL".to_string()])
+            .fetch_snapshots(&[ticker("AAPL")])
             .await
             .unwrap();
 
@@ -3648,7 +3629,12 @@ mod tests {
             snapshots.snapshots[0].latest_quote().is_none(),
             "half a book is no book"
         );
-        assert_eq!(snapshots.snapshots[0].reference_price(), Some(150.0));
+        assert_eq!(
+            snapshots.snapshots[0]
+                .reference_price_checked(snapshot_read_at(), QuoteLimits::default())
+                .map(|checked| checked.price()),
+            Some(150.0)
+        );
         mock.assert_async().await;
     }
 
@@ -3665,7 +3651,7 @@ mod tests {
             .await;
 
         let snapshots = client(server.url())
-            .fetch_snapshots(&["AAPL".to_string()])
+            .fetch_snapshots(&[ticker("AAPL")])
             .await
             .unwrap();
 
@@ -3695,18 +3681,21 @@ mod tests {
             .await;
 
         let snapshots = client(server.url())
-            .fetch_snapshots(&["AAPL".to_string(), "MSFT".to_string()])
+            .fetch_snapshots(&[ticker("AAPL"), ticker("MSFT")])
             .await
             .unwrap();
 
         for snapshot in &snapshots.snapshots {
             assert!(snapshot.latest_trade().is_none());
-            assert_eq!(snapshot.reference_price(), None);
+            assert_eq!(
+                snapshot
+                    .reference_price_checked(snapshot_read_at(), QuoteLimits::default())
+                    .map(|checked| checked.price()),
+                None
+            );
         }
         mock.assert_async().await;
     }
-
-    // --- the quote guard ---
 
     /// The `AER` reading from 2026-08-12: a book wide enough that its midpoint sat seven percent
     /// below where the symbol filled all session. The last trade is one of that day's real fills.
@@ -3717,9 +3706,6 @@ mod tests {
                 EquityQuote::new(ticker.clone(), quoted_at, 128.0, 150.86, 10, 12).unwrap(),
             ),
             latest_trade: Some(EquityTrade::new(ticker.clone(), quoted_at, 150.60).unwrap()),
-            minute_bar: None,
-            daily_bar: None,
-            previous_daily_bar: None,
             ticker,
         }
     }
@@ -3731,25 +3717,8 @@ mod tests {
                 EquityQuote::new(ticker.clone(), quoted_at, 150.58, 150.62, 10, 12).unwrap(),
             ),
             latest_trade: Some(EquityTrade::new(ticker.clone(), quoted_at, 150.60).unwrap()),
-            minute_bar: None,
-            daily_bar: None,
-            previous_daily_bar: None,
             ticker,
         }
-    }
-
-    /// The bug this guard exists for. `reference_price_with_source` is documented as the
-    /// convenience path and takes the midpoint whatever the book looks like; a pair entered on
-    /// 139.43 and read the spread back as converged once a sound quote arrived.
-    #[test]
-    fn test_the_unguarded_path_still_takes_a_wide_midpoint() {
-        let now = Utc.with_ymd_and_hms(2026, 8, 12, 14, 40, 0).unwrap();
-        let snapshot = wide_book_snapshot(now);
-
-        assert_eq!(
-            snapshot.reference_price_with_source(),
-            Some((139.43, PriceSource::QuoteMidpoint))
-        );
     }
 
     #[test]
@@ -3913,8 +3882,6 @@ mod tests {
         let snapshots = client(server.url()).fetch_snapshots(&[]).await.unwrap();
         assert!(snapshots.snapshots.is_empty());
     }
-
-    // --- corporate actions ---
 
     /// Field names and row shapes copied from live responses, including the placeholder rows. The
     /// splits feed taught that a payload which parses in a test and not against the feed is the

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -594,9 +594,8 @@ pub struct PositionFetch {
 
 /// One open position as Alpaca reports it.
 ///
-/// `quantity` is the absolute count; the direction lives in `side`. Alpaca signs the quantity for
-/// shorts, and carrying a signed count alongside a side means two representations of the same fact
-/// that can disagree.
+/// `quantity` is the absolute count and the direction lives in `side`; `market_value` and
+/// `unrealized_profit_and_loss` keep Alpaca's sign, so a short reports both as negative.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Position {
     ticker: Ticker,
@@ -1550,12 +1549,10 @@ fn order_state_from(order: OrderResponse) -> Result<OrderState, ClientError> {
                 average_price,
             })
         }
-        "canceled" | "expired" | "rejected" | "done_for_day" | "stopped" | "suspended" => {
-            Ok(OrderState::Abandoned {
-                status: order.status,
-                filled_quantity,
-            })
-        }
+        "canceled" | "expired" | "rejected" | "done_for_day" => Ok(OrderState::Abandoned {
+            status: order.status,
+            filled_quantity,
+        }),
         _ => Ok(OrderState::Working {
             status: order.status,
             filled_quantity,
@@ -1612,7 +1609,7 @@ struct OrderRequest {
     position_intent: &'static str,
     /// The caller's own identifier, chosen before the order is sent.
     ///
-    /// This is what makes an order recoverable after a crash between the session log write and
+    /// This is what makes an order recoverable after a crash between the journal write and
     /// Alpaca's response: the broker's identifier does not exist yet at that point, and this one
     /// does.
     client_order_id: String,
@@ -1866,7 +1863,7 @@ impl Default for QuoteLimits {
 
 /// Why a quote midpoint was not taken as the reference price.
 ///
-/// Each variant carries the reading that produced it, so the session log can say how far outside
+/// Each variant carries the reading that produced it, so the journal can say how far outside
 /// the bound the book was rather than only that it was.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum QuoteRejection {
@@ -1880,7 +1877,7 @@ pub enum QuoteRejection {
 }
 
 impl QuoteRejection {
-    /// A stable short name for the session log and the structured logs.
+    /// A stable short name for the journal and the structured logs.
     pub fn as_str(&self) -> &'static str {
         match self {
             QuoteRejection::Stale { .. } => "stale_quote",
@@ -1891,7 +1888,27 @@ impl QuoteRejection {
 
 impl Serialize for QuoteRejection {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(self.as_str())
+        use serde::ser::SerializeStruct;
+
+        let mut record = serializer.serialize_struct("QuoteRejection", 3)?;
+        record.serialize_field("reason", self.as_str())?;
+        match self {
+            QuoteRejection::Stale {
+                age_seconds,
+                limit_seconds,
+            } => {
+                record.serialize_field("age_seconds", age_seconds)?;
+                record.serialize_field("limit_seconds", limit_seconds)?;
+            }
+            QuoteRejection::Wide {
+                relative_spread,
+                limit,
+            } => {
+                record.serialize_field("relative_spread", relative_spread)?;
+                record.serialize_field("limit", limit)?;
+            }
+        }
+        record.end()
     }
 }
 
@@ -1963,7 +1980,7 @@ pub enum PriceSource {
 }
 
 impl PriceSource {
-    /// A stable short name for the session log and the structured logs.
+    /// A stable short name for the journal and the structured logs.
     pub fn as_str(self) -> &'static str {
         match self {
             PriceSource::QuoteMidpoint => "quote_midpoint",
@@ -2934,6 +2951,22 @@ mod tests {
                 order_state_from(order_response(status, "0", "0")).unwrap(),
                 OrderState::Working { .. }
             ));
+        }
+    }
+
+    /// Neither status ends an order. `stopped` means a trade is guaranteed at a stated price and
+    /// has not settled yet; `suspended` means temporarily ineligible to trade. Both were mapped to
+    /// `Abandoned`, so `is_terminal` stopped the poll on an order that could still fill and leave
+    /// an unhedged leg on the book.
+    #[test]
+    fn test_stopped_and_suspended_orders_are_still_working() {
+        for status in ["stopped", "suspended"] {
+            let state = order_state_from(order_response(status, "0", "0")).unwrap();
+            assert!(
+                matches!(state, OrderState::Working { .. }),
+                "{status} can still fill, so the caller has to keep waiting"
+            );
+            assert!(!state.is_terminal());
         }
     }
 

--- a/src/common/journal.rs
+++ b/src/common/journal.rs
@@ -6,37 +6,35 @@
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, NaiveDate, Utc};
+use rust_decimal::Decimal;
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 use tracing::{debug, error};
 use uuid::Uuid;
 
-use crate::common::types::SessionDate;
+use crate::common::alpaca::{ActivityType, OrderSide, PositionSide, PriceSource, QuoteRejection};
+use crate::common::types::{CloseReason, PairID, SessionDate, Ticker};
 
 /// Version stamped on every record written by this build.
 ///
 /// Readers map old versions forward rather than rewriting files, so this only ever goes up. What
 /// each version held is documented beside the DuckDB view in `tools/duckdb_initialization.sql`.
-pub const SCHEMA_VERSION: u32 = 2;
+pub const SCHEMA_VERSION: u32 = 3;
 
 /// Anything that stops a record reaching the disk.
 #[derive(Debug, thiserror::Error)]
-pub enum SessionLogError {
-    #[error("session log directory {directory} is unusable: {source}")]
+pub enum JournalError {
+    #[error("journal directory {directory} is unusable: {source}")]
     Directory {
         directory: String,
         #[source]
         source: std::io::Error,
     },
-    #[error("session log write failed: {0}")]
+    #[error("journal write failed: {0}")]
     Write(#[from] std::io::Error),
     #[error("observation could not be serialized: {0}")]
     Serialize(#[from] serde_json::Error),
 }
-
-// ---------------------------------------------------------------------------
-// Records
-// ---------------------------------------------------------------------------
 
 /// One observation, tagged with what kind it is.
 ///
@@ -45,38 +43,27 @@ pub enum SessionLogError {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(tag = "event_type", content = "payload", rename_all = "snake_case")]
 pub enum Observation {
-    /// One scheduled command, however it ended.
     CommandFinished(CommandFinished),
-    /// One five-minute pass: what it decided, and what stopped it doing more.
     PassEvaluated(Box<PassEvaluated>),
-    /// What one price fetch returned, and what it asked for and did not get.
     PricesObserved(PricesObserved),
-    /// The eligibility funnel: what reached the screen and what did not.
     UniverseScreened(UniverseScreened),
-    /// Every open pair as one pass measured it, closed or held.
     OpenPairsObserved(OpenPairsObserved),
-    /// What one round of a pass resolved to do, written before any of it is attempted.
     PlanDecided(PlanDecided),
-    /// A pair as it was written to the book.
     PairOpened(PairOpened),
-    /// A pair as it was marked closed.
     PairClosed(PairClosed),
-    /// What the post-close sync attributed to a closed pair.
     PairAttributed(PairAttributed),
-    /// An order as it was sent, written before the request leaves the process.
     OrderSubmitted(OrderSubmitted),
-    /// How the broker settled that order, filled or not.
     OrderResolved(OrderResolved),
-    /// A position the application asked Alpaca to close.
     PositionCloseRequested(PositionCloseRequested),
-    /// The pre-close flattening, whether or not it flattened anything.
     LiquidationAttempted(LiquidationAttempted),
-    /// The pre-open inference run, the artifact it resolved, and the predictions it produced.
     PredictionsGenerated(Box<PredictionsGenerated>),
-    /// One activity as Alpaca reported it, fill or transfer.
     ActivityObserved(ActivityObserved),
-    /// The post-close account state, which Alpaca cannot fully report again for a past date.
     AccountObserved(AccountObserved),
+    PositionsObserved(PositionsObserved),
+    BarsIngested(BarsIngested),
+    UniverseRefreshed(UniverseRefreshed),
+    CalendarObserved(CalendarObserved),
+    JournalExported(JournalExported),
 }
 
 impl Observation {
@@ -99,7 +86,65 @@ impl Observation {
             Observation::PredictionsGenerated(_) => "predictions_generated",
             Observation::ActivityObserved(_) => "activity_observed",
             Observation::AccountObserved(_) => "account_observed",
+            Observation::PositionsObserved(_) => "positions_observed",
+            Observation::BarsIngested(_) => "bars_ingested",
+            Observation::UniverseRefreshed(_) => "universe_refreshed",
+            Observation::CalendarObserved(_) => "calendar_observed",
+            Observation::JournalExported(_) => "journal_exported",
         }
+    }
+}
+
+/// Why a scheduled command did no work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkipReason {
+    NotATradingDay,
+    MarketHalted,
+}
+
+impl SkipReason {
+    pub const ALL: [SkipReason; 2] = [SkipReason::NotATradingDay, SkipReason::MarketHalted];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SkipReason::NotATradingDay => "not_a_trading_day",
+            SkipReason::MarketHalted => "market_halted",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        SkipReason::ALL.into_iter().find(|it| it.as_str() == raw)
+    }
+}
+
+/// How a scheduled command ended.
+///
+/// `Skipped` carries its reason rather than collapsing to a flag, because a holiday and a halt are
+/// the same absence of work for opposite causes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandOutcome {
+    Completed,
+    Errored,
+    /// The process was shutting down and never ran it.
+    DroppedInFlight,
+    Skipped(SkipReason),
+}
+
+impl CommandOutcome {
+    pub fn as_string(self) -> String {
+        match self {
+            CommandOutcome::Completed => "completed".to_string(),
+            CommandOutcome::Errored => "errored".to_string(),
+            CommandOutcome::DroppedInFlight => "dropped_in_flight".to_string(),
+            CommandOutcome::Skipped(reason) => format!("skipped_{}", reason.as_str()),
+        }
+    }
+}
+
+impl Serialize for CommandOutcome {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.as_string())
     }
 }
 
@@ -111,13 +156,10 @@ impl Observation {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct CommandFinished {
     pub command: String,
-    /// `completed`, `errored`, `dropped_in_flight`, or `skipped_` and the handler's reason.
-    pub outcome: String,
+    pub outcome: CommandOutcome,
     /// Absent for a command that never ran.
     pub duration_milliseconds: Option<u64>,
-    /// The rendered error, when the command failed.
     pub error: Option<String>,
-    /// The handler's own summary, as it reached the completion event.
     pub summary: Option<serde_json::Value>,
 }
 
@@ -128,10 +170,14 @@ pub struct CommandFinished {
 /// known until the pass ends.
 #[derive(Debug, Clone, PartialEq, Default, Serialize)]
 pub struct PassEvaluated {
-    pub account_equity: Option<f64>,
-    pub previous_session_equity: Option<f64>,
-    pub gross_exposure_used: Option<f64>,
-    pub gross_exposure_cap: Option<f64>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub account_equity: Option<Decimal>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub previous_session_equity: Option<Decimal>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub gross_exposure_used: Option<Decimal>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub gross_exposure_cap: Option<Decimal>,
     pub drawdown: Option<f64>,
     pub minutes_until_close: Option<i64>,
     pub open_pairs_at_start: usize,
@@ -141,26 +187,47 @@ pub struct PassEvaluated {
     pub eligible_tickers: usize,
     pub candidates_screened: usize,
     pub model_run_id: Option<String>,
-    /// Why the entry half did not run at all, if it did not.
+    /// The risk gate's rendered reason for not running the entry half at all.
     pub session_block: Option<String>,
     /// The error that ended the pass early, if one did.
     ///
     /// Set on every failing path, so a pass that died after pricing the book still says what it had
     /// measured. Its absence is the claim that the pass ran to completion.
-    pub failure: Option<String>,
+    pub error: Option<String>,
     pub candidates: Vec<CandidateReading>,
+}
+
+/// Which of a pass's two price fetches a reading came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PricePurpose {
+    /// The exit half, pricing the book it already holds.
+    OpenPairs,
+    /// The entry half, pricing what the screen is missing.
+    ScreenCandidates,
 }
 
 /// What one price fetch returned.
 ///
 /// Written per fetch rather than per pass: the exit half prices the open book and the entry half
 /// asks only for what it is missing, and those are two separate readings of the market.
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PricesObserved {
-    /// What the fetch was for — `open_pairs` or `screen_candidates`.
-    pub purpose: String,
+    pub purpose: PricePurpose,
     pub readings: Vec<PriceReading>,
     pub unavailable: Vec<UnavailablePrice>,
+}
+
+/// Why a symbol the fetch asked for came back without a usable price.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UnavailableCause {
+    /// Alpaca returned the symbol with neither a quote nor a trade.
+    NoQuote,
+    /// The request carrying the symbol failed, so it was never asked about.
+    ChunkFailed,
+    /// The guard refused the only book there was, with no last trade behind it.
+    QuoteRejected,
 }
 
 /// A symbol the fetch asked for and did not get a usable price for.
@@ -171,16 +238,13 @@ pub struct PricesObserved {
 /// symbol entirely, and "how far outside" is not answerable from the cause alone.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct UnavailablePrice {
-    pub ticker: String,
-    /// `no_quote`, `chunk_failed`, or `quote_rejected` when the guard refused the only book there
-    /// was and no last trade stood behind it.
-    pub cause: String,
+    pub ticker: Ticker,
+    pub cause: UnavailableCause,
     /// The refused book, set only on `quote_rejected`.
     pub bid_price: Option<f64>,
     pub ask_price: Option<f64>,
     pub quote_timestamp: Option<DateTime<Utc>>,
-    /// `stale_quote` or `wide_quote`.
-    pub quote_rejection: Option<String>,
+    pub quote_rejection: Option<QuoteRejection>,
 }
 
 /// The eligibility funnel for one pass.
@@ -214,6 +278,26 @@ pub enum PlannedActionKind {
     Open,
 }
 
+/// Why a planned action was chosen.
+///
+/// The two arms are not the same kind of answer: an exit is chosen by a rule, an entry by its
+/// position in an ordering, and collapsing both into one string made an empty plan unreadable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlannedReason {
+    Close(CloseReason),
+    /// The entry's one-based rank among the candidates that cleared.
+    Rank(u32),
+}
+
+impl Serialize for PlannedReason {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            PlannedReason::Close(reason) => serializer.serialize_str(reason.as_str()),
+            PlannedReason::Rank(rank) => serializer.serialize_str(&format!("rank_{rank}")),
+        }
+    }
+}
+
 /// What one round of a pass resolved to do, written before any of it is attempted.
 ///
 /// Its own record rather than a field on [`PassEvaluated`], which is written when the pass ends: a
@@ -231,15 +315,16 @@ pub struct PlanDecided {
 /// One thing a plan calls for, carrying enough to reconstruct the attempt if it never completes.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PlannedAction {
-    pub pair_id: String,
+    pub pair_id: PairID,
     pub action: PlannedActionKind,
-    /// The close reason, or the entry's rank among the candidates that cleared.
-    pub reason: String,
-    pub long_ticker: String,
-    pub short_ticker: String,
+    pub reason: PlannedReason,
+    pub long_ticker: Ticker,
+    pub short_ticker: Ticker,
     /// Present for an entry, which is sized before it is sent.
-    pub long_notional: Option<f64>,
-    pub short_shares: Option<f64>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub long_notional: Option<Decimal>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub short_quantity: Option<Decimal>,
 }
 
 /// One prediction as the screen consumed it.
@@ -248,21 +333,33 @@ pub struct PlannedAction {
 /// `equity_predictions` alone.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ScreenInputReading {
-    pub ticker: String,
+    pub ticker: Ticker,
     pub expected_return: f64,
     pub confidence: f64,
     pub is_shortable: bool,
 }
 
+/// Which eligibility test a prediction failed first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExclusionReason {
+    AlreadyHeld,
+    NoSector,
+    NoCloseHistory,
+    OutsideUniverse,
+    Unpriced,
+    UnusableInput,
+    StructuralBreak,
+}
+
 /// One prediction the eligibility filter removed, and why.
 ///
-/// Written every pass, because `held` changes within a session even though the other tests do not.
+/// Written every pass, because `already_held` changes within a session even though the other tests
+/// do not.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ExcludedTickerReading {
-    pub ticker: String,
-    /// `already_held`, `no_sector`, `no_close_history`, `outside_universe`, `unpriced`,
-    /// `unusable_input`, or `structural_break`.
-    pub reason: String,
+    pub ticker: Ticker,
+    pub reason: ExclusionReason,
     /// The reading the reason ruled on, where the name alone does not say how far outside it fell.
     ///
     /// Set for `structural_break` and absent for the set-membership tests, which have no number to
@@ -278,21 +375,52 @@ pub struct ExcludedTickerReading {
 /// right.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PriceReading {
-    pub ticker: String,
+    pub ticker: Ticker,
     pub price: f64,
-    pub price_source: String,
+    pub price_source: PriceSource,
     /// The book as it was offered. Absent when the snapshot carried no quote at all.
     pub bid_price: Option<f64>,
     pub ask_price: Option<f64>,
     /// When the quote was published, not when it was read — the gap between them is the staleness.
     pub quote_timestamp: Option<DateTime<Utc>>,
-    /// `stale_quote` or `wide_quote`, set only when a quote existed and the guard refused it.
-    pub quote_rejection: Option<String>,
+    /// Set only when a quote existed and the guard refused it.
+    pub quote_rejection: Option<QuoteRejection>,
     /// When the last trade printed, on the same terms as `quote_timestamp`.
     ///
     /// Unlike the quote, nothing refuses a trade for being old, so this is the only place a stale
     /// fallback price can be noticed at all. Absent when the snapshot carried no usable trade.
     pub trade_timestamp: Option<DateTime<Utc>>,
+}
+
+/// What a pass resolved to do about one open pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PairDecision {
+    /// Kept, because nothing said otherwise.
+    Held,
+    Convergence,
+    StopLoss,
+    EndOfDay,
+    PositionMissing,
+    /// No usable price for at least one leg.
+    Unpriced,
+    /// The session's spread model does not cover this pair.
+    NoSpreadModel,
+    /// The spread model covers it but its statistics could not be read.
+    UnreadableSpread,
+    /// A close was decided and the broker refused it.
+    CloseFailed,
+}
+
+impl From<CloseReason> for PairDecision {
+    fn from(reason: CloseReason) -> Self {
+        match reason {
+            CloseReason::Convergence => PairDecision::Convergence,
+            CloseReason::StopLoss => PairDecision::StopLoss,
+            CloseReason::EndOfDay => PairDecision::EndOfDay,
+            CloseReason::PositionMissing => PairDecision::PositionMissing,
+        }
+    }
 }
 
 /// An open pair as this pass measured it, whether or not it closed.
@@ -301,9 +429,9 @@ pub struct PriceReading {
 /// refit.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct OpenPairReading {
-    pub pair_id: String,
-    pub long_ticker: String,
-    pub short_ticker: String,
+    pub pair_id: PairID,
+    pub long_ticker: Ticker,
+    pub short_ticker: Ticker,
     pub stored_hedge_ratio: f64,
     pub model_hedge_ratio: Option<f64>,
     pub spread_mean: Option<f64>,
@@ -313,9 +441,20 @@ pub struct OpenPairReading {
     pub stop_at: f64,
     pub entry_session: SessionDate,
     pub minutes_held: i64,
-    /// `held`, `convergence`, `stop_loss`, `end_of_day`, `position_missing`, `unpriced`,
-    /// `no_spread_model`, `unreadable_spread`, or `close_failed`.
-    pub decision: String,
+    pub decision: PairDecision,
+}
+
+/// What became of a scored candidate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CandidateDecision {
+    Opened,
+    /// Selected and written into the plan, but the pass ended before it was attempted.
+    Planned,
+    NotSelected,
+    RiskRefused,
+    Unfilled,
+    AbandonedAtShutdown,
 }
 
 /// A scored candidate and what became of it.
@@ -323,37 +462,37 @@ pub struct OpenPairReading {
 /// The sizing fields are set for every candidate that reached the sizer, refused ones included.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct CandidateReading {
-    pub pair_id: String,
-    pub long_ticker: String,
-    pub short_ticker: String,
+    pub pair_id: PairID,
+    pub long_ticker: Ticker,
+    pub short_ticker: Ticker,
     pub hedge_ratio: f64,
     pub entry_z_score: f64,
     pub signal_strength: f64,
     pub rank_score: f64,
     /// Dollars the long leg was sized to, absent for a candidate that was never selected.
-    pub long_notional: Option<f64>,
-    /// Whole shares the short leg was sized to.
-    pub short_shares: Option<f64>,
-    pub gross_exposure: Option<f64>,
-    /// `opened`, `planned`, `not_selected`, `risk_refused`, `unfilled`, or
-    /// `abandoned_at_shutdown`.
-    pub decision: String,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub long_notional: Option<Decimal>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub short_quantity: Option<Decimal>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub gross_exposure: Option<Decimal>,
+    pub decision: CandidateDecision,
     /// The risk gate's rendered reason, when `decision` is `risk_refused`.
     pub refusal: Option<String>,
 }
 
 /// A pair as it was written to the book.
 ///
-/// `equity_pairs` is mutated in place three times over a pair's life, so the log needs three
+/// `equity_pairs` is mutated in place three times over a pair's life, so the journal needs three
 /// records where the table has one row. This is the only one carrying the entry rationale: nothing
 /// external knows which long was paired with which short, or on what.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PairOpened {
     /// The `equity_pairs` primary key, which the two later records join on.
-    pub pair_uuid: String,
-    pub pair_id: String,
-    pub long_ticker: String,
-    pub short_ticker: String,
+    pub equity_pair_id: Uuid,
+    pub pair_id: PairID,
+    pub long_ticker: Ticker,
+    pub short_ticker: Ticker,
     pub hedge_ratio: f64,
     pub entry_z_score: f64,
     pub signal_strength: f64,
@@ -368,16 +507,17 @@ pub struct PairOpened {
     pub short_decision_price: f64,
     /// What the legs actually filled at. Distinct from the decision prices, and the gap between
     /// them is entry slippage.
-    pub long_fill_price: f64,
-    pub short_fill_price: f64,
+    #[serde(with = "crate::common::types::decimal_number")]
+    pub long_fill_price: Decimal,
+    #[serde(with = "crate::common::types::decimal_number")]
+    pub short_fill_price: Decimal,
 }
 
 /// A pair as it was marked closed.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PairClosed {
-    pub pair_uuid: String,
-    /// `convergence`, `stop_loss`, `end_of_day`, or `position_missing`.
-    pub reason: String,
+    pub equity_pair_id: Uuid,
+    pub reason: CloseReason,
     pub closed_at: DateTime<Utc>,
     /// False when the pair was already closed, so this write changed nothing.
     ///
@@ -393,8 +533,9 @@ pub struct PairClosed {
 /// rows; what is not derivable is that this process put that number on that row and that it landed.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PairAttributed {
-    pub pair_uuid: String,
-    pub realized_profit_and_loss: Option<f64>,
+    pub equity_pair_id: Uuid,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub realized_profit_and_loss: Option<Decimal>,
     /// False when no closed pair matched, so the attribution landed nowhere.
     pub updated: bool,
 }
@@ -405,13 +546,34 @@ pub struct PairAttributed {
 /// the broker's identifier does not exist yet.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct OrderSubmitted {
-    pub client_order_id: String,
-    pub ticker: String,
-    pub side: String,
+    pub client_order_id: Uuid,
+    pub ticker: Ticker,
+    pub side: OrderSide,
     /// Set for the short leg, which is sized in shares.
-    pub shares: Option<f64>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub quantity: Option<Decimal>,
     /// Set for the long leg, which is sized in dollars.
-    pub notional: Option<f64>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub notional: Option<Decimal>,
+}
+
+/// How an order ended, in this application's vocabulary.
+///
+/// `TimedOut` is our word and not the broker's: it is the case `broker_status` exists to explain,
+/// since an order Alpaca still held at `pending_new` never reached the market while one at
+/// `accepted` reached it and found no contra side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrderOutcome {
+    Filled,
+    /// The request itself was refused, so nothing reached the market.
+    SubmitFailed,
+    /// The request could not be sent or its answer could not be read.
+    BrokerUnreachable,
+    /// This process stopped waiting before the order reached a terminal state.
+    TimedOut,
+    /// Alpaca ended it without a complete fill.
+    Abandoned,
 }
 
 /// How the broker settled an order.
@@ -420,24 +582,32 @@ pub struct OrderSubmitted {
 /// the two. Slippage is absent: it is this row joined to the pass that produced the order.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct OrderResolved {
-    pub client_order_id: String,
+    pub client_order_id: Uuid,
     /// Absent when the order never reached the broker.
     pub alpaca_order_id: Option<String>,
-    pub ticker: String,
-    /// `filled`, `submit_failed`, `broker_unreachable`, or the broker's terminal status.
-    pub outcome: String,
-    pub filled_shares: Option<f64>,
-    pub filled_average_price: Option<f64>,
+    pub ticker: Ticker,
+    pub outcome: OrderOutcome,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub filled_quantity: Option<Decimal>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub filled_average_price: Option<Decimal>,
     /// True when the fill was read after a cancel raced it.
     pub filled_after_cancel: bool,
     /// Alpaca's own status when this resolution was written, absent when nothing reached it.
-    ///
-    /// `outcome` is this application's word and `timed_out` is the case it cannot explain alone:
-    /// an order Alpaca still held at `pending_new` never reached the market, while one at
-    /// `accepted` reached it and found no contra side.
     pub broker_status: Option<String>,
-    /// The broker's error, when the order failed rather than settled.
     pub error: Option<String>,
+}
+
+/// Why a position was asked to close.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CloseRequestReason {
+    /// One leg of a pair the exit half decided to close.
+    PairExit,
+    /// A leg whose partner never filled, being unwound.
+    EntryUnwind,
+    /// The pre-close flattening, which does not consult the pair book.
+    Liquidation,
 }
 
 /// One position the application asked Alpaca to close.
@@ -446,16 +616,16 @@ pub struct OrderResolved {
 /// `alpaca_order_id` is the join to the fill once the post-close activity sync lands it.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PositionCloseRequested {
-    pub ticker: String,
+    pub ticker: Ticker,
     /// The pair this leg belonged to, absent when the account is flattened without consulting them.
-    pub pair_id: Option<String>,
+    pub pair_id: Option<PairID>,
     /// Absent when there was no position, or when Alpaca accepted the close and returned a body
     /// this client could not read.
     pub alpaca_order_id: Option<String>,
-    pub side: Option<String>,
-    pub quantity: Option<f64>,
-    /// `pair_exit`, `entry_unwind`, or `liquidation`.
-    pub reason: String,
+    pub side: Option<OrderSide>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub quantity: Option<Decimal>,
+    pub reason: CloseRequestReason,
     /// False when Alpaca refused the close, or when there was no position to close.
     pub accepted: bool,
     /// Alpaca's per-symbol status, on the bulk path that reports one.
@@ -474,17 +644,17 @@ pub struct PositionCloseRequested {
 pub struct LiquidationAttempted {
     pub pairs_closed: usize,
     pub positions_refused: usize,
-    pub pairs_still_open: Vec<String>,
+    pub pairs_still_open: Vec<PairID>,
     /// The error that ended the run early, if one did. Its absence is the claim that the run
     /// finished, not that the book is flat — `pairs_still_open` answers that.
-    pub failure: Option<String>,
+    pub error: Option<String>,
 }
 
 /// The pre-open inference run and everything it produced.
 ///
 /// The quantiles are here rather than left to `equity_predictions` and the nightly export, because
-/// those are the model's actual output and the log is meant to hold the originals. They arrive at
-/// one moment from one place, so unlike the pass readings there is nothing to gain by splitting
+/// those are the model's actual output and the journal is meant to hold the originals. They arrive
+/// at one moment from one place, so unlike the pass readings there is nothing to gain by splitting
 /// them out.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PredictionsGenerated {
@@ -501,7 +671,7 @@ pub struct PredictionsGenerated {
 /// One ticker's prediction, as the model produced it.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PredictionReading {
-    pub ticker: String,
+    pub ticker: Ticker,
     pub timestamp: DateTime<Utc>,
     pub quantile_10: f64,
     pub quantile_50: f64,
@@ -518,39 +688,152 @@ pub struct PredictionReading {
 pub struct ActivityObserved {
     /// Alpaca's activity identifier, which is what makes the sync idempotent.
     pub activity_id: String,
-    /// `FILL`, `CSD`, `CSW`, or `JNLC`.
-    pub activity_type: String,
+    pub activity_type: ActivityType,
     pub transaction_time: DateTime<Utc>,
-    pub ticker: Option<String>,
-    pub side: Option<String>,
-    pub quantity: Option<f64>,
-    pub price: Option<f64>,
+    pub ticker: Option<Ticker>,
+    pub side: Option<OrderSide>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub quantity: Option<Decimal>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub price: Option<Decimal>,
     /// Set on transfers, which carry this instead of a quantity and price.
-    pub net_amount: Option<f64>,
+    #[serde(with = "crate::common::types::decimal_number_option")]
+    pub net_amount: Option<Decimal>,
     /// Joins a fill back to the order that produced it.
-    pub order_id: Option<String>,
+    pub alpaca_order_id: Option<String>,
 }
 
 /// The post-close account state.
 ///
 /// Recorded in full because Alpaca backfills only equity for a past date, never the rest.
+///
+/// `Decimal` rather than `f64`, so nothing between Alpaca's response and this record rounds. It is
+/// written to the archive as a JSON number, which is a double a reader has to be careful
+/// aggregating — but the field can no longer be absent, which the `Option<f64>` this replaced
+/// could be for a value that never actually failed to convert.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct AccountObserved {
     /// The session these balances describe, which is not always the one the record was written in:
     /// a post-close sync re-run after Eastern midnight observes yesterday from today.
     pub session_date: SessionDate,
-    /// `None` when the broker's decimal will not fit an `f64`. A fabricated zero would be a false
-    /// observation, which is the one thing this log must not contain.
-    pub equity: Option<f64>,
-    pub cash: Option<f64>,
-    pub buying_power: Option<f64>,
-    pub long_market_value: Option<f64>,
-    pub short_market_value: Option<f64>,
+    #[serde(with = "crate::common::types::decimal_number")]
+    pub equity: Decimal,
+    #[serde(with = "crate::common::types::decimal_number")]
+    pub cash: Decimal,
+    #[serde(with = "crate::common::types::decimal_number")]
+    pub buying_power: Decimal,
+    #[serde(with = "crate::common::types::decimal_number")]
+    pub long_market_value: Decimal,
+    #[serde(with = "crate::common::types::decimal_number")]
+    pub short_market_value: Decimal,
 }
 
-/// One line of the log: an observation with the envelope that makes it addressable.
+/// The position book as Alpaca reported it.
 ///
-/// `session_date` is derived from `created_at`, so a record cannot be filed under a session it did
+/// The companion to [`AccountObserved`], and recorded for the same reason: Alpaca answers what is
+/// held now and never what was held on a past date, so a session whose book went unrecorded cannot
+/// have it reconstructed from anything but these rows.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct PositionsObserved {
+    pub readings: Vec<PositionReading>,
+    /// Rows Alpaca reported that could not be read, so an empty book and an unreadable one are
+    /// distinguishable.
+    pub unreadable: usize,
+}
+
+/// One held position, as Alpaca reported it.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PositionReading {
+    pub ticker: Ticker,
+    pub side: PositionSide,
+    /// Always positive; the direction is `side`.
+    #[serde(with = "crate::common::types::decimal_number")]
+    pub quantity: Decimal,
+    #[serde(with = "crate::common::types::decimal_number")]
+    pub market_value: Decimal,
+    #[serde(with = "crate::common::types::decimal_number")]
+    pub unrealized_profit_and_loss: Decimal,
+}
+
+/// One session's bar sync, from the whole-market feed to the archive.
+///
+/// The bar path is the most consequential thing the application does that the broker cannot be
+/// re-asked about: Massive serves a date once and the archive partition is frozen afterwards.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct BarsIngested {
+    /// The session the sync ran for, which is not the only session it covers: the window reaches
+    /// back far enough to close a gap left by a missed run.
+    pub session_date: SessionDate,
+    pub sessions_requested: usize,
+    /// Sessions the provider did not answer for, which are the gaps a later run has to close.
+    pub sessions_failed: Vec<SessionDate>,
+    /// Rows that became a validated bar. A row the provider sent and this build could not read is
+    /// dropped inside the parse, so this is the count that reached the database.
+    pub bars_parsed: usize,
+    pub rows_written: u64,
+    pub error: Option<String>,
+}
+
+/// One universe refresh: what became eligible to trade, and what fell out.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct UniverseRefreshed {
+    /// Symbols Alpaca reports as tradable, before the liquidity screen.
+    pub alpaca_tradable: usize,
+    pub alpaca_shortable: usize,
+    /// Symbols clearing the liquidity thresholds.
+    pub liquid: usize,
+    pub universe_size: usize,
+    /// Tickers this refresh admitted that the previous universe did not hold.
+    pub admitted: Vec<Ticker>,
+    /// Tickers the previous universe held that this refresh did not admit.
+    pub removed: Vec<Ticker>,
+    pub error: Option<String>,
+}
+
+/// The exchange calendar as Alpaca published it.
+///
+/// Every command consults this before doing anything, and the early closes are the part no local
+/// table can hold: a half-day's real 13:00 close is knowable only from this fetch, and the entry
+/// gate sizes its remaining-minutes check against it.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CalendarObserved {
+    pub horizon_start: SessionDate,
+    pub horizon_end: SessionDate,
+    pub sessions: usize,
+    pub trades_today: bool,
+    /// Sessions in the horizon closing before 16:00 Eastern, with the close Alpaca published.
+    pub early_closes: Vec<EarlyClose>,
+}
+
+/// One published session that ends before the usual bell.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct EarlyClose {
+    pub session_date: SessionDate,
+    /// The Eastern wall-clock close, as Alpaca publishes it.
+    pub session_close: String,
+}
+
+/// One run of the seal-ship-delete cycle over the journal itself.
+///
+/// Written after the seal releases, so it lands in the session the export ran in rather than one
+/// it just shipped — this record reaches S3 on the next run, which is the price of the journal
+/// being able to describe its own export at all.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct JournalExported {
+    pub sessions_exported: usize,
+    pub records_exported: usize,
+    /// Sessions whose upload failed, which stay on local disk for the next run.
+    pub sessions_failed: Vec<SessionDate>,
+    /// Sessions deleted from local disk, which had uploaded cleanly and aged out.
+    pub sessions_deleted: Vec<SessionDate>,
+    /// Lines the Parquet does not hold. A session with any is never deleted, so its original
+    /// remains the only copy of them.
+    pub unparsable_lines: usize,
+}
+
+/// One line of the journal: an observation with the envelope that makes it addressable.
+///
+/// `session_date` is derived from `timestamp`, so a record cannot be filed under a session it did
 /// not happen in.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Record {
@@ -559,28 +842,24 @@ pub struct Record {
     /// Threads a pass to the orders it caused to the fills they produced.
     pub correlation_id: Uuid,
     pub session_date: SessionDate,
-    pub created_at: DateTime<Utc>,
+    pub timestamp: DateTime<Utc>,
     #[serde(flatten)]
     pub observation: Observation,
 }
 
 impl Record {
-    /// Stamps an observation with a fresh identity at `created_at`.
-    pub fn new(correlation_id: Uuid, created_at: DateTime<Utc>, observation: Observation) -> Self {
+    /// Stamps an observation with a fresh identity at `timestamp`.
+    pub fn new(correlation_id: Uuid, timestamp: DateTime<Utc>, observation: Observation) -> Self {
         Self {
             schema_version: SCHEMA_VERSION,
             event_id: Uuid::new_v4(),
             correlation_id,
-            session_date: SessionDate::at(created_at),
-            created_at,
+            session_date: SessionDate::at(timestamp),
+            timestamp,
             observation,
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Writer
-// ---------------------------------------------------------------------------
 
 /// The file the writer currently holds open, and the session it belongs to.
 struct OpenSession {
@@ -592,16 +871,16 @@ struct OpenSession {
 ///
 /// The file rolls when the Eastern date does, so the session comes from the record rather than from
 /// construction.
-pub struct SessionLog {
+pub struct Journal {
     directory: PathBuf,
     open_session: tokio::sync::Mutex<Option<OpenSession>>,
 }
 
-impl SessionLog {
-    /// Opens a log against `directory`, creating it if needed.
-    pub fn new(directory: impl Into<PathBuf>) -> Result<Self, SessionLogError> {
+impl Journal {
+    /// Opens a journal against `directory`, creating it if needed.
+    pub fn new(directory: impl Into<PathBuf>) -> Result<Self, JournalError> {
         let directory = directory.into();
-        std::fs::create_dir_all(&directory).map_err(|source| SessionLogError::Directory {
+        std::fs::create_dir_all(&directory).map_err(|source| JournalError::Directory {
             directory: directory.display().to_string(),
             source,
         })?;
@@ -611,17 +890,10 @@ impl SessionLog {
         })
     }
 
-    /// Opens a log at `FUND_SESSION_LOG_DIR`, or `sessions/` under the configured log directory.
-    ///
-    /// Defaulting inside `FUND_LOG_DIR` inherits that path's existing writability fallback.
-    pub fn from_env() -> Result<Self, SessionLogError> {
-        let directory = match std::env::var("FUND_SESSION_LOG_DIR") {
-            Ok(directory) => PathBuf::from(directory),
-            Err(_) => Path::new(
-                &std::env::var("FUND_LOG_DIR").unwrap_or_else(|_| "/var/log/fund".to_string()),
-            )
-            .join("sessions"),
-        };
+    /// Opens a journal at `FUND_JOURNAL_DIRECTORY`, or `/var/journal/fund`.
+    pub fn from_env() -> Result<Self, JournalError> {
+        let directory = std::env::var("FUND_JOURNAL_DIRECTORY")
+            .unwrap_or_else(|_| DEFAULT_JOURNAL_DIRECTORY.to_string());
         Self::new(directory)
     }
 
@@ -633,7 +905,7 @@ impl SessionLog {
     ///
     /// A caller that awaits this before acting knows the observation survives the crash the action
     /// might cause.
-    pub async fn append(&self, record: &Record) -> Result<(), SessionLogError> {
+    pub async fn append(&self, record: &Record) -> Result<(), JournalError> {
         let mut line = serde_json::to_vec(record)?;
         line.push(b'\n');
 
@@ -661,37 +933,35 @@ impl SessionLog {
 
     /// Appends a record, reporting a failure without propagating it.
     ///
-    /// A log write must not become a new way for the fund to stop trading, so acting unobserved
+    /// A journal write must not become a new way for the fund to stop trading, so acting unobserved
     /// beats refusing to act.
     pub async fn record(
         &self,
         correlation_id: Uuid,
-        created_at: DateTime<Utc>,
+        timestamp: DateTime<Utc>,
         observation: Observation,
     ) {
-        let record = Record::new(correlation_id, created_at, observation);
+        let record = Record::new(correlation_id, timestamp, observation);
         let event_type = record.observation.event_type();
         match self.append(&record).await {
-            Ok(()) => debug!(event_type, %correlation_id, "Session log record written"),
+            Ok(()) => debug!(event_type, %correlation_id, "Journal record written"),
             Err(error) => error!(
                 event_type,
                 %correlation_id,
                 %error,
-                "Session log record could not be written; the action proceeds unobserved"
+                "Journal record could not be written; the action proceeds unobserved"
             ),
         }
     }
-}
 
-impl SessionLog {
     /// Blocks appends for as long as the returned guard is held.
     ///
     /// The export takes this before reading, so no reader sees a half-written line. The open handle
     /// is dropped, so the next append reopens the file.
-    pub async fn seal(&self) -> SessionLogGuard<'_> {
+    pub async fn seal(&self) -> JournalGuard<'_> {
         let mut open_session = self.open_session.lock().await;
         *open_session = None;
-        SessionLogGuard {
+        JournalGuard {
             _appends_blocked: open_session,
         }
     }
@@ -700,9 +970,16 @@ impl SessionLog {
 /// Proof that no append can run while it is alive.
 ///
 /// Opaque on purpose: holding it is the whole contract, and there is nothing inside worth reading.
-pub struct SessionLogGuard<'a> {
+pub struct JournalGuard<'a> {
     _appends_blocked: tokio::sync::MutexGuard<'a, Option<OpenSession>>,
 }
+
+/// Where the journal lives when nothing overrides it.
+///
+/// Its own tree rather than a subdirectory of the log directory: this is data, and the retention,
+/// permissions, and backup a log directory gets are the wrong ones for the only original the
+/// application owns.
+pub const DEFAULT_JOURNAL_DIRECTORY: &str = "/var/journal/fund";
 
 /// The file one session's records live in.
 pub(crate) fn file_name(session_date: SessionDate) -> String {
@@ -738,14 +1015,22 @@ mod tests {
             .with_timezone(&Utc)
     }
 
+    fn ticker(raw: &str) -> Ticker {
+        Ticker::new(raw).expect("valid ticker")
+    }
+
+    fn decimal(raw: &str) -> Decimal {
+        raw.parse().expect("valid decimal")
+    }
+
     fn account_observation() -> Observation {
         Observation::AccountObserved(AccountObserved {
             session_date: session(2026, 8, 11),
-            equity: Some(104_812.55),
-            cash: Some(12_000.0),
-            buying_power: Some(200_000.0),
-            long_market_value: Some(50_000.0),
-            short_market_value: Some(-50_000.0),
+            equity: decimal("104812.55"),
+            cash: decimal("12000.07"),
+            buying_power: decimal("200000.00"),
+            long_market_value: decimal("50000.00"),
+            short_market_value: decimal("-50000.01"),
         })
     }
 
@@ -774,6 +1059,11 @@ mod tests {
                 Observation::PredictionsGenerated(_) => "predictions_generated",
                 Observation::ActivityObserved(_) => "activity_observed",
                 Observation::AccountObserved(_) => "account_observed",
+                Observation::PositionsObserved(_) => "positions_observed",
+                Observation::BarsIngested(_) => "bars_ingested",
+                Observation::UniverseRefreshed(_) => "universe_refreshed",
+                Observation::CalendarObserved(_) => "calendar_observed",
+                Observation::JournalExported(_) => "journal_exported",
             }
         }
 
@@ -800,33 +1090,37 @@ mod tests {
         vec![
             Observation::CommandFinished(CommandFinished {
                 command: "portfolio_evaluation".to_string(),
-                outcome: "completed".to_string(),
+                outcome: CommandOutcome::Completed,
                 duration_milliseconds: Some(12),
                 error: None,
                 summary: None,
             }),
             Observation::PassEvaluated(Box::default()),
-            Observation::PricesObserved(PricesObserved::default()),
+            Observation::PricesObserved(PricesObserved {
+                purpose: PricePurpose::OpenPairs,
+                readings: Vec::new(),
+                unavailable: Vec::new(),
+            }),
             Observation::UniverseScreened(UniverseScreened::default()),
             Observation::OpenPairsObserved(OpenPairsObserved::default()),
             Observation::PlanDecided(PlanDecided {
                 phase: PlanPhase::Entries,
                 actions: vec![PlannedAction {
-                    pair_id: "AAAA-BBBB".to_string(),
+                    pair_id: PairID::new(ticker("AAAA"), ticker("BBBB")),
                     action: PlannedActionKind::Open,
-                    reason: "rank 1".to_string(),
-                    long_ticker: "AAAA".to_string(),
-                    short_ticker: "BBBB".to_string(),
-                    long_notional: Some(1_000.0),
-                    short_shares: Some(12.0),
+                    reason: PlannedReason::Rank(1),
+                    long_ticker: ticker("AAAA"),
+                    short_ticker: ticker("BBBB"),
+                    long_notional: Some(decimal("1000.00")),
+                    short_quantity: Some(decimal("12")),
                 }],
                 considered: 4,
             }),
             Observation::PairOpened(PairOpened {
-                pair_uuid: Uuid::nil().to_string(),
-                pair_id: "AAAA-BBBB".to_string(),
-                long_ticker: "AAAA".to_string(),
-                short_ticker: "BBBB".to_string(),
+                equity_pair_id: Uuid::nil(),
+                pair_id: PairID::new(ticker("AAAA"), ticker("BBBB")),
+                long_ticker: ticker("AAAA"),
+                short_ticker: ticker("BBBB"),
                 hedge_ratio: 1.0,
                 entry_z_score: 2.5,
                 signal_strength: 0.03,
@@ -834,45 +1128,45 @@ mod tests {
                 opened_at: instant("2026-08-11T14:35:00Z"),
                 long_decision_price: 100.0,
                 short_decision_price: 50.0,
-                long_fill_price: 100.05,
-                short_fill_price: 49.95,
+                long_fill_price: decimal("100.05"),
+                short_fill_price: decimal("49.95"),
             }),
             Observation::PairClosed(PairClosed {
-                pair_uuid: Uuid::nil().to_string(),
-                reason: "convergence".to_string(),
+                equity_pair_id: Uuid::nil(),
+                reason: CloseReason::Convergence,
                 closed_at: instant("2026-08-11T18:00:00Z"),
                 updated: true,
             }),
             Observation::PairAttributed(PairAttributed {
-                pair_uuid: Uuid::nil().to_string(),
-                realized_profit_and_loss: Some(100.0),
+                equity_pair_id: Uuid::nil(),
+                realized_profit_and_loss: Some(decimal("100.00")),
                 updated: true,
             }),
             Observation::OrderSubmitted(OrderSubmitted {
-                client_order_id: "k-long".to_string(),
-                ticker: "AAAA".to_string(),
-                side: "buy".to_string(),
-                shares: None,
-                notional: Some(1_000.0),
+                client_order_id: Uuid::nil(),
+                ticker: ticker("AAAA"),
+                side: OrderSide::Buy,
+                quantity: None,
+                notional: Some(decimal("1000.00")),
             }),
             Observation::OrderResolved(OrderResolved {
-                client_order_id: "k-long".to_string(),
+                client_order_id: Uuid::nil(),
                 alpaca_order_id: Some("o1".to_string()),
-                ticker: "AAAA".to_string(),
-                outcome: "filled".to_string(),
-                filled_shares: Some(10.0),
-                filled_average_price: Some(100.0),
+                ticker: ticker("AAAA"),
+                outcome: OrderOutcome::Filled,
+                filled_quantity: Some(decimal("10")),
+                filled_average_price: Some(decimal("100.00")),
                 filled_after_cancel: false,
                 broker_status: Some("filled".to_string()),
                 error: None,
             }),
             Observation::PositionCloseRequested(PositionCloseRequested {
-                ticker: "AAAA".to_string(),
+                ticker: ticker("AAAA"),
                 pair_id: None,
                 alpaca_order_id: None,
                 side: None,
                 quantity: None,
-                reason: "liquidation".to_string(),
+                reason: CloseRequestReason::Liquidation,
                 accepted: true,
                 status: Some(200),
                 error: None,
@@ -888,16 +1182,37 @@ mod tests {
             })),
             Observation::ActivityObserved(ActivityObserved {
                 activity_id: "a1".to_string(),
-                activity_type: "FILL".to_string(),
+                activity_type: ActivityType::Fill,
                 transaction_time: instant("2026-08-11T18:00:00Z"),
-                ticker: Some("AAAA".to_string()),
-                side: Some("buy".to_string()),
-                quantity: Some(10.0),
-                price: Some(100.0),
+                ticker: Some(ticker("AAAA")),
+                side: Some(OrderSide::Buy),
+                quantity: Some(decimal("10")),
+                price: Some(decimal("100.00")),
                 net_amount: None,
-                order_id: Some("o1".to_string()),
+                alpaca_order_id: Some("o1".to_string()),
             }),
             account_observation(),
+            Observation::PositionsObserved(PositionsObserved::default()),
+            Observation::BarsIngested(BarsIngested {
+                session_date: session(2026, 8, 11),
+                sessions_requested: 3,
+                sessions_failed: Vec::new(),
+                bars_parsed: 9_800,
+                rows_written: 9_800,
+                error: None,
+            }),
+            Observation::UniverseRefreshed(UniverseRefreshed::default()),
+            Observation::CalendarObserved(CalendarObserved {
+                horizon_start: session(2026, 7, 1),
+                horizon_end: session(2026, 9, 30),
+                sessions: 64,
+                trades_today: true,
+                early_closes: vec![EarlyClose {
+                    session_date: session(2026, 7, 3),
+                    session_close: "13:00".to_string(),
+                }],
+            }),
+            Observation::JournalExported(JournalExported::default()),
         ]
     }
 
@@ -910,7 +1225,7 @@ mod tests {
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
         let directory = std::env::temp_dir().join(format!(
-            "fund-session-log-{name}-{}-{unique}",
+            "fund-journal-{name}-{}-{unique}",
             std::process::id()
         ));
         let _ = std::fs::remove_dir_all(&directory);
@@ -964,31 +1279,59 @@ mod tests {
         );
         let value: Value = serde_json::to_value(&record).expect("record must serialize");
 
-        assert_eq!(value["schema_version"], json_number(SCHEMA_VERSION as i64));
+        assert_eq!(value["schema_version"], Value::Number(3.into()));
         assert_eq!(value["event_type"], "account_observed");
         assert_eq!(value["session_date"], "2026-08-11");
-        assert_eq!(value["payload"]["equity"], 104_812.55);
+        assert_eq!(value["timestamp"], "2026-08-11T20:15:00Z");
         assert!(
             value.get("event_id").and_then(Value::as_str).is_some(),
             "every record is addressable by its own identifier"
         );
     }
 
-    fn json_number(value: i64) -> Value {
-        Value::Number(value.into())
+    /// Balances reach the archive as numbers rather than quoted strings, so a reader can aggregate
+    /// them without casting. The value is the one Alpaca sent: nothing between the response and
+    /// this record rounds it.
+    #[test]
+    fn test_account_balances_are_recorded_as_numbers() {
+        let value =
+            serde_json::to_value(account_observation()).expect("an observation must serialize");
+        assert_eq!(value["payload"]["equity"], 104_812.55);
+        assert_eq!(value["payload"]["short_market_value"], -50_000.01);
+        assert!(
+            value["payload"]["cash"].is_number(),
+            "a balance is a number, not a string a query would have to cast"
+        );
     }
 
-    /// No conclusions in the log. Storing a computed value would create a second thing that can
+    /// The field cannot be absent. Its `Option<f64>` predecessor could be, for a conversion that
+    /// never actually fails, which put a null in the archive where a balance belonged.
+    #[test]
+    fn test_a_balance_is_never_absent() {
+        let value =
+            serde_json::to_value(account_observation()).expect("an observation must serialize");
+        for field in [
+            "equity",
+            "cash",
+            "buying_power",
+            "long_market_value",
+            "short_market_value",
+        ] {
+            assert!(!value["payload"][field].is_null(), "field: {field}");
+        }
+    }
+
+    /// No conclusions in the journal. Storing a computed value would create a second thing that can
     /// disagree with the observations it was derived from.
     #[test]
     fn test_a_fill_records_the_observation_and_not_the_slippage() {
         let filled = OrderResolved {
-            client_order_id: "kopep-long".to_string(),
+            client_order_id: Uuid::nil(),
             alpaca_order_id: Some("order-1".to_string()),
-            ticker: "KO".to_string(),
-            outcome: "filled".to_string(),
-            filled_shares: Some(412.0),
-            filled_average_price: Some(62.44),
+            ticker: ticker("KO"),
+            outcome: OrderOutcome::Filled,
+            filled_quantity: Some(decimal("412")),
+            filled_average_price: Some(decimal("62.44")),
             filled_after_cancel: false,
             broker_status: Some("filled".to_string()),
             error: None,
@@ -999,18 +1342,21 @@ mod tests {
         assert!(!object.contains_key("realized_profit_and_loss"));
     }
 
-    /// A refused quote has to survive into the record. A log holding only the books that passed
+    /// A refused quote has to survive into the record. A journal holding only the books that passed
     /// says nothing about where the limits should sit, which is the whole reason they are recorded.
     #[test]
     fn test_a_refused_quote_is_recorded_with_the_book_that_was_refused() {
         let refused = PriceReading {
-            ticker: "AER".to_string(),
+            ticker: ticker("AER"),
             price: 150.60,
-            price_source: "last_trade".to_string(),
+            price_source: PriceSource::LastTrade,
             bid_price: Some(128.0),
             ask_price: Some(150.86),
             quote_timestamp: Some(instant("2026-08-12T14:40:00Z")),
-            quote_rejection: Some("wide_quote".to_string()),
+            quote_rejection: Some(QuoteRejection::Wide {
+                relative_spread: 0.15,
+                limit: 0.02,
+            }),
             trade_timestamp: Some(instant("2026-08-12T13:12:00Z")),
         };
 
@@ -1026,23 +1372,52 @@ mod tests {
         assert_eq!(value["trade_timestamp"], "2026-08-12T13:12:00Z");
     }
 
+    /// A skip keeps its reason in the outcome, so a holiday and a halt stay distinguishable in a
+    /// query that filters on one field.
+    #[test]
+    fn test_a_skipped_command_carries_why_it_skipped() {
+        let value = serde_json::to_value(CommandOutcome::Skipped(SkipReason::NotATradingDay))
+            .expect("an outcome must serialize");
+        assert_eq!(value, "skipped_not_a_trading_day");
+        assert_eq!(
+            serde_json::to_value(CommandOutcome::Completed).expect("an outcome must serialize"),
+            "completed"
+        );
+    }
+
+    /// An entry's rank and an exit's rule are different kinds of answer, and the plan says which.
+    #[test]
+    fn test_a_planned_reason_distinguishes_a_rank_from_a_rule() {
+        assert_eq!(
+            serde_json::to_value(PlannedReason::Rank(3)).expect("a reason must serialize"),
+            "rank_3"
+        );
+        assert_eq!(
+            serde_json::to_value(PlannedReason::Close(CloseReason::StopLoss))
+                .expect("a reason must serialize"),
+            "stop_loss"
+        );
+    }
+
     #[tokio::test]
     async fn test_records_append_to_one_file_per_session() {
         let directory = temporary_directory("append");
-        let log = SessionLog::new(&directory).expect("the directory must be creatable");
+        let journal = Journal::new(&directory).expect("the directory must be creatable");
 
-        log.record(
-            Uuid::new_v4(),
-            instant("2026-08-11T14:35:00Z"),
-            account_observation(),
-        )
-        .await;
-        log.record(
-            Uuid::new_v4(),
-            instant("2026-08-11T18:00:00Z"),
-            account_observation(),
-        )
-        .await;
+        journal
+            .record(
+                Uuid::new_v4(),
+                instant("2026-08-11T14:35:00Z"),
+                account_observation(),
+            )
+            .await;
+        journal
+            .record(
+                Uuid::new_v4(),
+                instant("2026-08-11T18:00:00Z"),
+                account_observation(),
+            )
+            .await;
 
         let contents = std::fs::read_to_string(directory.join("session-2026-08-11.jsonl"))
             .expect("the session file must exist");
@@ -1058,20 +1433,22 @@ mod tests {
     #[tokio::test]
     async fn test_a_new_session_opens_a_new_file() {
         let directory = temporary_directory("rollover");
-        let log = SessionLog::new(&directory).expect("the directory must be creatable");
+        let journal = Journal::new(&directory).expect("the directory must be creatable");
 
-        log.record(
-            Uuid::new_v4(),
-            instant("2026-08-11T20:00:00Z"),
-            account_observation(),
-        )
-        .await;
-        log.record(
-            Uuid::new_v4(),
-            instant("2026-08-12T20:00:00Z"),
-            account_observation(),
-        )
-        .await;
+        journal
+            .record(
+                Uuid::new_v4(),
+                instant("2026-08-11T20:00:00Z"),
+                account_observation(),
+            )
+            .await;
+        journal
+            .record(
+                Uuid::new_v4(),
+                instant("2026-08-12T20:00:00Z"),
+                account_observation(),
+            )
+            .await;
 
         assert!(directory.join("session-2026-08-11.jsonl").is_file());
         assert!(directory.join("session-2026-08-12.jsonl").is_file());
@@ -1107,43 +1484,20 @@ mod tests {
         }
     }
 
-    /// The explicit override wins, and the directory is created rather than assumed.
-    ///
     /// This is what runs at startup: a service that cannot resolve a writable directory here fails
     /// to construct at all, which is the loud failure rather than a session silently unrecorded.
     #[test]
     #[serial_test::serial]
-    fn test_from_env_prefers_the_explicit_directory() {
+    fn test_from_env_uses_the_explicit_directory() {
         let directory = temporary_directory("from-env-explicit");
-        let _restore_session = EnvVarRestoreGuard::save("FUND_SESSION_LOG_DIR");
+        let _restore = EnvVarRestoreGuard::save("FUND_JOURNAL_DIRECTORY");
         // SAFETY: Protected by #[serial_test::serial] — no concurrent env access.
-        unsafe { std::env::set_var("FUND_SESSION_LOG_DIR", &directory) };
+        unsafe { std::env::set_var("FUND_JOURNAL_DIRECTORY", &directory) };
 
-        let log = SessionLog::from_env().expect("the log must resolve");
+        let journal = Journal::from_env().expect("the journal must resolve");
 
-        assert_eq!(log.directory(), directory);
+        assert_eq!(journal.directory(), directory);
         assert!(directory.is_dir());
         let _ = std::fs::remove_dir_all(&directory);
-    }
-
-    /// Falling back inside `FUND_LOG_DIR` is what lets this ship without provisioning: that path is
-    /// already created and already falls back to a writable location on an un-bootstrapped machine.
-    #[test]
-    #[serial_test::serial]
-    fn test_from_env_falls_back_beneath_the_log_directory() {
-        let log_directory = temporary_directory("from-env-fallback");
-        let _restore_session = EnvVarRestoreGuard::save("FUND_SESSION_LOG_DIR");
-        let _restore_log = EnvVarRestoreGuard::save("FUND_LOG_DIR");
-        // SAFETY: Protected by #[serial_test::serial] — no concurrent env access.
-        unsafe {
-            std::env::remove_var("FUND_SESSION_LOG_DIR");
-            std::env::set_var("FUND_LOG_DIR", &log_directory);
-        }
-
-        let log = SessionLog::from_env().expect("the log must resolve");
-
-        assert_eq!(log.directory(), log_directory.join("sessions"));
-        assert!(log.directory().is_dir());
-        let _ = std::fs::remove_dir_all(&log_directory);
     }
 }

--- a/src/common/journal.rs
+++ b/src/common/journal.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
 use rust_decimal::Decimal;
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
@@ -19,7 +19,7 @@ use crate::common::types::{CloseReason, PairID, SessionDate, Ticker};
 ///
 /// Readers map old versions forward rather than rewriting files, so this only ever goes up. What
 /// each version held is documented beside the DuckDB view in `tools/duckdb_initialization.sql`.
-pub const SCHEMA_VERSION: u32 = 3;
+pub const SCHEMA_VERSION: u32 = 4;
 
 /// Anything that stops a record reaching the disk.
 #[derive(Debug, thiserror::Error)]
@@ -705,12 +705,8 @@ pub struct ActivityObserved {
 
 /// The post-close account state.
 ///
-/// Recorded in full because Alpaca backfills only equity for a past date, never the rest.
-///
-/// `Decimal` rather than `f64`, so nothing between Alpaca's response and this record rounds. It is
-/// written to the archive as a JSON number, which is a double a reader has to be careful
-/// aggregating — but the field can no longer be absent, which the `Option<f64>` this replaced
-/// could be for a value that never actually failed to convert.
+/// Recorded in full because Alpaca backfills only equity for a past date, never the rest. The
+/// balances are `Decimal`, so nothing between Alpaca's response and this record rounds.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct AccountObserved {
     /// The session these balances describe, which is not always the one the record was written in:
@@ -810,14 +806,13 @@ pub struct CalendarObserved {
 pub struct EarlyClose {
     pub session_date: SessionDate,
     /// The Eastern wall-clock close, as Alpaca publishes it.
-    pub session_close: String,
+    pub session_close: NaiveTime,
 }
 
 /// One run of the seal-ship-delete cycle over the journal itself.
 ///
 /// Written after the seal releases, so it lands in the session the export ran in rather than one
-/// it just shipped — this record reaches S3 on the next run, which is the price of the journal
-/// being able to describe its own export at all.
+/// it just shipped, and reaches S3 only on the next run.
 #[derive(Debug, Clone, PartialEq, Default, Serialize)]
 pub struct JournalExported {
     pub sessions_exported: usize,
@@ -1209,7 +1204,7 @@ mod tests {
                 trades_today: true,
                 early_closes: vec![EarlyClose {
                     session_date: session(2026, 7, 3),
-                    session_close: "13:00".to_string(),
+                    session_close: NaiveTime::from_hms_opt(13, 0, 0).expect("a valid wall clock"),
                 }],
             }),
             Observation::JournalExported(JournalExported::default()),
@@ -1279,7 +1274,7 @@ mod tests {
         );
         let value: Value = serde_json::to_value(&record).expect("record must serialize");
 
-        assert_eq!(value["schema_version"], Value::Number(3.into()));
+        assert_eq!(value["schema_version"], Value::Number(4.into()));
         assert_eq!(value["event_type"], "account_observed");
         assert_eq!(value["session_date"], "2026-08-11");
         assert_eq!(value["timestamp"], "2026-08-11T20:15:00Z");
@@ -1362,7 +1357,11 @@ mod tests {
 
         let value = serde_json::to_value(&refused).expect("a reading must serialize");
         assert_eq!(value["price_source"], "last_trade");
-        assert_eq!(value["quote_rejection"], "wide_quote");
+        assert_eq!(value["quote_rejection"]["reason"], "wide_quote");
+        // How far outside the limit, not merely that it was outside: a journal that records only
+        // the verdict cannot say where the limit should have been.
+        assert_eq!(value["quote_rejection"]["relative_spread"], 0.15);
+        assert_eq!(value["quote_rejection"]["limit"], 0.02);
         assert_eq!(value["bid_price"], 128.0);
         assert_eq!(value["ask_price"], 150.86);
         assert!(

--- a/src/common/log.rs
+++ b/src/common/log.rs
@@ -5,15 +5,21 @@ use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
+/// Where service logs are written when nothing overrides it.
+///
+/// Distinct from [`crate::common::journal::DEFAULT_JOURNAL_DIRECTORY`]: these are diagnostics and
+/// are filtered by `RUST_LOG`, so a line that never reaches this tree is a line nobody asked for.
+/// The journal is the opposite and lives on its own path for that reason.
+pub const DEFAULT_LOG_DIRECTORY: &str = "/var/log/fund";
+
 /// Initialize structured JSON tracing for a service.
 ///
 /// `service` (e.g. `"fund"`, `"tide-model-trainer"`) is included in the initial log line for
 /// correlation.
 ///
-/// Logs to stdout at `RUST_LOG` (default `info`), and to a rolling daily file under `FUND_LOG_DIR`
-/// or `/var/log/fund` when that directory is writable. `file_filter` overrides the file layer's
-/// level; `None` follows stdout. An uncreatable log directory disables file logging rather than
-/// failing.
+/// Logs to stdout at `RUST_LOG` (default `info`), and to a rolling daily file under
+/// `FUND_LOG_DIRECTORY`. `file_filter` overrides the file layer's level; `None` follows stdout. An
+/// uncreatable log directory disables file logging rather than failing.
 ///
 /// `Some` means *this call* installed the file layer, and the `WorkerGuard` MUST then be held for
 /// the process lifetime — dropping it tears down the non-blocking writer and buffered lines are
@@ -32,12 +38,13 @@ pub fn init_tracing(
             .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
     };
 
-    let log_dir = env::var("FUND_LOG_DIR").unwrap_or_else(|_| "/var/log/fund".to_string());
-    let guard = match std::fs::create_dir_all(&log_dir).and_then(|()| {
+    let log_directory =
+        env::var("FUND_LOG_DIRECTORY").unwrap_or_else(|_| DEFAULT_LOG_DIRECTORY.to_string());
+    let guard = match std::fs::create_dir_all(&log_directory).and_then(|()| {
         RollingFileAppender::builder()
             .rotation(Rotation::DAILY)
             .filename_suffix(log_file)
-            .build(&log_dir)
+            .build(&log_directory)
             .map_err(std::io::Error::other)
     }) {
         Ok(file_appender) => {
@@ -92,12 +99,13 @@ pub fn init_tracing(
 pub fn init_tracing_file_only(log_file: &str, service: &str) -> Option<WorkerGuard> {
     let fund_profile = env::var("FUND_PROFILE").unwrap_or_else(|_| "unknown".to_string());
 
-    let log_dir = env::var("FUND_LOG_DIR").unwrap_or_else(|_| "/var/log/fund".to_string());
-    let guard = match std::fs::create_dir_all(&log_dir).and_then(|()| {
+    let log_directory =
+        env::var("FUND_LOG_DIRECTORY").unwrap_or_else(|_| DEFAULT_LOG_DIRECTORY.to_string());
+    let guard = match std::fs::create_dir_all(&log_directory).and_then(|()| {
         RollingFileAppender::builder()
             .rotation(Rotation::DAILY)
             .filename_suffix(log_file)
-            .build(&log_dir)
+            .build(&log_directory)
             .map_err(std::io::Error::other)
     }) {
         Ok(file_appender) => {
@@ -181,22 +189,22 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_fund_log_dir_override_enables_file_logging() {
-        let log_dir = env::temp_dir().join("fund-observability-test");
-        let _ = std::fs::remove_dir_all(&log_dir);
+    fn test_the_log_directory_override_enables_file_logging() {
+        let log_directory = env::temp_dir().join("fund-log-directory-test");
+        let _ = std::fs::remove_dir_all(&log_directory);
         // Restored on unwind as well as on return. The manual restore this replaces was skipped
-        // when the assertion below failed, leaving FUND_LOG_DIR pointing at a directory this test
+        // when the assertion below failed, leaving FUND_LOG_DIRECTORY pointing at a directory this test
         // then deleted -- which every later #[serial] test in the file inherited.
-        let _restore = EnvVarRestoreGuard::save("FUND_LOG_DIR");
+        let _restore = EnvVarRestoreGuard::save("FUND_LOG_DIRECTORY");
         // SAFETY: Protected by #[serial_test::serial] — no concurrent env access.
-        unsafe { env::set_var("FUND_LOG_DIR", &log_dir) };
+        unsafe { env::set_var("FUND_LOG_DIRECTORY", &log_directory) };
 
         let guard = init_tracing("test-observability.log", None, "test");
 
-        assert!(log_dir.is_dir());
+        assert!(log_directory.is_dir());
         let _ = guard;
 
-        let _ = std::fs::remove_dir_all(&log_dir);
+        let _ = std::fs::remove_dir_all(&log_directory);
     }
 
     #[test]

--- a/src/common/log.rs
+++ b/src/common/log.rs
@@ -12,14 +12,11 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 /// The journal is the opposite and lives on its own path for that reason.
 pub const DEFAULT_LOG_DIRECTORY: &str = "/var/log/fund";
 
-/// Initialize structured JSON tracing for a service.
+/// Initialize structured JSON tracing for `service`, to stdout at `RUST_LOG` (default `info`) and
+/// to a rolling daily file under `FUND_LOG_DIRECTORY`.
 ///
-/// `service` (e.g. `"fund"`, `"tide-model-trainer"`) is included in the initial log line for
-/// correlation.
-///
-/// Logs to stdout at `RUST_LOG` (default `info`), and to a rolling daily file under
-/// `FUND_LOG_DIRECTORY`. `file_filter` overrides the file layer's level; `None` follows stdout. An
-/// uncreatable log directory disables file logging rather than failing.
+/// `file_filter` overrides the file layer's level; an uncreatable directory disables file logging
+/// rather than failing.
 ///
 /// `Some` means *this call* installed the file layer, and the `WorkerGuard` MUST then be held for
 /// the process lifetime — dropping it tears down the non-blocking writer and buffered lines are
@@ -192,9 +189,8 @@ mod tests {
     fn test_the_log_directory_override_enables_file_logging() {
         let log_directory = env::temp_dir().join("fund-log-directory-test");
         let _ = std::fs::remove_dir_all(&log_directory);
-        // Restored on unwind as well as on return. The manual restore this replaces was skipped
-        // when the assertion below failed, leaving FUND_LOG_DIRECTORY pointing at a directory this test
-        // then deleted -- which every later #[serial] test in the file inherited.
+        // Restored on unwind as well as on return: the manual restore this replaces was skipped
+        // when the assertion below failed, and every later #[serial] test inherited the bad path.
         let _restore = EnvVarRestoreGuard::save("FUND_LOG_DIRECTORY");
         // SAFETY: Protected by #[serial_test::serial] — no concurrent env access.
         unsafe { env::set_var("FUND_LOG_DIRECTORY", &log_directory) };

--- a/src/common/massive.rs
+++ b/src/common/massive.rs
@@ -1,21 +1,4 @@
 //! Massive market data client: whole-market daily bars, one request per session.
-//!
-//! Deliberately narrow: Massive answers only what every US stock did on a date, and Alpaca answers
-//! everything about our account and the current moment. Three properties of the grouped endpoint
-//! make that split load-bearing rather than aesthetic.
-//!
-//! **It takes no symbol list.** A backfill through Alpaca's bars endpoint can only pass Alpaca's
-//! *current* tradable set, so every symbol delisted since the start date is absent from its own
-//! history and the model trains on a universe that survived by construction.
-//!
-//! **It returns the whole market, which keeps the universe open.** `load_liquidity` reads averages
-//! out of `equity_bars`, so a sync that refreshed only the tickers already in the universe could
-//! never admit a name that became liquid — it would ratchet closed `LIQUIDITY_LOOKBACK_DAYS` after
-//! the last seed and shrink from there.
-//!
-//! **It is the consolidated tape, with no feed tiers.** Alpaca's `iex` feed carries a few percent
-//! of consolidated volume — survivable for quotes, not for bars, since `volume` and `vw` would be
-//! computed over that few percent while the liquidity thresholds assume the real numbers.
 
 use chrono::{DateTime, NaiveDate};
 use serde::Deserialize;
@@ -61,9 +44,6 @@ pub struct MassiveCredentials {
 
 impl MassiveCredentials {
     /// Constructs from explicit values, rejecting empties.
-    ///
-    /// An empty key reaches Massive as a 401, which reads like a permissions problem rather than
-    /// the configuration one it is.
     pub fn new(base_url: String, api_key: String) -> Result<Self, CredentialsError> {
         if base_url.is_empty() {
             return Err(CredentialsError::Empty { field: "base_url" });
@@ -88,11 +68,6 @@ impl MassiveCredentials {
 }
 
 /// Builds the grouped-daily URL for one date.
-///
-/// The configured base may carry a trailing slash — the `development/chris.addy` secret is
-/// `https://api.massive.com/` — and joining it naively yields a `//` that the API answers with a
-/// 404. Normalized here rather than at the call site, because there is only one right answer and a
-/// 404 from a doubled slash reads like a wrong path.
 fn grouped_bars_url(base: &str, date: NaiveDate) -> String {
     format!(
         "{}/v2/aggs/grouped/locale/us/market/stocks/{}",
@@ -227,11 +202,6 @@ fn is_common_stock_symbol(raw: &str) -> bool {
 }
 
 /// Converts an untrusted row into a validated [`EquityBar`], or `None`.
-///
-/// Returns `None` for a non-common-stock symbol, an unparseable ticker, a missing OHLCV field, a
-/// volume that does not fit an `i64`, or prices that do not form a coherent candle. All of those
-/// are conditions to drop the row over rather than fail the date: a grouped response covers the
-/// whole market, so one malformed instrument would otherwise cost every other symbol that session.
 fn parse_bar(row: &GroupedBarRow) -> Option<EquityBar> {
     if !is_common_stock_symbol(&row.ticker) {
         return None;
@@ -647,8 +617,6 @@ mod tests {
             .expect_err("malformed JSON is an error");
         assert!(matches!(error, MassiveError::Parse(_)), "{error:?}");
     }
-
-    // --- splits ---
 
     /// Two rows as the live endpoint returns them: a forward split and a reverse one, with the
     /// execution date already an Eastern calendar date and no adjustment factor to read.

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -1305,7 +1305,7 @@ mod tests {
         SessionDate::from_date(NaiveDate::from_ymd_opt(year, month, day).unwrap())
     }
 
-    #[derive(Serialize)]
+    #[derive(Serialize, Deserialize)]
     struct Amount {
         #[serde(with = "decimal_number")]
         value: Decimal,
@@ -1358,6 +1358,34 @@ mod tests {
                 rendered["value"].is_number() && rendered["maybe"].is_number(),
                 "every amount renders as a number: {rendered}"
             );
+        }
+    }
+
+    /// The `f64` wire form is lossless over the values this system actually holds, which is what
+    /// makes it a fair trade for an unquoted JSON number. The bound is about seventeen significant
+    /// digits; a nine-figure balance and a nine-decimal share count together use ten.
+    #[test]
+    fn test_a_decimal_survives_the_round_trip_to_json_and_back() {
+        for literal in [
+            "123456789.99",   // a balance larger than this fund will hold
+            "0.000000001",    // the finest fractional share Alpaca quotes
+            "-48250.75",      // a short market value, which is signed
+            "0",              //
+            "1234.567890123", // ten significant digits
+        ] {
+            let value: Decimal = literal.parse().expect("the literal must parse");
+            let rendered = serde_json::to_string(&Amount {
+                value,
+                maybe: Some(value),
+            })
+            .expect("an amount must serialize");
+            let restored: Amount =
+                serde_json::from_str(&rendered).expect("an amount must deserialize");
+            assert_eq!(
+                restored.value, value,
+                "round trip of {literal} via {rendered}"
+            );
+            assert_eq!(restored.maybe, Some(value));
         }
     }
 
@@ -1484,6 +1512,36 @@ mod tests {
         for interval in BarInterval::ALL {
             assert_eq!(BarInterval::parse(interval.as_str()), Some(interval));
         }
+    }
+
+    /// These exact strings are the `close_reason` CHECK constraint in `schema.sql:105`, on the same
+    /// terms as [`BarInterval`] below: the column is TEXT, so a drift between the enum and the
+    /// constraint is invisible until every close fails at runtime.
+    #[test]
+    fn test_close_reason_stored_form_matches_the_check_constraint() {
+        assert_eq!(CloseReason::Convergence.as_str(), "convergence");
+        assert_eq!(CloseReason::StopLoss.as_str(), "stop_loss");
+        assert_eq!(CloseReason::EndOfDay.as_str(), "end_of_day");
+        assert_eq!(CloseReason::PositionMissing.as_str(), "position_missing");
+    }
+
+    #[test]
+    fn test_close_reason_round_trips_through_stored_form() {
+        for reason in CloseReason::ALL {
+            assert_eq!(CloseReason::parse(reason.as_str()), Some(reason));
+        }
+        assert!(CloseReason::parse("convergence ").is_none());
+        assert!(CloseReason::parse("Convergence").is_none());
+    }
+
+    /// The ratio of signal exits to end-of-day exits is the interim measure of whether the strategy
+    /// does anything, so which side each reason falls on is worth pinning rather than re-deriving.
+    #[test]
+    fn test_only_a_spread_opinion_counts_as_a_signal_exit() {
+        assert!(CloseReason::Convergence.is_signal());
+        assert!(CloseReason::StopLoss.is_signal());
+        assert!(!CloseReason::EndOfDay.is_signal());
+        assert!(!CloseReason::PositionMissing.is_signal());
     }
 
     /// These exact strings are the `bar_interval` CHECK constraint in `schema.sql`. Changing one

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -26,9 +26,54 @@ use uuid::Uuid;
 pub const MINIMUM_CLOSE_PRICE: f64 = 10.0;
 pub const MINIMUM_VOLUME: f64 = 1_000_000.0;
 
-// ---------------------------------------------------------------------------
-// Validated primitives
-// ---------------------------------------------------------------------------
+/// Serializes a [`Decimal`] as a JSON number rather than a quoted string.
+///
+/// `Decimal`'s own `Serialize` writes a string, which a reader has to cast before it can do
+/// arithmetic and which shows its quotes to anyone reading a rendered payload. Used through
+/// `#[serde(with = "...")]` on every field that reaches JSON.
+///
+/// Routes through [`Decimal::as_f64`], which returns an `f64` rather than an `Option`, so there is
+/// no failure to handle. `rust_decimal::serde::float` does the same conversion through `to_f64`
+/// and unwraps it — infallible in that crate today, since `to_f64` is `Some(self.as_f64())`, but
+/// an unwrap in the journal write path is not a thing to inherit from a dependency's internals.
+pub mod decimal_number {
+    use super::Decimal;
+    use serde::{de, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &Decimal, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_f64(value.as_f64())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Decimal, D::Error> {
+        let raw = f64::deserialize(deserializer)?;
+        Decimal::try_from(raw).map_err(de::Error::custom)
+    }
+}
+
+/// [`decimal_number`] for an optional amount, which stays `null` when absent.
+pub mod decimal_number_option {
+    use super::Decimal;
+    use serde::{de, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(
+        value: &Option<Decimal>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(amount) => serializer.serialize_f64(amount.as_f64()),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<Decimal>, D::Error> {
+        match Option::<f64>::deserialize(deserializer)? {
+            Some(raw) => Decimal::try_from(raw).map(Some).map_err(de::Error::custom),
+            None => Ok(None),
+        }
+    }
+}
 
 /// Error returned when constructing a validated primitive with an out-of-range value.
 #[derive(Debug, Clone, PartialEq)]
@@ -78,7 +123,7 @@ impl std::error::Error for NegativeAmountError {}
 
 /// Whole share count (always positive).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
-pub struct Shares(Decimal);
+pub struct Shares(#[serde(with = "decimal_number")] Decimal);
 
 impl Shares {
     /// Creates a new `Shares`, returning an error if `quantity` is not positive.
@@ -107,7 +152,7 @@ impl<'de> Deserialize<'de> for Shares {
 /// Every current use is a magnitude — fill notionals and limit prices — so the constructor rejects
 /// negative values.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize)]
-pub struct Dollars(Decimal);
+pub struct Dollars(#[serde(with = "decimal_number")] Decimal);
 
 impl Dollars {
     /// Creates a new `Dollars`, returning an error if `amount` is negative.
@@ -186,10 +231,6 @@ impl<'de> Deserialize<'de> for Notional {
         Ok(Notional::new(amount))
     }
 }
-
-// ---------------------------------------------------------------------------
-// SessionDate
-// ---------------------------------------------------------------------------
 
 /// A trading day, identified by its `America/New_York` calendar date.
 ///
@@ -294,10 +335,6 @@ impl std::fmt::Display for SessionDate {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Ticker
-// ---------------------------------------------------------------------------
-
 /// A normalized US equity ticker symbol.
 ///
 /// Enforces the Alpaca US equity ticker format: 1–5 uppercase ASCII letters, with an optional
@@ -397,10 +434,6 @@ fn is_valid_suffix(segment: &str) -> bool {
     !segment.is_empty() && segment.len() <= 3 && segment.chars().all(|c| c.is_ascii_uppercase())
 }
 
-// ---------------------------------------------------------------------------
-// PairID
-// ---------------------------------------------------------------------------
-
 /// A canonical long-short equity pair identifier.
 ///
 /// Combines two validated [`Ticker`] values into a `"LONG-SHORT"` formatted string, stored at
@@ -492,16 +525,11 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for PairID {
     }
 }
 
-// ---------------------------------------------------------------------------
-// BarInterval
-// ---------------------------------------------------------------------------
-
 /// The sampling interval of an OHLCV bar.
 ///
-/// Part of the `equity_bars` primary key. The post-close sync writes only
-/// [`BarInterval::OneDay`]; [`BarInterval::OneMinute`] is equally permitted by the CHECK constraint
-/// and is what `fetch_snapshots` tags Alpaca's `minuteBar` with in memory, so "daily only" is a
-/// property of the current writer rather than of the table.
+/// Part of the `equity_bars` primary key. Nothing writes [`BarInterval::OneMinute`] today; the
+/// CHECK constraint permits it, so "daily only" is a property of the current writers rather than of
+/// the table.
 ///
 /// [`BarInterval::as_str`] must match the `bar_interval` CHECK constraint exactly. It is the
 /// snake_case of the variant name, which lets `rename_all` derive the same string for serde so what
@@ -579,9 +607,71 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for BarInterval {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Records
-// ---------------------------------------------------------------------------
+/// Why an open pair was closed.
+///
+/// These four are the `close_reason` CHECK constraint in `schema.sql`, spelled as an enum so a
+/// reason the database would reject cannot be constructed in the first place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseReason {
+    /// The spread returned through its mean. The trade worked.
+    Convergence,
+    /// The spread widened past the stop, against the position. The trade did not.
+    StopLoss,
+    /// The pre-close fail-safe flattened the book. No opinion either way.
+    EndOfDay,
+    /// Alpaca no longer reports a position for one or both legs, so there is nothing left to hold.
+    PositionMissing,
+}
+
+impl CloseReason {
+    pub const ALL: [CloseReason; 4] = [
+        CloseReason::Convergence,
+        CloseReason::StopLoss,
+        CloseReason::EndOfDay,
+        CloseReason::PositionMissing,
+    ];
+
+    /// The stored form, which must match the CHECK constraint exactly.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CloseReason::Convergence => "convergence",
+            CloseReason::StopLoss => "stop_loss",
+            CloseReason::EndOfDay => "end_of_day",
+            CloseReason::PositionMissing => "position_missing",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        CloseReason::ALL
+            .into_iter()
+            .find(|reason| reason.as_str() == raw)
+    }
+
+    /// Whether this exit reflects the strategy's own opinion about the spread.
+    ///
+    /// A book that only ever exits at [`CloseReason::EndOfDay`] is one whose holding period is
+    /// shorter than the horizon it forecasts. The ratio of these two answers is the interim measure
+    /// of whether the strategy is doing anything, so the distinction is worth naming rather than
+    /// recomputing from a string at each call site.
+    pub fn is_signal(self) -> bool {
+        match self {
+            CloseReason::Convergence | CloseReason::StopLoss => true,
+            CloseReason::EndOfDay | CloseReason::PositionMissing => false,
+        }
+    }
+}
+
+impl std::fmt::Display for CloseReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl Serialize for CloseReason {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
 
 /// Error returned when a market data record's fields are not internally consistent.
 ///
@@ -1213,6 +1303,62 @@ mod tests {
 
     fn session(year: i32, month: u32, day: u32) -> SessionDate {
         SessionDate::from_date(NaiveDate::from_ymd_opt(year, month, day).unwrap())
+    }
+
+    #[derive(Serialize)]
+    struct Amount {
+        #[serde(with = "decimal_number")]
+        value: Decimal,
+        #[serde(with = "decimal_number_option")]
+        maybe: Option<Decimal>,
+    }
+
+    /// Amounts reach JSON as numbers. A quoted decimal has to be cast before a reader can do
+    /// arithmetic on it, and it shows its quotes on the dashboard's rendered payloads.
+    #[test]
+    fn test_an_amount_serializes_as_a_number() {
+        let rendered = serde_json::to_string(&Amount {
+            value: "104812.55".parse().expect("valid decimal"),
+            maybe: Some("-50000.01".parse().expect("valid decimal")),
+        })
+        .expect("an amount must serialize");
+        assert_eq!(rendered, r#"{"value":104812.55,"maybe":-50000.01}"#);
+    }
+
+    #[test]
+    fn test_an_absent_amount_stays_null() {
+        let rendered = serde_json::to_string(&Amount {
+            value: Decimal::ZERO,
+            maybe: None,
+        })
+        .expect("an amount must serialize");
+        assert_eq!(rendered, r#"{"value":0.0,"maybe":null}"#);
+    }
+
+    /// The conversion has no failure case to handle, so no journal write can panic on it. Checked
+    /// at the extremes of the type rather than on ordinary balances, which is where a fallible
+    /// conversion would give way.
+    #[test]
+    fn test_no_decimal_fails_to_render_as_a_number() {
+        for value in [
+            Decimal::MAX,
+            Decimal::MIN,
+            Decimal::ZERO,
+            Decimal::new(i64::MAX, 28),
+            "0.0000000000000000000000000001"
+                .parse()
+                .expect("valid decimal"),
+        ] {
+            let rendered = serde_json::to_value(Amount {
+                value,
+                maybe: Some(value),
+            })
+            .expect("every decimal must serialize");
+            assert!(
+                rendered["value"].is_number() && rendered["maybe"].is_number(),
+                "every amount renders as a number: {rendered}"
+            );
+        }
     }
 
     /// The Eastern date must roll at Eastern midnight. 03:00 UTC is still the previous evening in

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -18,7 +18,7 @@ use sqlx::postgres::PgPoolOptions;
 use tokio::sync::RwLock;
 use tracing::info;
 
-use crate::common::observability::init_tracing_file_only;
+use crate::common::log::init_tracing_file_only;
 
 /// Connections the dashboard pool may open: one for the poller, one for the listener, and headroom
 /// for the overlap while a dropped listener reconnects.

--- a/src/dashboard/cache.rs
+++ b/src/dashboard/cache.rs
@@ -22,7 +22,7 @@ use tracing::{error, info, warn};
 use crate::common::events::Notification;
 use crate::common::types::{PairID, SessionDate, Ticker};
 
-use crate::portfolio::pairs::CloseReason;
+use crate::common::types::CloseReason;
 
 /// How often the background task refreshes every view from PostgreSQL.
 pub const POLL_INTERVAL: Duration = Duration::from_secs(30);

--- a/src/dashboard/database.rs
+++ b/src/dashboard/database.rs
@@ -14,13 +14,19 @@ use rust_decimal::Decimal;
 use sqlx::{PgPool, Row};
 use tracing::warn;
 
-use crate::common::alpaca::TRANSFER_ACTIVITY_TYPES;
-use crate::common::types::{PairID, SessionDate, Ticker};
+use crate::common::alpaca::ActivityType;
+use crate::common::types::{CloseReason, PairID, SessionDate, Ticker};
 use crate::dashboard::cache::{
     AccountSnapshot, ClosedPair, ClosedSummary, EventEntry, OpenPair, PeriodReturns, Prediction,
 };
 
-use crate::portfolio::pairs::CloseReason;
+/// The stored spellings of every transfer type, for an `activity_type = ANY(...)` bind.
+fn transfer_activity_types() -> Vec<String> {
+    ActivityType::TRANSFERS
+        .iter()
+        .map(|activity_type| activity_type.as_str().to_string())
+        .collect()
+}
 
 /// Sessions of account snapshots fetched: the equity curve, and the newest row's balances.
 const ACCOUNT_HISTORY_DAYS: i64 = 365;
@@ -143,7 +149,7 @@ async fn fetch_transfer_sessions(
            AND transaction_time >= $2
            AND transaction_time < $3",
     )
-    .bind(TRANSFER_ACTIVITY_TYPES)
+    .bind(transfer_activity_types())
     .bind(start)
     .bind(end)
     .fetch_all(pool)

--- a/src/dashboard/html.rs
+++ b/src/dashboard/html.rs
@@ -558,12 +558,12 @@ tr:hover { background-color: rgba(255, 180, 0, 0.1); }
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::types::CloseReason;
     use crate::common::types::{PairID, Ticker};
     use crate::dashboard::cache::{
         AccountSnapshot, ClosedPair, EventEntry, OpenPair, PeriodReturns, Prediction,
     };
     use crate::dashboard::database::compute_closed_summary;
-    use crate::portfolio::pairs::CloseReason;
     use chrono::{NaiveDate, TimeZone};
     use serde_json::json;
     use std::str::FromStr;

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,7 +9,7 @@
 //! term record of them; [`export`] owns `exports/`, the application's own tables, which the purge
 //! deletes from PostgreSQL only once they are safely written. Neither writes the other's prefix.
 //!
-//! [`export`] also seals and ships [`crate::common::session_log`], the local original that both
+//! [`export`] also seals and ships [`crate::common::journal`], the local original that both
 //! PostgreSQL and S3 are derived from.
 
 pub mod adjust;

--- a/src/data/boundaries.rs
+++ b/src/data/boundaries.rs
@@ -1,6 +1,7 @@
-//! The dates a symbol's price series may not be read across; nothing reads them yet.
+//! The dates a symbol's price series may not be read across.
 //!
-//! One S3 object, refreshed over a date range and merged with what is stored.
+//! One S3 object, refreshed over a date range and merged with what is stored. Applied at read time
+//! by [`crate::data::truncate`].
 
 use chrono::{DateTime, Utc};
 use polars::prelude::*;

--- a/src/data/calendar.rs
+++ b/src/data/calendar.rs
@@ -18,7 +18,10 @@ use chrono::{DateTime, NaiveTime, Utc};
 use chrono_tz::America::New_York;
 use tracing::{info, warn};
 
+use uuid::Uuid;
+
 use crate::common::alpaca::{CalendarDay, ClientError, TradingClient};
+use crate::common::journal::{CalendarObserved, EarlyClose, Journal, Observation};
 use crate::common::types::SessionDate;
 
 /// How far forward to fetch published sessions.
@@ -107,6 +110,22 @@ impl TradingCalendar {
     }
 
     /// The number of published sessions held.
+    /// Every session in the horizon that closes before the usual 16:00 Eastern bell.
+    ///
+    /// The half-days are the reason the calendar is fetched rather than assumed, so they are named
+    /// rather than left to be recovered by comparing every session against a constant.
+    pub fn early_closes(&self) -> Vec<EarlyClose> {
+        let usual_close = NaiveTime::from_hms_opt(16, 0, 0).expect("16:00 is a valid wall clock");
+        self.days
+            .iter()
+            .filter(|(_, day)| day.session_close() < usual_close)
+            .map(|(session_date, day)| EarlyClose {
+                session_date: *session_date,
+                session_close: day.session_close().format("%H:%M").to_string(),
+            })
+            .collect()
+    }
+
     pub fn len(&self) -> usize {
         self.days.len()
     }
@@ -183,6 +202,8 @@ impl CalendarCache {
     pub async fn get(
         &self,
         client: &TradingClient,
+        journal: &Journal,
+        correlation_id: Uuid,
         now: DateTime<Utc>,
     ) -> Result<TradingCalendar, ClientError> {
         let today = SessionDate::at(now);
@@ -210,6 +231,20 @@ impl CalendarCache {
             );
             *self.inner.lock().await = Some((today, calendar.clone()));
         }
+
+        journal
+            .record(
+                correlation_id,
+                now,
+                Observation::CalendarObserved(CalendarObserved {
+                    horizon_start: start,
+                    horizon_end: end,
+                    sessions: calendar.len(),
+                    trades_today: calendar.is_trading_day(today),
+                    early_closes: calendar.early_closes(),
+                }),
+            )
+            .await;
         Ok(calendar)
     }
 
@@ -436,7 +471,16 @@ mod tests {
             "http://127.0.0.1:1".to_string(),
         );
         let served = cache
-            .get(&client, now)
+            .get(
+                &client,
+                &Journal::new(
+                    std::env::temp_dir()
+                        .join(format!("fund-calendar-cache-{}", std::process::id())),
+                )
+                .expect("the journal directory must be creatable"),
+                Uuid::nil(),
+                now,
+            )
             .await
             .expect("cache hit must not fetch");
         assert!(served.is_trading_day(date(2026, 11, 24)));

--- a/src/data/calendar.rs
+++ b/src/data/calendar.rs
@@ -109,7 +109,6 @@ impl TradingCalendar {
         Some((first, last))
     }
 
-    /// The number of published sessions held.
     /// Every session in the horizon that closes before the usual 16:00 Eastern bell.
     ///
     /// The half-days are the reason the calendar is fetched rather than assumed, so they are named
@@ -121,11 +120,12 @@ impl TradingCalendar {
             .filter(|(_, day)| day.session_close() < usual_close)
             .map(|(session_date, day)| EarlyClose {
                 session_date: *session_date,
-                session_close: day.session_close().format("%H:%M").to_string(),
+                session_close: day.session_close(),
             })
             .collect()
     }
 
+    /// The number of published sessions held.
     pub fn len(&self) -> usize {
         self.days.len()
     }

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -19,7 +19,7 @@
 //! completion event can report it. That list is also the purge's gate: [`crate::data::purge`] runs
 //! only when every dataset here wrote cleanly.
 //!
-//! [`export_session_logs`] ships a third shape: whole local JSONL files, one object per session,
+//! [`export_journals`] ships a third shape: whole local JSONL files, one object per session,
 //! independent of the database entirely.
 
 use std::path::Path;
@@ -33,7 +33,7 @@ use sqlx::PgPool;
 use tracing::{info, warn};
 
 use crate::common::aws::date_partitioned_key;
-use crate::common::session_log::{file_name, session_from_file_name, SessionLog};
+use crate::common::journal::{file_name, session_from_file_name, Journal};
 use crate::common::types::SessionDate;
 
 /// What one nightly export accomplished.
@@ -381,21 +381,17 @@ fn to_polars_error(error: sqlx::Error) -> PolarsError {
     PolarsError::ComputeError(error.to_string().into())
 }
 
-// ---------------------------------------------------------------------------
-// Session log
-// ---------------------------------------------------------------------------
-
 /// S3 prefix the sealed sessions are written under.
-pub const SESSION_LOG_PREFIX: &str = "exports/session_log";
+pub const JOURNAL_PREFIX: &str = "exports/journal";
 
 /// Calendar days of sealed sessions kept on local disk after a clean export.
 ///
 /// The window in which a bad Parquet conversion can still be repaired from the original bytes.
-pub const SESSION_LOG_RETENTION_DAYS: i64 = 7;
+pub const JOURNAL_RETENTION_DAYS: i64 = 7;
 
 /// What one export run accomplished.
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct SessionLogExportSummary {
+pub struct JournalExportSummary {
     /// `(session_date, records)` for each session written to S3.
     pub exported: Vec<(NaiveDate, usize)>,
     /// `(session_date, error)` for each session that failed.
@@ -409,7 +405,7 @@ pub struct SessionLogExportSummary {
     pub unparsable_lines: usize,
 }
 
-impl SessionLogExportSummary {
+impl JournalExportSummary {
     pub fn total_records(&self) -> usize {
         self.exported.iter().map(|(_, records)| records).sum()
     }
@@ -424,13 +420,13 @@ impl SessionLogExportSummary {
 /// Every file present is exported, not just the retention window: one whole file at a deterministic
 /// key makes a repeat a byte-identical overwrite, so a failed run repairs itself. Local files are
 /// deleted only after a clean run that skipped nothing.
-pub async fn export_session_logs(
-    log: &SessionLog,
+pub async fn export_journals(
+    log: &Journal,
     s3_client: &S3Client,
     bucket: &str,
     today: SessionDate,
-) -> SessionLogExportSummary {
-    let mut summary = SessionLogExportSummary::default();
+) -> JournalExportSummary {
+    let mut summary = JournalExportSummary::default();
 
     let mut sessions = match sealed_sessions(log.directory(), today) {
         Ok(sessions) => sessions,
@@ -466,7 +462,7 @@ pub async fn export_session_logs(
         match frame {
             Ok((mut frame, unparsable)) => {
                 summary.unparsable_lines += unparsable;
-                let key = date_partitioned_key(SESSION_LOG_PREFIX, session_date.date());
+                let key = date_partitioned_key(JOURNAL_PREFIX, session_date.date());
                 match write_frame(s3_client, bucket, &key, &mut frame).await {
                     Ok(()) => {
                         summary.exported.push((session_date.date(), frame.height()));
@@ -542,7 +538,7 @@ fn delete_aged_out(
     sessions: &[SessionDate],
     today: SessionDate,
 ) -> Vec<NaiveDate> {
-    let oldest_kept = today.plus_calendar_days(-SESSION_LOG_RETENTION_DAYS);
+    let oldest_kept = today.plus_calendar_days(-JOURNAL_RETENTION_DAYS);
     let mut deleted = Vec::new();
     for session_date in sessions.iter().filter(|session| **session < oldest_kept) {
         let path = directory.join(file_name(*session_date));
@@ -570,7 +566,7 @@ fn read_session_frame(path: &Path) -> Result<(DataFrame, usize), String> {
     let mut correlation_ids: Vec<Option<String>> = Vec::new();
     let mut event_types: Vec<Option<String>> = Vec::new();
     let mut session_dates: Vec<Option<String>> = Vec::new();
-    let mut created_ats: Vec<Option<i64>> = Vec::new();
+    let mut timestamps: Vec<Option<i64>> = Vec::new();
     let mut payloads: Vec<Option<String>> = Vec::new();
     let mut unparsable = 0usize;
 
@@ -591,14 +587,14 @@ fn read_session_frame(path: &Path) -> Result<(DataFrame, usize), String> {
             Some(correlation_id),
             Some(event_type),
             Some(session_date),
-            Some(created_at),
+            Some(timestamp),
         ) = (
             record.get("schema_version").and_then(Value::as_i64),
             text("event_id"),
             text("correlation_id"),
             text("event_type"),
             text("session_date"),
-            text("created_at").and_then(|stamp| {
+            text("timestamp").and_then(|stamp| {
                 DateTime::parse_from_rfc3339(&stamp)
                     .ok()
                     .map(|instant| instant.timestamp_millis())
@@ -614,7 +610,7 @@ fn read_session_frame(path: &Path) -> Result<(DataFrame, usize), String> {
         correlation_ids.push(Some(correlation_id));
         event_types.push(Some(event_type));
         session_dates.push(Some(session_date));
-        created_ats.push(Some(created_at));
+        timestamps.push(Some(timestamp));
         payloads.push(record.get("payload").map(Value::to_string));
     }
 
@@ -622,7 +618,7 @@ fn read_session_frame(path: &Path) -> Result<(DataFrame, usize), String> {
         warn!(
             path = %path.display(),
             unparsable,
-            "Skipped session log lines that would not parse"
+            "Skipped journal lines that would not parse"
         );
     }
 
@@ -632,7 +628,7 @@ fn read_session_frame(path: &Path) -> Result<(DataFrame, usize), String> {
         Column::new("correlation_id".into(), correlation_ids),
         Column::new("event_type".into(), event_types),
         Column::new("session_date".into(), session_dates),
-        Column::new("created_at".into(), created_ats),
+        Column::new("timestamp".into(), timestamps),
         Column::new("payload".into(), payloads),
     ])
     .map_err(|error| format!("failed to build frame for {}: {error}", path.display()))?;
@@ -647,7 +643,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::common::session_log::{AccountObserved, Observation, Record};
+    use crate::common::journal::{AccountObserved, Observation, Record};
 
     fn session(year: i32, month: u32, day: u32) -> SessionDate {
         SessionDate::from_date(NaiveDate::from_ymd_opt(year, month, day).expect("valid date"))
@@ -662,11 +658,11 @@ mod tests {
     fn account_observation() -> Observation {
         Observation::AccountObserved(AccountObserved {
             session_date: session(2026, 8, 11),
-            equity: Some(104_812.55),
-            cash: Some(12_000.0),
-            buying_power: Some(200_000.0),
-            long_market_value: Some(50_000.0),
-            short_market_value: Some(-50_000.0),
+            equity: "104812.55".parse().expect("valid decimal"),
+            cash: "12000.07".parse().expect("valid decimal"),
+            buying_power: "200000.00".parse().expect("valid decimal"),
+            long_market_value: "50000.00".parse().expect("valid decimal"),
+            short_market_value: "-50000.01".parse().expect("valid decimal"),
         })
     }
 
@@ -747,8 +743,8 @@ mod tests {
         .expect("the record must serialize");
         let lines = [
             complete.as_str(),
-            r#"{"schema_version":1,"event_type":"account_observed","created_at":"2026-08-11T20:15:00Z"}"#,
-            r#"{"schema_version":1,"event_id":"a","event_type":"account_observed","created_at":"not a time"}"#,
+            r#"{"schema_version":3,"event_type":"account_observed","timestamp":"2026-08-11T20:15:00Z"}"#,
+            r#"{"schema_version":3,"event_id":"a","event_type":"account_observed","timestamp":"not a time"}"#,
         ]
         .join("\n");
         std::fs::write(&path, lines).expect("the file must be writable");
@@ -794,7 +790,7 @@ mod tests {
                 "correlation_id",
                 "event_type",
                 "session_date",
-                "created_at",
+                "timestamp",
                 "payload"
             ]
         );
@@ -841,17 +837,17 @@ mod tests {
         std::fs::create_dir_all(&directory).expect("the directory must be creatable");
         let path = directory.join("session-2026-08-11.jsonl");
         let mut lines = String::new();
-        for equity in [104_812.55_f64, 105_000.0] {
+        for equity in ["104812.55", "105000.00"] {
             let record = Record::new(
                 Uuid::new_v4(),
                 instant("2026-08-11T20:15:00Z"),
                 Observation::AccountObserved(AccountObserved {
                     session_date: session(2026, 8, 11),
-                    equity: Some(equity),
-                    cash: Some(12_000.0),
-                    buying_power: Some(200_000.0),
-                    long_market_value: Some(50_000.0),
-                    short_market_value: Some(-50_000.0),
+                    equity: equity.parse().expect("valid decimal"),
+                    cash: "12000.07".parse().expect("valid decimal"),
+                    buying_power: "200000.00".parse().expect("valid decimal"),
+                    long_market_value: "50000.00".parse().expect("valid decimal"),
+                    short_market_value: "-50000.01".parse().expect("valid decimal"),
                 }),
             );
             lines.push_str(&serde_json::to_string(&record).expect("the record must serialize"));
@@ -873,10 +869,10 @@ mod tests {
         // The instant survives as milliseconds, which is what lets a reader recover 16:15 Eastern.
         assert_eq!(
             restored
-                .column("created_at")
-                .expect("created_at column")
+                .column("timestamp")
+                .expect("timestamp column")
                 .i64()
-                .expect("created_at is an integer")
+                .expect("the timestamp is an integer")
                 .get(0),
             Some(instant("2026-08-11T20:15:00Z").timestamp_millis())
         );
@@ -915,7 +911,7 @@ mod tests {
             "correlation_id",
             "event_type",
             "session_date",
-            "created_at",
+            "timestamp",
         ] {
             let mut record: serde_json::Map<String, Value> =
                 serde_json::from_str(&complete).expect("the record must parse");
@@ -946,8 +942,8 @@ mod tests {
 
         let today = session(2026, 8, 11);
         let aged_out = [
-            today.plus_calendar_days(-SESSION_LOG_RETENTION_DAYS - 2),
-            today.plus_calendar_days(-SESSION_LOG_RETENTION_DAYS - 1),
+            today.plus_calendar_days(-JOURNAL_RETENTION_DAYS - 2),
+            today.plus_calendar_days(-JOURNAL_RETENTION_DAYS - 1),
         ];
         for session_date in aged_out {
             std::fs::write(directory.join(file_name(session_date)), "")
@@ -966,54 +962,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&directory);
     }
 
-    /// A file written across a mid-session deploy holds both shapes. Every v1 record must survive
-    /// the stricter envelope check, or the deploy silently drops the morning from the archive.
-    #[test]
-    fn test_a_file_written_across_a_deploy_keeps_both_schema_versions() {
-        let directory = temporary_directory("mixed-versions");
-        std::fs::create_dir_all(&directory).unwrap();
-        let path = directory.join("session-2026-08-12.jsonl");
-
-        // The five shapes a real v1 session file holds, taken from one on disk rather than guessed.
-        // `predictions_generated` carries `predictions` as a *count* here; in v2 the same field is
-        // an array, which is the one field whose type the version bump changes.
-        let v1 = [
-            r#"{"schema_version":1,"event_id":"11111111-1111-1111-1111-111111111111","correlation_id":"22222222-2222-2222-2222-222222222222","session_date":"2026-08-12","created_at":"2026-08-12T14:35:00Z","event_type":"evaluation_pass","payload":{"universe_size":7000,"prices":[{"ticker":"AAAA","price":100.0,"price_source":"last_trade"}],"open_pairs":[],"screen_inputs":[],"excluded":[],"candidates":[]}}"#,
-            r#"{"schema_version":1,"event_id":"33333333-3333-3333-3333-333333333333","correlation_id":"22222222-2222-2222-2222-222222222222","session_date":"2026-08-12","created_at":"2026-08-12T14:35:01Z","event_type":"order_submitted","payload":{"client_order_id":"k-long","ticker":"AAAA","side":"buy","shares":null,"notional":1000.0}}"#,
-            r#"{"schema_version":1,"event_id":"44444444-4444-4444-4444-444444444444","correlation_id":"22222222-2222-2222-2222-222222222222","session_date":"2026-08-12","created_at":"2026-08-12T14:35:02Z","event_type":"order_resolved","payload":{"client_order_id":"k-long","alpaca_order_id":"o1","ticker":"AAAA","outcome":"filled","filled_shares":10.0,"filled_average_price":100.4,"filled_after_cancel":false,"error":null}}"#,
-            r#"{"schema_version":1,"event_id":"55555555-5555-5555-5555-555555555555","correlation_id":"22222222-2222-2222-2222-222222222222","session_date":"2026-08-12","created_at":"2026-08-12T14:35:03Z","event_type":"position_close_requested","payload":{"ticker":"AAAA","pair_id":"AAAA-BBBB","alpaca_order_id":"o2","side":"long","quantity":10.0,"reason":"pair_exit","accepted":true,"status":null,"error":null}}"#,
-            r#"{"schema_version":1,"event_id":"66666666-6666-6666-6666-666666666666","correlation_id":"77777777-7777-7777-7777-777777777777","session_date":"2026-08-12","created_at":"2026-08-12T13:00:00Z","event_type":"predictions_generated","payload":{"model_run_id":"run-1","artifact_key":"models/tide/run-1","artifact_staleness_sessions":0,"predictions":1043,"rows_written":1043,"universe_size":7000}}"#,
-        ];
-        // A v2 record appended after the restart, into the same file.
-        let v2 = serde_json::to_string(&Record::new(
-            Uuid::nil(),
-            DateTime::parse_from_rfc3339("2026-08-12T18:00:00Z")
-                .unwrap()
-                .with_timezone(&Utc),
-            Observation::PricesObserved(Default::default()),
-        ))
-        .unwrap();
-
-        let mut lines = v1.join("\n");
-        lines.push('\n');
-        lines.push_str(&v2);
-        std::fs::write(&path, lines).unwrap();
-
-        let (frame, unparsable) = read_session_frame(&path).unwrap();
-        assert_eq!(
-            unparsable, 0,
-            "no v1 record may be dropped by the new reader"
-        );
-        assert_eq!(frame.height(), 6, "five v1 records plus one v2");
-        let versions = frame.column("schema_version").unwrap().i64().unwrap();
-        assert_eq!(
-            (versions.get(0), versions.get(5)),
-            (Some(1), Some(2)),
-            "both versions coexist in one file, each row carrying its own"
-        );
-        let _ = std::fs::remove_dir_all(&directory);
-    }
-
     /// Only what has aged out goes, and the window's own edge stays. The local file is the
     /// crash-exact original, so deleting one still inside the window would remove the only thing a
     /// bad Parquet conversion could be repaired from.
@@ -1024,8 +972,8 @@ mod tests {
 
         let today = session(2026, 8, 11);
         let sessions = [
-            today.plus_calendar_days(-SESSION_LOG_RETENTION_DAYS - 1),
-            today.plus_calendar_days(-SESSION_LOG_RETENTION_DAYS),
+            today.plus_calendar_days(-JOURNAL_RETENTION_DAYS - 1),
+            today.plus_calendar_days(-JOURNAL_RETENTION_DAYS),
             today.plus_calendar_days(-1),
             today,
         ];
@@ -1051,14 +999,14 @@ mod tests {
     /// rather than a duplicate — and why there is no cursor to keep in sync.
     #[test]
     fn test_the_export_key_is_determined_by_the_session_alone() {
-        let key = date_partitioned_key(SESSION_LOG_PREFIX, session(2026, 8, 11).date());
+        let key = date_partitioned_key(JOURNAL_PREFIX, session(2026, 8, 11).date());
         assert_eq!(
             key,
-            "exports/session_log/year=2026/month=08/day=11/data.parquet"
+            "exports/journal/year=2026/month=08/day=11/data.parquet"
         );
         assert_eq!(
             key,
-            date_partitioned_key(SESSION_LOG_PREFIX, session(2026, 8, 11).date())
+            date_partitioned_key(JOURNAL_PREFIX, session(2026, 8, 11).date())
         );
     }
 }

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -421,33 +421,33 @@ impl JournalExportSummary {
 /// key makes a repeat a byte-identical overwrite, so a failed run repairs itself. Local files are
 /// deleted only after a clean run that skipped nothing.
 pub async fn export_journals(
-    log: &Journal,
+    journal: &Journal,
     s3_client: &S3Client,
     bucket: &str,
     today: SessionDate,
 ) -> JournalExportSummary {
     let mut summary = JournalExportSummary::default();
 
-    let mut sessions = match sealed_sessions(log.directory(), today) {
+    let mut sessions = match sealed_sessions(journal.directory(), today) {
         Ok(sessions) => sessions,
         Err(error) => {
-            warn!(%error, "Session log directory could not be read; nothing exported");
+            warn!(%error, "Journal directory could not be read; nothing exported");
             return summary;
         }
     };
     sessions.sort();
 
     // The seal covers the reads and nothing else. Holding it across the uploads would leave a
-    // concurrent `record` waiting on S3, and a log write that blocks on the network is the one
+    // concurrent `record` waiting on S3, and a journal write that blocks on the network is the one
     // thing this module promises never to be.
     let frames = {
-        let _sealed = log.seal().await;
+        let _sealed = journal.seal().await;
         sessions
             .iter()
             .map(|session_date| {
                 (
                     *session_date,
-                    read_session_frame(&log.directory().join(file_name(*session_date))),
+                    read_session_frame(&journal.directory().join(file_name(*session_date))),
                 )
             })
             .collect::<Vec<_>>()
@@ -462,6 +462,16 @@ pub async fn export_journals(
         match frame {
             Ok((mut frame, unparsable)) => {
                 summary.unparsable_lines += unparsable;
+                // A file that yielded no rows at all has nothing to ship, and the key is
+                // deterministic: uploading the empty frame would replace a good object from an
+                // earlier run with one holding none of it.
+                if frame.height() == 0 && unparsable > 0 {
+                    summary.failed.push((
+                        session_date.date(),
+                        format!("every one of {unparsable} lines was unparsable"),
+                    ));
+                    continue;
+                }
                 let key = date_partitioned_key(JOURNAL_PREFIX, session_date.date());
                 match write_frame(s3_client, bucket, &key, &mut frame).await {
                     Ok(()) => {
@@ -481,11 +491,11 @@ pub async fn export_journals(
         }
     }
 
-    summary.deleted = delete_aged_out(log.directory(), &deletable, today);
+    summary.deleted = delete_aged_out(journal.directory(), &deletable, today);
     for session_date in &held_back {
         warn!(
             %session_date,
-            "Session log held back from deletion: its original holds lines the Parquet does not"
+            "Journal held back from deletion: its original holds lines the Parquet does not"
         );
     }
 
@@ -495,10 +505,10 @@ pub async fn export_journals(
         failed = summary.failed.len(),
         deleted = summary.deleted.len(),
         unparsable_lines = summary.unparsable_lines,
-        "Session log export finished"
+        "Journal export finished"
     );
     for (session_date, error) in &summary.failed {
-        warn!(%session_date, error, "Session log failed to export");
+        warn!(%session_date, error, "Journal failed to export");
     }
     summary
 }
@@ -521,7 +531,7 @@ fn sealed_sessions(
             continue;
         };
         if session_date > today {
-            warn!(%session_date, %today, "Session log is dated ahead of today; not sealed");
+            warn!(%session_date, %today, "Journal is dated ahead of today; not sealed");
             continue;
         }
         sessions.push(session_date);
@@ -547,7 +557,7 @@ fn delete_aged_out(
             Err(error) => warn!(
                 path = %path.display(),
                 %error,
-                "Aged-out session log could not be deleted"
+                "Aged-out journal could not be deleted"
             ),
         }
     }
@@ -725,6 +735,23 @@ mod tests {
         let (frame, unparsable) = read_session_frame(&path).expect("the session must still read");
         assert_eq!(frame.height(), 1);
         assert_eq!(unparsable, 1);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// The state `export_journals` refuses to upload. A file whose every line is unparsable still
+    /// reads as `Ok`, and the session key is deterministic, so shipping this frame would replace a
+    /// good object from an earlier run with one holding none of it.
+    #[test]
+    fn test_a_wholly_unparsable_session_yields_an_empty_frame() {
+        let directory = temporary_directory("unreadable");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("session-2026-08-11.jsonl");
+        std::fs::write(&path, "not json at all\n{\"schema_version\":3}\n")
+            .expect("the file must be writable");
+
+        let (frame, unparsable) = read_session_frame(&path).expect("the session must read");
+        assert_eq!(frame.height(), 0);
+        assert_eq!(unparsable, 2);
         let _ = std::fs::remove_dir_all(&directory);
     }
 

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -111,11 +111,6 @@ impl Universe {
         &self.tickers
     }
 
-    /// Whether `ticker` is eligible to trade at all.
-    ///
-    /// Backed by a set rather than a scan of [`Universe::tickers`]. The screen asks this once per
-    /// prediction, and a linear scan there turns a seven-thousand-symbol universe into forty-nine
-    /// million comparisons on a pass that runs every five minutes.
     /// Tickers this universe holds that `other` does not, in the stable order this one keeps.
     pub fn difference(&self, other: &Universe) -> Vec<Ticker> {
         self.tickers
@@ -125,6 +120,11 @@ impl Universe {
             .collect()
     }
 
+    /// Whether `ticker` is eligible to trade at all.
+    ///
+    /// Backed by a set rather than a scan of [`Universe::tickers`]. The screen asks this once per
+    /// prediction, and a linear scan there turns a seven-thousand-symbol universe into forty-nine
+    /// million comparisons on a pass that runs every five minutes.
     pub fn contains(&self, ticker: &Ticker) -> bool {
         self.eligible.contains(ticker)
     }

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -19,7 +19,10 @@ use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 use tracing::info;
 
+use uuid::Uuid;
+
 use crate::common::alpaca::{ClientError, TradableAssets, TradingClient};
+use crate::common::journal::{Journal, Observation, UniverseRefreshed};
 use crate::common::types::{BarInterval, SessionDate, Ticker, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
 
 /// Trailing window over which liquidity is averaged.
@@ -85,11 +88,10 @@ impl Universe {
             if !row.is_liquid() {
                 continue;
             }
-            let symbol = row.ticker.as_str();
-            if !assets.is_tradable(symbol) {
+            if !assets.is_tradable(&row.ticker) {
                 continue;
             }
-            if assets.is_shortable(symbol) {
+            if assets.is_shortable(&row.ticker) {
                 shortable.insert(row.ticker.clone());
             }
             tickers.push(row.ticker.clone());
@@ -114,6 +116,15 @@ impl Universe {
     /// Backed by a set rather than a scan of [`Universe::tickers`]. The screen asks this once per
     /// prediction, and a linear scan there turns a seven-thousand-symbol universe into forty-nine
     /// million comparisons on a pass that runs every five minutes.
+    /// Tickers this universe holds that `other` does not, in the stable order this one keeps.
+    pub fn difference(&self, other: &Universe) -> Vec<Ticker> {
+        self.tickers
+            .iter()
+            .filter(|ticker| !other.contains(ticker))
+            .cloned()
+            .collect()
+    }
+
     pub fn contains(&self, ticker: &Ticker) -> bool {
         self.eligible.contains(ticker)
     }
@@ -203,6 +214,8 @@ impl UniverseCache {
         &self,
         client: &TradingClient,
         pool: &PgPool,
+        journal: &Journal,
+        correlation_id: Uuid,
         now: DateTime<Utc>,
     ) -> Result<Universe, UniverseError> {
         let today = SessionDate::at(now);
@@ -213,6 +226,12 @@ impl UniverseCache {
             }
         }
 
+        let previous = self
+            .inner
+            .lock()
+            .await
+            .as_ref()
+            .map(|(_, universe)| universe.clone());
         let assets = client.fetch_tradable_assets().await?;
         let liquidity = load_liquidity(pool, today).await?;
         let universe = Universe::build(&assets, &liquidity);
@@ -224,6 +243,31 @@ impl UniverseCache {
             shortable = universe.shortable_count(),
             "Tradable universe built"
         );
+
+        // What entered and what fell out, rather than only the size. A universe that holds steady
+        // at seven hundred names while churning fifty of them is the case a count cannot show.
+        let (admitted, removed) = match previous {
+            Some(previous) => (
+                universe.difference(&previous),
+                previous.difference(&universe),
+            ),
+            None => (Vec::new(), Vec::new()),
+        };
+        journal
+            .record(
+                correlation_id,
+                now,
+                Observation::UniverseRefreshed(UniverseRefreshed {
+                    alpaca_tradable: assets.tradable_count(),
+                    alpaca_shortable: assets.shortable_count(),
+                    liquid: liquidity.iter().filter(|row| row.is_liquid()).count(),
+                    universe_size: universe.len(),
+                    admitted,
+                    removed,
+                    error: None,
+                }),
+            )
+            .await;
 
         if !universe.is_empty() {
             *self.inner.lock().await = Some((today, universe.clone()));
@@ -248,13 +292,13 @@ mod tests {
     fn assets() -> TradableAssets {
         TradableAssets::from_sets(
             HashSet::from([
-                "AAPL".to_string(),
-                "MSFT".to_string(),
-                "NVDA".to_string(),
-                "PENNY".to_string(),
-                "THIN".to_string(),
+                ticker("AAPL"),
+                ticker("MSFT"),
+                ticker("NVDA"),
+                ticker("PENNY"),
+                ticker("THIN"),
             ]),
-            HashSet::from(["AAPL".to_string(), "MSFT".to_string()]),
+            HashSet::from([ticker("AAPL"), ticker("MSFT")]),
         )
     }
 
@@ -348,8 +392,12 @@ mod tests {
         );
         let pool = sqlx::PgPool::connect_lazy("postgresql://user:pass@127.0.0.1:1/none").unwrap();
 
+        let journal = Journal::new(
+            std::env::temp_dir().join(format!("fund-universe-cache-{}", std::process::id())),
+        )
+        .expect("the journal directory must be creatable");
         let served = cache
-            .get(&client, &pool, now)
+            .get(&client, &pool, &journal, Uuid::nil(), now)
             .await
             .expect("cache hit must not fetch");
         assert_eq!(served.len(), 1);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -18,11 +18,11 @@ use uuid::Uuid;
 
 use crate::common::alpaca::{AlpacaCredentials, ClientError, MarketDataClient, TradingClient};
 use crate::common::events::{self, Command, EventError};
-use crate::common::massive::MassiveClient;
-use crate::common::session_log::{
-    CommandFinished, Observation, PredictionReading, PredictionsGenerated, SessionLog,
-    SessionLogError,
+use crate::common::journal::{
+    BarsIngested, CommandFinished, CommandOutcome, Journal, JournalError, JournalExported,
+    Observation, PredictionReading, PredictionsGenerated, SkipReason,
 };
+use crate::common::massive::MassiveClient;
 use crate::common::types::{BarInterval, SessionDate};
 use crate::data::adjust::{SplitTable, SplitTableCache};
 use crate::data::bars::{self, CloseHistoryCache, HISTORY_LOOKBACK_DAYS};
@@ -76,7 +76,7 @@ pub enum HandlerError {
         message: String,
     },
     #[error("session log is unusable: {0}")]
-    SessionLog(#[from] SessionLogError),
+    Journal(#[from] JournalError),
     #[error("configuration is missing or unusable: {0}")]
     Configuration(String),
 }
@@ -106,7 +106,7 @@ pub struct ServiceState {
     sizing: SizingParameters,
     execution: ExecutionSettings,
     /// The append-only record of what this process observed before it acted.
-    session_log: SessionLog,
+    journal: Journal,
     /// Cancelled when the process is asked to stop.
     ///
     /// Held here so a handler can decline to *start* more work it would not be able to finish. The
@@ -150,7 +150,7 @@ impl ServiceState {
             boundary_table_cache: BoundaryTableCache::new(),
             sizing: SizingParameters::from_env(),
             execution: ExecutionSettings::default(),
-            session_log: SessionLog::from_env()?,
+            journal: Journal::from_env()?,
             shutdown,
             in_flight: std::sync::Mutex::new(HashSet::new()),
         })
@@ -160,8 +160,8 @@ impl ServiceState {
         &self.pool
     }
 
-    pub fn session_log(&self) -> &SessionLog {
-        &self.session_log
+    pub fn journal(&self) -> &Journal {
+        &self.journal
     }
 
     /// Claims a command, or reports that one is already running.
@@ -220,7 +220,7 @@ pub async fn handle(state: &ServiceState, command: Command) {
             Utc::now(),
             CommandFinished {
                 command: command.as_str().to_string(),
-                outcome: "dropped_in_flight".to_string(),
+                outcome: CommandOutcome::DroppedInFlight,
                 duration_milliseconds: None,
                 error: None,
                 summary: None,
@@ -276,7 +276,7 @@ pub async fn handle(state: &ServiceState, command: Command) {
                 Utc::now(),
                 CommandFinished {
                     command: command.as_str().to_string(),
-                    outcome: "errored".to_string(),
+                    outcome: CommandOutcome::Errored,
                     duration_milliseconds: Some(duration_milliseconds),
                     error: Some(error.to_string()),
                     summary: None,
@@ -294,13 +294,22 @@ pub async fn handle(state: &ServiceState, command: Command) {
 
 /// Whether a successful run did its work or declined to.
 ///
-/// A handler that returns early names its reason under `skipped`; today the only one is
-/// `not_a_trading_day`. Reading it here rather than matching on it keeps a new skip reason from
-/// silently reading as a completed run.
-fn completion_outcome(summary: &Value) -> String {
+/// A handler that returns early names its reason under `skipped`. An unrecognized reason is a
+/// completed run rather than a panic, but it is warned about: the alternative is a new skip
+/// silently reading as work done.
+fn completion_outcome(summary: &Value) -> CommandOutcome {
     match summary.get("skipped").and_then(Value::as_str) {
-        Some(reason) => format!("skipped_{reason}"),
-        None => "completed".to_string(),
+        None => CommandOutcome::Completed,
+        Some(raw) => match SkipReason::parse(raw) {
+            Some(reason) => CommandOutcome::Skipped(reason),
+            None => {
+                warn!(
+                    reason = raw,
+                    "Unrecognized skip reason recorded as completed"
+                );
+                CommandOutcome::Completed
+            }
+        },
     }
 }
 
@@ -311,7 +320,7 @@ async fn record_command(
     finished: CommandFinished,
 ) {
     state
-        .session_log
+        .journal
         .record(correlation_id, now, Observation::CommandFinished(finished))
         .await;
 }
@@ -326,8 +335,8 @@ async fn dispatch(
         Command::PortfolioEvaluation => handle_portfolio_evaluation(state, correlation_id).await,
         Command::PortfolioLiquidation => handle_portfolio_liquidation(state, correlation_id).await,
         Command::AccountSync => handle_account_sync(state, correlation_id).await,
-        Command::MarketDataSync => handle_market_data_sync(state).await,
-        Command::DatabaseExport => handle_database_export(state).await,
+        Command::MarketDataSync => handle_market_data_sync(state, correlation_id).await,
+        Command::DatabaseExport => handle_database_export(state, correlation_id).await,
     }
 }
 
@@ -342,7 +351,10 @@ async fn handle_predictions(
     let now = Utc::now();
     let today = SessionDate::at(now);
 
-    let calendar = state.calendar_cache.get(&state.trading, now).await?;
+    let calendar = state
+        .calendar_cache
+        .get(&state.trading, &state.journal, correlation_id, now)
+        .await?;
     if !calendar.is_trading_day(today) {
         info!(%today, "Not a trading day; predictions skipped");
         return Ok(json!({ "skipped": "not_a_trading_day", "session_date": today }));
@@ -350,7 +362,13 @@ async fn handle_predictions(
 
     let universe = state
         .universe_cache
-        .get(&state.trading, &state.pool, now)
+        .get(
+            &state.trading,
+            &state.pool,
+            &state.journal,
+            correlation_id,
+            now,
+        )
         .await?;
     // An absent table blocks the entry half through the risk gate rather than being papered over
     // here; the exit half runs on what it has, because closing reduces exposure and the end-of-day
@@ -415,7 +433,7 @@ async fn handle_predictions(
     let (rows, predictions) = run_inference(state, &model_state, correlation_id, now).await?;
 
     state
-        .session_log
+        .journal
         .record(
             correlation_id,
             now,
@@ -428,7 +446,7 @@ async fn handle_predictions(
                 predictions: predictions
                     .iter()
                     .map(|prediction| PredictionReading {
-                        ticker: prediction.ticker().to_string(),
+                        ticker: prediction.ticker().clone(),
                         timestamp: prediction.timestamp(),
                         quantile_10: prediction.quantile_10(),
                         quantile_50: prediction.quantile_50(),
@@ -531,7 +549,10 @@ async fn handle_portfolio_evaluation(
     let now = Utc::now();
     let today = SessionDate::at(now);
 
-    let calendar = state.calendar_cache.get(&state.trading, now).await?;
+    let calendar = state
+        .calendar_cache
+        .get(&state.trading, &state.journal, correlation_id, now)
+        .await?;
     if !calendar.is_trading_day(today) {
         // The holiday gate moved from SQL into Rust when `market_calendar` was dropped, so a
         // holiday produces a no-op pass rather than no pass at all. Cheap enough not to fight.
@@ -540,7 +561,13 @@ async fn handle_portfolio_evaluation(
 
     let universe = state
         .universe_cache
-        .get(&state.trading, &state.pool, now)
+        .get(
+            &state.trading,
+            &state.pool,
+            &state.journal,
+            correlation_id,
+            now,
+        )
         .await?;
     // An absent table blocks the entry half through the risk gate rather than being papered over
     // here; the exit half runs on what it has, because closing reduces exposure and the end-of-day
@@ -579,7 +606,7 @@ async fn handle_portfolio_evaluation(
         close_history: &close_history,
         sizing: state.sizing,
         execution: state.execution,
-        session_log: &state.session_log,
+        journal: &state.journal,
         correlation_id,
         shutdown: &state.shutdown,
         now,
@@ -601,7 +628,7 @@ async fn handle_portfolio_liquidation(
     let summary = evaluate::run_liquidation(
         &state.pool,
         &state.trading,
-        &state.session_log,
+        &state.journal,
         correlation_id,
         Utc::now(),
     )
@@ -617,7 +644,10 @@ async fn handle_account_sync(
     let now = Utc::now();
     let today = SessionDate::at(now);
 
-    let calendar = state.calendar_cache.get(&state.trading, now).await?;
+    let calendar = state
+        .calendar_cache
+        .get(&state.trading, &state.journal, correlation_id, now)
+        .await?;
     if !calendar.is_trading_day(today) {
         return Ok(json!({ "skipped": "not_a_trading_day", "session_date": today }));
     }
@@ -625,7 +655,7 @@ async fn handle_account_sync(
     let summary = account::sync_account(
         &state.pool,
         &state.trading,
-        &state.session_log,
+        &state.journal,
         correlation_id,
         &calendar,
         today,
@@ -638,11 +668,17 @@ async fn handle_account_sync(
 ///
 /// Chains the export rather than letting cron schedule it, so the export can never run against a
 /// half-synced database. The chain is emitted only on success for the same reason.
-async fn handle_market_data_sync(state: &ServiceState) -> Result<Value, HandlerError> {
+async fn handle_market_data_sync(
+    state: &ServiceState,
+    correlation_id: Uuid,
+) -> Result<Value, HandlerError> {
     let now = Utc::now();
     let today = SessionDate::at(now);
 
-    let calendar = state.calendar_cache.get(&state.trading, now).await?;
+    let calendar = state
+        .calendar_cache
+        .get(&state.trading, &state.journal, correlation_id, now)
+        .await?;
     if !calendar.is_trading_day(today) {
         return Ok(json!({ "skipped": "not_a_trading_day", "session_date": today }));
     }
@@ -680,6 +716,24 @@ async fn handle_market_data_sync(state: &ServiceState) -> Result<Value, HandlerE
 
     let fetched = bars::fetch_daily_bars(&state.massive, &sessions).await;
     let bar_rows = bars::store_bars(&state.pool, &fetched.bars).await?;
+
+    // The bar path is the one thing this application does that no provider can be re-asked about:
+    // Massive serves a session once and the archive partition freezes two sessions later.
+    state
+        .journal
+        .record(
+            correlation_id,
+            Utc::now(),
+            Observation::BarsIngested(BarsIngested {
+                session_date: today,
+                sessions_requested: sessions.len(),
+                sessions_failed: fetched.dates_failed.clone(),
+                bars_parsed: fetched.bars.len(),
+                rows_written: bar_rows,
+                error: None,
+            }),
+        )
+        .await;
 
     let detail_rows =
         details::store_details(&state.pool, &details::parse_embedded_details()?).await?;
@@ -719,13 +773,39 @@ async fn handle_market_data_sync(state: &ServiceState) -> Result<Value, HandlerE
 /// The session log seals independently and does not gate the purge. It holds different data written
 /// by a different path, and letting a failure there hold PostgreSQL rows would couple two things
 /// whose only relationship is that they run on the same schedule.
-async fn handle_database_export(state: &ServiceState) -> Result<Value, HandlerError> {
+async fn handle_database_export(
+    state: &ServiceState,
+    correlation_id: Uuid,
+) -> Result<Value, HandlerError> {
     let today = SessionDate::at(Utc::now());
 
     let sessions =
-        export::export_session_logs(&state.session_log, &state.s3_client, &state.bucket, today)
-            .await;
-    let session_log_summary = json!({
+        export::export_journals(&state.journal, &state.s3_client, &state.bucket, today).await;
+    // After the export, so the seal has released. This record lands in the session the export ran
+    // in and ships on the next run, which is what lets the journal describe its own export.
+    state
+        .journal
+        .record(
+            correlation_id,
+            Utc::now(),
+            Observation::JournalExported(JournalExported {
+                sessions_exported: sessions.exported.len(),
+                records_exported: sessions.total_records(),
+                sessions_failed: sessions
+                    .failed
+                    .iter()
+                    .map(|(session_date, _)| SessionDate::from_date(*session_date))
+                    .collect(),
+                sessions_deleted: sessions
+                    .deleted
+                    .iter()
+                    .map(|session_date| SessionDate::from_date(*session_date))
+                    .collect(),
+                unparsable_lines: sessions.unparsable_lines,
+            }),
+        )
+        .await;
+    let journal_summary = json!({
         "sessions_exported": sessions.exported.len(),
         "records_exported": sessions.total_records(),
         "sessions_failed": sessions.failed.iter().map(|(session_date, error)| json!({
@@ -749,7 +829,7 @@ async fn handle_database_export(state: &ServiceState) -> Result<Value, HandlerEr
                 "dataset": dataset, "error": error.to_string()
             })).collect::<Vec<_>>(),
             "purged": Value::Null,
-            "session_log": session_log_summary,
+            "journal": journal_summary,
         }));
     }
 
@@ -760,7 +840,7 @@ async fn handle_database_export(state: &ServiceState) -> Result<Value, HandlerEr
         "total_rows_exported": export.total_rows(),
         "purged_rows": purged.total_rows(),
         "purge_clean": purged.is_clean(),
-        "session_log": session_log_summary,
+        "journal": journal_summary,
     }))
 }
 
@@ -894,16 +974,16 @@ mod tests {
             completion_outcome(
                 &json!({ "skipped": "not_a_trading_day", "session_date": "2026-08-11" })
             ),
-            "skipped_not_a_trading_day"
+            CommandOutcome::Skipped(SkipReason::NotATradingDay)
         );
         assert_eq!(
             completion_outcome(&json!({ "pairs_opened": ["AAAA-BBBB"] })),
-            "completed"
+            CommandOutcome::Completed
         );
-        // A reason this function has never seen still reads as a skip, not as a finished run.
+        // The second documented skip, which the handlers use when the exchange halts.
         assert_eq!(
             completion_outcome(&json!({ "skipped": "market_halted" })),
-            "skipped_market_halted"
+            CommandOutcome::Skipped(SkipReason::MarketHalted)
         );
     }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -75,7 +75,7 @@ pub enum HandlerError {
         stage: &'static str,
         message: String,
     },
-    #[error("session log is unusable: {0}")]
+    #[error("journal is unusable: {0}")]
     Journal(#[from] JournalError),
     #[error("configuration is missing or unusable: {0}")]
     Configuration(String),
@@ -764,13 +764,13 @@ async fn handle_market_data_sync(
     }))
 }
 
-/// Chained from a completed market data sync: seal the session log, export to S3, then purge.
+/// Chained from a completed market data sync: seal the journal, export to S3, then purge.
 ///
 /// The order is fixed and the purge is conditional on the *database* export being clean. Purging
 /// after a partial export deletes rows that never reached S3, and nothing afterwards can tell that
 /// it happened.
 ///
-/// The session log seals independently and does not gate the purge. It holds different data written
+/// The journal seals independently and does not gate the purge. It holds different data written
 /// by a different path, and letting a failure there hold PostgreSQL rows would couple two things
 /// whose only relationship is that they run on the same schedule.
 async fn handle_database_export(

--- a/src/models/tide/artifact.rs
+++ b/src/models/tide/artifact.rs
@@ -22,10 +22,6 @@ use crate::models::tide::configuration::ModelParameters;
 use crate::models::tide::data::{FeatureMappings, Scaler};
 use crate::models::tide::model::TiDEModel;
 
-// --------------------------------------------------------------------------
-// The loaded artifact
-// --------------------------------------------------------------------------
-
 pub struct ModelState {
     /// The loaded weights, behind a mutex because the forward pass mutates them.
     ///
@@ -121,10 +117,6 @@ fn model_state_is_send_and_sync() {
     fn require<T: Send + Sync>() {}
     require::<ModelState>();
 }
-
-// --------------------------------------------------------------------------
-// Reading: resolve, download, load
-// --------------------------------------------------------------------------
 
 #[derive(Debug, thiserror::Error)]
 pub enum ArtifactError {
@@ -425,10 +417,6 @@ fn load_model_from_directory(dir: &Path, artifact_key: &str) -> Result<ModelStat
         load_timestamp,
     ))
 }
-
-// --------------------------------------------------------------------------
-// Writing: package and upload
-// --------------------------------------------------------------------------
 
 #[derive(Debug, thiserror::Error)]
 pub enum ArtifactWriteError {

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -261,10 +261,6 @@ mod tests {
         );
     }
 
-    // ---------------------------------------------------------------------------
-    // argmin / argmax / closest_to
-    // ---------------------------------------------------------------------------
-
     #[test]
     fn test_argmin_returns_index_of_smallest_value() {
         assert_eq!(argmin(&[0.9, 0.1, 0.5]), 1);
@@ -317,10 +313,6 @@ mod tests {
         assert_eq!(closest_to(&[], 0.5), 0);
     }
 
-    // ---------------------------------------------------------------------------
-    // EvaluationMetrics::zero
-    // ---------------------------------------------------------------------------
-
     #[test]
     fn test_evaluation_metrics_zero_fields_are_zero() {
         let metrics = EvaluationMetrics::zero();
@@ -329,10 +321,8 @@ mod tests {
         assert_eq!(metrics.quantile_coverage, 0.0);
     }
 
-    // ---------------------------------------------------------------------------
     // metrics_from: feeds a fixed prediction table through the shipped accumulator
     // so the math can be checked without running the neural network.
-    // ---------------------------------------------------------------------------
 
     /// Runs `predictions` and `targets` through `MetricAccumulator`, the same type `evaluate` uses.
     ///
@@ -489,10 +479,6 @@ mod tests {
             metrics.quantile_coverage
         );
     }
-
-    // ---------------------------------------------------------------------------
-    // evaluate() — early-return paths that do not require model inference
-    // ---------------------------------------------------------------------------
 
     /// Construct a minimal dataset with the array shapes expected for
     /// `input_length` and `output_length` so `build_input_tensor` does not

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -617,7 +617,7 @@ pub async fn insert_predictions(
     transaction.commit().await?;
     info!(rows = rows_affected, "Predictions inserted into PostgreSQL");
     // Returned rather than reparsed by the caller: these are the exact values that were written,
-    // so the session log records what the database holds and not a second reading of the payload.
+    // so the journal records what the database holds and not a second reading of the payload.
     Ok((rows_affected, validated))
 }
 

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -494,10 +494,6 @@ pub fn validate_predictions(predictions: &[serde_json::Value]) -> Result<(), Str
     Ok(())
 }
 
-// --------------------------------------------------------------------------
-// Persistence
-// --------------------------------------------------------------------------
-
 /// Converts a pipeline prediction JSON object into a validated [`EquityPrediction`].
 ///
 /// These come from our own pipeline, so a missing or mistyped field is a bug upstream. It fails

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -6,18 +6,17 @@
 use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Utc};
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Row};
 use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::common::alpaca::{
-    AccountActivity, AccountSnapshot, ClientError, TradingClient, FILL_ACTIVITY_TYPE,
-    RETURN_ACTIVITY_TYPES, TRANSFER_ACTIVITY_TYPES,
+    AccountActivity, AccountSnapshot, ActivityType, ClientError, Position, TradingClient,
 };
-use crate::common::session_log::{
-    AccountObserved, ActivityObserved, Observation, PairAttributed, SessionLog,
+use crate::common::journal::{
+    AccountObserved, ActivityObserved, Journal, Observation, PairAttributed, PositionReading,
+    PositionsObserved,
 };
 use crate::common::types::SessionDate;
 use crate::data::calendar::TradingCalendar;
@@ -27,22 +26,9 @@ use crate::portfolio::pairs::{self, ClosedPair, PairsError};
 ///
 /// Fills alone, because they are the only type that answers such a query: they carry a real
 /// `transaction_time`, where every other type is date-only and created the following morning, so
-/// `date=D` returns the row dated `D-1`. The rest come through [`windowed_activity_types`].
-pub fn synced_activity_types() -> Vec<&'static str> {
-    vec![FILL_ACTIVITY_TYPE]
-}
-
-/// The activity types asked for over a trailing window instead.
-///
-/// Everything Alpaca stamps with a date rather than a time. A session cannot observe its own fees
-/// or its own transfers — both are created hours after the 16:15 Eastern sync — so asking by
-/// session date would miss each one on the only run that looks for it.
-pub fn windowed_activity_types() -> Vec<&'static str> {
-    RETURN_ACTIVITY_TYPES
-        .iter()
-        .copied()
-        .chain(TRANSFER_ACTIVITY_TYPES)
-        .collect()
+/// `date=D` returns the row dated `D-1`. The rest come through [`ActivityType::windowed`].
+pub fn synced_activity_types() -> Vec<ActivityType> {
+    vec![ActivityType::Fill]
 }
 
 /// How far back each sync re-asks for [`windowed_activity_types`].
@@ -66,6 +52,7 @@ pub enum AccountError {
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct AccountSyncSummary {
     pub session_date: SessionDate,
+    #[serde(with = "crate::common::types::decimal_number")]
     pub equity: Decimal,
     pub activities_stored: u64,
     pub pairs_attributed: usize,
@@ -82,6 +69,7 @@ pub struct AccountSyncSummary {
     /// sessions rather than this one.
     pub return_activities_stored: usize,
     /// Their net effect on the balance, signed: dividends and interest add, fees subtract.
+    #[serde(with = "crate::common::types::decimal_number")]
     pub return_activities_net: Decimal,
 }
 
@@ -89,7 +77,7 @@ pub struct AccountSyncSummary {
 pub async fn sync_account(
     pool: &PgPool,
     client: &TradingClient,
-    session_log: &SessionLog,
+    journal: &Journal,
     correlation_id: uuid::Uuid,
     calendar: &TradingCalendar,
     session_date: SessionDate,
@@ -100,7 +88,7 @@ pub async fn sync_account(
     // Recorded in full, not just the equity. Alpaca's portfolio history can report equity for a
     // past date and nothing can report cash, buying power, or the market values, so this is the
     // only moment they are observable at all.
-    session_log
+    journal
         .record(
             correlation_id,
             Utc::now(),
@@ -108,14 +96,15 @@ pub async fn sync_account(
                 // The session this describes, which a sync re-run after Eastern midnight would
                 // otherwise lose: the envelope files a record under the session it *happened* in.
                 session_date,
-                equity: account.equity().to_f64(),
-                cash: account.cash().to_f64(),
-                buying_power: account.buying_power().to_f64(),
-                long_market_value: account.long_market_value().to_f64(),
-                short_market_value: account.short_market_value().to_f64(),
+                equity: account.equity(),
+                cash: account.cash(),
+                buying_power: account.buying_power(),
+                long_market_value: account.long_market_value(),
+                short_market_value: account.short_market_value(),
             }),
         )
         .await;
+    record_positions(client, journal, correlation_id).await;
     let previous_session_gap = missing_previous_snapshot(pool, calendar, session_date).await;
 
     // One request per type: Alpaca puts the activity type in the URL path, and the sync already
@@ -125,7 +114,7 @@ pub async fn sync_account(
     let mut activities_undated = 0;
     for activity_type in synced_activity_types() {
         let fetched = client
-            .fetch_activities(activity_type, session_date.date())
+            .fetch_activities(&activity_type, session_date.date())
             .await?;
         activities_truncated |= fetched.truncated;
         activities_undated += fetched.undated;
@@ -136,7 +125,7 @@ pub async fn sync_account(
     // sync runs. The overlap re-reads stored rows, which the activity id absorbs.
     let windowed = client
         .fetch_activities_since(
-            &windowed_activity_types(),
+            &ActivityType::windowed(),
             session_date.date() - chrono::Duration::days(ACTIVITY_WINDOW_DAYS),
         )
         .await?;
@@ -152,8 +141,7 @@ pub async fn sync_account(
     let return_activities: Vec<&AccountActivity> = activities
         .iter()
         .filter(|activity| {
-            newly_stored.contains(activity.id())
-                && RETURN_ACTIVITY_TYPES.contains(&activity.activity_type())
+            newly_stored.contains(activity.activity_id()) && activity.activity_type().is_return()
         })
         .collect();
     let return_activities_net: Decimal = return_activities
@@ -181,22 +169,22 @@ pub async fn sync_account(
     // deposit or withdrawal moved — reaches no other store this application owns.
     for activity in activities
         .iter()
-        .filter(|activity| newly_stored.contains(activity.id()))
+        .filter(|activity| newly_stored.contains(activity.activity_id()))
     {
-        session_log
+        journal
             .record(
                 correlation_id,
                 Utc::now(),
                 Observation::ActivityObserved(ActivityObserved {
-                    activity_id: activity.id().to_string(),
-                    activity_type: activity.activity_type().to_string(),
+                    activity_id: activity.activity_id().to_string(),
+                    activity_type: activity.activity_type().clone(),
                     transaction_time: activity.transaction_time(),
-                    ticker: activity.ticker().map(|ticker| ticker.to_string()),
-                    side: activity.side().map(str::to_string),
-                    quantity: activity.shares().and_then(|shares| shares.to_f64()),
-                    price: activity.price().and_then(|price| price.to_f64()),
-                    net_amount: activity.net_amount().and_then(|amount| amount.to_f64()),
-                    order_id: activity.order_id().map(str::to_string),
+                    ticker: activity.ticker().cloned(),
+                    side: activity.side(),
+                    quantity: activity.quantity(),
+                    price: activity.price(),
+                    net_amount: activity.net_amount(),
+                    alpaca_order_id: activity.alpaca_order_id().map(str::to_string),
                 }),
             )
             .await;
@@ -208,7 +196,7 @@ pub async fn sync_account(
     // one in would count it as unattributed and warn on every session that received capital.
     let fills: Vec<AccountActivity> = activities
         .iter()
-        .filter(|activity| activity.activity_type() == FILL_ACTIVITY_TYPE)
+        .filter(|activity| *activity.activity_type() == ActivityType::Fill)
         .cloned()
         .collect();
     let attribution = attribute(&closed, &fills);
@@ -216,13 +204,13 @@ pub async fn sync_account(
     let mut pairs_attributed = 0;
     for (id, amount) in &attribution.realized {
         let updated = pairs::record_realized_profit_and_loss(pool, *id, *amount).await?;
-        session_log
+        journal
             .record(
                 correlation_id,
                 Utc::now(),
                 Observation::PairAttributed(PairAttributed {
-                    pair_uuid: id.to_string(),
-                    realized_profit_and_loss: amount.to_f64(),
+                    equity_pair_id: *id,
+                    realized_profit_and_loss: Some(*amount),
                     updated,
                 }),
             )
@@ -339,15 +327,15 @@ pub async fn store_activities(
         );
         query_builder.push_values(chunk, |mut builder, activity| {
             builder
-                .push_bind(activity.id().to_string())
+                .push_bind(activity.activity_id().to_string())
                 .push_bind(activity.activity_type().to_string())
                 .push_bind(activity.transaction_time())
                 .push_bind(activity.ticker().map(|ticker| ticker.as_str().to_string()))
-                .push_bind(activity.side().map(str::to_string))
-                .push_bind(activity.shares())
+                .push_bind(activity.side().map(|side| side.as_str().to_string()))
+                .push_bind(activity.quantity())
                 .push_bind(activity.price())
                 .push_bind(activity.net_amount())
-                .push_bind(activity.order_id().map(str::to_string));
+                .push_bind(activity.alpaca_order_id().map(str::to_string));
         });
         query_builder.push(" ON CONFLICT (id) DO NOTHING RETURNING id");
 
@@ -364,6 +352,40 @@ pub async fn store_activities(
         "Account activities stored"
     );
     Ok(inserted)
+}
+
+/// Records the position book beside the balances.
+///
+/// A failure here is warned and swallowed for the same reason a journal write is: the sync's job is
+/// the balances and the activities, and the book going unobserved must not cost them.
+async fn record_positions(client: &TradingClient, journal: &Journal, correlation_id: Uuid) {
+    let observed = match client.fetch_positions().await {
+        Ok(positions) => positions,
+        Err(error) => {
+            warn!(%error, "Positions could not be fetched; the book goes unobserved");
+            return;
+        }
+    };
+    journal
+        .record(
+            correlation_id,
+            Utc::now(),
+            Observation::PositionsObserved(PositionsObserved {
+                readings: observed.positions.iter().map(position_reading).collect(),
+                unreadable: observed.unreadable,
+            }),
+        )
+        .await;
+}
+
+fn position_reading(position: &Position) -> PositionReading {
+    PositionReading {
+        ticker: position.ticker().clone(),
+        side: position.side(),
+        quantity: position.quantity(),
+        market_value: position.market_value(),
+        unrealized_profit_and_loss: position.unrealized_profit_and_loss(),
+    }
 }
 
 /// The previous trading session, when it has no snapshot of its own.
@@ -479,8 +501,9 @@ pub fn session_bounds(session_date: SessionDate) -> (DateTime<Utc>, DateTime<Utc
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::alpaca::OrderSide;
+    use crate::common::types::CloseReason;
     use crate::common::types::{PairID, Ticker};
-    use crate::portfolio::pairs::CloseReason;
     use chrono::NaiveDate;
 
     fn ticker(raw: &str) -> Ticker {
@@ -508,17 +531,17 @@ mod tests {
     fn fill(
         id: &str,
         symbol: &str,
-        side: &str,
+        side: OrderSide,
         shares: i64,
         price: i64,
         at: DateTime<Utc>,
     ) -> AccountActivity {
         AccountActivity::new(
             id.to_string(),
-            FILL_ACTIVITY_TYPE.to_string(),
+            ActivityType::Fill,
             at,
             Some(ticker(symbol)),
-            Some(side.to_string()),
+            Some(side),
             Some(Decimal::from(shares)),
             Some(Decimal::from(price)),
             None,
@@ -533,11 +556,11 @@ mod tests {
         let pair = closed_pair("AAAA", "BBBB", 14, 18);
         let activities = vec![
             // Long leg: bought 10 at 100, sold 10 at 110. +100.
-            fill("1", "AAAA", "buy", 10, 100, instant(14, 5)),
-            fill("2", "AAAA", "sell", 10, 110, instant(17, 55)),
+            fill("1", "AAAA", OrderSide::Buy, 10, 100, instant(14, 5)),
+            fill("2", "AAAA", OrderSide::Sell, 10, 110, instant(17, 55)),
             // Short leg: sold 10 at 200, bought back 10 at 195. +50.
-            fill("3", "BBBB", "sell_short", 10, 200, instant(14, 5)),
-            fill("4", "BBBB", "buy", 10, 195, instant(17, 55)),
+            fill("3", "BBBB", OrderSide::SellShort, 10, 200, instant(14, 5)),
+            fill("4", "BBBB", OrderSide::Buy, 10, 195, instant(17, 55)),
         ];
 
         let attribution = attribute(std::slice::from_ref(&pair), &activities);
@@ -558,7 +581,7 @@ mod tests {
     #[test]
     fn test_a_fill_outside_the_window_is_not_attributed() {
         let pair = closed_pair("AAAA", "BBBB", 14, 18);
-        let activities = vec![fill("1", "AAAA", "buy", 10, 100, instant(19, 0))];
+        let activities = vec![fill("1", "AAAA", OrderSide::Buy, 10, 100, instant(19, 0))];
         let attribution = attribute(std::slice::from_ref(&pair), &activities);
 
         assert_eq!(attribution.realized[&pair.id()], Decimal::ZERO);
@@ -568,7 +591,7 @@ mod tests {
     #[test]
     fn test_a_fill_in_a_symbol_the_pair_does_not_hold_is_not_attributed() {
         let pair = closed_pair("AAAA", "BBBB", 14, 18);
-        let activities = vec![fill("1", "CCCC", "buy", 10, 100, instant(15, 0))];
+        let activities = vec![fill("1", "CCCC", OrderSide::Buy, 10, 100, instant(15, 0))];
         assert_eq!(attribute(&[pair], &activities).unattributed, 1);
     }
 
@@ -578,7 +601,7 @@ mod tests {
     fn test_an_ambiguous_fill_is_attributed_to_neither_pair() {
         let first = closed_pair("AAAA", "BBBB", 14, 18);
         let second = closed_pair("AAAA", "CCCC", 15, 17);
-        let activities = vec![fill("1", "AAAA", "buy", 10, 100, instant(16, 0))];
+        let activities = vec![fill("1", "AAAA", OrderSide::Buy, 10, 100, instant(16, 0))];
 
         let attribution = attribute(&[first.clone(), second.clone()], &activities);
         assert_eq!(attribution.unattributed, 1);
@@ -593,7 +616,7 @@ mod tests {
         let pair = closed_pair("AAAA", "BBBB", 14, 18);
         let fee = AccountActivity::new(
             "f".to_string(),
-            "FEE".to_string(),
+            ActivityType::parse("FEE"),
             instant(16, 0),
             Some(ticker("AAAA")),
             None,

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -957,7 +957,7 @@ fn entry_plan_actions(plan: &EntryPlan) -> Vec<PlannedAction> {
         .collect()
 }
 
-/// Writes one round's plan to the session log before any of it is attempted.
+/// Writes one round's plan to the journal before any of it is attempted.
 ///
 /// Before, not after, and that is the whole reason it is its own record: a pass that dies partway
 /// through applying leaves a plan saying what it meant to do, against orders saying what it managed.
@@ -1271,7 +1271,7 @@ pub struct ScreenedUniverse {
     /// Predictions that passed the eligibility filter, before pricing removed any.
     pub eligible: usize,
     pub model_run_id: Option<String>,
-    /// Predictions the session had before any eligibility test, for the session log. The gap
+    /// Predictions the session had before any eligibility test, for the journal. The gap
     /// between this and `inputs.len()` is how much the filters removed.
     pub predictions_available: usize,
     /// Every ticker's sector, not just the screened ones. `select_disjoint` needs the held legs

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -10,7 +10,6 @@
 use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Utc};
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use serde::Serialize;
 use sqlx::PgPool;
@@ -21,13 +20,17 @@ use crate::common::alpaca::{
     AccountSnapshot, CheckedPrice, ClientError, MarketDataClient, QuoteLimits, QuoteRejection,
     TradingClient,
 };
-use crate::common::session_log::{
-    CandidateReading, ExcludedTickerReading, LiquidationAttempted, Observation, OpenPairReading,
-    OpenPairsObserved, PairClosed, PairOpened, PassEvaluated, PlanDecided, PlanPhase,
-    PlannedAction, PlannedActionKind, PositionCloseRequested, PriceReading, PricesObserved,
-    ScreenInputReading, SessionLog, UnavailablePrice, UniverseScreened,
+use crate::common::journal::{
+    CandidateDecision, CandidateReading, CloseRequestReason, ExcludedTickerReading,
+    ExclusionReason, Journal, LiquidationAttempted, Observation, OpenPairReading,
+    OpenPairsObserved, PairClosed, PairDecision, PairOpened, PassEvaluated, PlanDecided, PlanPhase,
+    PlannedAction, PlannedActionKind, PlannedReason, PositionCloseRequested, PricePurpose,
+    PriceReading, PricesObserved, ScreenInputReading, UnavailableCause, UnavailablePrice,
+    UniverseScreened,
 };
-use crate::common::types::{EquityPrediction, EquityQuote, PairID, SessionDate, Ticker};
+use crate::common::types::{
+    CloseReason, EquityPrediction, EquityQuote, PairID, SessionDate, Ticker,
+};
 use crate::data::calendar::TradingCalendar;
 use crate::data::details::{self, DetailsError};
 use crate::data::universe::Universe;
@@ -36,7 +39,7 @@ use crate::portfolio::account::{self, AccountError};
 use crate::portfolio::execute::{
     self, ExecutionContext, ExecutionError, ExecutionSettings, OpenOutcome,
 };
-use crate::portfolio::pairs::{self, CloseReason, OpenPair, PairsError};
+use crate::portfolio::pairs::{self, OpenPair, PairsError};
 use crate::portfolio::risk::{RiskBlock, RiskGate};
 use crate::portfolio::screen::{
     self, ScreenInput, SpreadModel, CONVERGENCE_Z_SCORE, CORRELATION_WINDOW_SESSIONS,
@@ -83,7 +86,7 @@ pub struct EvaluationContext<'a> {
     pub sizing: SizingParameters,
     pub execution: ExecutionSettings,
     /// Where the pass records what it observed before acting on it.
-    pub session_log: &'a SessionLog,
+    pub journal: &'a Journal,
     /// The dispatching command's identifier, carried onto every order the pass sends.
     pub correlation_id: uuid::Uuid,
     /// Cancelled when the process is asked to stop.
@@ -98,8 +101,8 @@ pub struct EvaluationContext<'a> {
 /// One pair the pass closed.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ClosedRecord {
-    pub pair_id: String,
-    pub reason: String,
+    pub pair_id: PairID,
+    pub reason: CloseReason,
 }
 
 /// What the exit round read from the world, before any judgment is applied to it.
@@ -117,8 +120,8 @@ pub struct ExitReading {
 /// One close the exit round resolved on, carrying everything needed to attempt it.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PlannedClose {
-    pub pair_uuid: uuid::Uuid,
-    pub pair_id: String,
+    pub equity_pair_id: uuid::Uuid,
+    pub pair_id: PairID,
     pub long_ticker: Ticker,
     pub short_ticker: Ticker,
     pub reason: CloseReason,
@@ -140,7 +143,7 @@ pub struct ExitPlan {
 pub struct ExitOutcome {
     pub closed: HashSet<uuid::Uuid>,
     pub closed_records: Vec<ClosedRecord>,
-    pub failed: Vec<String>,
+    pub failed: Vec<PairID>,
     /// The plan's readings with each attempt's result written in.
     pub readings: Vec<OpenPairReading>,
 }
@@ -219,7 +222,7 @@ pub struct EvaluationSummary {
     ///
     /// These stay open in the record and are retried next pass. Non-empty means the book is holding
     /// something it tried to let go of.
-    pub exits_failed: Vec<String>,
+    pub exits_failed: Vec<PairID>,
     pub candidates_screened: usize,
     /// Why the entry half did not run at all, if it did not.
     ///
@@ -297,10 +300,10 @@ pub async fn run_pass(
 
     let result = evaluate_pass(context, correlation_id, &mut observation).await;
     if let Err(error) = &result {
-        observation.failure = Some(error.to_string());
+        observation.error = Some(error.to_string());
     }
     context
-        .session_log
+        .journal
         .record(
             correlation_id,
             context.now,
@@ -320,7 +323,7 @@ async fn evaluate_pass(
     let execution = ExecutionContext {
         client: context.trading,
         settings: context.execution,
-        session_log: context.session_log,
+        journal: context.journal,
         correlation_id,
     };
 
@@ -328,13 +331,11 @@ async fn evaluate_pass(
     summary.open_pairs_at_start = open_pairs.len();
     observation.open_pairs_at_start = open_pairs.len();
 
-    // --- exits, unconditionally ---
-
     let prices = fetch_prices(
         context,
         correlation_id,
-        "open_pairs",
-        &leg_symbols(&open_pairs),
+        PricePurpose::OpenPairs,
+        &leg_tickers(&open_pairs),
     )
     .await?;
     let exit_reading = observe_exits(context, open_pairs, prices);
@@ -352,7 +353,7 @@ async fn evaluate_pass(
     // From the outcome, not the plan: a pass that died partway through closing had already closed
     // pairs, and reporting those as held would put the log at odds with the broker and the book.
     context
-        .session_log
+        .journal
         .record(
             correlation_id,
             context.now,
@@ -378,18 +379,14 @@ async fn evaluate_pass(
         .collect();
     let remaining_open = open_pairs.len() - exits.closed.len();
 
-    // --- entries, conditionally ---
-
     let account_reading = observe_account(context, remaining_open).await?;
     let (mut gate, admission) =
         decide_admission(&account_reading, context.sizing, context.prices_adjustable);
 
-    observation.account_equity = account_reading.account.equity().to_f64();
-    observation.previous_session_equity = account_reading
-        .previous_equity
-        .and_then(|equity| equity.to_f64());
-    observation.gross_exposure_used = account_reading.account.gross_exposure().to_f64();
-    observation.gross_exposure_cap = gate.gross_exposure_cap().to_f64();
+    observation.account_equity = Some(account_reading.account.equity());
+    observation.previous_session_equity = account_reading.previous_equity;
+    observation.gross_exposure_used = Some(account_reading.account.gross_exposure());
+    observation.gross_exposure_cap = Some(gate.gross_exposure_cap());
     observation.drawdown = gate.drawdown();
     observation.minutes_until_close = account_reading.minutes_until_close;
     observation.vacant_slots = Some(gate.vacant_slots());
@@ -437,7 +434,7 @@ async fn evaluate_pass(
     observation.candidates = entries.candidates.clone().into_values().collect();
     observation
         .candidates
-        .sort_by(|left, right| left.pair_id.cmp(&right.pair_id));
+        .sort_by(|left, right| left.pair_id.as_str().cmp(right.pair_id.as_str()));
 
     summary.pairs_opened = entries.opened;
     summary.entries_refused.extend(entries.refused);
@@ -461,7 +458,7 @@ pub struct LiquidationSummary {
     pub pairs_closed: usize,
     pub positions_refused: usize,
     /// Pairs left open because Alpaca would not close a leg. Non-empty means the book is not flat.
-    pub pairs_still_open: Vec<String>,
+    pub pairs_still_open: Vec<PairID>,
 }
 
 /// Flattens the account, then marks the pair records closed.
@@ -474,14 +471,14 @@ pub struct LiquidationSummary {
 pub async fn run_liquidation(
     pool: &PgPool,
     client: &TradingClient,
-    session_log: &SessionLog,
+    journal: &Journal,
     correlation_id: uuid::Uuid,
     now: DateTime<Utc>,
 ) -> Result<LiquidationSummary, EvaluationError> {
     let mut summary = LiquidationSummary::default();
-    let result = liquidate(pool, client, session_log, correlation_id, now, &mut summary).await;
+    let result = liquidate(pool, client, journal, correlation_id, now, &mut summary).await;
 
-    session_log
+    journal
         .record(
             correlation_id,
             now,
@@ -489,7 +486,7 @@ pub async fn run_liquidation(
                 pairs_closed: summary.pairs_closed,
                 positions_refused: summary.positions_refused,
                 pairs_still_open: summary.pairs_still_open.clone(),
-                failure: result.as_ref().err().map(ToString::to_string),
+                error: result.as_ref().err().map(ToString::to_string),
             }),
         )
         .await;
@@ -500,7 +497,7 @@ pub async fn run_liquidation(
 async fn liquidate(
     pool: &PgPool,
     client: &TradingClient,
-    session_log: &SessionLog,
+    journal: &Journal,
     correlation_id: uuid::Uuid,
     now: DateTime<Utc>,
     summary: &mut LiquidationSummary,
@@ -511,17 +508,17 @@ async fn liquidate(
     // positions the application does not know about — a leg from a pass that died before recording
     // its pair — and a count cannot name those.
     for outcome in &outcomes {
-        session_log
+        journal
             .record(
                 correlation_id,
                 now,
                 Observation::PositionCloseRequested(PositionCloseRequested {
-                    ticker: outcome.ticker().to_string(),
+                    ticker: outcome.ticker().clone(),
                     pair_id: None,
                     alpaca_order_id: outcome.alpaca_order_id().map(str::to_string),
                     side: None,
                     quantity: outcome.quantity(),
-                    reason: "liquidation".to_string(),
+                    reason: CloseRequestReason::Liquidation,
                     accepted: outcome.succeeded(),
                     status: Some(outcome.status()),
                     // The bulk path reports a per-symbol status rather than an error body, so a
@@ -545,17 +542,17 @@ async fn liquidate(
                 pair_id = %pair.pair_id(),
                 "Pair left open: Alpaca refused to close a leg"
             );
-            summary.pairs_still_open.push(pair.pair_id().to_string());
+            summary.pairs_still_open.push(pair.pair_id().clone());
             continue;
         }
         let updated = pairs::record_close(pool, pair.id(), CloseReason::EndOfDay, now).await?;
-        session_log
+        journal
             .record(
                 correlation_id,
                 now,
                 Observation::PairClosed(PairClosed {
-                    pair_uuid: pair.id().to_string(),
-                    reason: CloseReason::EndOfDay.as_str().to_string(),
+                    equity_pair_id: pair.id(),
+                    reason: CloseReason::EndOfDay,
                     closed_at: now,
                     updated,
                 }),
@@ -580,43 +577,39 @@ async fn liquidate(
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Pass internals
-// ---------------------------------------------------------------------------
-
-fn leg_symbols(open_pairs: &[OpenPair]) -> Vec<String> {
+fn leg_tickers(open_pairs: &[OpenPair]) -> Vec<Ticker> {
     let tickers: HashSet<&Ticker> = open_pairs
         .iter()
         .flat_map(|pair| [pair.long_ticker(), pair.short_ticker()])
         .collect();
-    tickers.iter().map(|ticker| ticker.to_string()).collect()
+    tickers.into_iter().cloned().collect()
 }
 
-/// Fetches reference prices for a symbol list, keyed by ticker, and records the reading.
+/// Fetches reference prices for a ticker list, keyed by ticker, and records the reading.
 ///
-/// Symbols Alpaca returns with no usable price are simply absent from the map. The callers treat an
+/// Tickers Alpaca returns with no usable price are simply absent from the map. The callers treat an
 /// absent price as "no reading", never as zero — and the record names them, so an absence has a
 /// cause rather than only a gap.
 async fn fetch_prices(
     context: &EvaluationContext<'_>,
     correlation_id: uuid::Uuid,
-    purpose: &str,
-    symbols: &[String],
+    purpose: PricePurpose,
+    tickers: &[Ticker],
 ) -> Result<HashMap<Ticker, CheckedPrice>, EvaluationError> {
-    if symbols.is_empty() {
+    if tickers.is_empty() {
         return Ok(HashMap::new());
     }
-    let fetched = context.market_data.fetch_snapshots(symbols).await?;
-    let failed: HashSet<&str> = fetched.failed_symbols.iter().map(String::as_str).collect();
+    let fetched = context.market_data.fetch_snapshots(tickers).await?;
+    let failed: HashSet<&Ticker> = fetched.failed_tickers.iter().collect();
     let limits = QuoteLimits::default();
 
     // Each snapshot is read once, with the book kept beside the price it produced. The map the
     // callers receive has already collapsed the quote away, so a refused book is recorded here or
-    // nowhere — and a log holding only the quotes that passed cannot say whether `limits` is set
-    // anywhere near right.
+    // nowhere — and a journal holding only the quotes that passed cannot say whether `limits` is
+    // set anywhere near right.
     let mut prices: HashMap<Ticker, CheckedPrice> = HashMap::new();
     let mut readings: Vec<PriceReading> = Vec::new();
-    let mut refused: HashMap<&str, (&EquityQuote, QuoteRejection)> = HashMap::new();
+    let mut refused: HashMap<&Ticker, (&EquityQuote, QuoteRejection)> = HashMap::new();
 
     for snapshot in &fetched.snapshots {
         let quote = snapshot.latest_quote();
@@ -624,15 +617,13 @@ async fn fetch_prices(
         match snapshot.reference_price_checked(context.now, limits) {
             Some(checked) => {
                 readings.push(PriceReading {
-                    ticker: snapshot.ticker().to_string(),
+                    ticker: snapshot.ticker().clone(),
                     price: checked.price(),
-                    price_source: checked.source().as_str().to_string(),
+                    price_source: checked.source(),
                     bid_price: quote.map(|quote| quote.bid_price()),
                     ask_price: quote.map(|quote| quote.ask_price()),
                     quote_timestamp: quote.map(|quote| quote.timestamp()),
-                    quote_rejection: checked
-                        .rejection()
-                        .map(|rejection| rejection.as_str().to_string()),
+                    quote_rejection: checked.rejection(),
                     trade_timestamp: trade.map(|trade| trade.timestamp()),
                 });
                 prices.insert(snapshot.ticker().clone(), checked);
@@ -644,48 +635,43 @@ async fn fetch_prices(
                 if let Some((quote, rejection)) =
                     quote.and_then(|quote| Some((quote, limits.refusal(quote, context.now)?)))
                 {
-                    refused.insert(snapshot.ticker().as_str(), (quote, rejection));
+                    refused.insert(snapshot.ticker(), (quote, rejection));
                 }
             }
         }
     }
     readings.sort_by(|left, right| left.ticker.cmp(&right.ticker));
 
-    let mut unavailable: Vec<UnavailablePrice> = symbols
+    let mut unavailable: Vec<UnavailablePrice> = tickers
         .iter()
-        .filter(|symbol| {
-            !prices
-                .keys()
-                .any(|ticker| ticker.as_str() == symbol.as_str())
-        })
-        .map(|symbol| {
-            let refusal = refused.get(symbol.as_str());
+        .filter(|ticker| !prices.contains_key(*ticker))
+        .map(|ticker| {
+            let refusal = refused.get(ticker);
             UnavailablePrice {
-                ticker: symbol.clone(),
-                cause: if failed.contains(symbol.as_str()) {
-                    "chunk_failed"
+                ticker: ticker.clone(),
+                cause: if failed.contains(ticker) {
+                    UnavailableCause::ChunkFailed
                 } else if refusal.is_some() {
-                    "quote_rejected"
+                    UnavailableCause::QuoteRejected
                 } else {
-                    "no_quote"
-                }
-                .to_string(),
+                    UnavailableCause::NoQuote
+                },
                 bid_price: refusal.map(|(quote, _)| quote.bid_price()),
                 ask_price: refusal.map(|(quote, _)| quote.ask_price()),
                 quote_timestamp: refusal.map(|(quote, _)| quote.timestamp()),
-                quote_rejection: refusal.map(|(_, rejection)| rejection.as_str().to_string()),
+                quote_rejection: refusal.map(|(_, rejection)| *rejection),
             }
         })
         .collect();
     unavailable.sort_by(|left, right| left.ticker.cmp(&right.ticker));
 
     context
-        .session_log
+        .journal
         .record(
             correlation_id,
             context.now,
             Observation::PricesObserved(PricesObserved {
-                purpose: purpose.to_string(),
+                purpose,
                 readings,
                 unavailable,
             }),
@@ -782,17 +768,17 @@ pub fn decide_entries(
                 (
                     candidate.pair_id().as_str().to_string(),
                     CandidateReading {
-                        pair_id: candidate.pair_id().as_str().to_string(),
-                        long_ticker: candidate.long_ticker().to_string(),
-                        short_ticker: candidate.short_ticker().to_string(),
+                        pair_id: candidate.pair_id().clone(),
+                        long_ticker: candidate.long_ticker().clone(),
+                        short_ticker: candidate.short_ticker().clone(),
                         hedge_ratio: candidate.hedge_ratio(),
                         entry_z_score: candidate.entry_z_score(),
                         signal_strength: candidate.signal_strength(),
                         rank_score: candidate.rank_score(),
                         long_notional: None,
-                        short_shares: None,
+                        short_quantity: None,
                         gross_exposure: None,
-                        decision: "not_selected".to_string(),
+                        decision: CandidateDecision::NotSelected,
                         refusal: None,
                     },
                 )
@@ -804,14 +790,14 @@ pub fn decide_entries(
     // Every candidate that reached the sizer carries what it was sized to, refused or not.
     for pair in &sized {
         if let Some(candidate) = plan.candidates.get_mut(pair.candidate().pair_id().as_str()) {
-            candidate.long_notional = pair.long_notional().value().to_f64();
-            candidate.short_shares = Some(f64::from(pair.short_shares().get()));
-            candidate.gross_exposure = pair.gross_exposure().to_f64();
+            candidate.long_notional = Some(pair.long_notional().value());
+            candidate.short_quantity = Some(Decimal::from(pair.short_shares().get()));
+            candidate.gross_exposure = Some(pair.gross_exposure());
         }
     }
     for refusal in &refusals {
         if let Some(candidate) = plan.candidates.get_mut(refusal.pair_id.as_str()) {
-            candidate.decision = "risk_refused".to_string();
+            candidate.decision = CandidateDecision::RiskRefused;
             candidate.refusal = Some(format!("{}: {}", refusal.block.as_str(), refusal.block));
         }
     }
@@ -830,7 +816,7 @@ pub fn decide_entries(
             .candidates
             .get_mut(planned.pair.candidate().pair_id().as_str())
         {
-            candidate.decision = "planned".to_string();
+            candidate.decision = CandidateDecision::Planned;
         }
     }
     plan
@@ -867,7 +853,7 @@ async fn apply_entries(
                     .candidates
                     .get_mut(remaining.pair.candidate().pair_id().as_str())
                 {
-                    candidate.decision = "abandoned_at_shutdown".to_string();
+                    candidate.decision = CandidateDecision::AbandonedAtShutdown;
                 }
             }
             break;
@@ -894,11 +880,11 @@ async fn apply_entries(
                         error!(
                             pair_id = %entry.pair_id(),
                             long_ticker = %long_fill.ticker(),
-                            long_shares = long_fill.shares(),
-                            long_price = long_fill.average_price(),
+                            long_quantity = %long_fill.quantity(),
+                            long_price = %long_fill.average_price(),
                             short_ticker = %short_fill.ticker(),
-                            short_shares = short_fill.shares(),
-                            short_price = short_fill.average_price(),
+                            short_quantity = %short_fill.quantity(),
+                            short_price = %short_fill.average_price(),
                             %error,
                             "Pair filled at the broker but could not be recorded; the position is \
                              live with no pair row and will be flattened by the pre-close \
@@ -908,15 +894,15 @@ async fn apply_entries(
                     }
                 };
                 context
-                    .session_log
+                    .journal
                     .record(
                         execution.correlation_id,
                         context.now,
                         Observation::PairOpened(PairOpened {
-                            pair_uuid: pair_uuid.to_string(),
-                            pair_id: entry.pair_id().to_string(),
-                            long_ticker: entry.long_ticker().to_string(),
-                            short_ticker: entry.short_ticker().to_string(),
+                            equity_pair_id: pair_uuid,
+                            pair_id: entry.pair_id().clone(),
+                            long_ticker: entry.long_ticker().clone(),
+                            short_ticker: entry.short_ticker().clone(),
                             hedge_ratio: entry.hedge_ratio(),
                             entry_z_score: entry.entry_z_score(),
                             signal_strength: entry.signal_strength(),
@@ -930,7 +916,7 @@ async fn apply_entries(
                     )
                     .await;
                 if let Some(candidate) = outcome.candidates.get_mut(entry.pair_id().as_str()) {
-                    candidate.decision = "opened".to_string();
+                    candidate.decision = CandidateDecision::Opened;
                 }
                 outcome.opened.push(entry.pair_id().to_string());
             }
@@ -940,7 +926,7 @@ async fn apply_entries(
                     .candidates
                     .get_mut(pair.candidate().pair_id().as_str())
                 {
-                    candidate.decision = "unfilled".to_string();
+                    candidate.decision = CandidateDecision::Unfilled;
                     candidate.refusal = Some(reason.clone());
                 }
                 outcome.refused.push(format!("unfilled:{ticker}"));
@@ -959,13 +945,13 @@ fn entry_plan_actions(plan: &EntryPlan) -> Vec<PlannedAction> {
         .map(|(rank, planned)| {
             let candidate = planned.pair.candidate();
             PlannedAction {
-                pair_id: candidate.pair_id().as_str().to_string(),
+                pair_id: candidate.pair_id().clone(),
                 action: PlannedActionKind::Open,
-                reason: format!("rank {}", rank + 1),
-                long_ticker: candidate.long_ticker().to_string(),
-                short_ticker: candidate.short_ticker().to_string(),
-                long_notional: planned.pair.long_notional().value().to_f64(),
-                short_shares: Some(f64::from(planned.pair.short_shares().get())),
+                reason: PlannedReason::Rank(rank as u32 + 1),
+                long_ticker: candidate.long_ticker().clone(),
+                short_ticker: candidate.short_ticker().clone(),
+                long_notional: Some(planned.pair.long_notional().value()),
+                short_quantity: Some(Decimal::from(planned.pair.short_shares().get())),
             }
         })
         .collect()
@@ -983,7 +969,7 @@ async fn record_plan(
     considered: usize,
 ) {
     context
-        .session_log
+        .journal
         .record(
             correlation_id,
             context.now,
@@ -1003,11 +989,11 @@ fn exit_plan_actions(plan: &ExitPlan) -> Vec<PlannedAction> {
         .map(|close| PlannedAction {
             pair_id: close.pair_id.clone(),
             action: PlannedActionKind::Close,
-            reason: close.reason.as_str().to_string(),
-            long_ticker: close.long_ticker.to_string(),
-            short_ticker: close.short_ticker.to_string(),
+            reason: PlannedReason::Close(close.reason),
+            long_ticker: close.long_ticker.clone(),
+            short_ticker: close.short_ticker.clone(),
             long_notional: None,
-            short_shares: None,
+            short_quantity: None,
         })
         .collect()
 }
@@ -1046,9 +1032,9 @@ pub fn decide_exits(reading: &ExitReading) -> ExitPlan {
 
     for pair in &reading.open_pairs {
         let mut open_pair_reading = OpenPairReading {
-            pair_id: pair.pair_id().to_string(),
-            long_ticker: pair.long_ticker().to_string(),
-            short_ticker: pair.short_ticker().to_string(),
+            pair_id: pair.pair_id().clone(),
+            long_ticker: pair.long_ticker().clone(),
+            short_ticker: pair.short_ticker().clone(),
             stored_hedge_ratio: pair.hedge_ratio(),
             model_hedge_ratio: None,
             spread_mean: None,
@@ -1058,7 +1044,7 @@ pub fn decide_exits(reading: &ExitReading) -> ExitPlan {
             stop_at: pair.entry_z_score() + screen::STOP_LOSS_WIDENING,
             entry_session: SessionDate::at(pair.opened_at()),
             minutes_held: pair.minutes_held(reading.now),
-            decision: "held".to_string(),
+            decision: PairDecision::Held,
         };
 
         let (Some(long_price), Some(short_price)) = (
@@ -1067,13 +1053,13 @@ pub fn decide_exits(reading: &ExitReading) -> ExitPlan {
         ) else {
             plan.unpriced += 1;
             warn!(pair_id = %pair.pair_id(), "Open pair could not be priced this pass");
-            open_pair_reading.decision = "unpriced".to_string();
+            open_pair_reading.decision = PairDecision::Unpriced;
             plan.readings.push(open_pair_reading);
             continue;
         };
         let Some(model) = reading.models.get(pair.pair_id()) else {
             warn!(pair_id = %pair.pair_id(), "Open pair has no rebuildable spread model");
-            open_pair_reading.decision = "no_spread_model".to_string();
+            open_pair_reading.decision = PairDecision::NoSpreadModel;
             plan.readings.push(open_pair_reading);
             continue;
         };
@@ -1083,7 +1069,7 @@ pub fn decide_exits(reading: &ExitReading) -> ExitPlan {
         open_pair_reading.spread_standard_deviation = Some(model.standard_deviation());
 
         let Some(z_score) = model.z_score(long_price.price(), short_price.price()) else {
-            open_pair_reading.decision = "unreadable_spread".to_string();
+            open_pair_reading.decision = PairDecision::UnreadableSpread;
             plan.readings.push(open_pair_reading);
             continue;
         };
@@ -1140,8 +1126,8 @@ pub fn decide_exits(reading: &ExitReading) -> ExitPlan {
         };
 
         plan.closes.push(PlannedClose {
-            pair_uuid: pair.id(),
-            pair_id: pair.pair_id().to_string(),
+            equity_pair_id: pair.id(),
+            pair_id: pair.pair_id().clone(),
             long_ticker: pair.long_ticker().clone(),
             short_ticker: pair.short_ticker().clone(),
             reason,
@@ -1179,7 +1165,7 @@ async fn apply_exits(
         };
         let broker_outcome = match execute::close_pair(
             execution,
-            close.pair_id.as_str(),
+            &close.pair_id,
             &close.long_ticker,
             &close.short_ticker,
         )
@@ -1193,7 +1179,7 @@ async fn apply_exits(
                     "Closing a pair failed; it stays open and the next pass retries"
                 );
                 outcome.failed.push(close.pair_id.clone());
-                reading.decision = "close_failed".to_string();
+                reading.decision = PairDecision::CloseFailed;
                 continue;
             }
         };
@@ -1204,36 +1190,42 @@ async fn apply_exits(
         } else {
             close.reason
         };
-        let updated =
-            match pairs::record_close(context.pool, close.pair_uuid, reason, context.now).await {
-                Ok(updated) => updated,
-                Err(error) => {
-                    reading.decision = "close_failed".to_string();
-                    // The outcome travels with the error. Pairs closed before this one reached the
-                    // broker and the database, and reporting them as never attempted is worse than
-                    // the failure itself.
-                    return (outcome, Some(error.into()));
-                }
-            };
+        let updated = match pairs::record_close(
+            context.pool,
+            close.equity_pair_id,
+            reason,
+            context.now,
+        )
+        .await
+        {
+            Ok(updated) => updated,
+            Err(error) => {
+                reading.decision = PairDecision::CloseFailed;
+                // The outcome travels with the error. Pairs closed before this one reached the
+                // broker and the database, and reporting them as never attempted is worse than
+                // the failure itself.
+                return (outcome, Some(error.into()));
+            }
+        };
         context
-            .session_log
+            .journal
             .record(
                 execution.correlation_id,
                 context.now,
                 Observation::PairClosed(PairClosed {
-                    pair_uuid: close.pair_uuid.to_string(),
-                    reason: reason.as_str().to_string(),
+                    equity_pair_id: close.equity_pair_id,
+                    reason,
                     closed_at: context.now,
                     updated,
                 }),
             )
             .await;
 
-        outcome.closed.insert(close.pair_uuid);
-        reading.decision = reason.as_str().to_string();
+        outcome.closed.insert(close.equity_pair_id);
+        reading.decision = reason.into();
         outcome.closed_records.push(ClosedRecord {
             pair_id: close.pair_id.clone(),
-            reason: reason.as_str().to_string(),
+            reason,
         });
     }
 
@@ -1337,32 +1329,40 @@ async fn build_screen_inputs(
     for prediction in &predictions {
         let ticker = prediction.ticker();
         let reason = if held.contains(ticker) {
-            Some("already_held")
+            Some(ExclusionReason::AlreadyHeld)
         } else if !sectors.contains_key(ticker) {
-            Some("no_sector")
+            Some(ExclusionReason::NoSector)
         } else if !context.close_history.contains_key(ticker) {
-            Some("no_close_history")
+            Some(ExclusionReason::NoCloseHistory)
         } else if !context.universe.contains(ticker) {
-            Some("outside_universe")
+            Some(ExclusionReason::OutsideUniverse)
         } else {
             None
         };
         match reason {
             Some(reason) => excluded.push(ExcludedTickerReading {
-                ticker: ticker.to_string(),
-                reason: reason.to_string(),
+                ticker: ticker.clone(),
+                reason,
                 detail: None,
             }),
             None => eligible.push(prediction),
         }
     }
 
-    let missing: Vec<String> = eligible
+    let missing: Vec<Ticker> = eligible
         .iter()
         .filter(|prediction| !prices.contains_key(prediction.ticker()))
-        .map(|prediction| prediction.ticker().to_string())
+        .map(|prediction| prediction.ticker().clone())
         .collect();
-    prices.extend(fetch_prices(context, correlation_id, "screen_candidates", &missing).await?);
+    prices.extend(
+        fetch_prices(
+            context,
+            correlation_id,
+            PricePurpose::ScreenCandidates,
+            &missing,
+        )
+        .await?,
+    );
 
     let mut inputs: Vec<ScreenInput> = Vec::with_capacity(eligible.len());
     let mut readings: Vec<ScreenInputReading> = Vec::with_capacity(eligible.len());
@@ -1374,8 +1374,8 @@ async fn build_screen_inputs(
             (context.close_history.get(ticker), prices.get(ticker))
         else {
             excluded.push(ExcludedTickerReading {
-                ticker: ticker.to_string(),
-                reason: "unpriced".to_string(),
+                ticker: ticker.clone(),
+                reason: ExclusionReason::Unpriced,
                 detail: None,
             });
             continue;
@@ -1391,15 +1391,15 @@ async fn build_screen_inputs(
             Ok(input) => input,
             Err(rejection) => {
                 excluded.push(ExcludedTickerReading {
-                    ticker: ticker.to_string(),
-                    reason: rejection.as_str().to_string(),
+                    ticker: ticker.clone(),
+                    reason: rejection.exclusion_reason(),
                     detail: rejection.detail(),
                 });
                 continue;
             }
         };
         readings.push(ScreenInputReading {
-            ticker: ticker.to_string(),
+            ticker: ticker.clone(),
             expected_return: prediction.expected_return(),
             confidence: prediction.confidence(),
             is_shortable: context.universe.is_shortable(ticker),
@@ -1415,7 +1415,7 @@ async fn build_screen_inputs(
         "Screen inputs assembled"
     );
     context
-        .session_log
+        .journal
         .record(
             correlation_id,
             context.now,
@@ -1519,7 +1519,7 @@ mod tests {
             "a spread back through its mean has converged"
         );
         assert_eq!(plan.closes[0].reason, CloseReason::Convergence);
-        assert_eq!(plan.closes[0].pair_id, "AAAA-BBBB");
+        assert_eq!(plan.closes[0].pair_id.as_str(), "AAAA-BBBB");
         assert_eq!(plan.readings.len(), 1, "every open pair is measured");
         assert_eq!(plan.unpriced, 0);
     }
@@ -1532,7 +1532,7 @@ mod tests {
 
         assert!(plan.closes.is_empty(), "nothing is closed unmeasured");
         assert_eq!(plan.unpriced, 1);
-        assert_eq!(plan.readings[0].decision, "unpriced");
+        assert_eq!(plan.readings[0].decision, PairDecision::Unpriced);
         assert_eq!(plan.readings[0].z_score, None);
     }
 
@@ -1542,7 +1542,7 @@ mod tests {
         let plan = decide_exits(&exit_reading_for(ENTRY_Z_SCORE, true));
 
         assert!(plan.closes.is_empty());
-        assert_eq!(plan.readings[0].decision, "held");
+        assert_eq!(plan.readings[0].decision, PairDecision::Held);
         assert_eq!(plan.unpriced, 0);
     }
 
@@ -1569,7 +1569,7 @@ mod tests {
             overnight.closes.is_empty(),
             "across sessions the stop is unreadable, so the pair is held"
         );
-        assert_eq!(overnight.readings[0].decision, "held");
+        assert_eq!(overnight.readings[0].decision, PairDecision::Held);
     }
 
     /// A pair whose spread model could not be rebuilt is held and named, never closed.
@@ -1578,7 +1578,7 @@ mod tests {
         let plan = decide_exits(&exit_reading_with(-1.0, true, false, 0));
 
         assert!(plan.closes.is_empty());
-        assert_eq!(plan.readings[0].decision, "no_spread_model");
+        assert_eq!(plan.readings[0].decision, PairDecision::NoSpreadModel);
         assert_eq!(
             plan.unpriced, 0,
             "it was priced; what it lacked was the model"
@@ -1703,12 +1703,12 @@ mod tests {
                 Utc::now(),
             )
         };
-        let symbols = leg_symbols(&[pair("AAAA", "BBBB"), pair("AAAA", "CCCC")]);
+        let symbols = leg_tickers(&[pair("AAAA", "BBBB"), pair("AAAA", "CCCC")]);
         assert_eq!(symbols.len(), 3);
     }
 
     #[test]
     fn test_leg_symbols_is_empty_for_an_empty_book() {
-        assert!(leg_symbols(&[]).is_empty());
+        assert!(leg_tickers(&[]).is_empty());
     }
 }

--- a/src/portfolio/execute.rs
+++ b/src/portfolio/execute.rs
@@ -10,15 +10,17 @@
 use std::time::Duration;
 
 use chrono::Utc;
-use rust_decimal::prelude::ToPrimitive;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
+use rust_decimal::Decimal;
+
 use crate::common::alpaca::{ClientError, OrderIntent, OrderState, PositionClose, TradingClient};
-use crate::common::session_log::{
-    Observation, OrderResolved, OrderSubmitted, PositionCloseRequested, SessionLog,
+use crate::common::journal::{
+    CloseRequestReason, Journal, Observation, OrderOutcome, OrderResolved, OrderSubmitted,
+    PositionCloseRequested,
 };
-use crate::common::types::Ticker;
+use crate::common::types::{PairID, Ticker};
 use crate::portfolio::pairs::PairEntry;
 use crate::portfolio::size::SizedPair;
 
@@ -73,7 +75,7 @@ impl Default for ExecutionSettings {
 pub struct ExecutionContext<'a> {
     pub client: &'a TradingClient,
     pub settings: ExecutionSettings,
-    pub session_log: &'a SessionLog,
+    pub journal: &'a Journal,
     /// The evaluation pass this order belongs to.
     pub correlation_id: Uuid,
 }
@@ -83,8 +85,8 @@ pub struct ExecutionContext<'a> {
 pub struct LegFill {
     ticker: Ticker,
     order_id: String,
-    shares: f64,
-    average_price: f64,
+    quantity: Decimal,
+    average_price: Decimal,
 }
 
 impl LegFill {
@@ -96,11 +98,11 @@ impl LegFill {
         &self.order_id
     }
 
-    pub fn shares(&self) -> f64 {
-        self.shares
+    pub fn quantity(&self) -> Decimal {
+        self.quantity
     }
 
-    pub fn average_price(&self) -> f64 {
+    pub fn average_price(&self) -> Decimal {
         self.average_price
     }
 }
@@ -113,8 +115,11 @@ impl LegFill {
 #[derive(Debug, Clone, PartialEq)]
 pub enum OpenOutcome {
     /// Both legs filled. The pair is on the book.
+    ///
+    /// Boxed because it dwarfs the other variant, and every caller matches on the enum before it
+    /// reaches the entry.
     Opened {
-        entry: PairEntry,
+        entry: Box<PairEntry>,
         long_fill: LegFill,
         short_fill: LegFill,
     },
@@ -145,7 +150,7 @@ impl CloseOutcome {
     /// Whether Alpaca had no position for either leg.
     ///
     /// The pair is closed either way; this only decides whether the recorded reason is the one the
-    /// strategy chose or [`crate::portfolio::pairs::CloseReason::PositionMissing`].
+    /// strategy chose or [`crate::common::types::CloseReason::PositionMissing`].
     pub fn was_already_gone(self) -> bool {
         !self.long_closed && !self.short_closed
     }
@@ -171,7 +176,7 @@ pub async fn open_pair(
         context,
         &OrderIntent::OpenShort {
             ticker: short_ticker.clone(),
-            shares: pair.short_shares(),
+            quantity: pair.short_shares(),
         },
     )
     .await?
@@ -216,8 +221,8 @@ pub async fn open_pair(
             record_close(
                 context,
                 &short_ticker,
-                Some(candidate.pair_id().as_str()),
-                "entry_unwind",
+                Some(candidate.pair_id()),
+                CloseRequestReason::EntryUnwind,
                 &unwind,
             )
             .await;
@@ -225,7 +230,7 @@ pub async fn open_pair(
                 error!(
                     pair_id = %candidate.pair_id(),
                     held_ticker = %short_ticker,
-                    held_shares = short_fill.shares,
+                    held_quantity = %short_fill.quantity,
                     %error,
                     "Unwind failed; an unhedged short position is held with no pair record"
                 );
@@ -248,12 +253,12 @@ pub async fn open_pair(
 
     info!(
         pair_id = %candidate.pair_id(),
-        long_shares = long_fill.shares,
-        short_shares = short_fill.shares,
+        long_quantity = %long_fill.quantity,
+        short_quantity = %short_fill.quantity,
         "Pair opened on Alpaca"
     );
     Ok(OpenOutcome::Opened {
-        entry,
+        entry: Box::new(entry),
         long_fill,
         short_fill,
     })
@@ -267,7 +272,7 @@ pub async fn open_pair(
 /// situation where it is most likely still held. The error is reported after both attempts.
 pub async fn close_pair(
     context: &ExecutionContext<'_>,
-    pair_id: &str,
+    pair_id: &PairID,
     long_ticker: &Ticker,
     short_ticker: &Ticker,
 ) -> Result<CloseOutcome, ExecutionError> {
@@ -277,7 +282,14 @@ pub async fn close_pair(
     // Recorded before the errors are propagated. A leg whose close failed is exactly the one worth
     // having a record of, and `?` below returns without reaching any later write.
     for (ticker, result) in [(long_ticker, &long_result), (short_ticker, &short_result)] {
-        record_close(context, ticker, Some(pair_id), "pair_exit", result).await;
+        record_close(
+            context,
+            ticker,
+            Some(pair_id),
+            CloseRequestReason::PairExit,
+            result,
+        )
+        .await;
     }
 
     if let Err(error) = &long_result {
@@ -312,26 +324,26 @@ pub async fn close_pair(
 async fn record_close(
     context: &ExecutionContext<'_>,
     ticker: &Ticker,
-    pair_id: Option<&str>,
-    reason: &str,
+    pair_id: Option<&PairID>,
+    reason: CloseRequestReason,
     result: &Result<Option<PositionClose>, ClientError>,
 ) {
     let close = result.as_ref().ok().and_then(Option::as_ref);
     let error = result.as_ref().err().map(ToString::to_string);
     context
-        .session_log
+        .journal
         .record(
             context.correlation_id,
             Utc::now(),
             Observation::PositionCloseRequested(PositionCloseRequested {
-                ticker: ticker.to_string(),
-                pair_id: pair_id.map(str::to_string),
+                ticker: ticker.clone(),
+                pair_id: pair_id.cloned(),
                 alpaca_order_id: close
                     .and_then(|close| close.alpaca_order_id())
                     .map(str::to_string),
-                side: close.and_then(|close| close.side()).map(str::to_string),
+                side: close.and_then(PositionClose::side),
                 quantity: close.and_then(PositionClose::quantity),
-                reason: reason.to_string(),
+                reason,
                 accepted: close.is_some(),
                 status: None,
                 error,
@@ -354,27 +366,27 @@ async fn submit_and_confirm(
     context: &ExecutionContext<'_>,
     intent: &OrderIntent,
 ) -> Result<Filled, ExecutionError> {
-    let client_order_id = Uuid::new_v4().to_string();
-    let (shares, notional) = match intent {
-        OrderIntent::OpenShort { shares, .. } => (Some(f64::from(shares.get())), None),
-        OrderIntent::OpenLong { notional, .. } => (None, notional.value().to_f64()),
+    let client_order_id = Uuid::new_v4();
+    let (quantity, notional) = match intent {
+        OrderIntent::OpenShort { quantity, .. } => (Some(Decimal::from(quantity.get())), None),
+        OrderIntent::OpenLong { notional, .. } => (None, Some(notional.value())),
     };
     context
-        .session_log
+        .journal
         .record(
             context.correlation_id,
             Utc::now(),
             Observation::OrderSubmitted(OrderSubmitted {
-                client_order_id: client_order_id.clone(),
-                ticker: intent.ticker().to_string(),
-                side: intent.side().to_string(),
-                shares,
+                client_order_id,
+                ticker: intent.ticker().clone(),
+                side: intent.side(),
+                quantity,
                 notional,
             }),
         )
         .await;
 
-    let order_id = match context.client.submit_order(intent, &client_order_id).await {
+    let order_id = match context.client.submit_order(intent, client_order_id).await {
         Ok(order_id) => order_id,
         Err(error) => {
             // The order never reached the broker, so there is no identifier to resolve it under.
@@ -384,9 +396,9 @@ async fn submit_and_confirm(
                 OrderResolved {
                     client_order_id,
                     alpaca_order_id: None,
-                    ticker: intent.ticker().to_string(),
-                    outcome: "submit_failed".to_string(),
-                    filled_shares: None,
+                    ticker: intent.ticker().clone(),
+                    outcome: OrderOutcome::SubmitFailed,
+                    filled_quantity: None,
                     filled_average_price: None,
                     filled_after_cancel: false,
                     broker_status: None,
@@ -398,16 +410,16 @@ async fn submit_and_confirm(
         }
     };
 
-    let confirmation = confirm_fill(context, intent, &client_order_id, &order_id).await;
+    let confirmation = confirm_fill(context, intent, client_order_id, &order_id).await;
     if let Err(error) = &confirmation {
         record_resolution(
             context,
             OrderResolved {
                 client_order_id,
                 alpaca_order_id: Some(order_id),
-                ticker: intent.ticker().to_string(),
-                outcome: "broker_unreachable".to_string(),
-                filled_shares: None,
+                ticker: intent.ticker().clone(),
+                outcome: OrderOutcome::BrokerUnreachable,
+                filled_quantity: None,
                 filled_average_price: None,
                 filled_after_cancel: false,
                 broker_status: None,
@@ -426,21 +438,21 @@ async fn submit_and_confirm(
 async fn confirm_fill(
     context: &ExecutionContext<'_>,
     intent: &OrderIntent,
-    client_order_id: &str,
+    client_order_id: Uuid,
     order_id: &str,
 ) -> Result<Filled, ExecutionError> {
     let deadline = tokio::time::Instant::now() + context.settings.fill_timeout;
 
     macro_rules! resolved {
-        ($outcome:expr, $shares:expr, $price:expr, $after_cancel:expr, $broker_status:expr) => {
+        ($outcome:expr, $quantity:expr, $price:expr, $after_cancel:expr, $broker_status:expr) => {
             record_resolution(
                 context,
                 OrderResolved {
-                    client_order_id: client_order_id.to_string(),
+                    client_order_id,
                     alpaca_order_id: Some(order_id.to_string()),
-                    ticker: intent.ticker().to_string(),
+                    ticker: intent.ticker().clone(),
                     outcome: $outcome,
-                    filled_shares: $shares,
+                    filled_quantity: $quantity,
                     filled_average_price: $price,
                     filled_after_cancel: $after_cancel,
                     broker_status: $broker_status,
@@ -455,12 +467,12 @@ async fn confirm_fill(
         match context.client.fetch_order(order_id).await? {
             OrderState::Filled {
                 status,
-                filled_shares,
+                filled_quantity,
                 average_price,
             } => {
                 resolved!(
-                    "filled".to_string(),
-                    Some(filled_shares),
+                    OrderOutcome::Filled,
+                    Some(filled_quantity),
                     Some(average_price),
                     false,
                     Some(status)
@@ -468,32 +480,39 @@ async fn confirm_fill(
                 return Ok(Filled::Yes(LegFill {
                     ticker: intent.ticker().clone(),
                     order_id: order_id.to_string(),
-                    shares: filled_shares,
+                    quantity: filled_quantity,
                     average_price,
                 }));
             }
             OrderState::Abandoned {
                 status,
-                filled_shares,
+                filled_quantity,
             } => {
                 resolved!(
-                    status.clone(),
-                    Some(filled_shares),
+                    OrderOutcome::Abandoned,
+                    Some(filled_quantity),
                     None,
                     false,
                     Some(status.clone())
                 );
                 // A partial fill that then terminated leaves shares held. Close the position rather
                 // than reporting the leg cleanly unfilled.
-                if filled_shares > 0.0 {
+                if filled_quantity > Decimal::ZERO {
                     warn!(
                         ticker = %intent.ticker(),
                         order_id,
-                        filled_shares,
+                        %filled_quantity,
                         "Order terminated after a partial fill; closing the remainder"
                     );
                     let cleanup = context.client.close_position(intent.ticker()).await;
-                    record_close(context, intent.ticker(), None, "entry_unwind", &cleanup).await;
+                    record_close(
+                        context,
+                        intent.ticker(),
+                        None,
+                        CloseRequestReason::EntryUnwind,
+                        &cleanup,
+                    )
+                    .await;
                     cleanup?;
                 }
                 return Ok(Filled::No(status));
@@ -511,13 +530,13 @@ async fn confirm_fill(
                     let after_cancel = context.client.fetch_order(order_id).await?;
                     if let OrderState::Filled {
                         status: filled_status,
-                        filled_shares,
+                        filled_quantity,
                         average_price,
                     } = &after_cancel
                     {
                         resolved!(
-                            "filled".to_string(),
-                            Some(*filled_shares),
+                            OrderOutcome::Filled,
+                            Some(*filled_quantity),
                             Some(*average_price),
                             true,
                             Some(filled_status.clone())
@@ -525,7 +544,7 @@ async fn confirm_fill(
                         return Ok(Filled::Yes(LegFill {
                             ticker: intent.ticker().clone(),
                             order_id: order_id.to_string(),
-                            shares: *filled_shares,
+                            quantity: *filled_quantity,
                             average_price: *average_price,
                         }));
                     }
@@ -533,14 +552,21 @@ async fn confirm_fill(
                     // terminated with a partial fill reports those shares here, and recording the
                     // pre-cancel status would contradict what `broker_status` claims to be.
                     resolved!(
-                        "timed_out".to_string(),
-                        Some(after_cancel.filled_shares()),
+                        OrderOutcome::TimedOut,
+                        Some(after_cancel.filled_quantity()),
                         None,
                         false,
                         Some(after_cancel.broker_status().to_string())
                     );
                     let cleanup = context.client.close_position(intent.ticker()).await;
-                    record_close(context, intent.ticker(), None, "entry_unwind", &cleanup).await;
+                    record_close(
+                        context,
+                        intent.ticker(),
+                        None,
+                        CloseRequestReason::EntryUnwind,
+                        &cleanup,
+                    )
+                    .await;
                     cleanup?;
                     return Ok(Filled::No("timed_out".to_string()));
                 }
@@ -553,7 +579,7 @@ async fn confirm_fill(
 /// Writes how the broker settled one order.
 async fn record_resolution(context: &ExecutionContext<'_>, resolved: OrderResolved) {
     context
-        .session_log
+        .journal
         .record(
             context.correlation_id,
             Utc::now(),
@@ -579,13 +605,17 @@ mod tests {
         Ticker::new(raw).unwrap()
     }
 
+    fn pair_id(raw: &str) -> PairID {
+        PairID::parse(raw).expect("the test pair identifier must be valid")
+    }
+
     fn settings() -> ExecutionSettings {
         ExecutionSettings::new(Duration::from_millis(50), Duration::from_millis(5))
     }
 
     /// A log in a directory of this test's own. Every order path writes to one, so the tests
     /// exercise the record-before-submit ordering rather than mocking it away.
-    fn session_log(name: &str) -> SessionLog {
+    fn journal(name: &str) -> Journal {
         use std::sync::atomic::{AtomicUsize, Ordering};
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -594,11 +624,11 @@ mod tests {
             std::process::id()
         ));
         let _ = std::fs::remove_dir_all(&directory);
-        SessionLog::new(directory).expect("the log directory must be creatable")
+        Journal::new(directory).expect("the log directory must be creatable")
     }
 
     /// Every record a log holds, in the order it was written.
-    fn recorded(log: &SessionLog) -> Vec<serde_json::Value> {
+    fn recorded(log: &Journal) -> Vec<serde_json::Value> {
         let mut files: Vec<_> = std::fs::read_dir(log.directory())
             .expect("the log directory must be readable")
             .filter_map(Result::ok)
@@ -617,11 +647,11 @@ mod tests {
             .collect()
     }
 
-    fn context<'a>(client: &'a TradingClient, log: &'a SessionLog) -> ExecutionContext<'a> {
+    fn context<'a>(client: &'a TradingClient, log: &'a Journal) -> ExecutionContext<'a> {
         ExecutionContext {
             client,
             settings: settings(),
-            session_log: log,
+            journal: log,
             correlation_id: Uuid::nil(),
         }
     }
@@ -665,7 +695,7 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let log = session_log("fills-both-legs");
+        let log = journal("fills-both-legs");
         let outcome = open_pair(&context(&client, &log), &pair(), Some("run-1".to_string()))
             .await
             .expect("the open must succeed");
@@ -679,7 +709,7 @@ mod tests {
                 assert_eq!(entry.model_run_id(), Some("run-1"));
                 assert_eq!(long_fill.ticker().as_str(), "AAAA");
                 assert_eq!(short_fill.ticker().as_str(), "BBBB");
-                assert_eq!(short_fill.average_price(), 100.0);
+                assert_eq!(short_fill.average_price(), Decimal::new(100, 0));
             }
             other => panic!("expected both legs to fill, got {other:?}"),
         }
@@ -707,7 +737,7 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let log = session_log("rejected-short");
+        let log = journal("rejected-short");
         let outcome = open_pair(&context(&client, &log), &pair(), None)
             .await
             .expect("an unfilled leg is not an error");
@@ -764,7 +794,7 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let log = session_log("failed-long");
+        let log = journal("failed-long");
         let outcome = open_pair(&context(&client, &log), &pair(), None)
             .await
             .expect("the unwind must succeed");
@@ -812,7 +842,7 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let log = session_log("timed-out");
+        let log = journal("timed-out");
         let outcome = open_pair(&context(&client, &log), &pair(), None)
             .await
             .expect("a timeout is not an error");
@@ -864,13 +894,13 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let log = session_log("timeout-after-cancel");
+        let log = journal("timeout-after-cancel");
         let context = ExecutionContext {
             client: &client,
             // No timeout at all, so the first poll is already past the deadline and the second read
             // is unambiguously the post-cancel one.
             settings: ExecutionSettings::new(Duration::from_millis(0), Duration::from_millis(5)),
-            session_log: &log,
+            journal: &log,
             correlation_id: Uuid::nil(),
         };
 
@@ -892,7 +922,7 @@ mod tests {
             "the post-cancel status, not the working one that preceded it"
         );
         assert_eq!(
-            timed_out["payload"]["filled_shares"], 12.0,
+            timed_out["payload"]["filled_quantity"], 12.0,
             "shares that filled before the cancel are not unknown"
         );
     }
@@ -923,7 +953,7 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let log = session_log("partial-fill");
+        let log = journal("partial-fill");
         let outcome = open_pair(&context(&client, &log), &pair(), None)
             .await
             .expect("a partial fill is not an error");
@@ -952,10 +982,10 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let log = session_log("close-both-legs");
+        let log = journal("close-both-legs");
         let outcome = close_pair(
             &context(&client, &log),
-            "AAAA-BBBB",
+            &pair_id("AAAA-BBBB"),
             &ticker("AAAA"),
             &ticker("BBBB"),
         )
@@ -991,10 +1021,10 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let log = session_log("close-long-errors");
+        let log = journal("close-long-errors");
         let result = close_pair(
             &context(&client, &log),
-            "AAAA-BBBB",
+            &pair_id("AAAA-BBBB"),
             &ticker("AAAA"),
             &ticker("BBBB"),
         )
@@ -1032,7 +1062,7 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let log = session_log("rejected-submission");
+        let log = journal("rejected-submission");
         let result = open_pair(&context(&client, &log), &pair(), None).await;
 
         assert!(result.is_err(), "the broker failure must still be reported");
@@ -1073,10 +1103,10 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let log = session_log("records-both-legs");
+        let log = journal("records-both-legs");
         close_pair(
             &context(&client, &log),
-            "AAAA-BBBB",
+            &pair_id("AAAA-BBBB"),
             &ticker("AAAA"),
             &ticker("BBBB"),
         )
@@ -1129,10 +1159,10 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let log = session_log("refused-close");
+        let log = journal("refused-close");
         let _ = close_pair(
             &context(&client, &log),
-            "AAAA-BBBB",
+            &pair_id("AAAA-BBBB"),
             &ticker("AAAA"),
             &ticker("BBBB"),
         )
@@ -1163,10 +1193,10 @@ mod tests {
             .await;
 
         let client = TradingClient::with_base_url(credentials(), server.url());
-        let log = session_log("already-gone");
+        let log = journal("already-gone");
         let outcome = close_pair(
             &context(&client, &log),
-            "AAAA-BBBB",
+            &pair_id("AAAA-BBBB"),
             &ticker("AAAA"),
             &ticker("BBBB"),
         )

--- a/src/portfolio/pairs.rs
+++ b/src/portfolio/pairs.rs
@@ -13,76 +13,13 @@ use sqlx::PgPool;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::common::types::{PairID, Ticker};
+use crate::common::types::{CloseReason, PairID, Ticker};
 
 /// Errors reading or writing the pair record.
 #[derive(Debug, thiserror::Error)]
 pub enum PairsError {
     #[error("equity_pairs access failed: {0}")]
     Database(#[from] sqlx::Error),
-}
-
-/// Why an open pair was closed.
-///
-/// These four are the `close_reason` CHECK constraint in `schema.sql`, spelled as an enum so a
-/// reason the database would reject cannot be constructed in the first place.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CloseReason {
-    /// The spread returned through its mean. The trade worked.
-    Convergence,
-    /// The spread widened past the stop, against the position. The trade did not.
-    StopLoss,
-    /// The pre-close fail-safe flattened the book. No opinion either way.
-    EndOfDay,
-    /// Alpaca no longer reports a position for one or both legs, so there is nothing left to hold.
-    PositionMissing,
-}
-
-impl CloseReason {
-    /// Every variant, for exhaustive iteration in tests.
-    pub const ALL: [CloseReason; 4] = [
-        CloseReason::Convergence,
-        CloseReason::StopLoss,
-        CloseReason::EndOfDay,
-        CloseReason::PositionMissing,
-    ];
-
-    /// The stored form, which must match the CHECK constraint exactly.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            CloseReason::Convergence => "convergence",
-            CloseReason::StopLoss => "stop_loss",
-            CloseReason::EndOfDay => "end_of_day",
-            CloseReason::PositionMissing => "position_missing",
-        }
-    }
-
-    /// Parses the stored form. Returns `None` for anything outside the vocabulary.
-    pub fn parse(raw: &str) -> Option<Self> {
-        CloseReason::ALL
-            .into_iter()
-            .find(|reason| reason.as_str() == raw)
-    }
-
-    /// Whether this exit reflects the strategy's own opinion about the spread.
-    ///
-    /// A book that only ever exits at [`CloseReason::EndOfDay`] is one whose holding period is
-    /// shorter than the horizon it forecasts, which is the mismatch recorded in
-    /// `improvements_intraday_horizon.md`. The ratio of these two answers is the interim measure of
-    /// whether the strategy is doing anything, so the distinction is worth naming rather than
-    /// recomputing from a string at each call site.
-    pub fn is_signal(self) -> bool {
-        match self {
-            CloseReason::Convergence | CloseReason::StopLoss => true,
-            CloseReason::EndOfDay | CloseReason::PositionMissing => false,
-        }
-    }
-}
-
-impl std::fmt::Display for CloseReason {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(self.as_str())
-    }
 }
 
 /// Why a pair entry was rejected before it could be recorded.

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -101,7 +101,7 @@ pub const MAXIMUM_SESSION_LOG_RETURN: f64 = 0.40;
 
 /// Why a symbol could not be screened.
 ///
-/// Carried out of [`ScreenInput::new`] rather than collapsed into `None`, so the session log can say
+/// Carried out of [`ScreenInput::new`] rather than collapsed into `None`, so the journal can say
 /// which test a ticker failed and — where the test is a number — by how much.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ScreenRejection {
@@ -1262,7 +1262,7 @@ mod tests {
             limit: MAXIMUM_SESSION_LOG_RETURN,
         };
         assert_eq!(broken.as_str(), "structural_break");
-        // The whole string: the detail exists to be aggregated out of session logs, so the format
+        // The whole string: the detail exists to be aggregated out of the journal, so the format
         // is the contract and a `contains` check would not notice it drifting.
         assert_eq!(
             broken.detail().expect("a break reports its reading"),

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -13,6 +13,7 @@ use std::collections::{HashMap, HashSet};
 
 use tracing::debug;
 
+use crate::common::journal::ExclusionReason;
 use crate::common::types::{PairID, Ticker};
 
 /// Sessions of daily closes the correlation and the spread distribution are fitted over.
@@ -116,6 +117,14 @@ impl ScreenRejection {
         match self {
             ScreenRejection::UnusableInput => "unusable_input",
             ScreenRejection::StructuralBreak { .. } => "structural_break",
+        }
+    }
+
+    /// Which funnel exit this rejection is, for the journal.
+    pub fn exclusion_reason(&self) -> ExclusionReason {
+        match self {
+            ScreenRejection::UnusableInput => ExclusionReason::UnusableInput,
+            ScreenRejection::StructuralBreak { .. } => ExclusionReason::StructuralBreak,
         }
     }
 
@@ -654,10 +663,6 @@ pub fn exit_models<'a>(
     models
 }
 
-// ---------------------------------------------------------------------------
-// Statistics
-// ---------------------------------------------------------------------------
-
 /// Takes the natural logarithm of two series, returning `None` unless both are the same usable
 /// length with no non-positive value.
 fn aligned_logs(long_closes: &[f64], short_closes: &[f64]) -> Option<(Vec<f64>, Vec<f64>)> {
@@ -823,8 +828,6 @@ mod tests {
             .expect("test input must be constructible")
     }
 
-    // --- the spread model ---
-
     /// The whole point of the type. An open pair's exit is judged against the hedge ratio it was
     /// entered on, so the spread being measured now is the one the entry threshold was applied to.
     /// Refitting instead would judge the position against a line it was never above.
@@ -922,8 +925,6 @@ mod tests {
         assert_eq!(model.z_score(100.0, f64::NAN), None);
     }
 
-    // --- statistics ---
-
     #[test]
     fn test_ordinary_least_squares_recovers_a_known_slope() {
         let x_values: Vec<f64> = (0..20).map(|index| index as f64).collect();
@@ -958,8 +959,6 @@ mod tests {
         assert_eq!(returns.len(), 2);
         assert!((returns[0] - returns[1]).abs() < 1e-12);
     }
-
-    // --- the screen ---
 
     /// The fixture has to actually produce pairs, or every assertion below it passes vacuously.
     /// This is the trap recorded in `statistical_arbitrage_test_fixtures`.
@@ -1164,8 +1163,6 @@ mod tests {
         );
     }
 
-    // --- structural breaks ---
-
     /// A window holding one persistent level change, the shape a collapse or a split leaves behind.
     fn window_with_one_move(log_return: f64) -> Vec<f64> {
         let mut closes = vec![100.0; CORRELATION_WINDOW_SESSIONS];
@@ -1280,8 +1277,6 @@ mod tests {
         let move_down = worst_session_move(&[100.0, 110.0, 55.0]).expect("a move must be found");
         assert!((move_down - (55.0_f64 / 110.0).ln()).abs() < 1e-12);
     }
-
-    // --- selection ---
 
     /// Assigns every named ticker to one sector, for the selection tests.
     fn sector_map(assignments: &[(&str, &str)]) -> HashMap<Ticker, String> {

--- a/tests/test_dashboard.rs
+++ b/tests/test_dashboard.rs
@@ -13,13 +13,14 @@
 mod common;
 
 use chrono::{Duration, Utc};
-use fund::common::alpaca::AccountSnapshot;
+use fund::common::alpaca::{AccountSnapshot, ActivityType};
 use fund::common::events::{self, Command, EventType, Outcome};
 use fund::common::types::{PairID, SessionDate, Ticker};
 use fund::dashboard::database::fetch_dashboard_data;
 
+use fund::common::types::CloseReason;
 use fund::portfolio::account;
-use fund::portfolio::pairs::{self, CloseReason, PairEntry};
+use fund::portfolio::pairs::{self, PairEntry};
 use rust_decimal::Decimal;
 use serde_json::json;
 use serial_test::serial;
@@ -318,7 +319,7 @@ async fn test_a_recorded_transfer_withholds_the_returns_it_invalidates() {
     let transfer = |id: &str, session: SessionDate| {
         AccountActivity::new(
             id.to_string(),
-            "CSD".to_string(),
+            ActivityType::CashDeposit,
             session.midnight(),
             None,
             None,

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -14,15 +14,17 @@
 mod common;
 
 use chrono::{Duration, NaiveDate, Utc};
+use fund::common::alpaca::{ActivityType, OrderSide};
 use fund::common::events::{self, Command, EventType, Outcome};
 use fund::common::types::{BarInterval, PairID, SessionDate, Ticker};
 use fund::data::adjust::SplitTable;
 use fund::data::bars;
 use fund::data::truncate::BoundaryTable;
 
+use fund::common::types::CloseReason;
 use fund::models::tide::predict;
 use fund::portfolio::account;
-use fund::portfolio::pairs::{self, CloseReason, PairEntry};
+use fund::portfolio::pairs::{self, PairEntry};
 use rust_decimal::Decimal;
 use serial_test::serial;
 use sqlx::PgPool;
@@ -52,10 +54,6 @@ async fn fresh_pool() -> PgPool {
     common::reset_tables(&pool).await;
     pool
 }
-
-// ---------------------------------------------------------------------------
-// equity_pairs
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 #[serial]
@@ -184,10 +182,6 @@ async fn test_realized_profit_and_loss_is_written_only_onto_a_closed_pair() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// account tables
-// ---------------------------------------------------------------------------
-
 /// Alpaca's activity identifier is the primary key, which is what makes the post-close sync
 /// idempotent by construction: a re-run conflicts on every row and changes nothing.
 #[tokio::test]
@@ -198,10 +192,10 @@ async fn test_activities_are_idempotent_on_alpacas_identifier() {
     let pool = fresh_pool().await;
     let activity = AccountActivity::new(
         "activity-1".to_string(),
-        "FILL".to_string(),
+        ActivityType::Fill,
         Utc::now(),
         Some(ticker("AAAA")),
-        Some("buy".to_string()),
+        Some(OrderSide::Buy),
         Some(Decimal::from(10)),
         Some(Decimal::from(150)),
         None,
@@ -212,7 +206,7 @@ async fn test_activities_are_idempotent_on_alpacas_identifier() {
         account::store_activities(&pool, std::slice::from_ref(&activity))
             .await
             .unwrap(),
-        vec![activity.id().to_string()],
+        vec![activity.activity_id().to_string()],
         "the first store reports the row it inserted"
     );
     assert_eq!(
@@ -360,10 +354,6 @@ async fn test_a_backfill_never_downgrades_a_complete_snapshot() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// bars and predictions
-// ---------------------------------------------------------------------------
-
 /// Position `i` in every returned series must be the same session. Two series of equal length over
 /// different dates produce a correlation between different days, and nothing downstream carries
 /// enough information to notice.
@@ -496,10 +486,6 @@ async fn test_predictions_return_the_newest_row_per_ticker() {
     assert_eq!(loaded.len(), 1);
     assert_eq!(loaded[0].model_run_id(), "run-late");
 }
-
-// ---------------------------------------------------------------------------
-// events
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 #[serial]

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -68,7 +68,7 @@ fn calendar_for_today() -> TradingCalendar {
     TradingCalendar::from_days(days)
 }
 
-/// A session log in a directory of this test's own.
+/// A journal in a directory of this test's own.
 ///
 /// Every path under test writes one, so a shared directory would let one test's records be read as
 /// another's — and these tests already share a database.
@@ -318,8 +318,8 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
         "the pass records the identifier the dispatcher supplied, not one of its own"
     );
     assert!(
-        pass["payload"]["failure"].is_null(),
-        "a pass that completed records no failure"
+        pass["payload"]["error"].is_null(),
+        "a pass that completed records no error"
     );
 
     assert_eq!(pass["payload"]["candidates"].as_array().unwrap().len(), 1);
@@ -1050,7 +1050,9 @@ async fn test_a_refused_book_with_no_trade_records_what_was_refused() {
         .expect("the refused symbol must be named");
 
     assert_eq!(refused["cause"], "quote_rejected");
-    assert_eq!(refused["quote_rejection"], "wide_quote");
+    assert_eq!(refused["quote_rejection"]["reason"], "wide_quote");
+    // The reading, not just the verdict: a 90/110 book is 0.20 wide around a midpoint of 100.
+    assert_eq!(refused["quote_rejection"]["relative_spread"], 0.2);
     assert_eq!(refused["bid_price"], 90.0);
     assert_eq!(refused["ask_price"], 110.0);
     assert!(refused["quote_timestamp"].is_string());
@@ -1111,7 +1113,7 @@ async fn test_liquidation_flattens_the_book_and_marks_every_pair() {
     let records = recorded(&log);
     let attempted = of_type(&records, "liquidation_attempted");
     assert_eq!(attempted.len(), 1);
-    assert!(attempted[0]["payload"]["failure"].is_null());
+    assert!(attempted[0]["payload"]["error"].is_null());
     assert_eq!(attempted[0]["payload"]["pairs_closed"], 2);
 
     // The table is mutated in place; the log needs its own record of the transition.

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -13,7 +13,8 @@ use chrono::{Duration, NaiveTime, Utc};
 use fund::common::alpaca::{
     AlpacaCredentials, CalendarDay, DataFeed, MarketDataClient, TradingClient,
 };
-use fund::common::session_log::SessionLog;
+use fund::common::journal::Journal;
+use fund::common::types::CloseReason;
 use fund::common::types::{BarInterval, SessionDate, Ticker};
 use fund::data::adjust::SplitTable;
 use fund::data::bars;
@@ -22,7 +23,7 @@ use fund::data::truncate::BoundaryTable;
 use fund::data::universe::{LiquidityRow, Universe};
 use fund::portfolio::evaluate::{self, EvaluationContext};
 use fund::portfolio::execute::ExecutionSettings;
-use fund::portfolio::pairs::{self, CloseReason, PairEntry};
+use fund::portfolio::pairs::{self, PairEntry};
 use fund::portfolio::size::SizingParameters;
 use serial_test::serial;
 use sqlx::PgPool;
@@ -71,7 +72,7 @@ fn calendar_for_today() -> TradingCalendar {
 ///
 /// Every path under test writes one, so a shared directory would let one test's records be read as
 /// another's — and these tests already share a database.
-fn session_log(name: &str) -> SessionLog {
+fn journal(name: &str) -> Journal {
     use std::sync::atomic::{AtomicUsize, Ordering};
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -80,11 +81,11 @@ fn session_log(name: &str) -> SessionLog {
         std::process::id()
     ));
     let _ = std::fs::remove_dir_all(&directory);
-    SessionLog::new(directory).expect("the log directory must be creatable")
+    Journal::new(directory).expect("the log directory must be creatable")
 }
 
 /// Every record a log holds, in the order it was written.
-fn recorded(log: &SessionLog) -> Vec<serde_json::Value> {
+fn recorded(log: &Journal) -> Vec<serde_json::Value> {
     let mut files: Vec<_> = std::fs::read_dir(log.directory())
         .expect("the log directory must be readable")
         .filter_map(Result::ok)
@@ -159,7 +160,8 @@ fn universe_of(tickers: &[&str]) -> Universe {
     use fund::common::alpaca::TradableAssets;
     use std::collections::HashSet;
 
-    let symbols: HashSet<String> = tickers.iter().map(|raw| raw.to_string()).collect();
+    let symbols: HashSet<fund::common::types::Ticker> =
+        tickers.iter().map(|raw| ticker(raw)).collect();
     let assets = TradableAssets::from_sets(symbols.clone(), symbols);
     let liquidity: Vec<LiquidityRow> = tickers
         .iter()
@@ -167,10 +169,6 @@ fn universe_of(tickers: &[&str]) -> Universe {
         .collect();
     Universe::build(&assets, &liquidity)
 }
-
-// ---------------------------------------------------------------------------
-// The evaluation pass
-// ---------------------------------------------------------------------------
 
 /// The whole entry half, end to end: history from the database, prices and orders from Alpaca, the
 /// pair recorded on the way out. This is the test that would catch a mis-wiring between the screen,
@@ -265,7 +263,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
     let universe = universe_of(&["AAAA", "BBBB"]);
 
     let running = CancellationToken::new();
-    let session_log = session_log("test-a-pass-opens-a-pair-and-records-it");
+    let journal = journal("test-a-pass-opens-a-pair-and-records-it");
     let dispatched_correlation_id = uuid::Uuid::new_v4();
     let context = EvaluationContext {
         prices_adjustable: true,
@@ -277,7 +275,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
         close_history: &close_history,
         sizing: SizingParameters::default(),
         execution: settings(),
-        session_log: &session_log,
+        journal: &journal,
         correlation_id: dispatched_correlation_id,
         shutdown: &running,
         now: session_instant(),
@@ -307,7 +305,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
 
     // The pass is only useful to a replay if the observation reached the disk. One evaluation
     // record, and one submission and one resolution per leg, all threaded by the pass's identifier.
-    let records = recorded(&session_log);
+    let records = recorded(&journal);
     let passes = of_type(&records, "pass_evaluated");
     assert_eq!(passes.len(), 1, "one record per pass");
     let pass = &passes[0];
@@ -331,7 +329,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
     // gate refuses is still answerable in the dimension that caused the refusal.
     assert!(
         candidate["long_notional"].is_number()
-            && candidate["short_shares"].is_number()
+            && candidate["short_quantity"].is_number()
             && candidate["gross_exposure"].is_number(),
         "a candidate that reached the sizer carries what it was sized to"
     );
@@ -444,7 +442,7 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
     );
     // The identifier the close and the attribution will join on.
     assert_eq!(
-        opened[0]["payload"]["pair_uuid"],
+        opened[0]["payload"]["equity_pair_id"],
         open[0].id().to_string(),
         "the record names the row it wrote"
     );
@@ -574,7 +572,7 @@ async fn test_a_pass_opens_nothing_once_shutdown_is_requested() {
     let running = CancellationToken::new();
     running.cancel();
 
-    let session_log = session_log("test-a-pass-opens-nothing-once-shutdown-is-requested");
+    let journal = journal("test-a-pass-opens-nothing-once-shutdown-is-requested");
     let context = EvaluationContext {
         prices_adjustable: true,
         pool: &pool,
@@ -585,7 +583,7 @@ async fn test_a_pass_opens_nothing_once_shutdown_is_requested() {
         close_history: &close_history,
         sizing: SizingParameters::default(),
         execution: settings(),
-        session_log: &session_log,
+        journal: &journal,
         correlation_id: uuid::Uuid::new_v4(),
         shutdown: &running,
         now: session_instant(),
@@ -699,7 +697,7 @@ async fn test_a_pass_closes_a_converged_pair_from_a_full_book() {
     let sizing = SizingParameters::new(4, 1.0).unwrap();
 
     let running = CancellationToken::new();
-    let session_log = session_log("test-a-pass-closes-a-converged-pair-from-a-full-book");
+    let journal = journal("test-a-pass-closes-a-converged-pair-from-a-full-book");
     let context = EvaluationContext {
         prices_adjustable: true,
         pool: &pool,
@@ -710,7 +708,7 @@ async fn test_a_pass_closes_a_converged_pair_from_a_full_book() {
         close_history: &close_history,
         sizing,
         execution: settings(),
-        session_log: &session_log,
+        journal: &journal,
         correlation_id: uuid::Uuid::new_v4(),
         shutdown: &running,
         now: session_instant(),
@@ -728,8 +726,8 @@ async fn test_a_pass_closes_a_converged_pair_from_a_full_book() {
         1,
         "the converged pair must close even though the book started full"
     );
-    assert_eq!(summary.pairs_closed[0].pair_id, "AAAA-BBBB");
-    assert_eq!(summary.pairs_closed[0].reason, "convergence");
+    assert_eq!(summary.pairs_closed[0].pair_id.as_str(), "AAAA-BBBB");
+    assert_eq!(summary.pairs_closed[0].reason, CloseReason::Convergence);
     assert!(summary.pairs_opened.is_empty());
 
     // Pin *why* nothing opened rather than only that nothing did. Closing the converged pair frees
@@ -742,7 +740,7 @@ async fn test_a_pass_closes_a_converged_pair_from_a_full_book() {
     // The exit half is recorded to the same standard as the entry half. Both legs of the pair that
     // closed, each carrying the order that will settle it — without these, realized profit and loss
     // is attributable in one direction only.
-    let records = recorded(&session_log);
+    let records = recorded(&journal);
     let closes = of_type(&records, "position_close_requested");
     assert_eq!(closes.len(), 2, "one record per leg of the closed pair");
     for record in &closes {
@@ -832,7 +830,7 @@ async fn test_a_failed_pass_records_what_it_had_already_observed() {
     let universe = universe_of(&["AAAA", "BBBB"]);
 
     let running = CancellationToken::new();
-    let session_log = session_log("test-a-failed-pass-records-what-it-had-already-observed");
+    let journal = journal("test-a-failed-pass-records-what-it-had-already-observed");
     let context = EvaluationContext {
         prices_adjustable: true,
         pool: &pool,
@@ -843,7 +841,7 @@ async fn test_a_failed_pass_records_what_it_had_already_observed() {
         close_history: &close_history,
         sizing: SizingParameters::default(),
         execution: settings(),
-        session_log: &session_log,
+        journal: &journal,
         correlation_id: uuid::Uuid::new_v4(),
         shutdown: &running,
         now: session_instant(),
@@ -853,11 +851,11 @@ async fn test_a_failed_pass_records_what_it_had_already_observed() {
         .await
         .expect_err("the account call must fail the pass");
 
-    let records = recorded(&session_log);
+    let records = recorded(&journal);
     let passes = of_type(&records, "pass_evaluated");
     assert_eq!(passes.len(), 1, "a failed pass is still recorded");
     assert!(
-        passes[0]["payload"]["failure"]
+        passes[0]["payload"]["error"]
             .as_str()
             .expect("the failure is named")
             .contains("Alpaca"),
@@ -931,7 +929,7 @@ async fn test_a_pair_that_cannot_be_priced_is_held_and_counted() {
     let universe = universe_of(&["AAAA", "BBBB"]);
 
     let running = CancellationToken::new();
-    let session_log = session_log("test-a-pair-that-cannot-be-priced-is-held-and-counted");
+    let journal = journal("test-a-pair-that-cannot-be-priced-is-held-and-counted");
     let context = EvaluationContext {
         prices_adjustable: true,
         pool: &pool,
@@ -942,7 +940,7 @@ async fn test_a_pair_that_cannot_be_priced_is_held_and_counted() {
         close_history: &close_history,
         sizing: SizingParameters::default(),
         execution: settings(),
-        session_log: &session_log,
+        journal: &journal,
         correlation_id: uuid::Uuid::new_v4(),
         shutdown: &running,
         now: session_instant(),
@@ -1019,7 +1017,7 @@ async fn test_a_refused_book_with_no_trade_records_what_was_refused() {
     let universe = universe_of(&["AAAA", "BBBB"]);
 
     let running = CancellationToken::new();
-    let session_log = session_log("test-a-refused-book-with-no-trade-records-what-was-refused");
+    let journal = journal("test-a-refused-book-with-no-trade-records-what-was-refused");
     let context = EvaluationContext {
         prices_adjustable: true,
         pool: &pool,
@@ -1030,7 +1028,7 @@ async fn test_a_refused_book_with_no_trade_records_what_was_refused() {
         close_history: &close_history,
         sizing: SizingParameters::default(),
         execution: settings(),
-        session_log: &session_log,
+        journal: &journal,
         correlation_id: uuid::Uuid::new_v4(),
         shutdown: &running,
         now: session_instant(),
@@ -1041,7 +1039,7 @@ async fn test_a_refused_book_with_no_trade_records_what_was_refused() {
         .expect("the pass must survive");
     assert_eq!(summary.pairs_unpriced, 1, "a refused book leaves no price");
 
-    let records = recorded(&session_log);
+    let records = recorded(&journal);
     let unavailable: Vec<&serde_json::Value> = of_type(&records, "prices_observed")
         .iter()
         .flat_map(|record| record["payload"]["unavailable"].as_array().unwrap())
@@ -1067,10 +1065,6 @@ async fn test_a_refused_book_with_no_trade_records_what_was_refused() {
         "no book means no book, not a defaulted one"
     );
 }
-
-// ---------------------------------------------------------------------------
-// Liquidation
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 #[serial]
@@ -1103,7 +1097,7 @@ async fn test_liquidation_flattens_the_book_and_marks_every_pair() {
         .await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
-    let log = session_log("test-liquidation-flattens-the-book-and-marks-every-pair");
+    let log = journal("test-liquidation-flattens-the-book-and-marks-every-pair");
     let summary =
         evaluate::run_liquidation(&pool, &trading, &log, uuid::Uuid::new_v4(), Utc::now())
             .await
@@ -1151,7 +1145,7 @@ async fn test_a_failed_liquidation_records_the_attempt() {
         .await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
-    let log = session_log("test-a-failed-liquidation-records-the-attempt");
+    let log = journal("test-a-failed-liquidation-records-the-attempt");
     evaluate::run_liquidation(&pool, &trading, &log, uuid::Uuid::new_v4(), Utc::now())
         .await
         .expect_err("the bulk close must fail");
@@ -1160,7 +1154,7 @@ async fn test_a_failed_liquidation_records_the_attempt() {
     let attempted = of_type(&records, "liquidation_attempted");
     assert_eq!(attempted.len(), 1, "the attempt is recorded even so");
     assert!(
-        attempted[0]["payload"]["failure"]
+        attempted[0]["payload"]["error"]
             .as_str()
             .expect("the failure is named")
             .contains("Alpaca"),
@@ -1209,7 +1203,7 @@ async fn test_a_refused_leg_leaves_its_pair_open() {
     let summary = evaluate::run_liquidation(
         &pool,
         &trading,
-        &session_log("test-a-refused-leg-leaves-its-pair-open"),
+        &journal("test-a-refused-leg-leaves-its-pair-open"),
         uuid::Uuid::new_v4(),
         Utc::now(),
     )
@@ -1218,16 +1212,19 @@ async fn test_a_refused_leg_leaves_its_pair_open() {
 
     assert_eq!(summary.positions_refused, 1);
     assert_eq!(summary.pairs_closed, 1);
-    assert_eq!(summary.pairs_still_open, vec!["AAAA-BBBB".to_string()]);
+    assert_eq!(
+        summary
+            .pairs_still_open
+            .iter()
+            .map(|pair_id| pair_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["AAAA-BBBB"]
+    );
 
     let open = pairs::load_open_pairs(&pool).await.unwrap();
     assert_eq!(open.len(), 1);
     assert_eq!(open[0].long_ticker().as_str(), "AAAA");
 }
-
-// ---------------------------------------------------------------------------
-// The post-close account sync
-// ---------------------------------------------------------------------------
 
 /// Balances stored, fills stored, and the round trip attributed back to the pair that made it.
 #[tokio::test]
@@ -1298,7 +1295,7 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
     mock_no_return_activities(&mut server).await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
-    let log = session_log("test-the-account-sync-stores-and-attributes-a-session");
+    let log = journal("test-the-account-sync-stores-and-attributes-a-session");
     let summary = account::sync_account(
         &pool,
         &trading,
@@ -1339,7 +1336,7 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
     assert!(
         observed
             .iter()
-            .all(|record| record["payload"]["order_id"].is_string()),
+            .all(|record| record["payload"]["alpaca_order_id"].is_string()),
         "every fill joins back to the order that produced it"
     );
 
@@ -1347,7 +1344,7 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
     // on so the stored figure can be checked against the fills it came from.
     let attributed = of_type(&records, "pair_attributed");
     assert_eq!(attributed.len(), 1);
-    assert_eq!(attributed[0]["payload"]["pair_uuid"], id.to_string());
+    assert_eq!(attributed[0]["payload"]["equity_pair_id"], id.to_string());
     assert_eq!(attributed[0]["payload"]["realized_profit_and_loss"], 100.0);
     assert_eq!(attributed[0]["payload"]["updated"], true);
 }
@@ -1388,7 +1385,7 @@ async fn test_the_account_sync_is_idempotent() {
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
     let calendar = calendar_ending_at(session_date);
-    let log = session_log("test-the-account-sync-is-idempotent-0");
+    let log = journal("test-the-account-sync-is-idempotent-0");
     let first = account::sync_account(
         &pool,
         &trading,
@@ -1399,7 +1396,7 @@ async fn test_the_account_sync_is_idempotent() {
     )
     .await
     .unwrap();
-    let log = session_log("test-the-account-sync-is-idempotent-1");
+    let log = journal("test-the-account-sync-is-idempotent-1");
     let second = account::sync_account(
         &pool,
         &trading,
@@ -1494,7 +1491,7 @@ async fn test_the_account_sync_stores_transfers_without_attributing_them() {
     let summary = account::sync_account(
         &pool,
         &trading,
-        &session_log("test-the-account-sync-stores-transfers-without-attributing-them"),
+        &journal("test-the-account-sync-stores-transfers-without-attributing-them"),
         uuid::Uuid::new_v4(),
         &calendar_ending_at(session_date),
         session_date,
@@ -1564,7 +1561,7 @@ async fn test_the_account_sync_reports_a_missing_previous_session() {
     mock_no_return_activities(&mut server).await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
-    let log = session_log("test-the-account-sync-reports-a-missing-previous-session-2");
+    let log = journal("test-the-account-sync-reports-a-missing-previous-session-2");
     let with_gap = account::sync_account(
         &pool,
         &trading,
@@ -1604,10 +1601,6 @@ async fn test_the_account_sync_reports_a_missing_previous_session() {
     .expect("the sync must run");
     assert_eq!(repaired.previous_session_gap, None);
 }
-
-// ---------------------------------------------------------------------------
-// Fixture helpers
-// ---------------------------------------------------------------------------
 
 fn account_body(equity: i64) -> String {
     format!(
@@ -1717,7 +1710,7 @@ async fn test_a_fee_from_an_earlier_session_is_stored_as_a_cost() {
         .await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
-    let log = session_log("test-a-fee-from-an-earlier-session-is-stored-as-a-cost");
+    let log = journal("test-a-fee-from-an-earlier-session-is-stored-as-a-cost");
     let summary = account::sync_account(
         &pool,
         &trading,

--- a/tools/bootstrap-machine
+++ b/tools/bootstrap-machine
@@ -313,12 +313,18 @@ cd "$REPO_ROOT"
 devenv allow
 
 # --------------------------------------------------------------------------- #
-# 8. Create log directory
+# 8. Create the log and journal directories
 # --------------------------------------------------------------------------- #
-step "Creating log directory"
+step "Creating the log and journal directories"
 sudo mkdir -p /var/log/fund
 sudo chown "$(whoami)" /var/log/fund
 echo "Created /var/log/fund"
+
+# The journal is data, not logs. Its own tree so the retention and rotation that apply to
+# /var/log/fund never reach the only original this application owns.
+sudo mkdir -p /var/journal/fund
+sudo chown "$(whoami)" /var/journal/fund
+echo "Created /var/journal/fund"
 
 # --------------------------------------------------------------------------- #
 # 8b. Write ~/fund-cron.sh (common cron shim for both profiles)

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -155,7 +155,7 @@ FROM read_parquet(
     hive_partitioning = true
 );
 
--- The session log is the application's own original: what it observed before it acted, appended to
+-- The journal is the application's own original: what it observed before it acted, appended to
 -- local disk as it happened and sealed to Parquet after the close. Everything above is a fold or a
 -- query over it, so this is where to go when the tables disagree with each other.
 --
@@ -163,32 +163,25 @@ FROM read_parquet(
 -- payload with the JSON operators:
 --
 --   SELECT payload->>'ticker', payload->>'outcome'
---   FROM session_log WHERE event_type = 'order_resolved';
+--   FROM journal WHERE event_type = 'order_resolved';
 --
 --   SELECT unnest(from_json(payload->'readings', '["json"]'))->>'ticker'
---   FROM session_log WHERE event_type = 'prices_observed';
+--   FROM journal WHERE event_type = 'prices_observed';
 --
 -- correlation_id threads a command to everything it did: one command_finished, the pass it ran, the
 -- prices it read, the orders it sent, the fills they produced. Joining on it is how a duration
 -- becomes an answer about where the time went.
 --
--- schema_version is 2 for anything written after 2026-08-12. Version 1 carried the pass's prices,
--- screen inputs, exclusions, and open book inline on an evaluation_pass record, and had no
--- command_finished, pair_opened, pair_closed, pair_attributed, or activity_observed.
---
--- One field changed type rather than name, which is the case a reader cannot detect on its own:
--- predictions_generated.predictions was a count in v1 and is the array of quantiles in v2. A query
--- reading it must filter on schema_version or check the type, or it silently reads a length as a
--- number of tickers. Only the single v1 session, 2026-08-12, is affected.
+-- schema_version is 3, which is the only version in this archive: v1 and v2 were development and
+-- their objects are gone. It exists so a future change can be told apart from a missing field.
 --
 -- Fields are added within a version as well as across one, and an absent key reads as NULL either
 -- way, so "the build predated this field" and "there was nothing to record" are the same answer.
--- prices_observed.readings[].trade_timestamp and universe_screened.excluded[].detail both start
--- mid-v2; anything counting them should bound the query below by the first session that has them
--- rather than treating an early NULL as a zero.
-.print 'Loading session_log...'
-DROP VIEW IF EXISTS session_log;
-CREATE OR REPLACE VIEW session_log AS
+-- Anything counting a field should bound the query by the first session that has it rather than
+-- treating an early NULL as a zero.
+.print 'Loading journal...'
+DROP VIEW IF EXISTS journal;
+CREATE OR REPLACE VIEW journal AS
 SELECT
     schema_version,
     event_id,
@@ -199,7 +192,7 @@ SELECT
     -- epoch_ms: the first returns a TIMESTAMPTZ anchored to UTC, the second a bare TIMESTAMP that
     -- reads as whatever zone the session happens to be in. An instant is always UTC here, and
     -- session_date beside it is always the Eastern trading day.
-    to_timestamp(created_at / 1000.0) AS created_at,
+    to_timestamp(timestamp / 1000.0) AS timestamp,
     payload,
     -- From the key layout rather than the file contents, so a filter on them skips whole files.
     -- session_date is inside each Parquet, so filtering on that alone opens every one, and the
@@ -208,7 +201,7 @@ SELECT
     month,
     day
 FROM read_parquet(
-    's3://' || getvariable('bucket') || '/exports/session_log/**/*.parquet',
+    's3://' || getvariable('bucket') || '/exports/journal/**/*.parquet',
     hive_partitioning = true
 );
 

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -12,7 +12,7 @@
 --            accumulates for as long as the bucket keeps it.
 --   exports/ the application's nightly export of the tables only it knows
 --            about -- events, predictions, pairs, account state -- plus the
---            session log, which is the original those tables are derived from.
+--            journal, which is the original those tables are derived from.
 --            This is what the retention window would otherwise discard.
 --
 -- Bars and ticker metadata appear under data/ and nowhere else. They used to be
@@ -172,14 +172,24 @@ FROM read_parquet(
 -- prices it read, the orders it sent, the fills they produced. Joining on it is how a duration
 -- becomes an answer about where the time went.
 --
--- schema_version is 3, which is the only version in this archive: v1 and v2 were development and
--- their objects are gone. It exists so a future change can be told apart from a missing field.
+-- schema_version is 3 or 4; v1 and v2 were development and their objects are gone. Two payload
+-- fields changed shape at v4, so a query reaching into either has to branch on the version:
+--
+--   quote_rejection was the bare reason string 'stale_quote' or 'wide_quote'. It is now an object
+--   whose 'reason' key holds that same string alongside the reading that produced it --
+--   age_seconds and limit_seconds for a stale quote, relative_spread and limit for a wide one.
+--   Under v3 the reading is simply gone; there is nothing to recover it from.
+--
+--   early_closes[].session_close was 'HH:MM' and is now 'HH:MM:SS'.
 --
 -- Fields are added within a version as well as across one, and an absent key reads as NULL either
 -- way, so "the build predated this field" and "there was nothing to record" are the same answer.
 -- Anything counting a field should bound the query by the first session that has it rather than
 -- treating an early NULL as a zero.
 .print 'Loading journal...'
+-- Dropped as well as `journal`: this script runs against a persistent ~/lab.duckdb, so a view
+-- created before the rename outlives it and still points at a prefix that no longer exists.
+DROP VIEW IF EXISTS session_log;
 DROP VIEW IF EXISTS journal;
 CREATE OR REPLACE VIEW journal AS
 SELECT


### PR DESCRIPTION
# Overview

A review pass over `common/`, applying the checklist it produced: raw types replaced with the domain types that already existed, documented-value strings replaced with enums, one vocabulary chosen where several competed, and the dead code either deleted or turned into the observation it should have been.

## Changes

- Adds `OrderSide`, `ActivityType` with `ReturnCode`, and `PositionFetch` to `common::alpaca`; `Position`, `OrderState`, `PositionClose`, and `LiquidationOutcome` carry `Decimal` where they carried `f64`
- Takes `Ticker` in `TradableAssets` and `fetch_snapshots`, which callers were converting to `String` for and this code was parsing straight back
- Renames `AccountActivity::id` to `activity_id` and `order_id` to `alpaca_order_id`, matching the three other types that already spelled it that way; `client_order_id` becomes the `Uuid` it was generated as
- Deletes `ClockSnapshot` and `fetch_clock`, `Snapshot`'s five unread getters and the bar fields behind them, and `TradableAssets::tradable_symbols`
- Renames `common::session_log` to `common::journal`, with `Journal`, `JournalError`, and `JournalGuard`; `observability` becomes `log`
- Replaces eleven documented-value strings with enums and deletes the doc lines that enumerated them
- Moves `CloseReason` to `common::types` so the journal and the pair writer share the definition that `schema.sql` constrains
- Standardises the vocabulary: `quantity` for share counts, `outcome` for how an attempt ended, `error` for the rendered failure, `reason` for a closed-set discriminant, `decision` for a choice among alternatives, `timestamp` for a record's own instant
- Records `positions_observed`, `calendar_observed`, `bars_ingested`, `universe_refreshed`, and `journal_exported`
- Renames `pair_uuid` to `equity_pair_id` and types it as `Uuid`; `pair_id` becomes `PairID`
- Moves the journal to `/var/journal/fund`, and spells out `FUND_LOG_DIRECTORY` and `FUND_JOURNAL_DIRECTORY`
- Bumps the journal schema to 3 and rewrites the DuckDB view for it
- Removes 58 banner comment lines and a stale claim in `data/boundaries.rs` that three later PRs had invalidated

## Context

**Balances were the least precise where they were supposed to be the most.** `AccountSnapshot` held `Decimal`, `account_snapshots` held `NUMERIC`, and the journal held `Option<f64>` — so the file that calls itself the only original this application owns was a lossier copy than the database folded from it. Summing three real balances through that path gives `66812.60999999999` rather than `66812.61`. The `Option` guarded a `to_f64` that is `Some(self.as_f64())` and cannot fail, while the rounding it did not guard happened on every write.

Amounts still reach JSON as numbers. `Decimal`'s own `Serialize` writes a quoted string, which a query has to cast and which the dashboard was rendering verbatim to a human reader — `AccountSyncSummary` flows through the `events` table into the rendered payload column. `decimal_number` and `decimal_number_option` in `types.rs` route through `Decimal::as_f64`, which returns an `f64` rather than an `Option`; `rust_decimal::serde::float` does the same conversion through `to_f64().unwrap()`, which cannot fire today but is not a panic worth inheriting in the journal's write path. Tested at `Decimal::MAX`, `MIN`, and 28 decimal places.

**Two of the deletions were not dead code.** `Position` and `TradableAssets::shortable_count` had no caller because the observation that needed them did not exist — Alpaca reports the position book only as it is now, and nothing recorded it. They are kept and feed `positions_observed` and `universe_refreshed`. `ClockSnapshot` was deleted on the opposite reasoning: `TradingCalendar` already answers whether the market is open, from a separate fetch, so keeping it warm meant keeping a second source that could disagree with the first.

**The trainer's split and boundary refreshes are deliberately not journaled.** They run in `tide_model_trainer`, on its own VM under the `trainer` profile, while the export that ships the journal runs on the application VM. A record written there would never reach S3, which is worse than no record. Adding them needs a decision about whether the trainer gets its own journal and export, or whether archive repair moves into the application.

**No backwards compatibility.** The exported sessions are development data, so the reader accepts only `timestamp` and the view reads only `exports/journal`. Once the archive holds anything worth keeping, that stops being true.

Verified with `cargo test --all-features` (701 passing), `cargo fmt --check`, `cargo clippy --all-features --all-targets` (one pre-existing `redundant_closure` in `tests/test_handlers.rs`), and `cargo sqlx prepare --check`. The journal output was read back as real JSONL from the actual serializer rather than assumed. No live Alpaca or Massive call was made: the transport changes are covered by unit tests and `mockito`, not against the real API.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a structured journal for portfolio, market-data, calendar, account, and order events.
  - Added separate configurable locations for application logs and journal data.
  - Added journal export support with updated archive and database views.
  - Added early-close calendar information and universe change tracking.

- **Improvements**
  - Improved financial precision and validation for quantities, prices, orders, and account activity.
  - Added clearer handling and reporting of incomplete market, position, and activity data.
  - Improved quote validation for stale or unusually wide markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->