### PR TITLE
Apply the module review checklist to the dashboard

### DIFF
--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -1,11 +1,7 @@
 //! The dashboard: a read-only page describing what the fund is doing.
 //!
-//! Its own process, connecting as `dashboard_reader` — SELECT on five tables and nothing else, so
-//! a bug here cannot write to the database the strategy trades from.
-//!
-//! A poller refreshes every view on a fixed interval; a listener appends events from the `events`
-//! NOTIFY channel as they arrive. Request handlers read that shared state and never query, so
-//! viewer count has no bearing on the connection pool.
+//! Its own process, connecting as `dashboard_reader` — SELECT on six tables and nothing else. A
+//! poller refreshes state on a fixed interval, a listener appends events, and handlers never query.
 
 pub mod cache;
 pub mod database;

--- a/src/dashboard/cache.rs
+++ b/src/dashboard/cache.rs
@@ -1,9 +1,5 @@
 //! Shared in-memory state for the dashboard, and the two tasks that keep it current.
 //!
-//! A polling task refreshes everything every [`POLL_INTERVAL`] behind an `RwLock`; a listener
-//! appends `events` as they arrive. Request handlers read the lock and never touch the database, so
-//! viewer count has no bearing on the connection pool.
-//!
 //! A failed poll leaves the previous state and records the error rather than blanking the page —
 //! stale numbers with a visible "last updated" beat no numbers.
 
@@ -19,18 +15,14 @@ use sqlx::PgPool;
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
-use crate::common::events::Notification;
-use crate::common::types::{PairID, SessionDate, Ticker};
+use crate::common::events::{EventType, Notification};
+use crate::common::types::{CloseReason, PairID, SessionDate, Ticker};
 
-use crate::common::types::CloseReason;
-
-/// How often the background task refreshes every view from PostgreSQL.
+/// How often the background task refreshes every view, and how often the page reloads itself.
 pub const POLL_INTERVAL: Duration = Duration::from_secs(30);
 
-/// How long to wait before reconnecting a dropped listener.
 const RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
 
-/// Events retained in the ring buffer.
 const EVENT_BUFFER_CAPACITY: usize = 500;
 
 /// One session's account state.
@@ -91,7 +83,6 @@ pub struct ClosedPair {
 }
 
 impl ClosedPair {
-    /// How long the pair was held.
     pub fn holding_hours(&self) -> f64 {
         (self.closed_at - self.opened_at).num_seconds() as f64 / 3_600.0
     }
@@ -107,9 +98,12 @@ pub struct Prediction {
 }
 
 /// A row from the event log, or a live arrival from the NOTIFY channel.
+///
+/// `created_at` is the row's own column when seeded from the table, and the moment the listener
+/// received the notification when it arrives live. The two are milliseconds apart.
 #[derive(Debug, Clone)]
 pub struct EventEntry {
-    pub event_type: String,
+    pub event_type: EventType,
     pub created_at: DateTime<Utc>,
     pub payload: Value,
 }
@@ -132,8 +126,8 @@ pub struct ClosedSummary {
     pub wins: usize,
     pub losses: usize,
     pub win_rate: Option<f64>,
-    pub total_realized: Decimal,
-    pub average_realized: Option<Decimal>,
+    pub total_realized_profit_and_loss: Decimal,
+    pub average_realized_profit_and_loss: Option<Decimal>,
     pub profit_factor: Option<f64>,
     pub average_holding_hours: Option<f64>,
     /// Every [`CloseReason`] with its count, including the ones at zero.
@@ -186,7 +180,7 @@ pub async fn apply_poll(state: &SharedState, data: crate::dashboard::database::D
     guard.last_error = None;
 
     // Only seeded when empty, so the listener's live arrivals are not overwritten by a snapshot
-    // taken thirty seconds ago.
+    // taken a whole poll interval ago.
     if guard.events.is_empty() {
         guard.events = data.recent_events.into_iter().collect();
     }
@@ -250,7 +244,7 @@ pub fn spawn_event_listener_task(state: SharedState, pool: PgPool) {
                                 append_event(
                                     &state,
                                     EventEntry {
-                                        event_type: parsed.event_type.as_str().to_string(),
+                                        event_type: parsed.event_type,
                                         created_at: Utc::now(),
                                         payload: parsed.payload,
                                     },
@@ -274,6 +268,7 @@ pub fn spawn_event_listener_task(state: SharedState, pool: PgPool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::events::{Command, Outcome};
     use chrono::{NaiveDate, TimeZone};
     use std::str::FromStr;
 
@@ -335,6 +330,8 @@ mod tests {
         assert_eq!(pair.holding_hours(), 30.0);
     }
 
+    /// The event type is a closed vocabulary, so arrival order is carried in the payload instead:
+    /// the newest entry must be at the front and the oldest must be gone.
     #[tokio::test]
     async fn test_the_ring_buffer_evicts_the_oldest_and_keeps_the_newest_first() {
         let state: SharedState = Arc::new(RwLock::new(DashboardState::default()));
@@ -342,9 +339,9 @@ mod tests {
             append_event(
                 &state,
                 EventEntry {
-                    event_type: format!("event_{index}"),
+                    event_type: EventType::new(Command::Predictions, Outcome::Completed),
                     created_at: Utc::now(),
-                    payload: Value::Null,
+                    payload: serde_json::json!({ "index": index }),
                 },
             )
             .await;
@@ -353,8 +350,12 @@ mod tests {
         let guard = state.read().await;
         assert_eq!(guard.events.len(), EVENT_BUFFER_CAPACITY);
         assert_eq!(
-            guard.events.front().expect("a newest event").event_type,
-            format!("event_{}", EVENT_BUFFER_CAPACITY + 9)
+            guard.events.front().expect("a newest event").payload["index"],
+            509
+        );
+        assert_eq!(
+            guard.events.back().expect("an oldest event").payload["index"],
+            10
         );
     }
 }

--- a/src/dashboard/database.rs
+++ b/src/dashboard/database.rs
@@ -1,20 +1,15 @@
 //! Read-only queries behind the dashboard, and the aggregations computed from them.
 //!
-//! Every query uses raw `sqlx::query` rather than the compile-time macros, so the dashboard adds
-//! no entries to the `.sqlx` offline cache. It connects as `dashboard_reader`, which holds SELECT
-//! on exactly the tables below and nothing else.
-//!
-//! The aggregations are separated from the queries deliberately: each is a pure function over rows
-//! it was handed, which is what makes win rate, profit factor, and period returns testable without
-//! a database.
+//! Raw `sqlx::query` rather than the macros, so the dashboard adds no `.sqlx` cache entries. The
+//! aggregations are pure functions over rows they were handed, testable without a database.
 
 use chrono::{DateTime, Datelike, NaiveDate, Utc};
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Row};
 use tracing::warn;
 
 use crate::common::alpaca::ActivityType;
+use crate::common::events::EventType;
 use crate::common::types::{CloseReason, PairID, SessionDate, Ticker};
 use crate::dashboard::cache::{
     AccountSnapshot, ClosedPair, ClosedSummary, EventEntry, OpenPair, PeriodReturns, Prediction,
@@ -31,13 +26,10 @@ fn transfer_activity_types() -> Vec<String> {
 /// Sessions of account snapshots fetched: the equity curve, and the newest row's balances.
 const ACCOUNT_HISTORY_DAYS: i64 = 365;
 
-/// Closed pairs fetched for the trade table and its summary.
 const CLOSED_PAIRS_LIMIT: i64 = 200;
 
-/// Rows shown from the most recent prediction batch.
 const PREDICTIONS_LIMIT: i64 = 50;
 
-/// Events read from the table to seed the ring buffer at startup.
 const RECENT_EVENTS_LIMIT: i64 = 100;
 
 /// One poll cycle's worth of data.
@@ -313,6 +305,10 @@ async fn fetch_latest_predictions(
 }
 
 /// Seeds the event ring buffer from the table, newest first.
+///
+/// A row naming an event type outside the current vocabulary is skipped rather than failing the
+/// poll, on the same reasoning [`EventType::parse`] gives: a stale cron job or a hand-issued row
+/// from an old vocabulary should be reported, not fatal.
 async fn fetch_recent_events(pool: &PgPool) -> Result<Vec<EventEntry>, sqlx::Error> {
     let rows = sqlx::query(
         "SELECT event_type, payload, created_at
@@ -324,15 +320,20 @@ async fn fetch_recent_events(pool: &PgPool) -> Result<Vec<EventEntry>, sqlx::Err
     .fetch_all(pool)
     .await?;
 
-    rows.into_iter()
-        .map(|row| {
-            Ok(EventEntry {
-                event_type: row.try_get("event_type")?,
-                payload: row.try_get("payload")?,
-                created_at: row.try_get("created_at")?,
-            })
-        })
-        .collect()
+    let mut events = Vec::with_capacity(rows.len());
+    for row in rows {
+        let raw_event_type: String = row.try_get("event_type")?;
+        let Some(event_type) = EventType::parse(&raw_event_type) else {
+            warn!(event_type = %raw_event_type, "Event has an unrecognized type, skipping");
+            continue;
+        };
+        events.push(EventEntry {
+            event_type,
+            payload: row.try_get("payload")?,
+            created_at: row.try_get("created_at")?,
+        });
+    }
+    Ok(events)
 }
 
 /// The freshness signal: when the most recent daily bar was written.
@@ -349,15 +350,14 @@ async fn fetch_latest_bars_inserted_at(
 
 /// Percentage change between two equity values.
 ///
-/// Returns `None` for a zero or negative baseline: a percentage against zero equity is a division
-/// by zero, and against negative equity it changes sign without changing meaning.
+/// `None` only ever means a zero or negative baseline: a percentage against zero equity is a
+/// division by zero, and against negative equity it changes sign without changing meaning.
 fn percentage_change(baseline: Decimal, latest: Decimal) -> Option<f64> {
     if baseline <= Decimal::ZERO {
         return None;
     }
-    let baseline = baseline.to_f64()?;
-    let latest = latest.to_f64()?;
-    Some((latest - baseline) / baseline * 100.0)
+    let baseline = baseline.as_f64();
+    Some((latest.as_f64() - baseline) / baseline * 100.0)
 }
 
 /// The last snapshot at or before `cutoff`, which is the baseline for a horizon.
@@ -379,8 +379,8 @@ fn baseline_at_or_before(
 /// **Flow-blind by construction.** Every figure here is a raw equity-to-equity change, so a deposit
 /// inside a horizon reads as performance — a $10,000 contribution into a flat $20,000 book publishes
 /// as +50%. Any horizon spanning a capital flow therefore returns `None` rather than a plausible
-/// wrong number. `nav_per_unit` replaces this calculation outright when the unit ledger lands, at
-/// which point the guard has nothing left to protect; see `.scratchpad/unit_accounting.md`.
+/// wrong number. A net-asset-value-per-unit series replaces this calculation outright once the unit
+/// ledger lands, at which point the guard has nothing left to protect.
 pub fn compute_period_returns(
     history: &[AccountSnapshot],
     transfer_sessions: &[SessionDate],
@@ -461,20 +461,17 @@ pub fn compute_closed_summary(closed: &[ClosedPair]) -> ClosedSummary {
         .sum::<Decimal>()
         .abs();
 
-    let total_realized: Decimal = realized.iter().sum();
-    let average_realized = if realized.is_empty() {
+    let total_realized_profit_and_loss: Decimal = realized.iter().sum();
+    let average_realized_profit_and_loss = if realized.is_empty() {
         None
     } else {
-        Some(total_realized / Decimal::from(realized.len()))
+        Some(total_realized_profit_and_loss / Decimal::from(realized.len()))
     };
 
     // A book with no losing trade has no profit factor rather than an infinite one. Reporting
     // infinity here would put the most flattering number on the smallest sample.
     let profit_factor = if gross_loss > Decimal::ZERO {
-        gross_profit
-            .to_f64()
-            .zip(gross_loss.to_f64())
-            .map(|(profit, loss)| profit / loss)
+        Some(gross_profit.as_f64() / gross_loss.as_f64())
     } else {
         None
     };
@@ -507,8 +504,8 @@ pub fn compute_closed_summary(closed: &[ClosedPair]) -> ClosedSummary {
         } else {
             None
         },
-        total_realized,
-        average_realized,
+        total_realized_profit_and_loss,
+        average_realized_profit_and_loss,
         profit_factor,
         average_holding_hours: Some(average_holding_hours),
         by_close_reason,
@@ -718,7 +715,7 @@ mod tests {
             (win_rate - 200.0 / 3.0).abs() < 1e-9,
             "expected two thirds, got {win_rate}"
         );
-        assert_eq!(summary.total_realized, decimal("200"));
+        assert_eq!(summary.total_realized_profit_and_loss, decimal("200"));
         assert_eq!(summary.profit_factor, Some(2.0));
         assert_eq!(summary.average_holding_hours, Some(4.0));
     }
@@ -770,6 +767,9 @@ mod tests {
         assert_eq!(summary.wins, 1);
         assert_eq!(summary.losses, 0);
         assert_eq!(summary.win_rate, Some(100.0));
-        assert_eq!(summary.average_realized, Some(decimal("100")));
+        assert_eq!(
+            summary.average_realized_profit_and_loss,
+            Some(decimal("100"))
+        );
     }
 }

--- a/src/dashboard/html.rs
+++ b/src/dashboard/html.rs
@@ -1,31 +1,29 @@
-//! The server-rendered page.
+//! The server-rendered page: five sections in an amber CRT aesthetic, no JavaScript and no CDN.
 //!
-//! Five sections stacked vertically — account, open pairs, predictions, closed pairs, events — in
-//! an amber CRT aesthetic. The page refreshes every thirty seconds with a `<meta>` tag, matching
-//! the poll interval; no client-side JavaScript and nothing loaded from a CDN.
-//!
-//! It renders only what the database can answer. There is no benchmark curve (the universe holds no
-//! index ETF) and no training metrics (the trainer publishes those to S3, not to a table).
+//! It renders only what the database can answer — no benchmark curve (the universe holds no index
+//! ETF) and no training metrics (the trainer publishes those to S3, not to a table).
 
 use chrono::{DateTime, Duration, Utc};
 use rust_decimal::Decimal;
 
-use crate::dashboard::cache::DashboardState;
+use crate::common::events::Outcome;
+use crate::dashboard::cache::{DashboardState, POLL_INTERVAL};
 
-/// Events shown on the page, out of the several hundred the buffer holds.
+/// How every unavailable figure renders. Withheld and never-recorded must read alike, so the page
+/// has one spelling of absence rather than one per formatter.
+const ABSENT: &str = "—";
+
 const EVENTS_DISPLAY_LIMIT: usize = 12;
 
 /// Closed pairs shown on the page. The summary underneath covers all of them.
 const CLOSED_PAIRS_DISPLAY_LIMIT: usize = 20;
 
-/// Predictions shown on the page.
 const PREDICTIONS_DISPLAY_LIMIT: usize = 15;
 
 /// How old daily bars may be before the freshness line turns amber, then red.
 const BARS_WARNING_AGE: Duration = Duration::hours(24);
 const BARS_STALE_AGE: Duration = Duration::hours(48);
 
-/// Renders the whole page from the current state.
 pub fn render_html(state: &DashboardState) -> String {
     render_html_at(state, Utc::now())
 }
@@ -66,6 +64,9 @@ fn render_html_at(state: &DashboardState, now: DateTime<Utc>) -> String {
     let predictions = render_predictions_section(state);
     let closed_pairs = render_closed_pairs_section(state);
     let events = render_events_section(state);
+    // The page reloads on the same cadence the poller refreshes on, so a viewer never waits on a
+    // value that has already changed and never reloads onto an identical one.
+    let refresh_seconds = POLL_INTERVAL.as_secs();
 
     format!(
         r#"<!DOCTYPE html>
@@ -73,7 +74,7 @@ fn render_html_at(state: &DashboardState, now: DateTime<Utc>) -> String {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta http-equiv="refresh" content="30">
+<meta http-equiv="refresh" content="{refresh_seconds}">
 <title>OSCM</title>
 <style>{CSS}</style>
 </head>
@@ -91,7 +92,7 @@ fn render_html_at(state: &DashboardState, now: DateTime<Utc>) -> String {
 {closed_pairs}
 {events}
 <footer class="sys-footer">
-<span>AUTO-REFRESH: 30S</span>
+<span>AUTO-REFRESH: {refresh_seconds}S</span>
 <span>STATUS: NOMINAL</span>
 </footer>
 </body>
@@ -273,7 +274,7 @@ fn render_closed_pairs_section(state: &DashboardState) -> String {
                 Some(value) if value > Decimal::ZERO => (format_dollars(value), "positive"),
                 Some(value) if value < Decimal::ZERO => (format_dollars(value), "negative"),
                 Some(value) => (format_dollars(value), "dim"),
-                None => ("—".to_string(), "dim"),
+                None => (ABSENT.to_string(), "dim"),
             };
             format!(
                 r#"<tr><td>{}</td><td>{:.2}</td><td class="{class}">{realized}</td><td>{}</td><td>{}</td><td>{}</td></tr>"#,
@@ -304,11 +305,11 @@ fn render_closed_pairs_section(state: &DashboardState) -> String {
         summary.total_closed,
         format_percent(summary.win_rate),
         format_ratio(summary.profit_factor),
-        format_dollars(summary.total_realized),
+        format_dollars(summary.total_realized_profit_and_loss),
         summary
             .average_holding_hours
             .map(format_holding)
-            .unwrap_or_else(|| "—".to_string()),
+            .unwrap_or_else(|| ABSENT.to_string()),
         format_percent(summary.signal_exit_share),
     );
     section("Closed pairs", body)
@@ -327,8 +328,8 @@ fn render_events_section(state: &DashboardState) -> String {
             format!(
                 r#"<tr><td>{}</td><td class="{}">{}</td><td>{}</td></tr>"#,
                 eastern_stamp(event.created_at, "%Y-%m-%d %H:%M:%S"),
-                event_css_class(&event.event_type),
-                html_escape(&event.event_type),
+                event_css_class(event.event_type.outcome()),
+                event.event_type,
                 html_escape(&truncate_payload(&event.payload)),
             )
         })
@@ -352,14 +353,12 @@ fn section(title: &str, body: String) -> String {
     )
 }
 
-/// Colours an event row by its outcome suffix, so an error is visible without reading the name.
-fn event_css_class(event_type: &str) -> &'static str {
-    if event_type.ends_with("_errored") {
-        "event-errored"
-    } else if event_type.ends_with("_completed") {
-        "event-completed"
-    } else {
-        "event-requested"
+/// Colours an event row by its outcome, so an error is visible without reading the name.
+fn event_css_class(outcome: Outcome) -> &'static str {
+    match outcome {
+        Outcome::Errored => "event-errored",
+        Outcome::Completed => "event-completed",
+        Outcome::Requested => "event-requested",
     }
 }
 
@@ -398,12 +397,10 @@ fn format_dollars(value: Decimal) -> String {
     format!("{sign}${grouped}.{}", &fraction[..2])
 }
 
-/// Formats a dollar amount a session may not have recorded, as the dim dash [`format_return`] uses
-/// for a withheld return. Both mean unavailable rather than zero, and should read alike.
 fn format_optional_dollars(value: Option<Decimal>) -> String {
     match value {
         Some(amount) => format_dollars(amount),
-        None => r#"<span class="dim">—</span>"#.to_string(),
+        None => ABSENT.to_string(),
     }
 }
 
@@ -415,20 +412,20 @@ fn format_return(value: Option<f64>) -> String {
         }
         Some(percent) if percent < 0.0 => format!(r#"<span class="negative">{percent:.2}%</span>"#),
         Some(percent) => format!("{percent:.2}%"),
-        None => r#"<span class="dim">—</span>"#.to_string(),
+        None => ABSENT.to_string(),
     }
 }
 
 fn format_percent(value: Option<f64>) -> String {
     value
         .map(|percent| format!("{percent:.1}%"))
-        .unwrap_or_else(|| "—".to_string())
+        .unwrap_or_else(|| ABSENT.to_string())
 }
 
 fn format_ratio(value: Option<f64>) -> String {
     value
         .map(|ratio| format!("{ratio:.2}"))
-        .unwrap_or_else(|| "—".to_string())
+        .unwrap_or_else(|| ABSENT.to_string())
 }
 
 /// Formats a holding period in the largest unit that keeps it readable.
@@ -463,9 +460,9 @@ fn format_age(elapsed: Duration) -> String {
 
 /// Escapes `&`, `<`, `>`, and `"` for safe embedding.
 ///
-/// Everything that reaches the page from the database goes through this. Tickers and close reasons
-/// are validated on the way in and cannot carry markup, but the event payload is arbitrary JSON
-/// written by handlers, and an error string in it can hold anything the broker returned.
+/// Tickers, close reasons, and event types are parsed into closed vocabularies on the way in and
+/// cannot carry markup. The event payload is the exception: arbitrary JSON written by handlers, and
+/// an error string in it can hold anything the broker returned.
 fn html_escape(input: &str) -> String {
     input
         .replace('&', "&amp;")
@@ -474,7 +471,6 @@ fn html_escape(input: &str) -> String {
         .replace('"', "&quot;")
 }
 
-/// Inline CSS. Amber CRT terminal aesthetic, carried forward unchanged.
 const CSS: &str = r#"
 :root {
     --bg: #0a0700;
@@ -558,6 +554,7 @@ tr:hover { background-color: rgba(255, 180, 0, 0.1); }
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::events::{Command, EventType};
     use crate::common::types::CloseReason;
     use crate::common::types::{PairID, Ticker};
     use crate::dashboard::cache::{
@@ -627,7 +624,7 @@ mod tests {
             prediction_model_run_id: Some("run-2026-07-31".to_string()),
             prediction_timestamp: Some(now() - Duration::hours(12)),
             events: vec![EventEntry {
-                event_type: "portfolio_evaluation_completed".to_string(),
+                event_type: EventType::new(Command::PortfolioEvaluation, Outcome::Completed),
                 created_at: now() - Duration::minutes(5),
                 payload: json!({"pairs_opened": 2}),
             }]
@@ -731,7 +728,7 @@ mod tests {
     fn test_an_event_payload_containing_markup_is_escaped() {
         let mut state = populated_state();
         state.events = vec![EventEntry {
-            event_type: "portfolio_evaluation_errored".to_string(),
+            event_type: EventType::new(Command::PortfolioEvaluation, Outcome::Errored),
             created_at: now(),
             payload: json!({"error": "<script>alert(1)</script>"}),
         }]
@@ -744,9 +741,9 @@ mod tests {
 
     #[test]
     fn test_event_rows_are_coloured_by_outcome() {
-        assert_eq!(event_css_class("predictions_errored"), "event-errored");
-        assert_eq!(event_css_class("predictions_completed"), "event-completed");
-        assert_eq!(event_css_class("predictions_requested"), "event-requested");
+        assert_eq!(event_css_class(Outcome::Errored), "event-errored");
+        assert_eq!(event_css_class(Outcome::Completed), "event-completed");
+        assert_eq!(event_css_class(Outcome::Requested), "event-requested");
     }
 
     /// Truncation counts characters, not bytes. A byte slice through a multi-byte character panics,
@@ -778,7 +775,27 @@ mod tests {
     fn test_returns_carry_a_sign_and_a_colour() {
         assert!(format_return(Some(1.5)).contains(r#"class="positive">+1.50%"#));
         assert!(format_return(Some(-1.5)).contains(r#"class="negative">-1.50%"#));
-        assert!(format_return(None).contains("—"));
+        assert_eq!(format_return(None), "—");
+    }
+
+    /// Withheld and never-recorded read alike, whatever the figure was going to be. The formatters
+    /// used to disagree — two of them wrapped the dash in a dim span and three did not.
+    #[test]
+    fn test_every_unavailable_figure_renders_the_same_way() {
+        assert_eq!(format_optional_dollars(None), "—");
+        assert_eq!(format_return(None), "—");
+        assert_eq!(format_percent(None), "—");
+        assert_eq!(format_ratio(None), "—");
+    }
+
+    /// The meta refresh and the footer both come from `POLL_INTERVAL`, so a change to the poll
+    /// cadence cannot leave the page claiming the old one. Pinned to the literal on purpose: this
+    /// must fail if the interval moves.
+    #[test]
+    fn test_the_page_reloads_on_the_poll_interval() {
+        let html = render_html_at(&DashboardState::default(), now());
+        assert!(html.contains(r#"<meta http-equiv="refresh" content="30">"#));
+        assert!(html.contains("AUTO-REFRESH: 30S"));
     }
 
     #[test]

--- a/src/dashboard/html.rs
+++ b/src/dashboard/html.rs
@@ -1,7 +1,6 @@
 //! The server-rendered page: five sections in an amber CRT aesthetic, no JavaScript and no CDN.
-//!
-//! It renders only what the database can answer — no benchmark curve (the universe holds no index
-//! ETF) and no training metrics (the trainer publishes those to S3, not to a table).
+//! It renders only what the database can answer — no benchmark curve, because the universe holds
+//! no index ETF, and no training metrics, because the trainer publishes those to S3.
 
 use chrono::{DateTime, Duration, Utc};
 use rust_decimal::Decimal;
@@ -64,8 +63,7 @@ fn render_html_at(state: &DashboardState, now: DateTime<Utc>) -> String {
     let predictions = render_predictions_section(state);
     let closed_pairs = render_closed_pairs_section(state);
     let events = render_events_section(state);
-    // The page reloads on the same cadence the poller refreshes on, so a viewer never waits on a
-    // value that has already changed and never reloads onto an identical one.
+    // The meta refresh and the footer below both read this rather than a number of their own.
     let refresh_seconds = POLL_INTERVAL.as_secs();
 
     format!(
@@ -778,8 +776,7 @@ mod tests {
         assert_eq!(format_return(None), "—");
     }
 
-    /// Withheld and never-recorded read alike, whatever the figure was going to be. The formatters
-    /// used to disagree — two of them wrapped the dash in a dim span and three did not.
+    /// Withheld and never-recorded read alike, whatever the figure was going to be.
     #[test]
     fn test_every_unavailable_figure_renders_the_same_way() {
         assert_eq!(format_optional_dollars(None), "—");

--- a/tests/test_dashboard.rs
+++ b/tests/test_dashboard.rs
@@ -185,7 +185,7 @@ async fn test_the_dashboard_reads_what_the_service_writes() {
     assert_eq!(data.recent_events.len(), 1);
     assert_eq!(
         data.recent_events[0].event_type,
-        "portfolio_evaluation_completed"
+        EventType::new(Command::PortfolioEvaluation, Outcome::Completed)
     );
     assert_eq!(data.recent_events[0].payload["pairs_opened"], json!(1));
 }


### PR DESCRIPTION
# Overview

The `common/` review in #1075 produced a checklist, kept in `.scratchpad/module_review.md`. This applies it to `src/dashboard/`, which is the first module read against it rather than the one it was derived from.

## Changes

- Type `EventEntry.event_type` as `EventType` instead of `String`. The listener held a parsed `EventType` and called `.as_str().to_string()` to satisfy the field; the renderer then recovered the outcome by testing that string for an `_errored` or `_completed` suffix. A vocabulary the event bus already models exhaustively was being reconstructed by substring match at the far end of the pipe. `event_css_class` now matches on `Outcome`, and `fetch_recent_events` parses and skips unknown rows with a warning, the way the three fetches beside it already did.
- Interpolate `POLL_INTERVAL` into the `<meta http-equiv="refresh">` tag and the footer text. The cadence lived in three places, so changing the constant would have left the page telling viewers a rate it no longer ran on. The test pins the literal, so a change to the interval fails rather than propagating silently.
- Collapse five `Option<T> -> String` formatters onto one `ABSENT` constant. Two wrapped the dash in a dim span and three did not, which meant withheld and never-recorded rendered differently despite meaning the same thing to a reader — invisible until two of them land in the same table.
- Drop `Decimal::to_f64()` in `percentage_change` and `profit_factor` for `as_f64()`. `to_f64` is `Some(self.as_f64())`, so its `None` arm was unreachable; removing the layer leaves `percentage_change`'s `None` meaning only what it was written to mean, which is a zero or negative baseline.
- Rename `total_realized` and `average_realized` to carry the noun `ClosedPair.realized_profit_and_loss` already spells out.
- Fix two false claims in the module docs: `dashboard.rs` said the reader role holds SELECT on five tables, where `tools/dashboard_reader_setup.sql` grants six and the module queries all six; `compute_period_returns` pointed readers at `.scratchpad/unit_accounting.md`, which is gitignored and so resolved for nobody but its author.
- Trim four module headers to the three-line ceiling and delete ten doc comments that restated the name above them.

## Context

Rebased onto master after #1075 merged. No file overlaps that pull request, and the dashboard renders event payloads as generic JSON, so the `quote_rejection` shape change at schema v4 does not reach it.

Verified against the local `fund` database as `dashboard_reader`: all 100 event rows parse through `EventType::parse` with none skipped, and the rendered rows carry the typed name and the outcome-derived class. The absent-value path is covered by unit test only — that database holds no account snapshots or closed pairs, so every section that could show a dash short-circuits to its empty message instead.

709 tests pass, `cargo fmt` and `cargo doc` are clean, and clippy sits at the one pre-existing `redundant_closure` in `tests/test_handlers.rs`.

This is the first of four stacked module reviews. `data-cleanup`, `models-cleanup`, and `portfolio-cleanup` follow, each currently based on the pre-#1075 commit and needing the same rebase before it goes up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Dashboard event displays now use consistent event types and outcome-based coloring.
  - Unavailable values are shown uniformly as `—` for clearer presentation.
  - Dashboard refresh timing is now consistent across automatic updates and footer messaging.
  - Recent event loading safely skips unrecognized event records instead of displaying invalid data.
  - Profit and loss summary labels are more explicit and easier to understand.
- **Documentation**
  - Updated dashboard documentation to clarify data access and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->