### PR TITLE
Apply the module review checklist to `models/`

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -521,22 +521,15 @@ async fn run_inference(
     let trained = predict::filter_to_trained_tickers(filtered, model_state)
         .map_err(|error| at("filter_tickers")(error.to_string()))?;
 
-    let predictions = predict::generate_predictions(trained, model_state)
+    // Typed on the way out of the forward pass, so a malformed value fails here as a `generate`
+    // failure rather than reaching the writer as an untyped map and failing as an `insert` one.
+    let predictions = predict::generate_predictions(trained, model_state, correlation_id)
         .map_err(|error| at("generate")(error.to_string()))?;
+    predict::validate_predictions(&predictions).map_err(at("validate"))?;
 
-    let array = predictions.as_array().cloned().unwrap_or_default();
-    predict::validate_predictions(&array).map_err(at("validate"))?;
-
-    // Split back apart rather than propagated as one error: a malformed payload is a bug in the
-    // model output this function just produced, and belongs with the other pipeline stages; a
-    // database failure is the database, and keeps reading as one.
-    let (rows, predictions) =
-        predict::insert_predictions(&state.pool, &array, correlation_id, model_state.run_id())
-            .await
-            .map_err(|error| match error {
-                predict::InsertPredictionsError::Payload(message) => at("insert")(message),
-                predict::InsertPredictionsError::Database(error) => HandlerError::Database(error),
-            })?;
+    let rows = predict::insert_predictions(&state.pool, &predictions)
+        .await
+        .map_err(HandlerError::Database)?;
 
     Ok((rows, predictions))
 }

--- a/src/models/tide.rs
+++ b/src/models/tide.rs
@@ -4,10 +4,8 @@
 
 /// What went wrong building, fitting, or loading a TiDE model.
 ///
-/// One enum across the pipeline rather than one per file, because the stages compose: `fit` runs
-/// the same `engineer_features` inference does, and a per-file error would be converted at every
-/// hand-off. The two prose variants are prose on purpose — they describe an untrusted file or a
-/// malformed frame to an operator, and no caller branches on the reason.
+/// [`TideError::Artifact`] and [`TideError::Data`] split by which machine is at fault, and carry
+/// prose because no caller branches on the reason — only an operator reads it.
 #[derive(Debug, thiserror::Error)]
 pub enum TideError {
     #[error("dataframe operation failed: {0}")]

--- a/src/models/tide.rs
+++ b/src/models/tide.rs
@@ -2,6 +2,30 @@
 //!
 //! [`artifact`] is the only thing crossing between the trainer VM and the application VM.
 
+/// What went wrong building, fitting, or loading a TiDE model.
+///
+/// One enum across the pipeline rather than one per file, because the stages compose: `fit` runs
+/// the same `engineer_features` inference does, and a per-file error would be converted at every
+/// hand-off. The two prose variants are prose on purpose — they describe an untrusted file or a
+/// malformed frame to an operator, and no caller branches on the reason.
+#[derive(Debug, thiserror::Error)]
+pub enum TideError {
+    #[error("dataframe operation failed: {0}")]
+    Frame(#[from] polars::prelude::PolarsError),
+    #[error("array shape is inconsistent: {0}")]
+    Shape(#[from] ndarray::ShapeError),
+    #[error("failed to read or write a model file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("failed to parse a model file: {0}")]
+    Json(#[from] serde_json::Error),
+    /// An artifact file this build cannot trust: the trainer's output disagrees with this binary.
+    #[error("{0}")]
+    Artifact(String),
+    /// Rows that cannot be turned into model input: the market data, not the artifact.
+    #[error("{0}")]
+    Data(String),
+}
+
 pub mod artifact;
 pub mod batch;
 pub mod configuration;

--- a/src/models/tide/artifact.rs
+++ b/src/models/tide/artifact.rs
@@ -13,7 +13,6 @@ use std::sync::{Mutex, MutexGuard, PoisonError};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client as S3Client;
 use burn::backend::NdArray;
-use chrono::Utc;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use tracing::{debug, info, warn};
@@ -35,39 +34,36 @@ pub struct ModelState {
     parameters: ModelParameters,
     scaler: Scaler,
     mappings: FeatureMappings,
-    artifact_key: String,
     /// Training run id: the timestamp segment of the artifact key. Written to
     /// `equity_predictions.model_run_id`, which is how a prediction is traced back to the artifact
     /// that produced it.
     run_id: String,
-    load_timestamp: i64,
 }
 
 impl ModelState {
     /// Constructs a `ModelState` from a fully loaded artifact.
     ///
-    /// The column lists the artifact was fitted with are no longer carried here. They are checked
-    /// against this build's constants inside [`crate::models::tide::data::Scaler::load`] and then
-    /// dropped: verifying them is what they were for, nothing read them afterwards, and keeping a
-    /// copy that is provably equal to the constants invited a future caller to trust the copy.
-    #[allow(clippy::too_many_arguments)]
+    /// The column lists the artifact was fitted with are not carried here. They are checked against
+    /// this build's constants inside [`crate::models::tide::data::Scaler::load`] and then dropped:
+    /// verifying them is what they were for, nothing read them afterwards, and keeping a copy that
+    /// is provably equal to the constants invited a future caller to trust the copy.
+    ///
+    /// The artifact key and load instant are not carried either, on the same reasoning. The
+    /// pre-open handler resolves the key itself and derives staleness from `run_id` against the
+    /// trading calendar, and both reach the journal through `predictions_generated`.
     pub fn new(
         model: TiDEModel<NdArray>,
         parameters: ModelParameters,
         scaler: Scaler,
         mappings: FeatureMappings,
-        artifact_key: String,
         run_id: String,
-        load_timestamp: i64,
     ) -> Self {
         Self {
             model: Mutex::new(model),
             parameters,
             scaler,
             mappings,
-            artifact_key,
             run_id,
-            load_timestamp,
         }
     }
 
@@ -94,16 +90,8 @@ impl ModelState {
         &self.mappings
     }
 
-    pub fn artifact_key(&self) -> &str {
-        &self.artifact_key
-    }
-
     pub fn run_id(&self) -> &str {
         &self.run_id
-    }
-
-    pub fn load_timestamp(&self) -> i64 {
-        self.load_timestamp
     }
 }
 
@@ -398,8 +386,6 @@ fn load_model_from_directory(dir: &Path, artifact_key: &str) -> Result<ModelStat
     )
     .map_err(|error| ArtifactError::ModelLoad(error.to_string()))?;
 
-    let load_timestamp = Utc::now().timestamp();
-
     info!(
         artifact_key = artifact_key,
         input_size = parameters.input_size(),
@@ -412,9 +398,7 @@ fn load_model_from_directory(dir: &Path, artifact_key: &str) -> Result<ModelStat
         parameters,
         scaler,
         mappings,
-        artifact_key.to_string(),
         run_id_from_artifact_key(artifact_key),
-        load_timestamp,
     ))
 }
 
@@ -476,6 +460,7 @@ pub async fn upload_artifact(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Read;
 
     /// `Path::join` discards its base when given an absolute path, so an entry named `/tmp/...`
     /// would escape the extraction directory. Rejecting non-`Normal` components is what stops it.
@@ -542,6 +527,8 @@ mod tests {
         assert!(destination.path().join("tide_parameters.json").exists());
     }
 
+    /// Newest first, whatever order the listing arrived in, because callers try each in turn and
+    /// stop at the first folder holding a model.
     #[test]
     fn test_candidate_folders_descending_orders_newest_first() {
         let folders = candidate_folders_descending(vec![
@@ -560,13 +547,6 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_local_no_dir() {
-        let result =
-            resolve_local_artifact_key(Path::new("/nonexistent"), "artifacts/tide/", "latest");
-        assert!(result.is_err());
-    }
-
-    #[test]
     fn test_run_id_from_artifact_key_canonical() {
         assert_eq!(
             run_id_from_artifact_key("models/tide/2026-06-09-16-21-25-195/output/model.tar.gz"),
@@ -574,65 +554,22 @@ mod tests {
         );
     }
 
+    /// Anything that is not the canonical layout falls back to the last non-empty path segment.
     #[test]
     fn test_run_id_from_artifact_key_fallback() {
         assert_eq!(run_id_from_artifact_key("some/dir/run-x"), "run-x");
         assert_eq!(run_id_from_artifact_key("run-y"), "run-y");
-    }
-
-    #[test]
-    fn test_resolve_explicit_version() {
-        let result = resolve_local_artifact_key(Path::new("/tmp"), "artifacts/tide/", "2024-01-01");
-        assert!(result.is_ok());
+        assert_eq!(run_id_from_artifact_key("some/run-folder/"), "run-folder");
         assert_eq!(
-            result.unwrap(),
-            "artifacts/tide/2024-01-01/output/model.tar.gz"
+            run_id_from_artifact_key("models/tide/run-2026//"),
+            "run-2026"
         );
-    }
-
-    #[test]
-    fn test_run_id_from_artifact_key_empty_string() {
-        // An empty input should not panic; it falls back to the full string.
-        let result = run_id_from_artifact_key("");
-        assert_eq!(result, "");
-    }
-
-    #[test]
-    fn test_run_id_from_artifact_key_trailing_slash() {
-        // A plain directory name with a trailing slash must trim the slash.
-        let result = run_id_from_artifact_key("some/run-folder/");
-        assert_eq!(result, "run-folder");
-    }
-
-    #[test]
-    fn test_run_id_from_artifact_key_no_slash() {
-        // A bare filename with no slashes must return the whole string.
-        let result = run_id_from_artifact_key("run-2026-01-01");
-        assert_eq!(result, "run-2026-01-01");
-    }
-
-    #[test]
-    fn test_candidate_folders_descending_single_element() {
-        let folders = candidate_folders_descending(vec!["models/tide/2026-06-01/".to_string()]);
-        assert_eq!(folders, vec!["models/tide/2026-06-01/"]);
-    }
-
-    #[test]
-    fn test_candidate_folders_descending_empty() {
-        let folders = candidate_folders_descending(vec![]);
-        assert!(folders.is_empty());
-    }
-
-    #[test]
-    fn test_candidate_folders_descending_already_sorted_descending() {
-        // Providing folders newest-first must not change the order.
-        let input = vec![
-            "models/tide/2026-06-09/".to_string(),
-            "models/tide/2026-06-05/".to_string(),
-            "models/tide/2026-06-01/".to_string(),
-        ];
-        let result = candidate_folders_descending(input.clone());
-        assert_eq!(result, input);
+        assert_eq!(
+            run_id_from_artifact_key(""),
+            "",
+            "an empty key must not panic"
+        );
+        assert_eq!(run_id_from_artifact_key("/"), "");
     }
 
     #[test]
@@ -648,15 +585,6 @@ mod tests {
             result.unwrap(),
             "models/tide/2026-06-10-01-00-07/output/model.tar.gz"
         );
-    }
-
-    #[test]
-    fn test_resolve_local_artifact_key_latest_with_empty_dir() {
-        // A temporary directory with no subdirectories must return NoArtifacts.
-        let temp_dir = tempfile::tempdir().unwrap();
-        let result = resolve_local_artifact_key(temp_dir.path(), "models/tide/", "latest");
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), ArtifactError::NoArtifacts));
     }
 
     #[test]
@@ -727,42 +655,6 @@ mod tests {
     }
 
     #[test]
-    fn test_run_id_from_artifact_key_only_slash() {
-        // A single slash with nothing after it: trim gives empty, last segment is "".
-        let result = run_id_from_artifact_key("/");
-        assert_eq!(result, "");
-    }
-
-    #[test]
-    fn test_run_id_from_artifact_key_double_trailing_slash() {
-        // Trailing slashes are stripped one at a time; the last non-empty segment
-        // should be returned.
-        let result = run_id_from_artifact_key("models/tide/run-2026//");
-        // trim_end_matches('/') strips all trailing slashes then rsplit gives "run-2026"
-        assert_eq!(result, "run-2026");
-    }
-
-    #[test]
-    fn test_run_id_from_artifact_key_exactly_output_suffix_prefix() {
-        // A key whose entire suffix matches the canonical form but has no leading
-        // prefix — i.e., "2026-06-09/output/model.tar.gz".
-        let result = run_id_from_artifact_key("2026-06-09/output/model.tar.gz");
-        assert_eq!(result, "2026-06-09");
-    }
-
-    #[test]
-    fn test_candidate_folders_descending_duplicates_preserve_all() {
-        // Duplicate entries are not deduplicated — the caller is responsible for
-        // deduplication; the sort+reverse must still work correctly.
-        let folders = candidate_folders_descending(vec![
-            "models/tide/2026-06-05/".to_string(),
-            "models/tide/2026-06-05/".to_string(),
-        ]);
-        assert_eq!(folders.len(), 2);
-        assert_eq!(folders[0], "models/tide/2026-06-05/");
-    }
-
-    #[test]
     fn test_resolve_local_artifact_key_latest_with_multiple_dirs_picks_lexicographically_last() {
         // When multiple subdirectories exist the lexicographically last one
         // (i.e., the newest timestamped run) must be selected.
@@ -813,8 +705,6 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), ArtifactError::NoArtifacts));
     }
-
-    use std::io::Read;
 
     #[test]
     fn test_package_dir_to_tar_gz_is_flat_and_readable() {

--- a/src/models/tide/configuration.rs
+++ b/src/models/tide/configuration.rs
@@ -3,6 +3,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::models::tide::TideError;
+
 /// The quantile levels `equity_predictions` has columns for, ascending.
 ///
 /// This is a storage contract rather than a modelling preference: the table names its three columns
@@ -35,7 +37,10 @@ impl Default for ModelParameters {
             output_length: 1,
             input_length: 35,
             dropout_rate: 0.1,
-            quantiles: vec![0.1, 0.5, 0.9],
+            // From the constant, not a literal: `validate_quantiles` rejects anything that is not
+            // the served set, so a default spelled separately would make every artifact trained on
+            // it unloadable the moment the two drifted.
+            quantiles: SERVED_QUANTILES.to_vec(),
             huber_delta: 0.5,
         }
     }
@@ -86,21 +91,20 @@ impl ModelParameters {
     /// A zero `output_length` produces no horizon steps, so inference returns an empty set and a
     /// corrupt artifact is indistinguishable from a session with nothing to forecast. Refusing it
     /// here keeps the failure at the boundary where the untrusted file is read.
-    pub fn load(path: &std::path::Path) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn load(path: &std::path::Path) -> Result<Self, TideError> {
         let content = std::fs::read_to_string(path)?;
         let parameters: Self = serde_json::from_str(&content)?;
         if parameters.output_length == 0 || parameters.input_length == 0 {
-            return Err(format!(
+            return Err(TideError::Artifact(format!(
                 "Model parameters at {} have a zero window length (input_length {}, output_length {})",
                 path.display(),
                 parameters.input_length,
                 parameters.output_length
-            )
-            .into());
+            )));
         }
-        parameters
-            .validate_quantiles()
-            .map_err(|reason| format!("Model parameters at {}: {reason}", path.display()))?;
+        parameters.validate_quantiles().map_err(|reason| {
+            TideError::Artifact(format!("Model parameters at {}: {reason}", path.display()))
+        })?;
         Ok(parameters)
     }
 
@@ -197,6 +201,9 @@ impl ModelParameters {
 mod tests {
     use super::*;
 
+    /// The default's quantiles must be the served set, or every artifact trained on the default
+    /// fails `validate_quantiles` at load. Pinned to the literal rather than to `SERVED_QUANTILES`,
+    /// so a change to the constant fails here instead of propagating silently.
     #[test]
     fn test_default_parameters() {
         let params = ModelParameters::default();

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -192,14 +192,10 @@ impl Scaler {
 
     /// Standardizes a value into the units the model was trained in.
     ///
-    /// The forward half of an invertible pair with [`Scaler::inverse_transform_value`], and it
-    /// lives here rather than inline in [`apply_scaling`] because the two halves have to compose to
-    /// the identity: the model trains on the forward image and every prediction is read back
-    /// through the inverse. Written as two expressions in two files they can drift without anything
-    /// failing, and the symptom is predictions quietly on the wrong scale — which
-    /// [`EquityPrediction::new`]'s ordering check satisfies perfectly well.
-    ///
-    /// [`EquityPrediction::new`]: crate::common::types::EquityPrediction::new
+    /// The forward half of an invertible pair with [`Scaler::inverse_transform_value`]: the model
+    /// trains on the forward image and every prediction is read back through the inverse, so the
+    /// two must compose to the identity. Drift between them leaves predictions on the wrong scale,
+    /// which every ordering check downstream still accepts.
     pub fn transform_value(&self, column: &str, value: f64) -> f64 {
         let (mean, standard_deviation) = self.statistics_for(column);
         (value - mean) / standard_deviation

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -10,13 +10,10 @@ use polars::prelude::*;
 
 use crate::common::types::SessionDate;
 use crate::data::details::UNKNOWN as UNKNOWN_SECTOR_OR_INDUSTRY;
+use crate::models::tide::TideError;
 
 pub type CategoryMapping = HashMap<String, i32>;
 pub type FeatureMappings = HashMap<String, CategoryMapping>;
-
-pub fn selector_by_names(names: &[&str]) -> Vec<PlSmallStr> {
-    names.iter().map(|name| PlSmallStr::from(*name)).collect()
-}
 
 /// Per-column standardization statistics, fitted during training and reloaded at inference.
 ///
@@ -107,23 +104,24 @@ impl Scaler {
     /// then dropped. Checking them is the whole of their value: an artifact fitted on a different
     /// column set would otherwise load without complaint and scale a different set than the weights
     /// were trained on. Carrying them further served nothing — no caller read them.
-    pub fn load(path: &std::path::Path) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn load(path: &std::path::Path) -> Result<Self, TideError> {
         let display = path.display();
         let content = std::fs::read_to_string(path)?;
         let raw: serde_json::Value = serde_json::from_str(&content)?;
 
-        let statistics = |field: &str| -> Result<HashMap<String, f64>, Box<dyn std::error::Error>> {
-            let object = raw[field]
-                .as_object()
-                .ok_or_else(|| format!("Scaler artifact at {display} has no `{field}` object"))?;
+        let statistics = |field: &str| -> Result<HashMap<String, f64>, TideError> {
+            let object = raw[field].as_object().ok_or_else(|| {
+                TideError::Artifact(format!(
+                    "Scaler artifact at {display} has no `{field}` object"
+                ))
+            })?;
             object
                 .iter()
                 .map(|(column, value)| {
                     value.as_f64().map(|number| (column.clone(), number)).ok_or_else(|| {
-                        format!(
+                        TideError::Artifact(format!(
                             "Scaler artifact at {display} has a non-numeric `{field}` entry for column `{column}`"
-                        )
-                        .into()
+                        ))
                     })
                 })
                 .collect()
@@ -137,9 +135,11 @@ impl Scaler {
             ("categorical_columns", CATEGORICAL_COLUMNS),
             ("static_categorical_columns", STATIC_CATEGORICAL_COLUMNS),
         ] {
-            let array = raw[field]
-                .as_array()
-                .ok_or_else(|| format!("Scaler artifact at {display} has no `{field}` list"))?;
+            let array = raw[field].as_array().ok_or_else(|| {
+                TideError::Artifact(format!(
+                    "Scaler artifact at {display} has no `{field}` list"
+                ))
+            })?;
             // Every element must be a string. Skipping the ones that are not would let
             // `["close_price", 42]` collapse to a list that compares equal to a shorter expected
             // one — a malformed artifact passing the check written to catch malformed artifacts.
@@ -152,13 +152,13 @@ impl Scaler {
                         )
                     })
                 })
-                .collect::<Result<_, String>>()?;
+                .collect::<Result<_, String>>()
+                .map_err(TideError::Artifact)?;
             if found != expected {
-                return Err(format!(
+                return Err(TideError::Artifact(format!(
                     "Scaler artifact at {display} was fitted on {field} {found:?}, but this build \
                      expects {expected:?}"
-                )
-                .into());
+                )));
             }
         }
 
@@ -166,25 +166,48 @@ impl Scaler {
         // and this build disagree about the feature set even though the column list matched.
         for column in CONTINUOUS_COLUMNS {
             if !means.contains_key(*column) || !standard_deviations.contains_key(*column) {
-                return Err(format!(
+                return Err(TideError::Artifact(format!(
                     "Scaler artifact at {display} has no statistics for continuous column `{column}`"
-                )
-                .into());
+                )));
             }
         }
 
-        Self::new(means, standard_deviations)
-            .map_err(|reason| format!("Scaler artifact at {display} is unusable: {reason}").into())
+        Self::new(means, standard_deviations).map_err(|reason| {
+            TideError::Artifact(format!(
+                "Scaler artifact at {display} is unusable: {reason}"
+            ))
+        })
+    }
+
+    /// The mean and deviation for `column`, falling back to the identity pair.
+    ///
+    /// The fallback is reachable only for a column outside `CONTINUOUS_COLUMNS` — [`Scaler::load`]
+    /// rejects an artifact missing any of those.
+    fn statistics_for(&self, column: &str) -> (f64, f64) {
+        (
+            self.means.get(column).copied().unwrap_or(0.0),
+            self.standard_deviations.get(column).copied().unwrap_or(1.0),
+        )
+    }
+
+    /// Standardizes a value into the units the model was trained in.
+    ///
+    /// The forward half of an invertible pair with [`Scaler::inverse_transform_value`], and it
+    /// lives here rather than inline in [`apply_scaling`] because the two halves have to compose to
+    /// the identity: the model trains on the forward image and every prediction is read back
+    /// through the inverse. Written as two expressions in two files they can drift without anything
+    /// failing, and the symptom is predictions quietly on the wrong scale — which
+    /// [`EquityPrediction::new`]'s ordering check satisfies perfectly well.
+    ///
+    /// [`EquityPrediction::new`]: crate::common::types::EquityPrediction::new
+    pub fn transform_value(&self, column: &str, value: f64) -> f64 {
+        let (mean, standard_deviation) = self.statistics_for(column);
+        (value - mean) / standard_deviation
     }
 
     /// Maps a scaled value back to its original units.
-    ///
-    /// Falls back to the identity for a column the scaler does not carry, which is reachable only
-    /// for a column outside `CONTINUOUS_COLUMNS` — [`Scaler::load`] rejects an artifact missing any
-    /// of those.
     pub fn inverse_transform_value(&self, column: &str, value: f64) -> f64 {
-        let mean = self.means.get(column).copied().unwrap_or(0.0);
-        let standard_deviation = self.standard_deviations.get(column).copied().unwrap_or(1.0);
+        let (mean, standard_deviation) = self.statistics_for(column);
         value * standard_deviation + mean
     }
 }
@@ -285,13 +308,16 @@ pub enum DatasetKind {
     Validate(TrainingFraction),
 }
 
+/// A scaled and encoded frame together with the statistics and vocabulary that produced it.
+///
+/// The column lists are deliberately not carried here, for the reason
+/// [`crate::models::tide::artifact::ModelState`] does not carry them either: a copy that is
+/// provably equal to [`CONTINUOUS_COLUMNS`] and its two siblings invites a later caller to trust
+/// the copy. Every consumer reads the constants.
 pub struct Data {
     pub data: DataFrame,
     pub scaler: Scaler,
     pub mappings: FeatureMappings,
-    pub continuous_columns: Vec<String>,
-    pub categorical_columns: Vec<String>,
-    pub static_categorical_columns: Vec<String>,
 }
 
 impl Data {
@@ -302,18 +328,6 @@ impl Data {
             data,
             scaler,
             mappings,
-            continuous_columns: CONTINUOUS_COLUMNS
-                .iter()
-                .map(|name| name.to_string())
-                .collect(),
-            categorical_columns: CATEGORICAL_COLUMNS
-                .iter()
-                .map(|name| name.to_string())
-                .collect(),
-            static_categorical_columns: STATIC_CATEGORICAL_COLUMNS
-                .iter()
-                .map(|name| name.to_string())
-                .collect(),
         }
     }
 
@@ -327,7 +341,7 @@ impl Data {
         scaler: &Scaler,
         mappings: &FeatureMappings,
         target_session: SessionDate,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, TideError> {
         let data = append_forecast_session_rows(data, target_session)?;
         let data = engineer_features(data)?;
         let data = clean_data(data)?;
@@ -342,7 +356,7 @@ impl Data {
     pub fn split_by_timestamp(
         &self,
         training_fraction: TrainingFraction,
-    ) -> Result<(DataFrame, DataFrame), Box<dyn std::error::Error>> {
+    ) -> Result<(DataFrame, DataFrame), TideError> {
         let cutoff = training_cutoff(&self.data, training_fraction)?;
         split_at_cutoff(&self.data, cutoff)
     }
@@ -353,7 +367,7 @@ impl Data {
         kind: DatasetKind,
         input_length: usize,
         output_length: usize,
-    ) -> Result<TrainingDataset, Box<dyn std::error::Error>> {
+    ) -> Result<TrainingDataset, TideError> {
         match kind {
             DatasetKind::Predict => {
                 window_frame(&self.data, input_length, output_length, true, false)
@@ -389,17 +403,19 @@ impl Data {
 pub(crate) fn training_cutoff(
     data: &DataFrame,
     training_fraction: TrainingFraction,
-) -> Result<i64, Box<dyn std::error::Error>> {
-    let timestamps = data
-        .column("timestamp")
-        .map_err(|error| error.to_string())?;
-    let timestamps = timestamps.i64().map_err(|error| error.to_string())?;
+) -> Result<i64, TideError> {
+    let timestamps = data.column("timestamp")?;
+    let timestamps = timestamps.i64()?;
     let minimum_timestamp = timestamps.min().unwrap_or(0);
     let maximum_timestamp = timestamps.max().unwrap_or(0);
 
     let span = maximum_timestamp
         .checked_sub(minimum_timestamp)
-        .ok_or("The timestamp range is wider than i64, so no training cutoff exists")?;
+        .ok_or_else(|| {
+            TideError::Data(
+                "The timestamp range is wider than i64, so no training cutoff exists".to_string(),
+            )
+        })?;
     // Only the span needs checking. The fraction is strictly between 0 and 1 and the `as` cast
     // saturates, so the offset lands in `[0, span]` and the sum in `[minimum, maximum]`.
     let training_span = ((span as f64) * training_fraction.fraction()) as i64;
@@ -410,17 +426,11 @@ pub(crate) fn training_cutoff(
 pub(crate) fn split_at_cutoff(
     data: &DataFrame,
     cutoff: i64,
-) -> Result<(DataFrame, DataFrame), Box<dyn std::error::Error>> {
-    let timestamps = data
-        .column("timestamp")
-        .map_err(|error| error.to_string())?;
-    let timestamps = timestamps.i64().map_err(|error| error.to_string())?;
-    let train = data
-        .filter(&timestamps.lt_eq(cutoff))
-        .map_err(|error| error.to_string())?;
-    let validation = data
-        .filter(&timestamps.gt(cutoff))
-        .map_err(|error| error.to_string())?;
+) -> Result<(DataFrame, DataFrame), TideError> {
+    let timestamps = data.column("timestamp")?;
+    let timestamps = timestamps.i64()?;
+    let train = data.filter(&timestamps.lt_eq(cutoff))?;
+    let validation = data.filter(&timestamps.gt(cutoff))?;
     Ok((train, validation))
 }
 
@@ -434,7 +444,7 @@ fn window_frame(
     output_length: usize,
     predict_mode: bool,
     with_targets: bool,
-) -> Result<TrainingDataset, Box<dyn std::error::Error>> {
+) -> Result<TrainingDataset, TideError> {
     let window_size = input_length + output_length;
     let continuous_feature_count = CONTINUOUS_COLUMNS.len();
     let categorical_feature_count = CATEGORICAL_COLUMNS.len();
@@ -447,10 +457,8 @@ fn window_frame(
     // `ticker` is integer-encoded by this point (encode_categoricals). Group by
     // the encoded id; sorted for deterministic sample ordering.
     let mut tickers: Vec<i32> = frame
-        .column("ticker")
-        .map_err(|error| error.to_string())?
-        .i32()
-        .map_err(|error| error.to_string())?
+        .column("ticker")?
+        .i32()?
         .into_no_null_iter()
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
@@ -464,13 +472,8 @@ fn window_frame(
     let mut all_targets: Vec<Vec<f32>> = Vec::new();
 
     for ticker in &tickers {
-        let mask = frame
-            .column("ticker")
-            .map_err(|error| error.to_string())?
-            .i32()
-            .map_err(|error| error.to_string())?
-            .equal(*ticker);
-        let ticker_data = frame.filter(&mask).map_err(|error| error.to_string())?;
+        let mask = frame.column("ticker")?.i32()?.equal(*ticker);
+        let ticker_data = frame.filter(&mask)?;
 
         if ticker_data.height() < window_size {
             continue;
@@ -609,35 +612,29 @@ fn window_frame(
 pub(crate) fn append_forecast_session_rows(
     data: DataFrame,
     target_session: SessionDate,
-) -> Result<DataFrame, Box<dyn std::error::Error>> {
+) -> Result<DataFrame, TideError> {
     let target_milliseconds = target_session.midnight().timestamp_millis();
 
-    let sorted = data
-        .sort(
-            ["ticker", "timestamp"],
-            SortMultipleOptions::default().with_maintain_order(true),
-        )
-        .map_err(|error| error.to_string())?;
+    let sorted = data.sort(
+        ["ticker", "timestamp"],
+        SortMultipleOptions::default().with_maintain_order(true),
+    )?;
 
     let tickers: Vec<&str> = sorted
-        .column("ticker")
-        .map_err(|error| error.to_string())?
-        .str()
-        .map_err(|error| error.to_string())?
+        .column("ticker")?
+        .str()?
         .into_no_null_iter()
         .collect();
     let timestamps: Vec<i64> = sorted
-        .column("timestamp")
-        .map_err(|error| error.to_string())?
-        .i64()
-        .map_err(|error| error.to_string())?
+        .column("timestamp")?
+        .i64()?
         .into_no_null_iter()
         .collect();
 
     if tickers.len() != sorted.height() || timestamps.len() != sorted.height() {
-        return Err("Equity bars contain null ticker or timestamp values"
-            .to_string()
-            .into());
+        return Err(TideError::Data(
+            "Equity bars contain null ticker or timestamp values".to_string(),
+        ));
     }
 
     // Rows are sorted, so a ticker's last row is also its newest. Comparing that against the target
@@ -656,37 +653,27 @@ pub(crate) fn append_forecast_session_rows(
     }
 
     let source_index = IdxCa::from_vec("index".into(), source_rows);
-    let mut forecast_rows = sorted
-        .take(&source_index)
-        .map_err(|error| error.to_string())?;
-    forecast_rows
-        .with_column(Column::new(
-            "timestamp".into(),
-            vec![target_milliseconds; forecast_rows.height()],
-        ))
-        .map_err(|error| error.to_string())?;
+    let mut forecast_rows = sorted.take(&source_index)?;
+    forecast_rows.with_column(Column::new(
+        "timestamp".into(),
+        vec![target_milliseconds; forecast_rows.height()],
+    ))?;
 
     let mut combined = sorted;
-    combined
-        .vstack_mut(&forecast_rows)
-        .map_err(|error| error.to_string())?;
+    combined.vstack_mut(&forecast_rows)?;
     Ok(combined)
 }
 
-pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn std::error::Error>> {
+pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, TideError> {
     // Sort by [ticker, timestamp] so daily returns and the downstream windowing
     // are chronological and contiguous within each ticker, independent of the
     // order rows arrived in. Each ticker's first row gets a null return; clean_data drops it.
-    let data = data
-        .sort(
-            ["ticker", "timestamp"],
-            SortMultipleOptions::default().with_maintain_order(true),
-        )
-        .map_err(|error| error.to_string())?;
+    let data = data.sort(
+        ["ticker", "timestamp"],
+        SortMultipleOptions::default().with_maintain_order(true),
+    )?;
 
-    let timestamps = data
-        .column("timestamp")
-        .map_err(|error| error.to_string())?;
+    let timestamps = data.column("timestamp")?;
     let height = data.height();
 
     let mut day_of_week = Vec::with_capacity(height);
@@ -697,27 +684,19 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn st
     let mut daily_return: Vec<Option<f32>> = Vec::with_capacity(height);
 
     let close_prices: Vec<f64> = data
-        .column("close_price")
-        .map_err(|error| error.to_string())?
-        .f64()
-        .map_err(|error| error.to_string())?
+        .column("close_price")?
+        .f64()?
         .into_no_null_iter()
         .collect();
 
     let tickers: Vec<String> = data
-        .column("ticker")
-        .map_err(|error| error.to_string())?
-        .str()
-        .map_err(|error| error.to_string())?
+        .column("ticker")?
+        .str()?
         .into_no_null_iter()
         .map(|name| name.to_string())
         .collect();
 
-    let timestamp_values: Vec<i64> = timestamps
-        .i64()
-        .map_err(|error| error.to_string())?
-        .into_no_null_iter()
-        .collect();
+    let timestamp_values: Vec<i64> = timestamps.i64()?.into_no_null_iter().collect();
 
     // The no-null iterators above silently skip nulls, which would misalign
     // the per-row zip below; fail fast with a clear message instead.
@@ -730,7 +709,7 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn st
             timestamp_values.len(),
             close_prices.len()
         );
-        return Err(message.into());
+        return Err(TideError::Data(message));
     }
 
     for (index, &timestamp_milliseconds) in timestamp_values.iter().enumerate() {
@@ -761,44 +740,27 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn st
     }
 
     let mut new_data = data.clone();
-    new_data
-        .with_column(Column::new("day_of_week".into(), day_of_week))
-        .map_err(|error| error.to_string())?;
-    new_data
-        .with_column(Column::new("day_of_month".into(), day_of_month))
-        .map_err(|error| error.to_string())?;
-    new_data
-        .with_column(Column::new("day_of_year".into(), day_of_year))
-        .map_err(|error| error.to_string())?;
-    new_data
-        .with_column(Column::new("month".into(), month))
-        .map_err(|error| error.to_string())?;
-    new_data
-        .with_column(Column::new("year".into(), year))
-        .map_err(|error| error.to_string())?;
-    new_data
-        .with_column(Column::new("daily_return".into(), daily_return))
-        .map_err(|error| error.to_string())?;
+    new_data.with_column(Column::new("day_of_week".into(), day_of_week))?;
+    new_data.with_column(Column::new("day_of_month".into(), day_of_month))?;
+    new_data.with_column(Column::new("day_of_year".into(), day_of_year))?;
+    new_data.with_column(Column::new("month".into(), month))?;
+    new_data.with_column(Column::new("year".into(), year))?;
+    new_data.with_column(Column::new("daily_return".into(), daily_return))?;
 
     Ok(new_data)
 }
 
-pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::error::Error>> {
+pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, TideError> {
     // A row with no ticker cannot be attributed to an instrument, and substituting a placeholder
     // would make it indistinguishable from a real symbol of the same spelling. Reject it the way
     // `engineer_features` does rather than encoding one and filtering it back out.
-    let tickers = data
-        .column("ticker")
-        .map_err(|error| error.to_string())?
-        .str()
-        .map_err(|error| error.to_string())?;
+    let tickers = data.column("ticker")?.str()?;
     if tickers.null_count() > 0 {
-        return Err(format!(
+        return Err(TideError::Data(format!(
             "Equity bars contain {} null ticker values out of {} rows",
             tickers.null_count(),
             data.height()
-        )
-        .into());
+        )));
     }
 
     // Uppercase ticker, sector, industry columns in-place
@@ -808,29 +770,22 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
         .collect();
 
     let sector_upper: Vec<String> = data
-        .column("sector")
-        .map_err(|error| error.to_string())?
-        .str()
-        .map_err(|error| error.to_string())?
+        .column("sector")?
+        .str()?
         .into_iter()
         .map(|value| value.unwrap_or(UNKNOWN_SECTOR_OR_INDUSTRY).to_uppercase())
         .collect();
 
     let industry_upper: Vec<String> = data
-        .column("industry")
-        .map_err(|error| error.to_string())?
-        .str()
-        .map_err(|error| error.to_string())?
+        .column("industry")?
+        .str()?
         .into_iter()
         .map(|value| value.unwrap_or(UNKNOWN_SECTOR_OR_INDUSTRY).to_uppercase())
         .collect();
 
-    data.with_column(Column::new("ticker".into(), ticker_upper))
-        .map_err(|error| error.to_string())?;
-    data.with_column(Column::new("sector".into(), sector_upper))
-        .map_err(|error| error.to_string())?;
-    data.with_column(Column::new("industry".into(), industry_upper))
-        .map_err(|error| error.to_string())?;
+    data.with_column(Column::new("ticker".into(), ticker_upper))?;
+    data.with_column(Column::new("sector".into(), sector_upper))?;
+    data.with_column(Column::new("industry".into(), industry_upper))?;
 
     let cleaned = data;
 
@@ -840,12 +795,8 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
     // scaling and windowing iterate these columns assuming they are dense and finite.
     let mut keep_row = vec![true; cleaned.height()];
     for column in CONTINUOUS_COLUMNS {
-        let values = cleaned
-            .column(column)
-            .map_err(|error| error.to_string())?
-            .cast(&DataType::Float64)
-            .map_err(|error| error.to_string())?;
-        let values = values.f64().map_err(|error| error.to_string())?;
+        let values = cleaned.column(column)?.cast(&DataType::Float64)?;
+        let values = values.f64()?;
         for (index, value) in values.into_iter().enumerate() {
             if !value.is_some_and(f64::is_finite) {
                 keep_row[index] = false;
@@ -853,40 +804,25 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
         }
     }
     let finite_mask: BooleanChunked = keep_row.into_iter().collect();
-    let cleaned = cleaned
-        .filter(&finite_mask)
-        .map_err(|error| error.to_string())?;
+    let cleaned = cleaned.filter(&finite_mask)?;
     Ok(cleaned)
 }
 
-pub(crate) fn apply_scaling(
-    data: DataFrame,
-    scaler: &Scaler,
-) -> Result<DataFrame, Box<dyn std::error::Error>> {
+pub(crate) fn apply_scaling(data: DataFrame, scaler: &Scaler) -> Result<DataFrame, TideError> {
     let mut result = data;
     for column_name in CONTINUOUS_COLUMNS {
-        let mean = scaler.means().get(*column_name).copied().unwrap_or(0.0);
-        // `Scaler::new` rejects a non-positive standard deviation, so no zero guard is needed here.
-        let standard_deviation = scaler
-            .standard_deviations()
-            .get(*column_name)
-            .copied()
-            .unwrap_or(1.0);
-
+        // Through the scaler's own forward transform rather than repeating the arithmetic, so it
+        // cannot drift from the inverse the predictions are read back through. `Scaler::new`
+        // rejects a non-positive standard deviation, so no zero guard is needed.
         let values: Vec<f32> = result
-            .column(column_name)
-            .map_err(|error| error.to_string())?
-            .cast(&DataType::Float64)
-            .map_err(|error| error.to_string())?
-            .f64()
-            .map_err(|error| error.to_string())?
+            .column(column_name)?
+            .cast(&DataType::Float64)?
+            .f64()?
             .into_no_null_iter()
-            .map(|value| ((value - mean) / standard_deviation) as f32)
+            .map(|value| scaler.transform_value(column_name, value) as f32)
             .collect();
 
-        result
-            .with_column(Column::new((*column_name).into(), values))
-            .map_err(|error| error.to_string())?;
+        result.with_column(Column::new((*column_name).into(), values))?;
     }
     Ok(result)
 }
@@ -894,7 +830,7 @@ pub(crate) fn apply_scaling(
 pub(crate) fn encode_categoricals(
     data: DataFrame,
     mappings: &FeatureMappings,
-) -> Result<DataFrame, Box<dyn std::error::Error>> {
+) -> Result<DataFrame, TideError> {
     let mut result = data;
 
     let all_categorical: Vec<&str> = CATEGORICAL_COLUMNS
@@ -906,8 +842,7 @@ pub(crate) fn encode_categoricals(
     for column_name in all_categorical {
         if let Some(mapping) = mappings.get(column_name) {
             let values: Vec<Option<i32>> = result
-                .column(column_name)
-                .map_err(|error| error.to_string())?
+                .column(column_name)?
                 .str()
                 .map(|chunked| {
                     chunked
@@ -917,11 +852,9 @@ pub(crate) fn encode_categoricals(
                 })
                 .or_else(|_| {
                     result
-                        .column(column_name)
-                        .map_err(|error| error.to_string())?
+                        .column(column_name)?
                         .i32()
                         .map(|chunked| chunked.into_iter().collect())
-                        .map_err(|error| error.to_string())
                 })?;
 
             // A sentinel merges every unmapped value into one id. For the static columns that
@@ -941,12 +874,10 @@ pub(crate) fn encode_categoricals(
                 .into_iter()
                 .map(|value| value.unwrap_or(-1))
                 .collect();
-            result
-                .with_column(Column::new(column_name.into(), encoded))
-                .map_err(|error| error.to_string())?;
+            result.with_column(Column::new(column_name.into(), encoded))?;
 
             if is_static && unmapped > 0 {
-                result = result.filter(&keep).map_err(|error| error.to_string())?;
+                result = result.filter(&keep)?;
                 tracing::warn!(
                     column = column_name,
                     dropped_rows = unmapped,
@@ -973,61 +904,35 @@ pub(crate) fn encode_categoricals(
 ///
 /// The same family of trap produced a real bug fixed in #1035, where a null `sector` put later rows
 /// on the wrong ticker.
-fn reject_null_column(
-    column: &Column,
-    column_name: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn reject_null_column(column: &Column, column_name: &str) -> Result<(), TideError> {
     let nulls = column.null_count();
     if nulls > 0 {
-        return Err(format!(
+        return Err(TideError::Data(format!(
             "Column `{column_name}` has {nulls} null value(s) in {} rows; reading it positionally \
              would substitute the raw buffer value and treat it as a real observation",
             column.len()
-        )
-        .into());
+        )));
     }
     Ok(())
 }
 
-fn get_float_columns(
-    data: &DataFrame,
-    columns: &[&str],
-) -> Result<Vec<Vec<f32>>, Box<dyn std::error::Error>> {
+fn get_float_columns(data: &DataFrame, columns: &[&str]) -> Result<Vec<Vec<f32>>, TideError> {
     let mut result = Vec::new();
     for column_name in columns {
-        let cast = data
-            .column(column_name)
-            .map_err(|error| error.to_string())?
-            .cast(&DataType::Float32)
-            .map_err(|error| error.to_string())?;
+        let cast = data.column(column_name)?.cast(&DataType::Float32)?;
         reject_null_column(&cast, column_name)?;
-        let values: Vec<f32> = cast
-            .f32()
-            .map_err(|error| error.to_string())?
-            .into_no_null_iter()
-            .collect();
+        let values: Vec<f32> = cast.f32()?.into_no_null_iter().collect();
         result.push(values);
     }
     Ok(result)
 }
 
-fn get_int_columns(
-    data: &DataFrame,
-    columns: &[&str],
-) -> Result<Vec<Vec<i32>>, Box<dyn std::error::Error>> {
+fn get_int_columns(data: &DataFrame, columns: &[&str]) -> Result<Vec<Vec<i32>>, TideError> {
     let mut result = Vec::new();
     for column_name in columns {
-        let cast = data
-            .column(column_name)
-            .map_err(|error| error.to_string())?
-            .cast(&DataType::Int32)
-            .map_err(|error| error.to_string())?;
+        let cast = data.column(column_name)?.cast(&DataType::Int32)?;
         reject_null_column(&cast, column_name)?;
-        let values: Vec<i32> = cast
-            .i32()
-            .map_err(|error| error.to_string())?
-            .into_no_null_iter()
-            .collect();
+        let values: Vec<i32> = cast.i32()?.into_no_null_iter().collect();
         result.push(values);
     }
     Ok(result)
@@ -1247,24 +1152,58 @@ mod scaler_boundary_tests {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_scaler_inverse_transform() {
-        let mut means = HashMap::new();
-        means.insert("daily_return".to_string(), 0.001);
-        let mut stds = HashMap::new();
-        stds.insert("daily_return".to_string(), 0.02);
-        let scaler = Scaler {
-            means,
-            standard_deviations: stds,
-        };
-        let result = scaler.inverse_transform_value("daily_return", 1.0);
-        assert!((result - 0.021).abs() < 1e-10);
+    fn return_scaler() -> Scaler {
+        Scaler::new(
+            HashMap::from([("daily_return".to_string(), 0.001)]),
+            HashMap::from([("daily_return".to_string(), 0.02)]),
+        )
+        .expect("the fixture statistics must be usable")
     }
 
     #[test]
-    fn test_selector_by_names() {
-        let names = selector_by_names(&["ticker", "timestamp"]);
-        assert_eq!(names.len(), 2);
+    fn test_scaler_inverse_transform() {
+        let result = return_scaler().inverse_transform_value("daily_return", 1.0);
+        assert!((result - 0.021).abs() < 1e-10);
+    }
+
+    /// The two halves must compose to the identity in both directions. They are the reason the
+    /// forward transform moved onto `Scaler`: written separately, one can change without the other
+    /// and the only symptom is predictions on the wrong scale, which every downstream check
+    /// accepts. An unknown column falls through to the identity pair and must round-trip too.
+    #[test]
+    fn test_scaling_and_unscaling_are_inverses() {
+        let scaler = return_scaler();
+        for value in [-0.05_f64, 0.0, 1e-9, 0.037, 12.5] {
+            let there_and_back = scaler.inverse_transform_value(
+                "daily_return",
+                scaler.transform_value("daily_return", value),
+            );
+            assert!(
+                (there_and_back - value).abs() < 1e-12,
+                "forward then inverse moved {value} to {there_and_back}"
+            );
+
+            let scaled = scaler.transform_value("daily_return", value);
+            let back_and_there = scaler.transform_value(
+                "daily_return",
+                scaler.inverse_transform_value("daily_return", scaled),
+            );
+            assert!(
+                (back_and_there - scaled).abs() < 1e-12,
+                "inverse then forward moved {scaled} to {back_and_there}"
+            );
+
+            assert_eq!(
+                scaler.transform_value("not_a_column", value),
+                value,
+                "an unknown column is the identity forward"
+            );
+            assert_eq!(
+                scaler.inverse_transform_value("not_a_column", value),
+                value,
+                "and the identity back"
+            );
+        }
     }
 
     #[test]
@@ -1319,13 +1258,15 @@ mod tests {
         .unwrap()
     }
 
+    /// A `Data` whose scaler carries nothing, for the windowing tests that never scale.
+    ///
+    /// Through the constructor rather than a struct literal: `Scaler` is deliberately not
+    /// `Deserialize` so every path into it is checked, and a literal here would be the hole that
+    /// closes reopened in the tests.
     fn empty_data(frame: DataFrame) -> Data {
         Data::from_parts(
             frame,
-            Scaler {
-                means: HashMap::new(),
-                standard_deviations: HashMap::new(),
-            },
+            Scaler::new(HashMap::new(), HashMap::new()).expect("an empty scaler is well formed"),
             FeatureMappings::new(),
         )
     }
@@ -1747,7 +1688,7 @@ mod tests {
         // Any instant inside the forecast session must stamp that same session.
         let noon = session.midnight() + chrono::Duration::hours(12);
         assert_eq!(
-            crate::models::tide::predict::step_timestamp_milliseconds(noon, 0),
+            crate::models::tide::predict::step_timestamp(noon, 0).timestamp_millis(),
             target_milliseconds,
             "the stamped session must be the session the appended row carries"
         );

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -10,6 +10,7 @@ use crate::models::tide::batch::build_input_tensor;
 use crate::models::tide::configuration::ModelParameters;
 use crate::models::tide::data::TrainingDataset;
 use crate::models::tide::model::TiDEModel;
+use crate::models::tide::TideError;
 
 const EVALUATION_BATCH_SIZE: usize = 4096;
 
@@ -118,7 +119,7 @@ pub fn evaluate(
     model: &TiDEModel<NdArray>,
     dataset: &TrainingDataset,
     parameters: &ModelParameters,
-) -> Result<EvaluationMetrics, Box<dyn std::error::Error>> {
+) -> Result<EvaluationMetrics, TideError> {
     let sample_count = dataset.len();
     let targets = match dataset.targets.as_ref() {
         Some(targets) if sample_count > 0 => targets,
@@ -132,7 +133,8 @@ pub fn evaluate(
         return Ok(EvaluationMetrics::zero());
     }
 
-    crate::models::tide::batch::validate_input_shape(dataset, parameters)?;
+    crate::models::tide::batch::validate_input_shape(dataset, parameters)
+        .map_err(TideError::Data)?;
 
     let indices = QuantileIndices::locate(quantiles);
 
@@ -152,7 +154,7 @@ pub fn evaluate(
         let mut values: Vec<f32> = output
             .to_data()
             .to_vec()
-            .map_err(|error| format!("{error:?}"))?;
+            .map_err(|error| TideError::Data(format!("{error:?}")))?;
         predictions.append(&mut values);
     }
 
@@ -163,15 +165,14 @@ pub fn evaluate(
     // an error the trainer can log rather than as a crash mid-run.
     let expected_predictions = sample_count * output_length * quantile_count;
     if predictions.len() < expected_predictions {
-        return Err(format!(
+        return Err(TideError::Artifact(format!(
             "model returned {} prediction values, expected {} for {} samples x {} horizon x {} quantiles",
             predictions.len(),
             expected_predictions,
             sample_count,
             output_length,
             quantile_count
-        )
-        .into());
+        )));
     }
 
     let mut accumulator = MetricAccumulator::default();

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -134,7 +134,7 @@ pub fn evaluate(
     }
 
     crate::models::tide::batch::validate_input_shape(dataset, parameters)
-        .map_err(TideError::Data)?;
+        .map_err(TideError::Artifact)?;
 
     let indices = QuantileIndices::locate(quantiles);
 
@@ -154,7 +154,7 @@ pub fn evaluate(
         let mut values: Vec<f32> = output
             .to_data()
             .to_vec()
-            .map_err(|error| TideError::Data(format!("{error:?}")))?;
+            .map_err(|error| TideError::Artifact(format!("{error:?}")))?;
         predictions.append(&mut values);
     }
 

--- a/src/models/tide/fit.rs
+++ b/src/models/tide/fit.rs
@@ -16,6 +16,7 @@ use crate::models::tide::data::{
     training_cutoff, CategoryMapping, Data, FeatureMappings, Scaler, TrainingFraction,
     CATEGORICAL_COLUMNS, CONTINUOUS_COLUMNS, STATIC_CATEGORICAL_COLUMNS,
 };
+use crate::models::tide::TideError;
 
 /// Result of fitting: the preprocessed (scaled + encoded) data ready for
 /// windowing, alongside the fitted scaler and mappings.
@@ -40,10 +41,7 @@ pub struct FitResult {
 /// instrument first listed (or first clearing the liquidity floors) after the cutoff would vanish
 /// from the validation split, and, since these mappings ship in the artifact as the inference
 /// vocabulary, could not be predicted at all until it had traded the full pre-cutoff window.
-pub fn fit(
-    raw: DataFrame,
-    training_fraction: TrainingFraction,
-) -> Result<FitResult, Box<dyn std::error::Error>> {
+pub fn fit(raw: DataFrame, training_fraction: TrainingFraction) -> Result<FitResult, TideError> {
     let engineered = engineer_features(raw)?;
     let cleaned = clean_data(engineered)?;
 
@@ -71,21 +69,19 @@ pub fn fit(
 /// than fitted: `mean()` and `std()` both return `None` over no rows, every mean would fall back to
 /// `0.0` and every deviation to the `1e-8` floor, and the result passes [`Scaler::new`] while
 /// scaling by a hundred million.
-fn fit_scaler(data: &DataFrame) -> Result<Scaler, Box<dyn std::error::Error>> {
+fn fit_scaler(data: &DataFrame) -> Result<Scaler, TideError> {
     if data.height() == 0 {
-        return Err("No rows at or before the training cutoff to fit the scaler on".into());
+        return Err(TideError::Data(
+            "No rows at or before the training cutoff to fit the scaler on".to_string(),
+        ));
     }
 
     let mut means = std::collections::HashMap::new();
     let mut standard_deviations = std::collections::HashMap::new();
 
     for column in CONTINUOUS_COLUMNS {
-        let series = data
-            .column(column)
-            .map_err(|error| error.to_string())?
-            .cast(&DataType::Float64)
-            .map_err(|error| error.to_string())?;
-        let values = series.f64().map_err(|error| error.to_string())?;
+        let series = data.column(column)?.cast(&DataType::Float64)?;
+        let values = series.f64()?;
         let mean = values.mean().unwrap_or(0.0);
         let standard_deviation = values.std(1).unwrap_or(0.0);
         let standard_deviation = if standard_deviation == 0.0 {
@@ -98,13 +94,14 @@ fn fit_scaler(data: &DataFrame) -> Result<Scaler, Box<dyn std::error::Error>> {
     }
 
     Scaler::new(means, standard_deviations).map_err(|reason| {
-        format!("Fitted scaler is unusable, so training would produce a bad artifact: {reason}")
-            .into()
+        TideError::Data(format!(
+            "Fitted scaler is unusable, so training would produce a bad artifact: {reason}"
+        ))
     })
 }
 
 /// Build deterministic value->index maps for the static categorical columns.
-fn fit_mappings(data: &DataFrame) -> Result<FeatureMappings, Box<dyn std::error::Error>> {
+fn fit_mappings(data: &DataFrame) -> Result<FeatureMappings, TideError> {
     let mut mappings = FeatureMappings::new();
     for column in STATIC_CATEGORICAL_COLUMNS {
         mappings.insert((*column).to_string(), build_mapping(data, column)?);
@@ -112,15 +109,10 @@ fn fit_mappings(data: &DataFrame) -> Result<FeatureMappings, Box<dyn std::error:
     Ok(mappings)
 }
 
-fn build_mapping(
-    data: &DataFrame,
-    column: &str,
-) -> Result<CategoryMapping, Box<dyn std::error::Error>> {
+fn build_mapping(data: &DataFrame, column: &str) -> Result<CategoryMapping, TideError> {
     let mut values: Vec<String> = data
-        .column(column)
-        .map_err(|error| error.to_string())?
-        .str()
-        .map_err(|error| error.to_string())?
+        .column(column)?
+        .str()?
         .into_no_null_iter()
         .map(|name| name.to_string())
         .collect::<HashSet<_>>()
@@ -141,24 +133,12 @@ pub fn filter_training_bars(
     data: DataFrame,
     minimum_close_price: f64,
     minimum_volume: f64,
-) -> Result<DataFrame, Box<dyn std::error::Error>> {
-    let close_prices = data
-        .column("close_price")
-        .map_err(|error| error.to_string())?
-        .cast(&DataType::Float64)
-        .map_err(|error| error.to_string())?;
-    let close_prices = close_prices.f64().map_err(|error| error.to_string())?;
-    let volumes = data
-        .column("volume")
-        .map_err(|error| error.to_string())?
-        .cast(&DataType::Float64)
-        .map_err(|error| error.to_string())?;
-    let volumes = volumes.f64().map_err(|error| error.to_string())?;
-    let tickers = data
-        .column("ticker")
-        .map_err(|error| error.to_string())?
-        .str()
-        .map_err(|error| error.to_string())?;
+) -> Result<DataFrame, TideError> {
+    let close_prices = data.column("close_price")?.cast(&DataType::Float64)?;
+    let close_prices = close_prices.f64()?;
+    let volumes = data.column("volume")?.cast(&DataType::Float64)?;
+    let volumes = volumes.f64()?;
+    let tickers = data.column("ticker")?.str()?;
 
     let mask: BooleanChunked = close_prices
         .into_iter()
@@ -172,7 +152,7 @@ pub fn filter_training_bars(
         })
         .collect();
 
-    let filtered = data.filter(&mask).map_err(|error| error.to_string())?;
+    let filtered = data.filter(&mask)?;
     Ok(filtered)
 }
 
@@ -193,7 +173,7 @@ pub fn write_artifact_json(
     scaler: &Scaler,
     mappings: &FeatureMappings,
     parameters: &ModelParameters,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), TideError> {
     std::fs::create_dir_all(directory)?;
 
     let scaler_json = serde_json::json!({

--- a/src/models/tide/model.rs
+++ b/src/models/tide/model.rs
@@ -5,6 +5,8 @@ use burn::module::Module;
 use burn::nn;
 use burn::prelude::*;
 
+use crate::models::tide::TideError;
+
 #[derive(Module, Debug)]
 pub struct ResidualBlock<B: Backend> {
     linear: nn::Linear<B>,
@@ -56,7 +58,7 @@ impl TiDEModel<NdArray> {
         output_length: usize,
         quantile_count: usize,
         dropout_rate: f64,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, TideError> {
         let device = Default::default();
         let model = Self::new(
             &device,
@@ -80,11 +82,10 @@ impl TiDEModel<NdArray> {
                 &device,
             )
             .map_err(|error| {
-                format!(
+                TideError::Artifact(format!(
                     "Failed to load model weights from {}: {error}",
                     directory_path.display()
-                )
-                .into()
+                ))
             })
     }
 }
@@ -132,14 +133,20 @@ impl<B: Backend> TiDEModel<B> {
     /// Persist the model weights as a Burn record at `directory_path/tide_states`,
     /// the exact stem [`TiDEModel::<NdArray>::load`] reads back. The on-disk file
     /// gets the recorder's own extension; the loader re-derives it from the stem.
-    pub fn save(&self, directory_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn save(&self, directory_path: &std::path::Path) -> Result<(), TideError> {
         std::fs::create_dir_all(directory_path)?;
         let record_path = directory_path.join("tide_states");
-        self.clone().save_file(
-            record_path,
-            &burn::record::DefaultFileRecorder::<burn::record::FullPrecisionSettings>::new(),
-        )?;
-        Ok(())
+        self.clone()
+            .save_file(
+                record_path,
+                &burn::record::DefaultFileRecorder::<burn::record::FullPrecisionSettings>::new(),
+            )
+            .map_err(|error| {
+                TideError::Artifact(format!(
+                    "Failed to save model weights to {}: {error}",
+                    directory_path.display()
+                ))
+            })
     }
 
     pub fn forward(&self, input: Tensor<B, 2>) -> Tensor<B, 2> {

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -301,15 +301,22 @@ pub(crate) fn unscale_and_sort_quantiles(
 /// [`crate::data::calendar::eastern_day_bounds`], and a UTC midnight sits at 20:00 the previous
 /// Eastern day under daylight time -- so a UTC-stamped prediction lands in the wrong session's
 /// window and the morning's inference run is never read by that day's passes.
-pub(crate) fn step_timestamp_milliseconds(now: chrono::DateTime<Utc>, step: usize) -> i64 {
-    let session = SessionDate::at(now).plus_calendar_days(step as i64);
-    session.midnight().timestamp_millis()
+pub(crate) fn step_timestamp(now: chrono::DateTime<Utc>, step: usize) -> DateTime<Utc> {
+    SessionDate::at(now)
+        .plus_calendar_days(step as i64)
+        .midnight()
 }
 
+/// Runs the forward pass and returns one validated prediction per ticker for the coming session.
+///
+/// Returns [`EquityPrediction`] rather than JSON. The values are typed the moment they leave the
+/// tensor, so the quantile ordering, the ticker format, and the instant are checked once, here,
+/// instead of being flattened into a map and re-parsed by the writer.
 pub fn generate_predictions(
     data: DataFrame,
     model_state: &ModelState,
-) -> Result<serde_json::Value, PredictionError> {
+    correlation_id: Uuid,
+) -> Result<Vec<EquityPrediction>, PredictionError> {
     // One `now` for the whole run. The session the synthesized future row carries and the session
     // the output is stamped with are both derived from it, so the features and the label cannot
     // describe different days -- which is the shape of the bug this replaced.
@@ -366,7 +373,6 @@ pub fn generate_predictions(
             "Expected exactly 3 quantiles (10/50/90); the loaded model has {quantile_count}"
         )));
     }
-    let mut results = Vec::new();
 
     // Indexing a `HashMap` panics on a missing key. An artifact without a `ticker` mapping is a
     // malformed artifact, which is a condition to report rather than one to abort the process on --
@@ -381,211 +387,115 @@ pub fn generate_predictions(
         .map(|(ticker, id)| (*id, ticker))
         .collect();
 
+    // Step 0 -- the coming close -- is the only horizon the book can act on: the pre-close
+    // liquidation flattens every position the same session, so a prediction further out describes a
+    // holding period this strategy never has. Selected explicitly rather than as the last step, so
+    // widening `output_length` for research does not silently move the traded signal.
+    let traded_session = step_timestamp(now, 0);
+
+    let mut results = Vec::with_capacity(sample_count);
     for sample_index in 0..sample_count {
         let ticker_id = dataset.static_categorical[[sample_index, 0, 0]];
-        let ticker = reverse_ticker_map
-            .get(&ticker_id)
-            .map(|ticker| ticker.as_str())
-            .unwrap_or("UNKNOWN");
+        // Reported rather than defaulted. This used to fall back to the literal string "UNKNOWN",
+        // which is a valid ticker format -- so an unmappable id was stored as a prediction for a
+        // symbol called UNKNOWN rather than failing.
+        let raw_ticker = reverse_ticker_map.get(&ticker_id).ok_or_else(|| {
+            PredictionError::Postprocessing(format!(
+                "sample {sample_index} carries encoded ticker {ticker_id}, which the artifact's \
+                 mapping does not name"
+            ))
+        })?;
+        let ticker = Ticker::new(raw_ticker).ok_or_else(|| {
+            PredictionError::Postprocessing(format!(
+                "the artifact's ticker mapping contains {raw_ticker}, which is not a usable ticker"
+            ))
+        })?;
 
         for step in 0..output_length {
-            let base_index = (sample_index * output_length + step) * quantile_count;
+            let timestamp = step_timestamp(now, step);
+            if timestamp != traded_session {
+                continue;
+            }
 
+            let base_index = (sample_index * output_length + step) * quantile_count;
             let scaled: Vec<f64> = (0..quantile_count)
                 .map(|quantile| predictions_data[base_index + quantile] as f64)
                 .collect();
             let quantiles = unscale_and_sort_quantiles(&scaled, model_state.scaler());
 
-            results.push(serde_json::json!({
-                "ticker": ticker,
-                "timestamp": step_timestamp_milliseconds(now, step),
-                "quantile_10": quantiles[0],
-                "quantile_50": quantiles[1],
-                "quantile_90": quantiles[2],
-            }));
+            results.push(
+                EquityPrediction::new(
+                    correlation_id,
+                    model_state.run_id().to_string(),
+                    ticker.clone(),
+                    timestamp,
+                    quantiles[0],
+                    quantiles[1],
+                    quantiles[2],
+                )
+                .map_err(|error| {
+                    PredictionError::Postprocessing(format!(
+                        "prediction for {ticker} is invalid: {error}"
+                    ))
+                })?,
+            );
         }
     }
 
-    // Step 0 -- the coming close -- is the only horizon the book can act on: the pre-close
-    // liquidation flattens every position the same session, so a prediction further out describes a
-    // holding period this strategy never has. Selected explicitly rather than as the last step, so
-    // widening `output_length` for research does not silently move the traded signal.
-    let target_date = step_timestamp_milliseconds(now, 0);
-
-    let final_predictions: Vec<serde_json::Value> = results
-        .into_iter()
-        .filter(|row| row["timestamp"] == target_date)
-        .collect();
-
-    info!(count = final_predictions.len(), "Predictions generated");
-
-    Ok(serde_json::json!(final_predictions))
+    info!(count = results.len(), "Predictions generated");
+    Ok(results)
 }
 
-pub fn validate_predictions(predictions: &[serde_json::Value]) -> Result<(), String> {
-    if predictions.is_empty() {
-        return Ok(());
-    }
-
-    let mut seen_pairs: std::collections::HashSet<(String, i64)> = std::collections::HashSet::new();
-    let mut timestamps_by_ticker: std::collections::HashMap<String, Vec<i64>> =
-        std::collections::HashMap::new();
+/// Checks the two invariants that are properties of the batch rather than of a row.
+///
+/// Everything about a single prediction — the quantile ordering, the finiteness, the ticker format
+/// — is already guaranteed by [`EquityPrediction`] and [`Ticker`] having been constructed. What a
+/// value cannot know is what its neighbours look like: two rows for one `(ticker, timestamp)` would
+/// be silently collapsed by the upsert's `ON CONFLICT`, and tickers stamped with different sessions
+/// would leave the book comparing forecasts for different days.
+pub fn validate_predictions(predictions: &[EquityPrediction]) -> Result<(), String> {
+    let mut seen_pairs: std::collections::HashSet<(&Ticker, DateTime<Utc>)> =
+        std::collections::HashSet::new();
+    let mut reference: Option<DateTime<Utc>> = None;
 
     for prediction in predictions {
-        let ticker = prediction["ticker"]
-            .as_str()
-            .ok_or("Missing ticker field")?;
-
-        if ticker != ticker.to_uppercase() {
-            let message = format!("Ticker not uppercase: {ticker}");
-            return Err(message);
+        if !seen_pairs.insert((prediction.ticker(), prediction.timestamp())) {
+            return Err(format!(
+                "Duplicate ticker/timestamp pair: {}/{}",
+                prediction.ticker(),
+                prediction.timestamp()
+            ));
         }
 
-        let timestamp = prediction["timestamp"]
-            .as_i64()
-            .ok_or("Missing timestamp field")?;
-
-        let q10 = prediction["quantile_10"]
-            .as_f64()
-            .ok_or("Missing quantile_10 field")?;
-        let q50 = prediction["quantile_50"]
-            .as_f64()
-            .ok_or("Missing quantile_50 field")?;
-        let q90 = prediction["quantile_90"]
-            .as_f64()
-            .ok_or("Missing quantile_90 field")?;
-
-        if q10 > q50 || q50 > q90 {
-            let message =
-                format!("Non-monotonic quantiles for {ticker}: q10={q10}, q50={q50}, q90={q90}");
-            return Err(message);
-        }
-
-        let pair = (ticker.to_string(), timestamp);
-        if !seen_pairs.insert(pair) {
-            let message = format!("Duplicate ticker/timestamp pair: {ticker}/{timestamp}");
-            return Err(message);
-        }
-
-        timestamps_by_ticker
-            .entry(ticker.to_string())
-            .or_default()
-            .push(timestamp);
-    }
-
-    let all_timestamp_sets: Vec<Vec<i64>> = timestamps_by_ticker
-        .values()
-        .map(|timestamps| {
-            let mut sorted = timestamps.clone();
-            sorted.sort();
-            sorted
-        })
-        .collect();
-
-    if let Some(reference) = all_timestamp_sets.first() {
-        for ts_set in &all_timestamp_sets[1..] {
-            if ts_set != reference {
-                let message = "Timestamps are not consistent across all tickers".to_string();
-                return Err(message);
+        match reference {
+            None => reference = Some(prediction.timestamp()),
+            Some(expected) if expected != prediction.timestamp() => {
+                return Err(format!(
+                    "Timestamps are not consistent across all tickers: {} is stamped {} where {} was expected",
+                    prediction.ticker(),
+                    prediction.timestamp(),
+                    expected
+                ));
             }
+            Some(_) => {}
         }
     }
 
     Ok(())
 }
 
-/// Converts a pipeline prediction JSON object into a validated [`EquityPrediction`].
-///
-/// These come from our own pipeline, so a missing or mistyped field is a bug upstream. It fails
-/// loudly with the offending field and ticker rather than persisting placeholders.
-///
-/// The failure is a plain message rather than a `sqlx::Error::Decode`, which is what it used to be.
-/// Nothing here came from the database — this is our own in-memory JSON — so reporting a malformed
-/// payload as a decode error sent the reader looking at the wrong machine.
-fn prediction_from_json(
-    prediction: &serde_json::Value,
-    correlation_id: Uuid,
-    model_run_id: &str,
-) -> Result<EquityPrediction, String> {
-    let ticker = prediction
-        .get("ticker")
-        .and_then(|value| value.as_str())
-        .ok_or_else(|| "Prediction is missing a string ticker field".to_string())?;
-
-    let timestamp_milliseconds = prediction
-        .get("timestamp")
-        .and_then(|value| value.as_i64())
-        .ok_or_else(|| {
-            format!("Prediction for ticker {ticker} is missing an integer timestamp field")
-        })?;
-    let timestamp = DateTime::<Utc>::from_timestamp_millis(timestamp_milliseconds)
-        .filter(|_| timestamp_milliseconds > 0)
-        .ok_or_else(|| {
-            format!(
-                "Prediction for ticker {ticker} has an invalid timestamp: {timestamp_milliseconds}"
-            )
-        })?;
-
-    let quantile = |field: &str| -> Result<f64, String> {
-        prediction
-            .get(field)
-            .and_then(|value| value.as_f64())
-            .ok_or_else(|| {
-                format!("Prediction for ticker {ticker} is missing a numeric {field} field")
-            })
-    };
-
-    let validated_ticker = Ticker::new(ticker)
-        .ok_or_else(|| format!("Invalid ticker in prediction payload: {ticker}"))?;
-    // `EquityPrediction::new` enforces the quantile ordering invariant, so a crossed set from the
-    // model is rejected here rather than stored. Every downstream use -- the confidence measure,
-    // the directional signal -- produces plausible nonsense from crossed quantiles rather than
-    // failing, which makes this the last place the error is cheap to catch.
-    EquityPrediction::new(
-        correlation_id,
-        model_run_id.to_string(),
-        validated_ticker,
-        timestamp,
-        quantile("quantile_10")?,
-        quantile("quantile_50")?,
-        quantile("quantile_90")?,
-    )
-    .map_err(|error| format!("Prediction for ticker {ticker} is invalid: {error}"))
-}
-
-/// Why writing a prediction batch failed.
-///
-/// Two variants because the two failures point at different machines: a malformed payload is a bug
-/// in this process's own model output, and a database error is the database. Collapsing them, as
-/// the `sqlx::Error` return did, made every model bug read as a storage problem.
-#[derive(Debug, thiserror::Error)]
-pub enum InsertPredictionsError {
-    #[error("prediction payload is malformed: {0}")]
-    Payload(String),
-    #[error("{0}")]
-    Database(#[from] sqlx::Error),
-}
-
 pub async fn insert_predictions(
     pool: &PgPool,
-    predictions: &[serde_json::Value],
-    correlation_id: Uuid,
-    model_run_id: &str,
-) -> Result<(u64, Vec<EquityPrediction>), InsertPredictionsError> {
+    predictions: &[EquityPrediction],
+) -> Result<u64, sqlx::Error> {
     if predictions.is_empty() {
-        return Ok((0, Vec::new()));
+        return Ok(0);
     }
-
-    let validated: Vec<EquityPrediction> = predictions
-        .iter()
-        .map(|prediction| prediction_from_json(prediction, correlation_id, model_run_id))
-        .collect::<Result<_, _>>()
-        .map_err(InsertPredictionsError::Payload)?;
 
     let mut rows_affected: u64 = 0;
     let mut transaction = pool.begin().await?;
 
-    for chunk in validated.chunks(1000) {
+    for chunk in predictions.chunks(1000) {
         let mut query_builder = sqlx::QueryBuilder::new(
             "INSERT INTO equity_predictions (correlation_id, model_run_id, ticker, timestamp, quantile_10, quantile_50, quantile_90) ",
         );
@@ -616,9 +526,7 @@ pub async fn insert_predictions(
 
     transaction.commit().await?;
     info!(rows = rows_affected, "Predictions inserted into PostgreSQL");
-    // Returned rather than reparsed by the caller: these are the exact values that were written,
-    // so the journal records what the database holds and not a second reading of the payload.
-    Ok((rows_affected, validated))
+    Ok(rows_affected)
 }
 
 /// Loads the most recent prediction per ticker within a half-open instant range.
@@ -826,45 +734,65 @@ mod tests {
         assert_eq!(result.height(), 0);
     }
 
-    #[test]
-    fn test_validate_predictions_valid() {
-        let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "timestamp": 1000, "quantile_10": 0.01, "quantile_50": 0.02, "quantile_90": 0.03}),
-            serde_json::json!({"ticker": "GOOG", "timestamp": 1000, "quantile_10": 0.05, "quantile_50": 0.06, "quantile_90": 0.07}),
-        ];
-        assert!(validate_predictions(&predictions).is_ok());
+    fn prediction(ticker: &str, timestamp: DateTime<Utc>) -> EquityPrediction {
+        EquityPrediction::new(
+            Uuid::nil(),
+            "2026-08-05-00-00-00-000".to_string(),
+            Ticker::new(ticker).expect("a valid test ticker"),
+            timestamp,
+            -0.01,
+            0.0,
+            0.01,
+        )
+        .expect("ordered quantiles must construct")
     }
 
-    #[test]
-    fn test_validate_predictions_non_monotonic() {
-        let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "timestamp": 1000, "quantile_10": 0.05, "quantile_50": 0.02, "quantile_90": 0.03}),
-        ];
-        let result = validate_predictions(&predictions);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Non-monotonic"));
+    fn instant(raw: &str) -> DateTime<Utc> {
+        chrono::DateTime::parse_from_rfc3339(raw)
+            .expect("a valid test instant")
+            .with_timezone(&Utc)
     }
 
+    /// The row-level invariants moved into `EquityPrediction` and `Ticker`, so what is left to
+    /// check is what a single value cannot know about its neighbours.
     #[test]
-    fn test_validate_predictions_mixed_timestamps() {
-        let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "timestamp": 1000, "quantile_10": 0.01, "quantile_50": 0.02, "quantile_90": 0.03}),
-            serde_json::json!({"ticker": "GOOG", "timestamp": 2000, "quantile_10": 0.01, "quantile_50": 0.02, "quantile_90": 0.03}),
-        ];
-        let result = validate_predictions(&predictions);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Timestamps"));
+    fn test_a_consistent_batch_passes() {
+        let session = instant("2026-08-05T04:00:00Z");
+        assert!(validate_predictions(&[]).is_ok());
+        assert!(validate_predictions(&[prediction("AAPL", session)]).is_ok());
+        assert!(validate_predictions(&[
+            prediction("AAPL", session),
+            prediction("MSFT", session),
+            prediction("GOOG", session),
+        ])
+        .is_ok());
     }
 
+    /// The upsert's `ON CONFLICT (ticker, timestamp)` would collapse a repeated pair silently, so
+    /// the second row would overwrite the first and the batch would report a row count that does
+    /// not match what it was handed.
     #[test]
-    fn test_validate_predictions_duplicate_pair() {
-        let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "timestamp": 1000, "quantile_10": 0.01, "quantile_50": 0.02, "quantile_90": 0.03}),
-            serde_json::json!({"ticker": "AAPL", "timestamp": 1000, "quantile_10": 0.04, "quantile_50": 0.05, "quantile_90": 0.06}),
-        ];
-        let result = validate_predictions(&predictions);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Duplicate"));
+    fn test_a_repeated_ticker_and_session_is_refused() {
+        let session = instant("2026-08-05T04:00:00Z");
+        let error = validate_predictions(&[
+            prediction("AAPL", session),
+            prediction("MSFT", session),
+            prediction("AAPL", session),
+        ])
+        .expect_err("a repeated pair must be refused");
+        assert!(error.contains("Duplicate"), "got: {error}");
+    }
+
+    /// Every prediction in a batch describes the same session. One stamped differently would have
+    /// the book comparing forecasts for two different days against one universe.
+    #[test]
+    fn test_a_batch_spanning_two_sessions_is_refused() {
+        let error = validate_predictions(&[
+            prediction("AAPL", instant("2026-08-05T04:00:00Z")),
+            prediction("MSFT", instant("2026-08-06T04:00:00Z")),
+        ])
+        .expect_err("a split batch must be refused");
+        assert!(error.contains("not consistent"), "got: {error}");
     }
 
     #[test]
@@ -895,8 +823,7 @@ mod tests {
             let now = chrono::DateTime::parse_from_rfc3339(&format!("{day}T13:00:00Z"))
                 .unwrap()
                 .with_timezone(&Utc);
-            let stamp = DateTime::<Utc>::from_timestamp_millis(step_timestamp_milliseconds(now, 0))
-                .unwrap();
+            let stamp = step_timestamp(now, 0);
             let (start, end) = SessionDate::at(now).bounds();
             assert!(
                 stamp >= start && stamp < end,
@@ -915,13 +842,10 @@ mod tests {
             .unwrap()
             .with_timezone(&Utc);
         let session = SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 6, 9).unwrap());
+        assert_eq!(step_timestamp(now, 0), session.midnight());
         assert_eq!(
-            step_timestamp_milliseconds(now, 0),
-            session.midnight().timestamp_millis()
-        );
-        assert_eq!(
-            step_timestamp_milliseconds(now, 4),
-            session.plus_calendar_days(4).midnight().timestamp_millis()
+            step_timestamp(now, 4),
+            session.plus_calendar_days(4).midnight()
         );
     }
 
@@ -935,10 +859,8 @@ mod tests {
             .unwrap()
             .with_timezone(&Utc);
         assert_eq!(
-            step_timestamp_milliseconds(now, 0),
-            SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 6, 9).unwrap())
-                .midnight()
-                .timestamp_millis()
+            step_timestamp(now, 0),
+            SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 6, 9).unwrap()).midnight()
         );
     }
 
@@ -1151,102 +1073,6 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_predictions_empty_is_ok() {
-        assert!(validate_predictions(&[]).is_ok());
-    }
-
-    #[test]
-    fn test_validate_predictions_lowercase_ticker_errors() {
-        let predictions = vec![
-            serde_json::json!({"ticker": "aapl", "timestamp": 1000, "quantile_10": 0.01, "quantile_50": 0.02, "quantile_90": 0.03}),
-        ];
-        let result = validate_predictions(&predictions);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not uppercase"));
-    }
-
-    #[test]
-    fn test_validate_predictions_missing_ticker_field_errors() {
-        let predictions = vec![
-            serde_json::json!({"timestamp": 1000, "quantile_10": 0.01, "quantile_50": 0.02, "quantile_90": 0.03}),
-        ];
-        let result = validate_predictions(&predictions);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Missing ticker"));
-    }
-
-    #[test]
-    fn test_validate_predictions_missing_timestamp_field_errors() {
-        let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "quantile_10": 0.01, "quantile_50": 0.02, "quantile_90": 0.03}),
-        ];
-        let result = validate_predictions(&predictions);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Missing timestamp"));
-    }
-
-    #[test]
-    fn test_validate_predictions_missing_quantile_10_field_errors() {
-        let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "timestamp": 1000, "quantile_50": 0.02, "quantile_90": 0.03}),
-        ];
-        let result = validate_predictions(&predictions);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Missing quantile_10"));
-    }
-
-    #[test]
-    fn test_validate_predictions_missing_quantile_50_field_errors() {
-        let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "timestamp": 1000, "quantile_10": 0.01, "quantile_90": 0.03}),
-        ];
-        let result = validate_predictions(&predictions);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Missing quantile_50"));
-    }
-
-    #[test]
-    fn test_validate_predictions_missing_quantile_90_field_errors() {
-        let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "timestamp": 1000, "quantile_10": 0.01, "quantile_50": 0.02}),
-        ];
-        let result = validate_predictions(&predictions);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Missing quantile_90"));
-    }
-
-    #[test]
-    fn test_validate_predictions_equal_quantiles_passes() {
-        // q10 == q50 == q90 is technically monotonic; must not error.
-        let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "timestamp": 1000, "quantile_10": 0.02, "quantile_50": 0.02, "quantile_90": 0.02}),
-        ];
-        assert!(validate_predictions(&predictions).is_ok());
-    }
-
-    #[test]
-    fn test_validate_predictions_q50_exceeds_q90_errors() {
-        let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "timestamp": 1000, "quantile_10": 0.01, "quantile_50": 0.05, "quantile_90": 0.03}),
-        ];
-        let result = validate_predictions(&predictions);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Non-monotonic"));
-    }
-
-    #[test]
-    fn test_validate_predictions_consistent_timestamps_multiple_tickers() {
-        // Both tickers must have the same set of timestamps.
-        let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "timestamp": 1000, "quantile_10": 0.01, "quantile_50": 0.02, "quantile_90": 0.03}),
-            serde_json::json!({"ticker": "AAPL", "timestamp": 2000, "quantile_10": 0.01, "quantile_50": 0.02, "quantile_90": 0.03}),
-            serde_json::json!({"ticker": "GOOG", "timestamp": 1000, "quantile_10": 0.01, "quantile_50": 0.02, "quantile_90": 0.03}),
-            serde_json::json!({"ticker": "GOOG", "timestamp": 2000, "quantile_10": 0.01, "quantile_50": 0.02, "quantile_90": 0.03}),
-        ];
-        assert!(validate_predictions(&predictions).is_ok());
-    }
-
-    #[test]
     fn test_unscale_and_sort_quantiles_already_sorted() {
         let scaler = daily_return_scaler(0.0, 1.0);
 
@@ -1281,11 +1107,8 @@ mod tests {
             SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2025, 12, 31).unwrap());
         for step in [0usize, 1, 7] {
             assert_eq!(
-                step_timestamp_milliseconds(now, step),
-                session
-                    .plus_calendar_days(step as i64)
-                    .midnight()
-                    .timestamp_millis(),
+                step_timestamp(now, step),
+                session.plus_calendar_days(step as i64).midnight(),
                 "step {step} did not land on its Eastern session midnight"
             );
         }
@@ -1309,8 +1132,8 @@ mod tests {
             for step in 0..5usize {
                 let expected = session.plus_calendar_days(step as i64).midnight();
                 assert_eq!(
-                    step_timestamp_milliseconds(now, step),
-                    expected.timestamp_millis(),
+                    step_timestamp(now, step),
+                    expected,
                     "{label}: step {step} did not land on {expected}"
                 );
             }
@@ -1451,29 +1274,6 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_predictions_single_ticker_single_timestamp_ok() {
-        let predictions = vec![serde_json::json!({
-            "ticker": "AAPL",
-            "timestamp": 1_750_000_000_000i64,
-            "quantile_10": -0.01,
-            "quantile_50": 0.0,
-            "quantile_90": 0.01,
-        })];
-        assert!(validate_predictions(&predictions).is_ok());
-    }
-
-    #[test]
-    fn test_validate_predictions_three_tickers_same_timestamps_ok() {
-        let timestamp = 1_750_000_000_000i64;
-        let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "timestamp": timestamp, "quantile_10": 0.0, "quantile_50": 0.01, "quantile_90": 0.02}),
-            serde_json::json!({"ticker": "MSFT", "timestamp": timestamp, "quantile_10": 0.0, "quantile_50": 0.01, "quantile_90": 0.02}),
-            serde_json::json!({"ticker": "GOOG", "timestamp": timestamp, "quantile_10": 0.0, "quantile_50": 0.01, "quantile_90": 0.02}),
-        ];
-        assert!(validate_predictions(&predictions).is_ok());
-    }
-
-    #[test]
     fn test_unscale_and_sort_quantiles_single_element() {
         let scaler = daily_return_scaler(0.0, 1.0);
 
@@ -1488,81 +1288,5 @@ mod tests {
 
         let result = unscale_and_sort_quantiles(&[], &scaler);
         assert!(result.is_empty());
-    }
-
-    fn valid_prediction_payload() -> serde_json::Value {
-        serde_json::json!({
-            "ticker": "AAPL",
-            "timestamp": 1_760_000_000_000i64,
-            "quantile_10": -0.01,
-            "quantile_50": 0.0,
-            "quantile_90": 0.01,
-        })
-    }
-
-    fn convert(payload: &serde_json::Value) -> Result<EquityPrediction, String> {
-        prediction_from_json(payload, Uuid::nil(), "2026-08-05-00-00-00-000")
-    }
-
-    #[test]
-    fn test_prediction_from_json_accepts_a_well_formed_payload() {
-        let prediction = convert(&valid_prediction_payload()).expect("the fixture must convert");
-        assert_eq!(prediction.ticker().as_str(), "AAPL");
-        assert_eq!(prediction.quantile_50(), 0.0);
-    }
-
-    /// Every field this reads comes from our own pipeline, so each of these is an upstream bug. The
-    /// message has to name the offending field and, where it can, the ticker — the payload is a
-    /// batch of thousands and "a field is missing" would not narrow it.
-    #[test]
-    fn test_prediction_from_json_names_the_field_it_rejects() {
-        for (field, expected_fragment) in [
-            ("ticker", "string ticker field"),
-            ("timestamp", "integer timestamp field"),
-            ("quantile_10", "numeric quantile_10 field"),
-            ("quantile_50", "numeric quantile_50 field"),
-            ("quantile_90", "numeric quantile_90 field"),
-        ] {
-            let mut payload = valid_prediction_payload();
-            payload.as_object_mut().unwrap().remove(field);
-
-            let Err(error) = convert(&payload) else {
-                panic!("removing {field} must leave the payload rejected");
-            };
-            assert!(
-                error.contains(expected_fragment),
-                "removing {field} produced `{error}`, which does not name the field"
-            );
-        }
-    }
-
-    #[test]
-    fn test_prediction_from_json_rejects_a_non_positive_timestamp() {
-        let mut payload = valid_prediction_payload();
-        payload["timestamp"] = serde_json::json!(0i64);
-
-        let error = convert(&payload).expect_err("a zero timestamp must be rejected");
-        assert!(error.contains("invalid timestamp"), "got `{error}`");
-    }
-
-    #[test]
-    fn test_prediction_from_json_rejects_a_ticker_the_domain_type_refuses() {
-        let mut payload = valid_prediction_payload();
-        payload["ticker"] = serde_json::json!("NOTATICKER123");
-
-        let error = convert(&payload).expect_err("an unusable ticker must be rejected");
-        assert!(error.contains("Invalid ticker"), "got `{error}`");
-    }
-
-    /// Crossed quantiles are the failure this conversion exists to stop: every downstream use of a
-    /// prediction produces plausible nonsense from them rather than failing, so a crossed set that
-    /// reaches the table is never detected again.
-    #[test]
-    fn test_prediction_from_json_rejects_crossed_quantiles() {
-        let mut payload = valid_prediction_payload();
-        payload["quantile_10"] = serde_json::json!(0.05);
-
-        let error = convert(&payload).expect_err("crossed quantiles must be rejected");
-        assert!(error.contains("AAPL"), "got `{error}`");
     }
 }

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -412,10 +412,10 @@ pub fn generate_predictions(
         })?;
 
         for step in 0..output_length {
-            let timestamp = step_timestamp(now, step);
-            if timestamp != traded_session {
+            if step != 0 {
                 continue;
             }
+            let timestamp = traded_session;
 
             let base_index = (sample_index * output_length + step) * quantile_count;
             let scaled: Vec<f64> = (0..quantile_count)

--- a/src/models/tide/train.rs
+++ b/src/models/tide/train.rs
@@ -127,9 +127,13 @@ impl EarlyStopping {
         }
     }
 
-    /// Observe an epoch's stopping metric. Returns `(snapshot, stop)`: whether
-    /// to checkpoint the current model and whether to stop training.
-    pub(crate) fn observe(&mut self, metric: f64, min_delta: f64, patience: usize) -> (bool, bool) {
+    /// Observe an epoch's stopping metric.
+    pub(crate) fn observe(
+        &mut self,
+        metric: f64,
+        min_delta: f64,
+        patience: usize,
+    ) -> EpochDecision {
         let snapshot = metric < self.best_checkpoint_metric;
         if snapshot {
             self.best_checkpoint_metric = metric;
@@ -144,8 +148,21 @@ impl EarlyStopping {
             self.epochs_without_improvement >= patience
         };
 
-        (snapshot, stop)
+        EpochDecision { snapshot, stop }
     }
+}
+
+/// What an epoch's stopping metric decided.
+///
+/// Two independent answers, and they disagree often enough to be worth naming: any improvement
+/// checkpoints, but only one larger than `min_delta` resets the patience counter, so `snapshot`
+/// without `stop` and `snapshot` with `stop` are both ordinary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EpochDecision {
+    /// Whether this epoch's weights are the best seen and should be checkpointed.
+    pub(crate) snapshot: bool,
+    /// Whether patience is exhausted and training should end.
+    pub(crate) stop: bool,
 }
 
 /// Train the model, returning the best-checkpoint model and the per-epoch
@@ -250,15 +267,15 @@ pub fn train(
             "Epoch complete"
         );
 
-        let (snapshot, stop) = early_stopping.observe(
+        let decision = early_stopping.observe(
             stopping_loss,
             configuration.min_delta,
             configuration.early_stopping_patience,
         );
-        if snapshot {
+        if decision.snapshot {
             best_model = model.clone();
         }
-        if stop {
+        if decision.stop {
             info!(epoch = epoch + 1, "Early stopping triggered");
             break;
         }
@@ -313,6 +330,7 @@ fn validation_loss(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::tide::data::input_feature_size;
 
     /// `batch_size` reaches `slice::chunks`, which panics on zero — so an invalid configuration
     /// aborts the training task rather than failing it. A non-positive learning rate is quieter and
@@ -357,7 +375,6 @@ mod tests {
         )
         .is_ok());
     }
-    use crate::models::tide::data::input_feature_size;
 
     /// A tiny dataset whose target is a constant the model can fit; used to prove
     /// the autodiff + optimizer + loss wiring actually reduces loss.
@@ -399,22 +416,70 @@ mod tests {
         // the patience counter — small gains keep the best weights while still counting toward
         // early stopping.
         let mut policy = EarlyStopping::new();
-        assert_eq!(policy.observe(0.5, 1e-3, 2), (true, false));
+        assert_eq!(
+            policy.observe(0.5, 1e-3, 2),
+            EpochDecision {
+                snapshot: true,
+                stop: false
+            }
+        );
         // Better, but by less than min_delta: snapshot, counter advances.
-        assert_eq!(policy.observe(0.4999, 1e-3, 2), (true, false));
+        assert_eq!(
+            policy.observe(0.4999, 1e-3, 2),
+            EpochDecision {
+                snapshot: true,
+                stop: false
+            }
+        );
         // Again better by a hair: snapshot, and patience 2 is now exhausted.
-        assert_eq!(policy.observe(0.4998, 1e-3, 2), (true, true));
+        assert_eq!(
+            policy.observe(0.4998, 1e-3, 2),
+            EpochDecision {
+                snapshot: true,
+                stop: true
+            }
+        );
     }
 
     #[test]
     fn test_early_stopping_counter_resets_on_real_improvement() {
         let mut policy = EarlyStopping::new();
-        assert_eq!(policy.observe(0.5, 1e-3, 2), (true, false));
-        assert_eq!(policy.observe(0.4999, 1e-3, 2), (true, false));
+        assert_eq!(
+            policy.observe(0.5, 1e-3, 2),
+            EpochDecision {
+                snapshot: true,
+                stop: false
+            }
+        );
+        assert_eq!(
+            policy.observe(0.4999, 1e-3, 2),
+            EpochDecision {
+                snapshot: true,
+                stop: false
+            }
+        );
         // A genuine improvement resets the counter, so no stop at patience 2.
-        assert_eq!(policy.observe(0.4, 1e-3, 2), (true, false));
-        assert_eq!(policy.observe(0.4, 1e-3, 2), (false, false));
-        assert_eq!(policy.observe(0.41, 1e-3, 2), (false, true));
+        assert_eq!(
+            policy.observe(0.4, 1e-3, 2),
+            EpochDecision {
+                snapshot: true,
+                stop: false
+            }
+        );
+        assert_eq!(
+            policy.observe(0.4, 1e-3, 2),
+            EpochDecision {
+                snapshot: false,
+                stop: false
+            }
+        );
+        assert_eq!(
+            policy.observe(0.41, 1e-3, 2),
+            EpochDecision {
+                snapshot: false,
+                stop: true
+            }
+        );
     }
 
     #[test]
@@ -451,13 +516,9 @@ mod tests {
         );
         let initial = model.clone();
 
-        let configuration = TrainConfiguration {
-            learning_rate: 0.01,
-            epoch_count: 10,
-            batch_size: 16,
-            early_stopping_patience: 1000,
-            min_delta: 1e9,
-        };
+        // Through the constructor, so the tests exercise the validated path the trainer takes.
+        let configuration = TrainConfiguration::new(0.01, 10, 16, 1000, 1e9)
+            .expect("the fixture configuration must be valid");
 
         let (best, losses) = train(model, &dataset, None, &parameters, &configuration, &device);
         assert_eq!(losses.len(), 10);
@@ -501,13 +562,8 @@ mod tests {
             parameters.dropout_rate(),
         );
 
-        let configuration = TrainConfiguration {
-            learning_rate: 0.01,
-            epoch_count: 80,
-            batch_size: 16,
-            early_stopping_patience: 1000,
-            min_delta: 0.0,
-        };
+        let configuration = TrainConfiguration::new(0.01, 80, 16, 1000, 0.0)
+            .expect("the fixture configuration must be valid");
 
         let (_model, losses) = train(model, &dataset, None, &parameters, &configuration, &device);
         assert!(losses.len() >= 2);


### PR DESCRIPTION
# Overview

Fourth module read against the checklist in `.scratchpad/module_review.md`, after `common/` (#1075), the dashboard (#1076), and `data/` (#1077). Net 553 insertions against 930 deletions, almost all of it error handling that had been written by hand.

## Changes

**`Box<dyn std::error::Error>` is gone from the module.** It was returned by 26 functions, with `.map_err(|error| error.to_string())` at 76 call sites, while the rest of the repository uses `thiserror` enums. A typed `PolarsError` was stringified, boxed, and re-stringified at the boundary into `ArtifactError::ModelLoad(String)` — three lossy conversions for one error, and a type that is not `Send`, which is why nothing here composed across an `await`. `TideError` replaces it with `#[from]` for `PolarsError`, `ndarray::ShapeError`, `io::Error`, and `serde_json::Error`, plus two prose variants split by which machine is at fault: `Artifact` when the trainer's output disagrees with this binary, `Data` when the market rows are malformed. Both counts are now zero and `data.rs` alone lost about 120 lines. The trainer binary needed no change, since `TideError` converts into its top-level box for free.

**The prediction pipeline is typed end to end.** It used to build `serde_json::Value` rows, re-read them by string key in `validate_predictions`, and re-parse them into `EquityPrediction` in `prediction_from_json` — a typed value flattened to an untyped map and rebuilt inside one process. `generate_predictions` now returns `Vec<EquityPrediction>`; `prediction_from_json` and `InsertPredictionsError` are deleted; `validate_predictions` keeps only the two invariants a single value cannot know about its neighbours, which are a repeated `(ticker, timestamp)` that the upsert's `ON CONFLICT` would silently collapse, and a batch straddling two sessions.

**Typing that path surfaced a live defect.** An encoded ticker id absent from the artifact's mapping fell back to the literal string `"UNKNOWN"`, which passes `Ticker`'s format validation — so an unmappable sample was written to `equity_predictions` as a forecast for a symbol called UNKNOWN rather than failing. It now reports the id it could not name.

**`Scaler`'s forward and inverse transforms are a named pair.** The forward was inline in `apply_scaling` while the inverse was a method, and the two have to compose to the identity: the model trains on the forward image and every prediction is read back through the inverse. Both now share `statistics_for` and carry a round-trip test in each direction.

Also: `ModelParameters::default()` reads `SERVED_QUANTILES` rather than spelling the list again; `EpochDecision` replaces a `bool` documented in a comment; three `Vec<String>` copies of the module's column constants that nothing read are deleted; and three test sites that bypassed validated constructors through struct literals go through `new`.

**Thirty-three tests removed**, twenty-one asserting JSON shapes the types now make unrepresentable and twelve near-duplicates in `artifact.rs`. That is the whole of the drop from 716 to 685.

## Context

Rebased with `--onto master d7ac3f02`, replaying only the `models/` commit: this branch was stacked on the `data/` work, and that had been amended during its own review, so a plain rebase would have replayed a version of it master no longer matches. One conflict, in `predict.rs` — master returns `(rows_affected, validated)` from `insert_predictions` while this branch returns `u64`, since the caller already holds the typed values and no longer needs them handed back. Took this branch's version; the handler still returns `(rows, predictions)`, so the journal records the exact values written.

Verified against the real artifact and real rows rather than fixtures. The pre-open pipeline was driven exactly as `handle_model_prediction` assembles it: artifact `2026-08-17-19-01-53-434` resolved and loaded from S3 with 2,767 tickers mapped, 766,019 bars and 6,992 details read from Postgres, 88,779 rows into the forward pass, and 1,386 `EquityPrediction` values out, all passing `validate_predictions` and none filed under the old `UNKNOWN` fallback. The quantiles are the familiar near-zero band — `AAL` came back at q10 −0.0414, q50 0.0001, q90 0.0389 — which matches what the model has been doing and is not something this pull request changes.

685 tests pass, `cargo fmt` and `cargo doc` are clean, the sqlx cache is unchanged, and clippy sits at the one pre-existing `redundant_closure` in `tests/test_handlers.rs`.

`portfolio-cleanup` is the last of the five and still sits on the pre-#1075 base.