### PR TITLE
Apply the module review checklist to `data/`, fixing the rename walk

### DIFF
--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -309,9 +309,8 @@ impl SessionDate {
     /// This session shifted by whole **calendar** days.
     ///
     /// Named for the distinction it must not lose: this steps over weekends and holidays, unlike
-    /// [`crate::data::calendar::TradingCalendar::previous_trading_day`] and
-    /// [`crate::data::calendar::TradingCalendar::next_trading_day`], which land on published
-    /// sessions. Used to bound fetch ranges, where overshooting is free.
+    /// [`crate::data::calendar::TradingCalendar::previous_trading_day`], which lands on a published
+    /// session. Used to bound fetch ranges, where overshooting is free.
     pub fn plus_calendar_days(self, days: i64) -> Self {
         Self(self.0 + Duration::days(days))
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -16,6 +16,7 @@ pub mod adjust;
 pub mod archive;
 pub mod bars;
 pub mod boundaries;
+pub mod cache;
 pub mod calendar;
 pub mod details;
 pub mod export;
@@ -23,3 +24,39 @@ pub mod purge;
 pub mod splits;
 pub mod truncate;
 pub mod universe;
+
+use polars::prelude::*;
+
+/// Keeps each row's earliest `first_seen` when a fetched table is merged with the stored one.
+///
+/// The column is provenance: it answers whether a corporate action was known to us when a given bar
+/// partition was written, which is the question an adjustment disagreement turns into. Taking the
+/// minimum makes it a semilattice — commutative, associative, idempotent — so re-running a refresh
+/// can never advance the date.
+///
+/// Shared because [`splits`] and [`boundaries`] carry the same column and have to agree about it.
+pub(crate) fn keep_earliest_first_seen(fetched: LazyFrame, existing: LazyFrame) -> LazyFrame {
+    let previously_seen = existing
+        .select([col("id"), col("first_seen").alias("previous_first_seen")])
+        .group_by([col("id")])
+        .agg([col("previous_first_seen").min()]);
+
+    fetched
+        .join(
+            previously_seen,
+            [col("id")],
+            [col("id")],
+            JoinArgs::new(JoinType::Left),
+        )
+        // Defaulted before it is compared, because a row absent from the stored table joins to null
+        // and a null comparison would propagate rather than choose a branch.
+        .with_column(
+            coalesce(&[col("previous_first_seen"), col("first_seen")]).alias("previous_first_seen"),
+        )
+        .with_column(
+            when(col("previous_first_seen").lt(col("first_seen")))
+                .then(col("previous_first_seen"))
+                .otherwise(col("first_seen"))
+                .alias("first_seen"),
+        )
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -29,12 +29,9 @@ use polars::prelude::*;
 
 /// Keeps each row's earliest `first_seen` when a fetched table is merged with the stored one.
 ///
-/// The column is provenance: it answers whether a corporate action was known to us when a given bar
-/// partition was written, which is the question an adjustment disagreement turns into. Taking the
-/// minimum makes it a semilattice — commutative, associative, idempotent — so re-running a refresh
-/// can never advance the date.
-///
-/// Shared because [`splits`] and [`boundaries`] carry the same column and have to agree about it.
+/// The column is provenance: whether a corporate action was known to us when a given bar partition
+/// was written, which is the question an adjustment disagreement turns into. Taking the minimum is
+/// idempotent, commutative, and associative, so re-running a refresh can never advance the date.
 pub(crate) fn keep_earliest_first_seen(fetched: LazyFrame, existing: LazyFrame) -> LazyFrame {
     let previously_seen = existing
         .select([col("id"), col("first_seen").alias("previous_first_seen")])

--- a/src/data/adjust.rs
+++ b/src/data/adjust.rs
@@ -11,15 +11,61 @@ use tracing::warn;
 
 use crate::common::types::SessionDate;
 use crate::data::archive::{read_partition, ArchiveError, SPLITS_ARCHIVE_KEY};
+use crate::data::cache::DailyCache;
 use crate::data::truncate::BoundaryTable;
+
+/// A multiplicative factor restating a price onto another session's share basis.
+///
+/// A group under multiplication: [`AdjustmentFactor::IDENTITY`] is the unit, factors over adjacent
+/// intervals compose, and every one is invertible. Construction admits only a finite, strictly
+/// positive value, so a factor in scope is proof it is safe to multiply and divide by rather than a
+/// number the caller has to re-check.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct AdjustmentFactor(f64);
+
+impl AdjustmentFactor {
+    /// The factor that restates nothing, and the answer for a ticker with no split.
+    pub const IDENTITY: AdjustmentFactor = AdjustmentFactor(1.0);
+
+    /// Returns `None` unless `value` is finite and strictly positive.
+    pub fn new(value: f64) -> Option<Self> {
+        (value.is_finite() && value > 0.0).then_some(AdjustmentFactor(value))
+    }
+
+    /// The two factors applied in succession.
+    ///
+    /// The group law holds in the reals but `f64` is a partial view of it, so a product of two
+    /// ordinary factors can still leave the representable range. That is the one place composition
+    /// can fail, and it fails here rather than at the divisor.
+    pub fn compose(self, other: Self) -> Option<Self> {
+        AdjustmentFactor::new(self.0 * other.0)
+    }
+
+    /// A price restated onto this basis.
+    pub fn apply_to_price(self, price: f64) -> f64 {
+        price * self.0
+    }
+
+    /// A share count restated onto this basis.
+    ///
+    /// Against the factor rather than with it: a two-for-one halves the price and doubles the
+    /// shares, so a frame that moved both the same way is internally inconsistent.
+    pub fn apply_to_volume(self, volume: i64) -> i64 {
+        (volume as f64 / self.0).round() as i64
+    }
+
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
 
 /// The splits table indexed for lookup, as read from the archive.
 ///
-/// Holds only the ratio and the date, because that is all an adjustment needs — the identifier and
+/// Holds only the factor and the date, because that is all an adjustment needs — the identifier and
 /// provenance answer other questions.
 #[derive(Debug, Clone, Default)]
 pub struct SplitTable {
-    by_ticker: HashMap<String, Vec<(SessionDate, f64)>>,
+    by_ticker: HashMap<String, Vec<(SessionDate, AdjustmentFactor)>>,
 }
 
 impl SplitTable {
@@ -33,7 +79,7 @@ impl SplitTable {
         let splits_from = frame.column("split_from")?.f64()?;
         let splits_to = frame.column("split_to")?.f64()?;
 
-        let mut by_ticker: HashMap<String, Vec<(SessionDate, f64)>> = HashMap::new();
+        let mut by_ticker: HashMap<String, Vec<(SessionDate, AdjustmentFactor)>> = HashMap::new();
         for row in 0..frame.height() {
             let (Some(ticker), Some(execution_date), Some(split_from), Some(split_to)) = (
                 tickers.get(row),
@@ -48,22 +94,19 @@ impl SplitTable {
             };
             // Guarded rather than assumed, because a frame can be read from an object this build
             // did not write. Both sides *and* the quotient: two negatives divide to a plausible
-            // ratio, and two positives can still overflow or underflow to one that is not.
-            if !split_from.is_finite()
-                || !split_to.is_finite()
-                || split_from <= 0.0
-                || split_to <= 0.0
+            // factor, and two positives can still overflow or underflow to one that is not.
+            if AdjustmentFactor::new(split_from).is_none()
+                || AdjustmentFactor::new(split_to).is_none()
             {
                 continue;
             }
-            let ratio = split_from / split_to;
-            if !ratio.is_finite() || ratio <= 0.0 {
+            let Some(factor) = AdjustmentFactor::new(split_from / split_to) else {
                 continue;
-            }
+            };
             by_ticker
                 .entry(ticker.to_string())
                 .or_default()
-                .push((SessionDate::from_date(execution_date), ratio));
+                .push((SessionDate::from_date(execution_date), factor));
         }
 
         Ok(Self { by_ticker })
@@ -77,29 +120,27 @@ impl SplitTable {
     /// carries them months ahead, and applying one would restate today's history onto a basis the
     /// market has not moved to, leaving it incomparable with the live quote it gets screened against.
     ///
-    /// Always a usable factor. Each ratio is finite and positive, but a product of them need not
-    /// be, and an unusable one falls back to 1.0 — the same answer an unknown ticker gets — so no
-    /// caller has to re-check a number it is about to divide by.
-    pub fn factor_at(&self, ticker: &str, session: SessionDate, as_of: SessionDate) -> f64 {
-        let factor: f64 = self
-            .by_ticker
+    /// A composition that leaves the representable range falls back to
+    /// [`AdjustmentFactor::IDENTITY`] — the same answer an unknown ticker gets.
+    pub fn factor_at(
+        &self,
+        ticker: &str,
+        session: SessionDate,
+        as_of: SessionDate,
+    ) -> AdjustmentFactor {
+        self.by_ticker
             .get(ticker)
-            .map(|splits| {
+            .and_then(|splits| {
                 splits
                     .iter()
                     .filter(|(execution_date, _)| {
                         *execution_date > session && *execution_date <= as_of
                     })
-                    .map(|(_, ratio)| ratio)
-                    .product()
+                    .try_fold(AdjustmentFactor::IDENTITY, |accumulated, (_, factor)| {
+                        accumulated.compose(*factor)
+                    })
             })
-            .unwrap_or(1.0);
-
-        if factor.is_finite() && factor > 0.0 {
-            factor
-        } else {
-            1.0
-        }
+            .unwrap_or(AdjustmentFactor::IDENTITY)
     }
 
     /// Re-files each split under the symbol its company trades as now.
@@ -113,16 +154,16 @@ impl SplitTable {
             return self.clone();
         }
 
-        let mut by_ticker: HashMap<String, Vec<(SessionDate, f64)>> = HashMap::new();
+        let mut by_ticker: HashMap<String, Vec<(SessionDate, AdjustmentFactor)>> = HashMap::new();
         for (ticker, splits) in &self.by_ticker {
-            for (execution_date, ratio) in splits {
+            for (execution_date, factor) in splits {
                 let symbol = boundaries
                     .current_symbol(ticker, *execution_date)
                     .unwrap_or_else(|| ticker.clone());
                 by_ticker
                     .entry(symbol)
                     .or_default()
-                    .push((*execution_date, *ratio));
+                    .push((*execution_date, *factor));
             }
         }
 
@@ -141,7 +182,7 @@ impl SplitTable {
 /// start applying part-way through a session.
 #[derive(Default)]
 pub struct SplitTableCache {
-    inner: tokio::sync::Mutex<Option<(SessionDate, Arc<SplitTable>)>>,
+    inner: DailyCache<Option<Arc<SplitTable>>>,
 }
 
 impl SplitTableCache {
@@ -153,36 +194,30 @@ impl SplitTableCache {
     ///
     /// Absent is reported rather than flattened to an empty table, because the two mean opposite
     /// things: empty says no split affects these prices, missing says nothing is known about whether
-    /// one does. An absent object is also not cached, so the next pass retries it.
-    ///
-    /// The lock is released before the S3 read and re-taken to store, like
-    /// [`crate::data::bars::CloseHistoryCache`], so two cold callers may both read; both reads are
-    /// deterministic, and the second store is a harmless overwrite.
+    /// one does. Only the absence is refused by the cache — an empty table is a real answer.
     pub async fn get(
         &self,
         s3_client: &aws_sdk_s3::Client,
         bucket: &str,
         now: DateTime<Utc>,
     ) -> Result<Option<Arc<SplitTable>>, ArchiveError> {
-        let today = SessionDate::at(now);
-
-        if let Some((cached_date, table)) = self.inner.lock().await.as_ref() {
-            if *cached_date == today {
-                return Ok(Some(Arc::clone(table)));
-            }
-        }
-
-        let Some(frame) = read_partition(s3_client, bucket, SPLITS_ARCHIVE_KEY).await? else {
-            warn!(
-                key = SPLITS_ARCHIVE_KEY,
-                "No splits table in the archive; prices cannot be adjusted"
-            );
-            return Ok(None);
-        };
-
-        let table = Arc::new(SplitTable::from_dataframe(&frame)?);
-        *self.inner.lock().await = Some((today, Arc::clone(&table)));
-        Ok(Some(table))
+        self.inner
+            .get(
+                SessionDate::at(now),
+                || async {
+                    let Some(frame) = read_partition(s3_client, bucket, SPLITS_ARCHIVE_KEY).await?
+                    else {
+                        warn!(
+                            key = SPLITS_ARCHIVE_KEY,
+                            "No splits table in the archive; prices cannot be adjusted"
+                        );
+                        return Ok(None);
+                    };
+                    Ok(Some(Arc::new(SplitTable::from_dataframe(&frame)?)))
+                },
+                |table| table.is_some(),
+            )
+            .await
     }
 }
 
@@ -222,18 +257,17 @@ pub fn adjust_bars(
             .f64()?
             .into_iter()
             .zip(&factors)
-            .map(|(price, factor)| price.map(|price| price * factor))
+            .map(|(price, factor)| price.map(|price| factor.apply_to_price(price)))
             .collect();
         adjusted.with_column(scaled.into_series().with_name(name.into()))?;
     }
 
     if let Ok(column) = adjusted.column("volume") {
-        // Against the factor, not with it: a two-for-one halves the price and doubles the shares.
         let scaled: Int64Chunked = column
             .i64()?
             .into_iter()
             .zip(&factors)
-            .map(|(volume, factor)| volume.map(|volume| (volume as f64 / factor).round() as i64))
+            .map(|(volume, factor)| volume.map(|volume| factor.apply_to_volume(volume)))
             .collect();
         adjusted.with_column(scaled.into_series().with_name("volume".into()))?;
     }
@@ -246,17 +280,17 @@ fn bar_factors(
     frame: &DataFrame,
     table: &SplitTable,
     as_of: SessionDate,
-) -> Result<Vec<f64>, PolarsError> {
+) -> Result<Vec<AdjustmentFactor>, PolarsError> {
     let tickers = frame.column("ticker")?.str()?;
     let timestamps = frame.column("timestamp")?.i64()?;
 
     Ok((0..frame.height())
         .map(|row| {
             let (Some(ticker), Some(timestamp)) = (tickers.get(row), timestamps.get(row)) else {
-                return 1.0;
+                return AdjustmentFactor::IDENTITY;
             };
             let Some(instant) = chrono::DateTime::from_timestamp_millis(timestamp) else {
-                return 1.0;
+                return AdjustmentFactor::IDENTITY;
             };
             table.factor_at(ticker, SessionDate::at(instant), as_of)
         })
@@ -299,7 +333,10 @@ mod tests {
 
         let factor = table.factor_at("MNST", session("2026-06-26"), session("2026-08-14"));
 
-        assert!((96.38 * factor - 48.19).abs() < 1e-9, "factor was {factor}");
+        assert!(
+            (factor.apply_to_price(96.38) - 48.19).abs() < 1e-9,
+            "factor was {factor:?}"
+        );
     }
 
     /// `NVDA`'s ten-for-one, the largest recent factor, checked against the same feed. A ratio this
@@ -310,7 +347,10 @@ mod tests {
 
         let factor = table.factor_at("NVDA", session("2024-06-07"), session("2024-08-14"));
 
-        assert!((factor - 0.1).abs() < 1e-12, "factor was {factor}");
+        assert!(
+            (factor.value() - 0.1).abs() < 1e-12,
+            "factor was {factor:?}"
+        );
     }
 
     /// A split executes at the open, so the bar stamped that day already reflects it and applying
@@ -321,11 +361,11 @@ mod tests {
 
         assert_eq!(
             table.factor_at("MNST", session("2026-08-11"), session("2026-08-14")),
-            1.0
+            AdjustmentFactor::IDENTITY
         );
         assert_eq!(
             table.factor_at("MNST", session("2026-08-12"), session("2026-08-14")),
-            1.0,
+            AdjustmentFactor::IDENTITY,
             "a bar after the split needs no restating either"
         );
     }
@@ -339,11 +379,13 @@ mod tests {
 
         assert_eq!(
             table.factor_at("DPU", session("2026-08-01"), session("2026-08-13")),
-            1.0,
+            AdjustmentFactor::IDENTITY,
             "a split that has not executed yet must not touch anything"
         );
         assert_eq!(
-            table.factor_at("DPU", session("2026-08-01"), session("2026-12-18")),
+            table
+                .factor_at("DPU", session("2026-08-01"), session("2026-12-18"))
+                .value(),
             50.0,
             "and must apply once it has"
         );
@@ -359,7 +401,10 @@ mod tests {
 
         let factor = table.factor_at("AAAA", session("2026-01-05"), session("2026-08-13"));
 
-        assert!((factor - 1.0 / 6.0).abs() < 1e-12, "factor was {factor}");
+        assert!(
+            (factor.value() - 1.0 / 6.0).abs() < 1e-12,
+            "factor was {factor:?}"
+        );
     }
 
     #[test]
@@ -368,7 +413,7 @@ mod tests {
 
         let factor = table.factor_at("TGOSY", session("2026-09-01"), session("2026-10-06"));
 
-        assert_eq!(factor, 5.0);
+        assert_eq!(factor.value(), 5.0);
     }
 
     #[test]
@@ -377,7 +422,7 @@ mod tests {
 
         assert_eq!(
             table.factor_at("AAPL", session("2026-06-26"), session("2026-08-14")),
-            1.0
+            AdjustmentFactor::IDENTITY
         );
     }
 
@@ -491,14 +536,16 @@ mod tests {
         let table = SplitTable::from_dataframe(&frame).expect("the table must index");
 
         assert_eq!(
-            table.factor_at("AAAA", session("2026-07-02"), session("2026-08-13")),
+            table
+                .factor_at("AAAA", session("2026-07-02"), session("2026-08-13"))
+                .value(),
             0.5,
             "an ordinary ratio still indexes"
         );
         for skipped in ["BBBB", "CCCC", "DDDD", "EEEE", "FFFF"] {
             assert_eq!(
                 table.factor_at(skipped, session("2026-07-02"), session("2026-08-13")),
-                1.0,
+                AdjustmentFactor::IDENTITY,
                 "{skipped}"
             );
         }
@@ -515,7 +562,7 @@ mod tests {
 
         assert_eq!(
             overflowing.factor_at("AAAA", session("2026-07-02"), session("2026-08-13")),
-            1.0,
+            AdjustmentFactor::IDENTITY,
             "a product past f64 is not a factor to scale prices by"
         );
     }

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -51,7 +51,10 @@ pub const BAR_ARCHIVE_PREFIX: &str = "data/equity/bars";
 /// without a model run noticing.
 pub const DETAILS_ARCHIVE_KEY: &str = "data/equity/details/details.csv";
 
-/// S3 key for the stock splits the bars will be adjusted against; nothing reads it yet.
+/// S3 key for the stock splits the bars are adjusted against.
+///
+/// Read by [`crate::data::adjust::SplitTableCache`] at read time and by the trainer before it
+/// builds a dataset, so both see the same basis.
 ///
 /// One object rather than a partition per session, unlike the bars beside it. A split belongs to
 /// its execution date, but the feed revises and cancels announced ones, so a per-date layout would
@@ -487,9 +490,6 @@ fn merge_or_replace(
 }
 
 /// Fetches the whole splits table and writes it, keeping each row's earliest `first_seen`.
-///
-/// Accumulates the history that makes the switch to unadjusted bars possible; nothing reads the
-/// result yet.
 ///
 /// Not a gap scan like [`archive_missing_sessions`], because there are no gaps to find: the feed
 /// answers with its entire current opinion in a few seconds, and that opinion is the answer. Rows

--- a/src/data/bars.rs
+++ b/src/data/bars.rs
@@ -481,7 +481,7 @@ pub async fn load_aligned_closes(
 /// Session-aligned close series, shared by reference because every caller only reads.
 pub type AlignedCloses = Arc<HashMap<Ticker, Vec<f64>>>;
 
-/// The aligned close history, loaded at most once per Eastern date.
+/// The aligned close history, cached per Eastern date.
 ///
 /// Daily bars are written after the close, so this cannot change intraday, and the evaluation pass
 /// needs all of it on every screening pass — seventy-eight times a session.

--- a/src/data/bars.rs
+++ b/src/data/bars.rs
@@ -18,6 +18,7 @@ use tracing::{info, warn};
 use crate::common::massive::{MassiveClient, MassiveError};
 use crate::common::types::{BarInterval, EquityBar, SessionDate, Ticker};
 use crate::data::adjust::{self, SplitTable};
+use crate::data::cache::DailyCache;
 use crate::data::truncate::{self, BoundaryTable};
 
 /// Rows per insert chunk.
@@ -425,10 +426,11 @@ pub async fn load_aligned_closes(
             }
         }
         let factor = splits.factor_at(ticker.as_str(), session, as_of);
-        dated_closes
-            .entry(ticker)
-            .or_default()
-            .push((session, row.close_price * factor, own));
+        dated_closes.entry(ticker).or_default().push((
+            session,
+            factor.apply_to_price(row.close_price),
+            own,
+        ));
     }
 
     // Sorted because a stitched series arrives in two runs — the successor's rows and the
@@ -488,7 +490,7 @@ pub type AlignedCloses = Arc<HashMap<Ticker, Vec<f64>>>;
 /// universe caches.
 #[derive(Default)]
 pub struct CloseHistoryCache {
-    inner: tokio::sync::Mutex<Option<(SessionDate, AlignedCloses)>>,
+    inner: DailyCache<AlignedCloses>,
 }
 
 impl CloseHistoryCache {
@@ -498,9 +500,9 @@ impl CloseHistoryCache {
 
     /// Returns today's aligned close history, loading it if the cache is cold or stale.
     ///
-    /// Behind an `Arc` because the map is large and every caller only reads it. The lock is
-    /// released before the query and re-taken to store, which lets two cold callers both load; both
-    /// reads are deterministic, so the second store is a harmless overwrite.
+    /// Behind an `Arc` because the map is large and every caller only reads it. Keyed by the Eastern
+    /// date, which is also what the closes were restated onto, so a cache hit can never hand back a
+    /// series adjusted for a different day than it is asked about.
     pub async fn get(
         &self,
         pool: &PgPool,
@@ -511,36 +513,39 @@ impl CloseHistoryCache {
         now: DateTime<Utc>,
     ) -> Result<AlignedCloses, BarsError> {
         let today = SessionDate::at(now);
-
-        if let Some((cached_date, closes)) = self.inner.lock().await.as_ref() {
-            if *cached_date == today {
-                return Ok(Arc::clone(closes));
-            }
-        }
-
-        // Keyed by the Eastern date, which is also what the closes were restated onto, so a cache
-        // hit can never hand back a series adjusted for a different day than it is asked about.
-        let closes = Arc::new(
-            load_aligned_closes(pool, bar_interval, sessions, splits, boundaries, today).await?,
-        );
-        if !closes.is_empty() {
-            *self.inner.lock().await = Some((today, Arc::clone(&closes)));
-        }
-        Ok(closes)
+        self.inner
+            .get(
+                today,
+                || async {
+                    Ok(Arc::new(
+                        load_aligned_closes(
+                            pool,
+                            bar_interval,
+                            sessions,
+                            splits,
+                            boundaries,
+                            today,
+                        )
+                        .await?,
+                    ))
+                },
+                |closes| !closes.is_empty(),
+            )
+            .await
     }
 
     /// Replaces the cached history. Used by tests and by the pre-open warm path.
     pub async fn install(&self, now: DateTime<Utc>, closes: HashMap<Ticker, Vec<f64>>) {
-        *self.inner.lock().await = Some((SessionDate::at(now), Arc::new(closes)));
+        self.inner
+            .install(SessionDate::at(now), Arc::new(closes))
+            .await;
     }
 
     /// Drops the cached history so the next caller reloads it.
     ///
-    /// Used after the post-close bar sync, whose new rows the cached window predates. Clearing is
-    /// not the same as installing an empty map: an empty map keyed to today would answer "no
-    /// history" for the rest of the Eastern date rather than reloading.
+    /// Used after the post-close bar sync, whose new rows the cached window predates.
     pub async fn invalidate(&self) {
-        *self.inner.lock().await = None;
+        self.inner.invalidate().await;
     }
 }
 

--- a/src/data/boundaries.rs
+++ b/src/data/boundaries.rs
@@ -93,48 +93,24 @@ pub fn merge_boundaries(
                 .or(col("process_date").gt(lit(end_text.clone()))),
         );
 
-    let previously_seen = existing
-        .lazy()
-        .select([col("id"), col("first_seen").alias("previous_first_seen")])
-        .group_by([col("id")])
-        .agg([col("previous_first_seen").min()]);
+    // One row per identifier before the merge, so a repeat across pages cannot become two rows.
+    let deduplicated = fetched.lazy().unique_stable(
+        Some(polars::prelude::Selector::ByName {
+            names: vec![PlSmallStr::from("id")].into(),
+            strict: false,
+        }),
+        UniqueKeepStrategy::First,
+    );
 
-    let refreshed = fetched
-        .lazy()
-        // One row per identifier before the join, so a repeat across pages cannot become two rows.
-        .unique_stable(
-            Some(polars::prelude::Selector::ByName {
-                names: vec![PlSmallStr::from("id")].into(),
-                strict: false,
-            }),
-            UniqueKeepStrategy::First,
-        )
-        .join(
-            previously_seen,
-            [col("id")],
-            [col("id")],
-            JoinArgs::new(JoinType::Left),
-        )
-        // Defaulted before it is compared, because a row absent from the stored table joins to null
-        // and a null comparison would propagate rather than choose a branch.
-        .with_column(
-            coalesce(&[col("previous_first_seen"), col("first_seen")]).alias("previous_first_seen"),
-        )
-        .with_column(
-            when(col("previous_first_seen").lt(col("first_seen")))
-                .then(col("previous_first_seen"))
-                .otherwise(col("first_seen"))
-                .alias("first_seen"),
-        )
-        .select([
-            col("id"),
-            col("ticker"),
-            col("date"),
-            col("process_date"),
-            col("reason"),
-            col("related_ticker"),
-            col("first_seen"),
-        ]);
+    let refreshed = crate::data::keep_earliest_first_seen(deduplicated, existing.lazy()).select([
+        col("id"),
+        col("ticker"),
+        col("date"),
+        col("process_date"),
+        col("reason"),
+        col("related_ticker"),
+        col("first_seen"),
+    ]);
 
     concat(
         [outside_window, refreshed],

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -8,17 +8,29 @@ use crate::common::types::SessionDate;
 
 /// A value cached per Eastern date, so the rollover invalidates it without a timer.
 ///
-/// Not a bound on rebuilds. The lock is released across the rebuild and re-taken only to store, so
-/// two callers arriving cold both rebuild, and a value `worth_caching` rejects is rebuilt on every
-/// call until it passes. Both are harmless because a rebuild is a deterministic read of one date.
+/// Not a bound on rebuilds. The lock is released across the rebuild, so two callers arriving cold
+/// both rebuild, and a value `worth_caching` rejects is rebuilt on every call until it passes.
 pub struct DailyCache<T> {
-    inner: tokio::sync::Mutex<Option<(SessionDate, T)>>,
+    inner: tokio::sync::Mutex<Slot<T>>,
+}
+
+/// The cached value beside a counter of every write that has landed on it.
+///
+/// The counter is what lets a rebuild tell whether it was superseded while the lock was released.
+/// It lives inside the mutex rather than beside it as an atomic so that the value and the count
+/// cannot be read out of step with each other.
+struct Slot<T> {
+    value: Option<(SessionDate, T)>,
+    writes: u64,
 }
 
 impl<T> Default for DailyCache<T> {
     fn default() -> Self {
         Self {
-            inner: tokio::sync::Mutex::new(None),
+            inner: tokio::sync::Mutex::new(Slot {
+                value: None,
+                writes: 0,
+            }),
         }
     }
 }
@@ -34,6 +46,10 @@ impl<T: Clone> DailyCache<T> {
     /// yes. An empty universe or an empty close history is a failed read, and storing one would
     /// answer "nothing is there" for the rest of the Eastern date; an empty splits table is a real
     /// answer that should be kept.
+    ///
+    /// A rebuild that finds the slot written since it started discards its own result rather than
+    /// storing it. Otherwise an [`DailyCache::invalidate`] landing mid-rebuild would be undone by
+    /// the rebuild it was meant to invalidate, pinning the superseded value until the date rolls.
     pub async fn get<Error, Rebuild, Rebuilding>(
         &self,
         today: SessionDate,
@@ -44,20 +60,28 @@ impl<T: Clone> DailyCache<T> {
         Rebuild: FnOnce() -> Rebuilding,
         Rebuilding: Future<Output = Result<T, Error>>,
     {
-        if let Some(fresh) = self.get_if_fresh(today).await {
-            return Ok(fresh);
-        }
+        let writes_before = {
+            let slot = self.inner.lock().await;
+            match &slot.value {
+                Some((cached_date, value)) if *cached_date == today => return Ok(value.clone()),
+                _ => slot.writes,
+            }
+        };
 
         let value = rebuild().await?;
         if worth_caching(&value) {
-            *self.inner.lock().await = Some((today, value.clone()));
+            let mut slot = self.inner.lock().await;
+            if slot.writes == writes_before {
+                slot.value = Some((today, value.clone()));
+                slot.writes += 1;
+            }
         }
         Ok(value)
     }
 
     /// The cached value when it was filled on `today`, without rebuilding.
     pub async fn get_if_fresh(&self, today: SessionDate) -> Option<T> {
-        match self.inner.lock().await.as_ref() {
+        match &self.inner.lock().await.value {
             Some((cached_date, value)) if *cached_date == today => Some(value.clone()),
             _ => None,
         }
@@ -71,13 +95,16 @@ impl<T: Clone> DailyCache<T> {
         self.inner
             .lock()
             .await
+            .value
             .as_ref()
             .map(|(_, value)| value.clone())
     }
 
     /// Replaces the cached value. Used by tests and by the pre-open warm path.
     pub async fn install(&self, today: SessionDate, value: T) {
-        *self.inner.lock().await = Some((today, value));
+        let mut slot = self.inner.lock().await;
+        slot.value = Some((today, value));
+        slot.writes += 1;
     }
 
     /// Drops the cached value so the next caller rebuilds.
@@ -85,7 +112,9 @@ impl<T: Clone> DailyCache<T> {
     /// Not the same as installing an empty one: an empty value keyed to today would answer "nothing
     /// is there" for the rest of the Eastern date rather than reloading.
     pub async fn invalidate(&self) {
-        *self.inner.lock().await = None;
+        let mut slot = self.inner.lock().await;
+        slot.value = None;
+        slot.writes += 1;
     }
 }
 
@@ -179,6 +208,47 @@ mod tests {
         cache.invalidate().await;
         assert_eq!(counted(&cache, today, &rebuilds, 1, |_| true).await, 1);
         assert_eq!(rebuilds.load(Ordering::Relaxed), 1);
+    }
+
+    /// An invalidation that lands while a rebuild is in flight must survive it.
+    ///
+    /// The post-close bar sync invalidates the close history because the cached window predates the
+    /// rows it just wrote. A pass already loading that window read the old rows, so storing its
+    /// result would undo the invalidation and serve pre-sync closes until the date rolled over.
+    #[tokio::test]
+    async fn test_an_invalidation_during_a_rebuild_is_not_undone_by_it() {
+        let cache: DailyCache<usize> = DailyCache::new();
+        let today = session("2026-08-17");
+        let reading = tokio::sync::Notify::new();
+        let invalidated = tokio::sync::Notify::new();
+
+        let rebuilding = cache.get::<(), _, _>(
+            today,
+            || async {
+                reading.notify_one();
+                invalidated.notified().await;
+                Ok(1)
+            },
+            |_| true,
+        );
+
+        let invalidating = async {
+            reading.notified().await;
+            cache.invalidate().await;
+            invalidated.notify_one();
+        };
+
+        let (rebuilt, ()) = tokio::join!(rebuilding, invalidating);
+        assert_eq!(
+            rebuilt,
+            Ok(1),
+            "the caller still gets the value it asked for"
+        );
+        assert_eq!(
+            cache.get_if_fresh(today).await,
+            None,
+            "the invalidation stands, so the next caller reloads"
+        );
     }
 
     /// `previous` ignores the date, which is what makes a day-over-day difference possible.

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -1,0 +1,195 @@
+//! A value rebuilt at most once per Eastern date.
+//!
+//! Five caches in this module wanted this and each hand-rolled it.
+
+use std::future::Future;
+
+use crate::common::types::SessionDate;
+
+/// A value rebuilt at most once per Eastern date.
+///
+/// Keying on the date rather than an elapsed duration means the rollover invalidates without a
+/// timer. The lock is released across the rebuild and re-taken only to store, so a cold cache never
+/// blocks a caller for the length of one; two callers arriving cold may both rebuild, which is
+/// harmless because every rebuild here is a deterministic read scoped to one Eastern date.
+pub struct DailyCache<T> {
+    inner: tokio::sync::Mutex<Option<(SessionDate, T)>>,
+}
+
+impl<T> Default for DailyCache<T> {
+    fn default() -> Self {
+        Self {
+            inner: tokio::sync::Mutex::new(None),
+        }
+    }
+}
+
+impl<T: Clone> DailyCache<T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Today's value, rebuilding it when the cache is cold or was filled on an earlier date.
+    ///
+    /// `worth_caching` decides whether the rebuilt value is stored, and the answer is not always
+    /// yes. An empty universe or an empty close history is a failed read, and storing one would
+    /// answer "nothing is there" for the rest of the Eastern date; an empty splits table is a real
+    /// answer that should be kept.
+    pub async fn get<Error, Rebuild, Rebuilding>(
+        &self,
+        today: SessionDate,
+        rebuild: Rebuild,
+        worth_caching: impl Fn(&T) -> bool,
+    ) -> Result<T, Error>
+    where
+        Rebuild: FnOnce() -> Rebuilding,
+        Rebuilding: Future<Output = Result<T, Error>>,
+    {
+        if let Some(fresh) = self.get_if_fresh(today).await {
+            return Ok(fresh);
+        }
+
+        let value = rebuild().await?;
+        if worth_caching(&value) {
+            *self.inner.lock().await = Some((today, value.clone()));
+        }
+        Ok(value)
+    }
+
+    /// The cached value when it was filled on `today`, without rebuilding.
+    pub async fn get_if_fresh(&self, today: SessionDate) -> Option<T> {
+        match self.inner.lock().await.as_ref() {
+            Some((cached_date, value)) if *cached_date == today => Some(value.clone()),
+            _ => None,
+        }
+    }
+
+    /// The cached value whatever date it was filled on.
+    ///
+    /// For a rebuild that reports what changed: the universe names what entered and what fell out,
+    /// which needs the previous answer as well as the new one.
+    pub async fn previous(&self) -> Option<T> {
+        self.inner
+            .lock()
+            .await
+            .as_ref()
+            .map(|(_, value)| value.clone())
+    }
+
+    /// Replaces the cached value. Used by tests and by the pre-open warm path.
+    pub async fn install(&self, today: SessionDate, value: T) {
+        *self.inner.lock().await = Some((today, value));
+    }
+
+    /// Drops the cached value so the next caller rebuilds.
+    ///
+    /// Not the same as installing an empty one: an empty value keyed to today would answer "nothing
+    /// is there" for the rest of the Eastern date rather than reloading.
+    pub async fn invalidate(&self) {
+        *self.inner.lock().await = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn session(value: &str) -> SessionDate {
+        SessionDate::from_date(value.parse().expect("a valid session date"))
+    }
+
+    /// Counts rebuilds so a cache hit is proved by the rebuild not running, rather than by the
+    /// value happening to match.
+    async fn counted(
+        cache: &DailyCache<usize>,
+        today: SessionDate,
+        rebuilds: &AtomicUsize,
+        value: usize,
+        worth_caching: impl Fn(&usize) -> bool,
+    ) -> usize {
+        cache
+            .get::<(), _, _>(
+                today,
+                || async {
+                    rebuilds.fetch_add(1, Ordering::Relaxed);
+                    Ok(value)
+                },
+                worth_caching,
+            )
+            .await
+            .expect("the rebuild cannot fail")
+    }
+
+    #[tokio::test]
+    async fn test_a_second_read_on_the_same_date_does_not_rebuild() {
+        let cache = DailyCache::new();
+        let rebuilds = AtomicUsize::new(0);
+        let today = session("2026-08-17");
+
+        assert_eq!(counted(&cache, today, &rebuilds, 1, |_| true).await, 1);
+        assert_eq!(counted(&cache, today, &rebuilds, 2, |_| true).await, 1);
+        assert_eq!(rebuilds.load(Ordering::Relaxed), 1);
+    }
+
+    /// The rollover is the whole point of keying on the date.
+    #[tokio::test]
+    async fn test_the_next_eastern_date_rebuilds() {
+        let cache = DailyCache::new();
+        let rebuilds = AtomicUsize::new(0);
+
+        assert_eq!(
+            counted(&cache, session("2026-08-17"), &rebuilds, 1, |_| true).await,
+            1
+        );
+        assert_eq!(
+            counted(&cache, session("2026-08-18"), &rebuilds, 2, |_| true).await,
+            2
+        );
+        assert_eq!(rebuilds.load(Ordering::Relaxed), 2);
+    }
+
+    /// A refused value is still returned to the caller that asked for it, and still rebuilt for the
+    /// next one. Storing it would answer "nothing is there" until the date rolls over.
+    #[tokio::test]
+    async fn test_a_value_not_worth_caching_is_returned_but_not_kept() {
+        let cache = DailyCache::new();
+        let rebuilds = AtomicUsize::new(0);
+        let today = session("2026-08-17");
+        let non_empty = |value: &usize| *value > 0;
+
+        assert_eq!(counted(&cache, today, &rebuilds, 0, non_empty).await, 0);
+        assert_eq!(counted(&cache, today, &rebuilds, 0, non_empty).await, 0);
+        assert_eq!(rebuilds.load(Ordering::Relaxed), 2, "neither was cached");
+
+        assert_eq!(counted(&cache, today, &rebuilds, 7, non_empty).await, 7);
+        assert_eq!(counted(&cache, today, &rebuilds, 9, non_empty).await, 7);
+        assert_eq!(rebuilds.load(Ordering::Relaxed), 3, "the third one stuck");
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_rebuilds_where_installing_an_empty_value_would_not() {
+        let cache = DailyCache::new();
+        let rebuilds = AtomicUsize::new(0);
+        let today = session("2026-08-17");
+
+        cache.install(today, 5).await;
+        assert_eq!(counted(&cache, today, &rebuilds, 1, |_| true).await, 5);
+        assert_eq!(rebuilds.load(Ordering::Relaxed), 0);
+
+        cache.invalidate().await;
+        assert_eq!(counted(&cache, today, &rebuilds, 1, |_| true).await, 1);
+        assert_eq!(rebuilds.load(Ordering::Relaxed), 1);
+    }
+
+    /// `previous` ignores the date, which is what makes a day-over-day difference possible.
+    #[tokio::test]
+    async fn test_previous_answers_across_the_rollover() {
+        let cache = DailyCache::new();
+        assert_eq!(cache.previous().await, None);
+
+        cache.install(session("2026-08-17"), 5).await;
+        assert_eq!(cache.get_if_fresh(session("2026-08-18")).await, None);
+        assert_eq!(cache.previous().await, Some(5));
+    }
+}

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -1,4 +1,4 @@
-//! A value rebuilt at most once per Eastern date.
+//! A value cached per Eastern date.
 //!
 //! Five caches in this module wanted this and each hand-rolled it.
 
@@ -6,12 +6,11 @@ use std::future::Future;
 
 use crate::common::types::SessionDate;
 
-/// A value rebuilt at most once per Eastern date.
+/// A value cached per Eastern date, so the rollover invalidates it without a timer.
 ///
-/// Keying on the date rather than an elapsed duration means the rollover invalidates without a
-/// timer. The lock is released across the rebuild and re-taken only to store, so a cold cache never
-/// blocks a caller for the length of one; two callers arriving cold may both rebuild, which is
-/// harmless because every rebuild here is a deterministic read scoped to one Eastern date.
+/// Not a bound on rebuilds. The lock is released across the rebuild and re-taken only to store, so
+/// two callers arriving cold both rebuild, and a value `worth_caching` rejects is rebuilt on every
+/// call until it passes. Both are harmless because a rebuild is a deterministic read of one date.
 pub struct DailyCache<T> {
     inner: tokio::sync::Mutex<Option<(SessionDate, T)>>,
 }

--- a/src/data/calendar.rs
+++ b/src/data/calendar.rs
@@ -23,6 +23,7 @@ use uuid::Uuid;
 use crate::common::alpaca::{CalendarDay, ClientError, TradingClient};
 use crate::common::journal::{CalendarObserved, EarlyClose, Journal, Observation};
 use crate::common::types::SessionDate;
+use crate::data::cache::DailyCache;
 
 /// How far forward to fetch published sessions.
 ///
@@ -37,7 +38,7 @@ const HORIZON_DAYS_FORWARD: i64 = 90;
 const HORIZON_DAYS_BACKWARD: i64 = 30;
 
 /// The Eastern wall-clock time at an instant.
-pub fn eastern_time(instant: DateTime<Utc>) -> NaiveTime {
+fn eastern_time(instant: DateTime<Utc>) -> NaiveTime {
     instant.with_timezone(&New_York).time()
 }
 
@@ -90,25 +91,6 @@ impl TradingCalendar {
         self.days.get(&date)
     }
 
-    /// Whether the calendar has an opinion about `date` at all.
-    ///
-    /// Distinct from [`TradingCalendar::is_trading_day`]: a date inside the horizon with no session
-    /// is a holiday, while a date outside it is unknown. Both answer `false` to "does it trade",
-    /// but only the second means the calendar needs refreshing.
-    pub fn covers(&self, date: SessionDate) -> bool {
-        match self.horizon() {
-            Some((first, last)) => date >= first && date <= last,
-            None => false,
-        }
-    }
-
-    /// The first and last published dates, if any.
-    pub fn horizon(&self) -> Option<(SessionDate, SessionDate)> {
-        let first = *self.days.keys().next()?;
-        let last = *self.days.keys().next_back()?;
-        Some((first, last))
-    }
-
     /// Every session in the horizon that closes before the usual 16:00 Eastern bell.
     ///
     /// The half-days are the reason the calendar is fetched rather than assumed, so they are named
@@ -141,11 +123,6 @@ impl TradingCalendar {
         self.days.range(..date).next_back().map(|(day, _)| *day)
     }
 
-    /// The next trading day on or after `date`.
-    pub fn next_trading_day(&self, date: SessionDate) -> Option<SessionDate> {
-        self.days.range(date..).next().map(|(day, _)| *day)
-    }
-
     /// Every trading day in an inclusive range.
     pub fn trading_days_in_range(&self, start: SessionDate, end: SessionDate) -> Vec<SessionDate> {
         self.days.range(start..=end).map(|(day, _)| *day).collect()
@@ -168,6 +145,10 @@ impl TradingCalendar {
     }
 
     /// Whether the regular session is open at `instant`.
+    ///
+    /// The only thing that answers this. Alpaca's `/v2/clock` was removed because this calendar
+    /// already knew, and `minutes_until_close` is not a substitute — it says nothing about whether
+    /// the open has happened yet.
     pub fn is_open_at(&self, instant: DateTime<Utc>) -> bool {
         match self.session(SessionDate::at(instant)) {
             Some(session) => {
@@ -186,7 +167,7 @@ impl TradingCalendar {
 /// rather than an elapsed duration means the rollover invalidates without a timer.
 #[derive(Default)]
 pub struct CalendarCache {
-    inner: tokio::sync::Mutex<Option<(SessionDate, TradingCalendar)>>,
+    inner: DailyCache<TradingCalendar>,
 }
 
 impl CalendarCache {
@@ -196,9 +177,8 @@ impl CalendarCache {
 
     /// Returns today's calendar, fetching it if the cache is cold or was filled on an earlier date.
     ///
-    /// The lock is released before the Alpaca call and re-taken only to store the result, so a cold
-    /// fetch does not block every other caller for its duration. Two callers arriving cold may both
-    /// fetch; the request is read-only and the result deterministic, so the duplicate is harmless.
+    /// An empty calendar is returned but never stored: caching one would pin "nothing trades" for
+    /// the rest of the Eastern date, and the next caller should get a real attempt.
     pub async fn get(
         &self,
         client: &TradingClient,
@@ -207,50 +187,50 @@ impl CalendarCache {
         now: DateTime<Utc>,
     ) -> Result<TradingCalendar, ClientError> {
         let today = SessionDate::at(now);
-
-        if let Some((cached_date, calendar)) = self.inner.lock().await.as_ref() {
-            if *cached_date == today {
-                return Ok(calendar.clone());
-            }
-        }
-
         let start = today.plus_calendar_days(-HORIZON_DAYS_BACKWARD);
         let end = today.plus_calendar_days(HORIZON_DAYS_FORWARD);
-        let calendar =
-            TradingCalendar::from_days(client.fetch_calendar(start.date(), end.date()).await?);
 
-        if calendar.is_empty() {
-            // Reported rather than cached: an empty calendar would otherwise pin "nothing trades"
-            // for the rest of the day, and the next caller should get a real attempt.
-            warn!(start = %start, end = %end, "Alpaca published no trading days for the horizon");
-        } else {
-            info!(
-                sessions = calendar.len(),
-                trades_today = calendar.is_trading_day(today),
-                "Trading calendar cached"
-            );
-            *self.inner.lock().await = Some((today, calendar.clone()));
-        }
+        self.inner
+            .get(
+                today,
+                || async {
+                    let calendar = TradingCalendar::from_days(
+                        client.fetch_calendar(start.date(), end.date()).await?,
+                    );
 
-        journal
-            .record(
-                correlation_id,
-                now,
-                Observation::CalendarObserved(CalendarObserved {
-                    horizon_start: start,
-                    horizon_end: end,
-                    sessions: calendar.len(),
-                    trades_today: calendar.is_trading_day(today),
-                    early_closes: calendar.early_closes(),
-                }),
+                    if calendar.is_empty() {
+                        warn!(start = %start, end = %end, "Alpaca published no trading days for the horizon");
+                    } else {
+                        info!(
+                            sessions = calendar.len(),
+                            trades_today = calendar.is_trading_day(today),
+                            "Trading calendar cached"
+                        );
+                    }
+
+                    journal
+                        .record(
+                            correlation_id,
+                            now,
+                            Observation::CalendarObserved(CalendarObserved {
+                                horizon_start: start,
+                                horizon_end: end,
+                                sessions: calendar.len(),
+                                trades_today: calendar.is_trading_day(today),
+                                early_closes: calendar.early_closes(),
+                            }),
+                        )
+                        .await;
+                    Ok(calendar)
+                },
+                |calendar| !calendar.is_empty(),
             )
-            .await;
-        Ok(calendar)
+            .await
     }
 
     /// Replaces the cached calendar. Used by tests and by the pre-open warm path.
     pub async fn install(&self, now: DateTime<Utc>, calendar: TradingCalendar) {
-        *self.inner.lock().await = Some((SessionDate::at(now), calendar));
+        self.inner.install(SessionDate::at(now), calendar).await;
     }
 }
 
@@ -310,7 +290,6 @@ mod tests {
     #[test]
     fn test_unknown_date_does_not_trade() {
         assert!(!calendar().is_trading_day(date(2030, 1, 2)));
-        assert!(!calendar().covers(date(2030, 1, 2)));
     }
 
     /// An empty calendar must refuse every date rather than defaulting to open.
@@ -318,8 +297,8 @@ mod tests {
     fn test_empty_calendar_refuses_everything() {
         let empty = TradingCalendar::default();
         assert!(!empty.is_trading_day(date(2026, 11, 24)));
-        assert!(!empty.covers(date(2026, 11, 24)));
-        assert_eq!(empty.horizon(), None);
+        assert!(!empty.is_open_at("2026-11-24T16:00:00Z".parse::<DateTime<Utc>>().unwrap()));
+        assert_eq!(empty.previous_trading_day(date(2026, 11, 24)), None);
         assert!(empty.is_empty());
     }
 
@@ -337,19 +316,6 @@ mod tests {
             calendar.previous_trading_day(date(2026, 11, 30)),
             Some(date(2026, 11, 27)),
             "the weekend must be skipped"
-        );
-    }
-
-    #[test]
-    fn test_next_trading_day_is_inclusive_of_today() {
-        let calendar = calendar();
-        assert_eq!(
-            calendar.next_trading_day(date(2026, 11, 26)),
-            Some(date(2026, 11, 27))
-        );
-        assert_eq!(
-            calendar.next_trading_day(date(2026, 11, 27)),
-            Some(date(2026, 11, 27))
         );
     }
 

--- a/src/data/calendar.rs
+++ b/src/data/calendar.rs
@@ -160,7 +160,7 @@ impl TradingCalendar {
     }
 }
 
-/// A [`TradingCalendar`] refreshed from Alpaca at most once per Eastern date.
+/// A [`TradingCalendar`] fetched from Alpaca and cached per Eastern date.
 ///
 /// The pre-open handler warms it; anything that finds it cold or stale refreshes on demand, so a
 /// restart mid-session repopulates without waiting for the next morning. Keying on the Eastern date

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -447,7 +447,7 @@ pub async fn export_journals(
             .map(|session_date| {
                 (
                     *session_date,
-                    read_session_frame(&journal.directory().join(file_name(*session_date))),
+                    read_journal_frame(&journal.directory().join(file_name(*session_date))),
                 )
             })
             .collect::<Vec<_>>()
@@ -567,7 +567,7 @@ fn delete_aged_out(
 /// Reads one session file into a frame, returning it with the number of lines skipped.
 ///
 /// Discarding a torn final line is why the original is JSONL rather than Parquet.
-fn read_session_frame(path: &Path) -> Result<(DataFrame, usize), String> {
+fn read_journal_frame(path: &Path) -> Result<(DataFrame, usize), String> {
     let contents = std::fs::read_to_string(path)
         .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
 
@@ -685,7 +685,7 @@ mod tests {
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
         let directory = std::env::temp_dir().join(format!(
-            "fund-session-export-{name}-{}-{unique}",
+            "fund-journal-export-{name}-{}-{unique}",
             std::process::id()
         ));
         let _ = std::fs::remove_dir_all(&directory);
@@ -732,7 +732,7 @@ mod tests {
         std::fs::write(&path, format!("{complete}\n{{\"schema_version\":1,\"eve"))
             .expect("the file must be writable");
 
-        let (frame, unparsable) = read_session_frame(&path).expect("the session must still read");
+        let (frame, unparsable) = read_journal_frame(&path).expect("the session must still read");
         assert_eq!(frame.height(), 1);
         assert_eq!(unparsable, 1);
         let _ = std::fs::remove_dir_all(&directory);
@@ -749,7 +749,7 @@ mod tests {
         std::fs::write(&path, "not json at all\n{\"schema_version\":3}\n")
             .expect("the file must be writable");
 
-        let (frame, unparsable) = read_session_frame(&path).expect("the session must read");
+        let (frame, unparsable) = read_journal_frame(&path).expect("the session must read");
         assert_eq!(frame.height(), 0);
         assert_eq!(unparsable, 2);
         let _ = std::fs::remove_dir_all(&directory);
@@ -776,7 +776,7 @@ mod tests {
         .join("\n");
         std::fs::write(&path, lines).expect("the file must be writable");
 
-        let (frame, unparsable) = read_session_frame(&path).expect("the session must read");
+        let (frame, unparsable) = read_journal_frame(&path).expect("the session must read");
         assert_eq!(
             frame.height(),
             1,
@@ -808,7 +808,7 @@ mod tests {
         )
         .expect("the file must be writable");
 
-        let (frame, _) = read_session_frame(&path).expect("the session must read");
+        let (frame, _) = read_journal_frame(&path).expect("the session must read");
         assert_eq!(
             frame.get_column_names(),
             [
@@ -882,7 +882,7 @@ mod tests {
         }
         std::fs::write(&path, lines).expect("the file must be writable");
 
-        let (mut frame, _) = read_session_frame(&path).expect("the session must read");
+        let (mut frame, _) = read_journal_frame(&path).expect("the session must read");
         let mut buffer: Vec<u8> = Vec::new();
         ParquetWriter::new(&mut buffer)
             .finish(&mut frame)
@@ -947,7 +947,7 @@ mod tests {
         }
         std::fs::write(&path, lines.join("\n")).expect("the file must be writable");
 
-        let (frame, unparsable) = read_session_frame(&path).expect("the session must read");
+        let (frame, unparsable) = read_journal_frame(&path).expect("the session must read");
         assert_eq!(
             frame.height(),
             1,

--- a/src/data/splits.rs
+++ b/src/data/splits.rs
@@ -1,4 +1,4 @@
-//! The stock splits the bar archive will be adjusted against; nothing reads them yet.
+//! The stock splits the bar archive is adjusted against, read by [`crate::data::adjust`].
 //!
 //! One S3 object rather than a partition per session: a split belongs to its execution date, but
 //! the feed revises and cancels announced ones, so only the whole table is ever authoritative.
@@ -58,31 +58,7 @@ pub fn merge_splits(existing: DataFrame, fetched: DataFrame) -> Result<DataFrame
         return Ok(existing);
     }
 
-    let previously_seen = existing
-        .lazy()
-        .select([col("id"), col("first_seen").alias("previous_first_seen")])
-        .group_by([col("id")])
-        .agg([col("previous_first_seen").min()]);
-
-    fetched
-        .lazy()
-        .join(
-            previously_seen,
-            [col("id")],
-            [col("id")],
-            JoinArgs::new(JoinType::Left),
-        )
-        // Defaulted before it is compared, because a row absent from the stored table joins to null
-        // and a null comparison would propagate rather than choose a branch.
-        .with_column(
-            coalesce(&[col("previous_first_seen"), col("first_seen")]).alias("previous_first_seen"),
-        )
-        .with_column(
-            when(col("previous_first_seen").lt(col("first_seen")))
-                .then(col("previous_first_seen"))
-                .otherwise(col("first_seen"))
-                .alias("first_seen"),
-        )
+    crate::data::keep_earliest_first_seen(fetched.lazy(), existing.lazy())
         // Named rather than dropped, so the merged frame is written back with the same schema
         // `splits_to_dataframe` produces and the next read finds what it expects.
         .select([

--- a/src/data/truncate.rs
+++ b/src/data/truncate.rs
@@ -100,17 +100,10 @@ impl BoundaryTable {
 
     /// The symbol a fact about `ticker` dated `session` belongs to now, if it moved.
     ///
-    /// Each step starts from the date of the one before it, so the walk tracks one company forward
-    /// through time. A rename at or before the floor is somebody else's: the symbol was free by
-    /// then, and whoever took it is who it means from that date on.
-    ///
-    /// Used for splits as well as bars, which is what keeps the fold correct across a rename —
-    /// otherwise a stitched bar takes the successor's splits and misses its own, or the reverse.
-    ///
-    /// Needs no cycle guard. The dates strictly increase and there are finitely many, so the walk
-    /// terminates by construction — and a symbol that leaves and returns resolves to where it ended
-    /// rather than to the midpoint a visited-set guard stops on. That is not hypothetical: a reverse
-    /// split moves a symbol to a `D` suffix for about a month and back, ten times in the last year.
+    /// A rename at or before the floor is somebody else's: the symbol was free by then, and whoever
+    /// took it is who it means from that date on. Needs no cycle guard, because each step moves the
+    /// floor strictly forward over a finite table — so a symbol that leaves and returns resolves to
+    /// itself rather than to the midpoint a visited-set guard stops on.
     pub fn current_symbol(&self, ticker: &str, session: SessionDate) -> Option<String> {
         let mut symbol = ticker.to_string();
         let mut floor = session;

--- a/src/data/truncate.rs
+++ b/src/data/truncate.rs
@@ -11,15 +11,10 @@ use tracing::warn;
 
 use crate::common::types::{SessionDate, Ticker};
 use crate::data::archive::{read_partition, ArchiveError, BOUNDARIES_ARCHIVE_KEY};
+use crate::data::cache::DailyCache;
 
 /// Column the join threshold is carried on, dropped before the frame is returned.
 const THRESHOLD_COLUMN: &str = "earliest_usable_millis";
-
-/// Renames followed before a chain is declared circular.
-///
-/// A symbol changing hands eight times inside one lookback is not something the feed describes; a
-/// table that pointed a symbol back at itself is, and would otherwise loop forever.
-const RENAME_CHAIN_LIMIT: usize = 8;
 
 /// The boundary dates indexed for lookup, as read from the archive.
 ///
@@ -105,36 +100,28 @@ impl BoundaryTable {
 
     /// The symbol a fact about `ticker` dated `session` belongs to now, if it moved.
     ///
-    /// Follows every rename dated after the session, so a company renamed twice is reached in two
-    /// steps. A rename dated at or before the session is somebody else's: the symbol was free by
-    /// then, and whoever took it is who `ticker` means from that date on.
+    /// Each step starts from the date of the one before it, so the walk tracks one company forward
+    /// through time. A rename at or before the floor is somebody else's: the symbol was free by
+    /// then, and whoever took it is who it means from that date on.
     ///
     /// Used for splits as well as bars, which is what keeps the fold correct across a rename —
     /// otherwise a stitched bar takes the successor's splits and misses its own, or the reverse.
-    /// A chain that revisits a symbol stops there rather than going round again, keeping the last
-    /// symbol reached: the table is malformed at that point, and the walk so far is still the best
-    /// answer available.
+    ///
+    /// Needs no cycle guard. The dates strictly increase and there are finitely many, so the walk
+    /// terminates by construction — and a symbol that leaves and returns resolves to where it ended
+    /// rather than to the midpoint a visited-set guard stops on. That is not hypothetical: a reverse
+    /// split moves a symbol to a `D` suffix for about a month and back, ten times in the last year.
     pub fn current_symbol(&self, ticker: &str, session: SessionDate) -> Option<String> {
         let mut symbol = ticker.to_string();
-        let mut visited: HashSet<String> = HashSet::from([symbol.clone()]);
-        for _ in 0..RENAME_CHAIN_LIMIT {
-            let Some(successor) = self
-                .renames
-                .get(&symbol)
-                .and_then(|renames| {
-                    renames
-                        .iter()
-                        .filter(|(date, _)| *date > session)
-                        .min_by_key(|(date, _)| *date)
-                })
-                .map(|(_, successor)| successor.clone())
-            else {
-                break;
-            };
-            if !visited.insert(successor.clone()) {
-                break;
-            }
-            symbol = successor;
+        let mut floor = session;
+        while let Some((date, successor)) = self.renames.get(&symbol).and_then(|renames| {
+            renames
+                .iter()
+                .filter(|(date, _)| *date > floor)
+                .min_by_key(|(date, _)| *date)
+        }) {
+            floor = *date;
+            symbol = successor.clone();
         }
 
         (symbol != ticker).then_some(symbol)
@@ -152,7 +139,7 @@ impl BoundaryTable {
 /// falls on a session, so it cannot start applying part-way through one.
 #[derive(Default)]
 pub struct BoundaryTableCache {
-    inner: tokio::sync::Mutex<Option<(SessionDate, Arc<BoundaryTable>)>>,
+    inner: DailyCache<Option<Arc<BoundaryTable>>>,
 }
 
 impl BoundaryTableCache {
@@ -164,32 +151,31 @@ impl BoundaryTableCache {
     ///
     /// Absent is reported rather than flattened to an empty table, because the two mean opposite
     /// things: empty says no symbol changed hands, missing says nothing is known about whether one
-    /// did. An absent object is not cached, so the next pass retries it.
+    /// did. Only the absence is refused by the cache — an empty table is a real answer.
     pub async fn get(
         &self,
         s3_client: &aws_sdk_s3::Client,
         bucket: &str,
         now: DateTime<Utc>,
     ) -> Result<Option<Arc<BoundaryTable>>, ArchiveError> {
-        let today = SessionDate::at(now);
-
-        if let Some((cached_date, table)) = self.inner.lock().await.as_ref() {
-            if *cached_date == today {
-                return Ok(Some(Arc::clone(table)));
-            }
-        }
-
-        let Some(frame) = read_partition(s3_client, bucket, BOUNDARIES_ARCHIVE_KEY).await? else {
-            warn!(
-                key = BOUNDARIES_ARCHIVE_KEY,
-                "No boundary table in the archive; series cannot be bounded"
-            );
-            return Ok(None);
-        };
-
-        let table = Arc::new(BoundaryTable::from_dataframe(&frame)?);
-        *self.inner.lock().await = Some((today, Arc::clone(&table)));
-        Ok(Some(table))
+        self.inner
+            .get(
+                SessionDate::at(now),
+                || async {
+                    let Some(frame) =
+                        read_partition(s3_client, bucket, BOUNDARIES_ARCHIVE_KEY).await?
+                    else {
+                        warn!(
+                            key = BOUNDARIES_ARCHIVE_KEY,
+                            "No boundary table in the archive; series cannot be bounded"
+                        );
+                        return Ok(None);
+                    };
+                    Ok(Some(Arc::new(BoundaryTable::from_dataframe(&frame)?)))
+                },
+                |table| table.is_some(),
+            )
+            .await
     }
 }
 
@@ -485,19 +471,69 @@ mod tests {
         );
     }
 
-    /// A table pointing a symbol back at itself is malformed rather than impossible, and would
-    /// otherwise be followed forever.
+    /// Each step moves the date floor strictly forward over a finite table, so the walk terminates
+    /// on its own and needs no length bound. Nine links is past the fixed limit this used to carry,
+    /// which stopped one short and returned a symbol the company had already left.
     #[test]
-    fn test_a_circular_rename_terminates() {
+    fn test_a_chain_longer_than_the_old_bound_reaches_its_end() {
+        let rows = [
+            ("TA", "2026-01-01", Some("TB")),
+            ("TB", "2026-02-01", Some("TC")),
+            ("TC", "2026-03-01", Some("TD")),
+            ("TD", "2026-04-01", Some("TE")),
+            ("TE", "2026-05-01", Some("TF")),
+            ("TF", "2026-06-01", Some("TG")),
+            ("TG", "2026-07-01", Some("TH")),
+            ("TH", "2026-08-01", Some("TI")),
+            ("TI", "2026-09-01", Some("TJ")),
+        ];
+
+        assert_eq!(
+            renamed_table(&rows).current_symbol("TA", session("2025-01-01")),
+            Some("TJ".to_string()),
+            "nine links, one past the bound this used to carry"
+        );
+    }
+
+    /// A symbol that leaves and comes back belongs to itself, not to the symbol it passed through.
+    ///
+    /// The live shape, taken from the boundary table: a reverse split moves `LGMK` to `LGMKD` on
+    /// 2025-10-28 and back on 2025-11-25, and nine other pairs did the same in the last year. A
+    /// visited-set guard stopped on `LGMKD` — a symbol that has not traded since — and every bar
+    /// before the split was relabelled onto it and then truncated away.
+    #[test]
+    fn test_a_symbol_that_leaves_and_returns_resolves_to_itself() {
+        let table = renamed_table(&[
+            ("LGMK", "2025-10-28", Some("LGMKD")),
+            ("LGMKD", "2025-11-25", Some("LGMK")),
+        ]);
+
+        assert_eq!(
+            table.current_symbol("LGMK", session("2025-10-01")),
+            None,
+            "the company ended where it started, so the bar does not move"
+        );
+        assert_eq!(
+            table.current_symbol("LGMKD", session("2025-11-01")),
+            Some("LGMK".to_string()),
+            "a bar stamped while it traded as LGMKD does move"
+        );
+    }
+
+    /// Termination is the date order, not a guard: a table pointing a symbol back at itself with no
+    /// later rename simply runs out of steps.
+    #[test]
+    fn test_a_rename_back_to_the_origin_terminates() {
         let table = renamed_table(&[
             ("AAA", "2026-03-01", Some("BBB")),
             ("BBB", "2026-05-01", Some("AAA")),
         ]);
 
+        assert_eq!(table.current_symbol("AAA", session("2026-01-05")), None);
         assert_eq!(
-            table.current_symbol("AAA", session("2026-01-05")),
-            Some("BBB".to_string()),
-            "the walk stops where the cycle closes rather than going round again"
+            table.current_symbol("AAA", session("2026-04-01")),
+            None,
+            "the outbound rename is already behind the floor"
         );
     }
 
@@ -610,12 +646,16 @@ mod tests {
         let followed = splits.following_renames(&boundaries);
 
         assert_eq!(
-            followed.factor_at("RNAM", session("2026-02-01"), session("2026-08-15")),
+            followed
+                .factor_at("RNAM", session("2026-02-01"), session("2026-08-15"))
+                .value(),
             0.5,
             "the pre-rename split follows the company onto its new symbol"
         );
         assert_eq!(
-            followed.factor_at("RNA", session("2026-03-01"), session("2026-08-15")),
+            followed
+                .factor_at("RNA", session("2026-03-01"), session("2026-08-15"))
+                .value(),
             0.25,
             "the post-rename split stays with whoever holds the old symbol now"
         );

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -213,11 +213,14 @@ impl UniverseCache {
     ) -> Result<Universe, UniverseError> {
         let today = SessionDate::at(now);
 
+        // Read before the call rather than inside the rebuild, which would re-enter the cache and
+        // hold only because the lock happens to be released across it. `get` writes nothing until
+        // the rebuild returns, so the answer is the same either way.
+        let previous = self.inner.previous().await;
         self.inner
             .get(
                 today,
                 || async {
-                    let previous = self.inner.previous().await;
                     let assets = client.fetch_tradable_assets().await?;
                     let liquidity = load_liquidity(pool, today).await?;
                     let universe = Universe::build(&assets, &liquidity);

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 use crate::common::alpaca::{ClientError, TradableAssets, TradingClient};
 use crate::common::journal::{Journal, Observation, UniverseRefreshed};
 use crate::common::types::{BarInterval, SessionDate, Ticker, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
+use crate::data::cache::DailyCache;
 
 /// Trailing window over which liquidity is averaged.
 ///
@@ -145,11 +146,6 @@ impl Universe {
     pub fn shortable_count(&self) -> usize {
         self.shortable.len()
     }
-
-    /// The symbols as plain strings, for passing to the snapshot fetch.
-    pub fn symbols(&self) -> Vec<String> {
-        self.tickers.iter().map(Ticker::to_string).collect()
-    }
 }
 
 /// Reads per-ticker average close and volume over the trailing window.
@@ -194,7 +190,7 @@ pub async fn load_liquidity(
 /// restart mid-session repopulates rather than trading an empty universe until the next morning.
 #[derive(Default)]
 pub struct UniverseCache {
-    inner: tokio::sync::Mutex<Option<(SessionDate, Universe)>>,
+    inner: DailyCache<Universe>,
 }
 
 impl UniverseCache {
@@ -205,11 +201,8 @@ impl UniverseCache {
     /// Returns today's universe, rebuilding it if the cache is cold or was filled on an earlier
     /// date.
     ///
-    /// The lock is released before the Alpaca call and the liquidity query, and re-taken only to
-    /// store, so two callers on a cold cache may both rebuild and the later completion wins. Both
-    /// reads are read-only and scoped to one Eastern date, over which the universe does not change,
-    /// so the two rebuilds agree in practice — cheaper than blocking every caller for the duration
-    /// of a cold rebuild. Single-flight coordination would be the fix if that ever stopped holding.
+    /// An empty universe is returned but never stored: it means the Alpaca read or the liquidity
+    /// query came back with nothing, and caching that would leave the session untradable.
     pub async fn get(
         &self,
         client: &TradingClient,
@@ -220,64 +213,59 @@ impl UniverseCache {
     ) -> Result<Universe, UniverseError> {
         let today = SessionDate::at(now);
 
-        if let Some((cached_date, universe)) = self.inner.lock().await.as_ref() {
-            if *cached_date == today {
-                return Ok(universe.clone());
-            }
-        }
+        self.inner
+            .get(
+                today,
+                || async {
+                    let previous = self.inner.previous().await;
+                    let assets = client.fetch_tradable_assets().await?;
+                    let liquidity = load_liquidity(pool, today).await?;
+                    let universe = Universe::build(&assets, &liquidity);
 
-        let previous = self
-            .inner
-            .lock()
-            .await
-            .as_ref()
-            .map(|(_, universe)| universe.clone());
-        let assets = client.fetch_tradable_assets().await?;
-        let liquidity = load_liquidity(pool, today).await?;
-        let universe = Universe::build(&assets, &liquidity);
+                    info!(
+                        alpaca_tradable = assets.tradable_count(),
+                        with_history = liquidity.len(),
+                        eligible = universe.len(),
+                        shortable = universe.shortable_count(),
+                        "Tradable universe built"
+                    );
 
-        info!(
-            alpaca_tradable = assets.tradable_count(),
-            with_history = liquidity.len(),
-            eligible = universe.len(),
-            shortable = universe.shortable_count(),
-            "Tradable universe built"
-        );
+                    // What entered and what fell out, rather than only the size. A universe that
+                    // holds steady at seven hundred names while churning fifty of them is the case
+                    // a count cannot show.
+                    let (admitted, removed) = match previous {
+                        Some(previous) => (
+                            universe.difference(&previous),
+                            previous.difference(&universe),
+                        ),
+                        None => (Vec::new(), Vec::new()),
+                    };
+                    journal
+                        .record(
+                            correlation_id,
+                            now,
+                            Observation::UniverseRefreshed(UniverseRefreshed {
+                                alpaca_tradable: assets.tradable_count(),
+                                alpaca_shortable: assets.shortable_count(),
+                                liquid: liquidity.iter().filter(|row| row.is_liquid()).count(),
+                                universe_size: universe.len(),
+                                admitted,
+                                removed,
+                                error: None,
+                            }),
+                        )
+                        .await;
 
-        // What entered and what fell out, rather than only the size. A universe that holds steady
-        // at seven hundred names while churning fifty of them is the case a count cannot show.
-        let (admitted, removed) = match previous {
-            Some(previous) => (
-                universe.difference(&previous),
-                previous.difference(&universe),
-            ),
-            None => (Vec::new(), Vec::new()),
-        };
-        journal
-            .record(
-                correlation_id,
-                now,
-                Observation::UniverseRefreshed(UniverseRefreshed {
-                    alpaca_tradable: assets.tradable_count(),
-                    alpaca_shortable: assets.shortable_count(),
-                    liquid: liquidity.iter().filter(|row| row.is_liquid()).count(),
-                    universe_size: universe.len(),
-                    admitted,
-                    removed,
-                    error: None,
-                }),
+                    Ok(universe)
+                },
+                |universe| !universe.is_empty(),
             )
-            .await;
-
-        if !universe.is_empty() {
-            *self.inner.lock().await = Some((today, universe.clone()));
-        }
-        Ok(universe)
+            .await
     }
 
     /// Replaces the cached universe. Used by tests and by the pre-open warm path.
     pub async fn install(&self, now: DateTime<Utc>, universe: Universe) {
-        *self.inner.lock().await = Some((SessionDate::at(now), universe));
+        self.inner.install(SessionDate::at(now), universe).await;
     }
 }
 
@@ -366,10 +354,13 @@ mod tests {
     }
 
     #[test]
-    fn test_symbols_are_sorted_and_stable() {
+    fn test_tickers_are_sorted_and_stable() {
         let universe =
             Universe::build(&assets(), &[liquid("NVDA"), liquid("AAPL"), liquid("MSFT")]);
-        assert_eq!(universe.symbols(), vec!["AAPL", "MSFT", "NVDA"]);
+        assert_eq!(
+            universe.tickers(),
+            &[ticker("AAPL"), ticker("MSFT"), ticker("NVDA")]
+        );
     }
 
     #[test]

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -184,7 +184,7 @@ pub async fn load_liquidity(
         .collect())
 }
 
-/// A [`Universe`] rebuilt at most once per Eastern date.
+/// A [`Universe`] cached per Eastern date.
 ///
 /// Warmed by the pre-open handler and refreshed on demand by anything that finds it cold, so a
 /// restart mid-session repopulates rather than trading an empty universe until the next morning.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -684,7 +684,7 @@ async fn handle_market_data_sync(
     }
 
     // Deliberately no universe load. `load_liquidity` builds the universe from averages over
-    // `equity_bars`, so fetching only `universe.symbols()` would mean the sole tickers getting
+    // `equity_bars`, so fetching only the universe's own tickers would mean the sole ones getting
     // fresh bars are the ones already in it. Past `LIQUIDITY_LOOKBACK_DAYS`, nothing outside would
     // have bars in the window and a stock that became liquid could never enter — the universe
     // ratchets closed and can only shrink. Massive's grouped endpoint takes a date rather than a

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -100,7 +100,7 @@ pub struct ServiceState {
     calendar_cache: CalendarCache,
     universe_cache: UniverseCache,
     close_history_cache: CloseHistoryCache,
-    /// The splits every stored price is restated against, read once per Eastern date.
+    /// The splits every stored price is restated against, cached per Eastern date.
     split_table_cache: SplitTableCache,
     boundary_table_cache: BoundaryTableCache,
     sizing: SizingParameters,


### PR DESCRIPTION
# Overview

Third module read against the checklist in `.scratchpad/module_review.md`, after `common/` (#1075) and the dashboard (#1076). This one turned up a live bug rather than only vocabulary, so the walk fix is the reason to read the diff.

## Changes

**The rename walk was losing history.** `BoundaryTable::current_symbol` followed a chain of renames guarded by a visited set and a fixed length bound of 8. Neither survives contact with the real boundary table, which contains ten genuine two-cycles — a reverse split moves a symbol to a `D` suffix for about a month and then back. On `LGMK`, the visited-set guard stopped at `LGMKD`, a symbol untraded since 2025-11-25, so `stitch_bars` relabelled every pre-split `LGMK` bar onto it and `truncate_bars` then dropped them. The history did not move; it disappeared.

The checklist's own suggestion — prove the graph acyclic at construction — is unachievable, because the cycles are real and correct. The walk is now date-monotone instead: each step only considers renames strictly after the last one taken, so termination follows from a strictly increasing date over a finite table. `RENAME_CHAIN_LIMIT` and the visited set are both deleted. The longest genuine acyclic chain in the real data is two links, so the bound of 8 was never the thing doing the work.

**`AdjustmentFactor` is a group, not a bare `f64`.** `IDENTITY`, a validated `new` requiring finite and strictly positive, a `compose` returning `Option` because `f64` is a partial view of the positive reals, and `apply_to_price`/`apply_to_volume` so the two directions cannot be confused at a call site. `factor_at` folds through it.

**`DailyCache<T>` replaces five hand-rolled caches.** `CalendarCache`, `UniverseCache`, `CloseHistoryCache`, `SplitTableCache`, and `BoundaryTableCache` each carried their own copy of the same rebuild-if-stale logic. The last two cache an `Option`, which is why `get` takes a `worth_caching` predicate rather than assuming a value is always worth keeping.

**`keep_earliest_first_seen` shares the min-fold** that `splits.rs` and `boundaries.rs` had each written out, so a re-fetched row keeps the first time it was seen rather than the latest.

**Dead code, checked against journal coverage first.** `TradingCalendar::covers`, `horizon`, and `next_trading_day` are deleted — nothing calls them and the calendar answers the same questions elsewhere. `eastern_time` is not deleted but made private, since `minutes_until_close` and `is_open_at` still use it and nothing outside the module does. `is_open_at` is kept.

Also: `to_f64()?` becomes `as_f64()` where the `None` arm was unreachable, and doc comments come down to the four categories the checklist admits.

## Context

Rebased onto master after #1076. Two conflicts, both from #1075's follow-up landing in the same files: `calendar.rs` (master kept `covers`/`horizon`, this branch deletes them — took the deletion, having confirmed the only `covers` callers are on `ClosedPair`, a different type) and `export.rs` (`read_session_frame` versus this branch's `read_journal_frame` — took the rename, and fixed one straggler inside a test master added).

Deleting `next_trading_day` re-broke an intra-doc link at `common/types.rs:313`, which `cargo doc` catches and `build`, `clippy`, and `test` all do not. Fixed here.

Verified against the real boundary table in S3 rather than fixtures: `data/equity/corporate_actions/boundaries.parquet` holds 805 boundaries over 765 tickers spanning 2017-11-30 to 2026-08-14. All 564 rename rows were fed through the actual `BoundaryTable::current_symbol`; the walk terminates on every one, and each of the ten reverse-split cycles resolves back to itself. `RNA` is the instructive non-cycle — it goes to `RNAM` and stays there, because the return leg the next day is a `spun_off` rather than a rename, so the spinoff boundary correctly treats the new `RNA` as a different entity.

715 tests pass, `cargo fmt` and `cargo doc` are clean, the sqlx cache is unchanged, and clippy sits at the one pre-existing `redundant_closure` in `tests/test_handlers.rs`.

`models-cleanup` and `portfolio-cleanup` follow, both still on the pre-#1075 base.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved stock split handling with validated adjustment factors for more reliable price and volume calculations.
  * Enhanced market-data caching to refresh correctly across trading days, retry unavailable data, and avoid storing invalid results.
  * Improved preservation of historical “first seen” dates when combining fetched and stored data.
  * Improved symbol rename tracking, including long rename chains and symbols that later return.
* **Documentation**
  * Clarified data usage and trading-session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->