### PR TITLE
Apply the module review checklist to `portfolio/`

### DIFF
--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Row};
 use tracing::{info, warn};
@@ -31,7 +31,7 @@ pub fn synced_activity_types() -> Vec<ActivityType> {
     vec![ActivityType::Fill]
 }
 
-/// How far back each sync re-asks for [`windowed_activity_types`].
+/// How far back each sync re-asks for [`ActivityType::windowed`].
 ///
 /// Seven days spans a long weekend with room for a missed sync, and costs one request whose rows
 /// are already stored.
@@ -493,17 +493,13 @@ pub fn attribute(closed: &[ClosedPair], activities: &[AccountActivity]) -> Attri
     }
 }
 
-/// The instant bounds of a session date, for callers that need them alongside a sync.
-pub fn session_bounds(session_date: SessionDate) -> (DateTime<Utc>, DateTime<Utc>) {
-    session_date.bounds()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::common::alpaca::OrderSide;
     use crate::common::types::CloseReason;
     use crate::common::types::{PairID, Ticker};
+    use chrono::DateTime;
     use chrono::NaiveDate;
 
     fn ticker(raw: &str) -> Ticker {
@@ -628,14 +624,5 @@ mod tests {
         let attribution = attribute(std::slice::from_ref(&pair), &[fee]);
         assert_eq!(attribution.unattributed, 1);
         assert_eq!(attribution.realized[&pair.id()], Decimal::ZERO);
-    }
-
-    #[test]
-    fn test_session_bounds_are_half_open_across_the_eastern_day() {
-        let (start, end) = session_bounds(SessionDate::from_date(
-            NaiveDate::from_ymd_opt(2026, 7, 30).unwrap(),
-        ));
-        assert!(start < end);
-        assert_eq!((end - start).num_hours(), 24);
     }
 }

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -1,11 +1,7 @@
 //! The five-minute pass, and the pre-close liquidation that backs it up.
 //!
-//! Two properties the implementation has to preserve, and both are easy to lose:
-//!
-//! 1. **Exits run unconditionally.** Every early return below is in the entry half.
-//! 2. **The entry half reuses the prices the exit half already fetched**, asking Alpaca only for
-//!    symbols it does not have. Re-fetching an open leg between the two decisions would make them
-//!    two opinions that can disagree; here they are one measurement used twice.
+//! Each half is observe, decide, apply, with the decision a pure function of its reading; see
+//! [`evaluate_pass`] for the two properties that arrangement exists to protect.
 
 use std::collections::{HashMap, HashSet};
 
@@ -314,6 +310,13 @@ pub async fn run_pass(
 }
 
 /// The pass itself, free to propagate: [`run_pass`] records the observation either way.
+///
+/// Two properties the body has to preserve, and both are easy to lose:
+///
+/// 1. **Exits run unconditionally.** Every early return below is in the entry half.
+/// 2. **The entry half reuses the prices the exit half already fetched**, asking Alpaca only for
+///    symbols it does not have. Re-fetching an open leg between the two decisions would make them
+///    two opinions that can disagree; here they are one measurement used twice.
 async fn evaluate_pass(
     context: &EvaluationContext<'_>,
     correlation_id: uuid::Uuid,

--- a/src/portfolio/execute.rs
+++ b/src/portfolio/execute.rs
@@ -155,9 +155,7 @@ impl CloseOutcome {
 /// Opens both legs of a sized pair, unwinding whatever filled if either leg fails.
 ///
 /// The short leg goes first and its fill is confirmed before the long is submitted: a short can be
-/// rejected for borrow reasons a long never is, so the common failure costs nothing to recover from
-/// because nothing is held yet. The unwind exists for the uncommon case — the short fills and the
-/// long does not — which is the one that leaves an unhedged position.
+/// rejected for borrow reasons a long never is, so the common failure holds nothing yet.
 ///
 /// Returns [`OpenOutcome::Abandoned`] when a leg does not fill and the unwind succeeded, and an
 /// error only when the unwind itself failed — the case where something is held that nothing knows

--- a/src/portfolio/execute.rs
+++ b/src/portfolio/execute.rs
@@ -1,11 +1,7 @@
 //! Order submission and fill confirmation. The only module that sends an order.
 //!
-//! Opening a pair is two orders that must both work or neither hold. The short leg goes first and
-//! its fill is confirmed before the long is submitted: a short can be rejected for borrow reasons a
-//! long never is, so the common failure costs nothing to recover from because nothing is held yet.
-//!
-//! Unwinding is still implemented for the uncommon case — the short fills and the long does not —
-//! which is the one that leaves an unhedged position.
+//! Opening a pair is two orders that must both work or neither hold; see [`open_pair`] for the
+//! ordering that makes the common failure free to recover from.
 
 use std::time::Duration;
 
@@ -157,6 +153,11 @@ impl CloseOutcome {
 }
 
 /// Opens both legs of a sized pair, unwinding whatever filled if either leg fails.
+///
+/// The short leg goes first and its fill is confirmed before the long is submitted: a short can be
+/// rejected for borrow reasons a long never is, so the common failure costs nothing to recover from
+/// because nothing is held yet. The unwind exists for the uncommon case — the short fills and the
+/// long does not — which is the one that leaves an unhedged position.
 ///
 /// Returns [`OpenOutcome::Abandoned`] when a leg does not fill and the unwind succeeded, and an
 /// error only when the unwind itself failed — the case where something is held that nothing knows
@@ -613,7 +614,7 @@ mod tests {
         ExecutionSettings::new(Duration::from_millis(50), Duration::from_millis(5))
     }
 
-    /// A log in a directory of this test's own. Every order path writes to one, so the tests
+    /// A journal in a directory of this test's own. Every order path writes to one, so the tests
     /// exercise the record-before-submit ordering rather than mocking it away.
     fn journal(name: &str) -> Journal {
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -624,13 +625,13 @@ mod tests {
             std::process::id()
         ));
         let _ = std::fs::remove_dir_all(&directory);
-        Journal::new(directory).expect("the log directory must be creatable")
+        Journal::new(directory).expect("the journal directory must be creatable")
     }
 
-    /// Every record a log holds, in the order it was written.
-    fn recorded(log: &Journal) -> Vec<serde_json::Value> {
-        let mut files: Vec<_> = std::fs::read_dir(log.directory())
-            .expect("the log directory must be readable")
+    /// Every record a journal holds, in the order it was written.
+    fn recorded(journal: &Journal) -> Vec<serde_json::Value> {
+        let mut files: Vec<_> = std::fs::read_dir(journal.directory())
+            .expect("the journal directory must be readable")
             .filter_map(Result::ok)
             .map(|entry| entry.path())
             .collect();
@@ -647,11 +648,11 @@ mod tests {
             .collect()
     }
 
-    fn context<'a>(client: &'a TradingClient, log: &'a Journal) -> ExecutionContext<'a> {
+    fn context<'a>(client: &'a TradingClient, journal: &'a Journal) -> ExecutionContext<'a> {
         ExecutionContext {
             client,
             settings: settings(),
-            journal: log,
+            journal,
             correlation_id: Uuid::nil(),
         }
     }

--- a/src/portfolio/pairs.rs
+++ b/src/portfolio/pairs.rs
@@ -1,11 +1,7 @@
 //! `equity_pairs` persistence: which long belongs with which short, and why.
 //!
-//! Alpaca holds the authoritative position, quantity, and fill. What it cannot answer is which long
-//! belongs with which short and what signal put them there, so that — and only that — is stored
-//! here. This is not a position ledger and should never be trusted over Alpaca.
-//!
-//! `realized_profit_and_loss` is written by the post-close sync in [`crate::portfolio::account`],
-//! not by the evaluation pass: the pass knows a pair closed, not what the fills came back at.
+//! Alpaca holds the authoritative position, quantity, and fill; this stores only what it cannot
+//! answer. Not a position ledger, and never to be trusted over Alpaca.
 
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
@@ -401,6 +397,9 @@ pub async fn load_closed_between(
 }
 
 /// Writes the realized profit and loss attributed to a closed pair.
+///
+/// Written by the post-close sync in [`crate::portfolio::account`] rather than by the evaluation
+/// pass: the pass knows a pair closed, not what the fills came back at.
 ///
 /// Idempotent by overwrite rather than by predicate: re-running the account sync for a session
 /// recomputes the same figure from the same activities, and an attribution that has been corrected

--- a/src/portfolio/risk.rs
+++ b/src/portfolio/risk.rs
@@ -1,13 +1,8 @@
-//! The risk gate: four conditions, all of which only ever stop an *entry*.
+//! The risk gate: every condition here only ever stops an *entry*.
 //!
-//! Nothing here can block an exit. The book is flat overnight without exception, so a gate that
-//! could refuse to close a position would be a way to carry one. Exits run first and
-//! unconditionally in [`crate::portfolio::evaluate`]; this is consulted only afterwards.
-//!
-//! Deliberately small: everything modelling overnight exposure went with the requirement to hold
-//! overnight, and the beta-neutral optimizer went with the machinery that estimated the betas.
+//! Nothing can block an exit. The book is flat overnight without exception, so a gate that could
+//! refuse to close a position would be a way to carry one.
 
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use tracing::{info, warn};
 
@@ -151,9 +146,7 @@ impl RiskGate {
 
     /// The gross exposure ceiling: equity times the configured multiple.
     pub fn gross_exposure_cap(&self) -> Decimal {
-        Decimal::from_f64_retain(self.parameters.gross_exposure_multiple())
-            .map(|multiple| self.equity * multiple)
-            .unwrap_or(Decimal::ZERO)
+        self.equity * self.parameters.gross_exposure_multiple()
     }
 
     /// Realized drawdown against the previous session, as a fraction in `[0, 1]`.
@@ -166,14 +159,15 @@ impl RiskGate {
             return None;
         }
         let fall = (previous - self.equity) / previous;
-        fall.to_f64().map(|value| value.max(0.0))
+        Some(fall.as_f64().max(0.0))
     }
 
     /// Conditions that stop the pass opening anything at all.
     ///
     /// Checked once, before any screening, because each of them makes the whole entry half of the
     /// pass pointless — screening seven thousand symbols to then refuse every result is the
-    /// expensive way to do nothing.
+    /// expensive way to do nothing. Exits run first and unconditionally in
+    /// [`crate::portfolio::evaluate`]; this is consulted only afterwards.
     pub fn session_block(&self) -> Option<RiskBlock> {
         if let Some(drawdown) = self.drawdown() {
             if drawdown >= DRAWDOWN_THRESHOLD {

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -1,13 +1,7 @@
 //! Pair selection: which two symbols, which way round, and how strong the signal.
 //!
-//! The screen is quadratic in the eligible universe, so everything cheap runs first: the confidence
-//! floor and the shortable check shrink the input before a single correlation is computed.
-//!
-//! Sector is not one of those tests. It constrains the *book* rather than the pair, so it is applied
-//! during selection — see [`MAXIMUM_LEGS_PER_SECTOR`].
-//!
-//! [`SpreadModel`] is load-bearing. An open pair's model is rebuilt from its *stored* hedge ratio
-//! rather than refitted, so entry and exit measure the same spread.
+//! Quadratic in the eligible universe, so everything cheap runs first: the confidence floor and the
+//! shortable check shrink the input before a single correlation is computed.
 
 use std::collections::{HashMap, HashSet};
 

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -1,7 +1,7 @@
 //! Pair selection: which two symbols, which way round, and how strong the signal.
 //!
-//! Quadratic in the eligible universe, so everything cheap runs first: the confidence floor and the
-//! shortable check shrink the input before a single correlation is computed.
+//! Quadratic in the eligible universe, so the cheap tests come first: the confidence floor shrinks
+//! the input, and a pair with no shortable leg is skipped before its correlation is computed.
 
 use std::collections::{HashMap, HashSet};
 

--- a/src/portfolio/size.rs
+++ b/src/portfolio/size.rs
@@ -1,16 +1,5 @@
 //! Position sizing: fixed-fraction, equal-weight, both legs the same dollar amount.
-//!
-//! Each pair is allocated the same slice of equity whether the book holds one pair or ten, so a
-//! pair's size does not change when an unrelated pair closes. The consequence, and it is
-//! deliberate: a book holding three of ten slots runs at roughly three tenths of its exposure
-//! target rather than concentrating the full target into the pairs that happen to be open.
-//!
-//! **Both legs get equal notional, not hedge-ratio-weighted notional.** The hedge ratio decides
-//! where the spread's mean is, not how much to buy. Sizing the short at `hedge_ratio x` the long
-//! would make the book hedge-ratio-neutral rather than dollar-neutral — a larger claim about what
-//! the two legs share than this version can support.
 
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use std::num::NonZeroU32;
 use tracing::{debug, warn};
@@ -35,11 +24,16 @@ const LEGS_PER_PAIR: u32 = 2;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SizingParameters {
     maximum_concurrent_pairs: usize,
-    gross_exposure_multiple: f64,
+    gross_exposure_multiple: Decimal,
 }
 
 impl SizingParameters {
     /// Constructs parameters, rejecting values that cannot describe a book.
+    ///
+    /// The multiple is converted to `Decimal` once, here, and stored that way. Both places that use
+    /// it multiply an equity by it, and a conversion at either would have to decide what an
+    /// unrepresentable value means — `gross_exposure_cap` answered zero, which silently refuses
+    /// every entry rather than reporting anything. Rejecting it at construction removes the choice.
     pub fn new(maximum_concurrent_pairs: usize, gross_exposure_multiple: f64) -> Option<Self> {
         if maximum_concurrent_pairs == 0 {
             return None;
@@ -49,7 +43,7 @@ impl SizingParameters {
         }
         Some(Self {
             maximum_concurrent_pairs,
-            gross_exposure_multiple,
+            gross_exposure_multiple: Decimal::from_f64_retain(gross_exposure_multiple)?,
         })
     }
 
@@ -77,21 +71,24 @@ impl SizingParameters {
         self.maximum_concurrent_pairs
     }
 
-    pub fn gross_exposure_multiple(&self) -> f64 {
+    pub fn gross_exposure_multiple(&self) -> Decimal {
         self.gross_exposure_multiple
     }
 
     /// The dollar notional allocated to one leg of one pair.
     ///
-    /// `equity x multiple / (pairs x 2)`. Returns `None` for non-positive equity, which is an
-    /// account that cannot open anything.
+    /// `equity x multiple / (pairs x 2)`. The denominator is every slot, not the vacant ones, so a
+    /// pair's size does not change when an unrelated pair closes. The consequence is deliberate: a
+    /// book holding three of ten slots runs at roughly three tenths of its exposure target rather
+    /// than concentrating the full target into whichever pairs happen to be open.
+    ///
+    /// Returns `None` for non-positive equity, which is an account that cannot open anything.
     pub fn notional_per_leg(&self, equity: Decimal) -> Option<Dollars> {
         if equity <= Decimal::ZERO {
             return None;
         }
-        let multiple = Decimal::from_f64_retain(self.gross_exposure_multiple)?;
         let slots = Decimal::from(self.maximum_concurrent_pairs as u64 * LEGS_PER_PAIR as u64);
-        Dollars::new((equity * multiple / slots).round_dp(2)).ok()
+        Dollars::new((equity * self.gross_exposure_multiple / slots).round_dp(2)).ok()
     }
 }
 
@@ -151,11 +148,16 @@ impl SizedPair {
 
 /// Sizes one candidate against a per-leg budget.
 ///
+/// **Both legs get equal notional, not hedge-ratio-weighted notional.** The hedge ratio decides
+/// where the spread's mean is, not how much to buy. Sizing the short at `hedge_ratio x` the long
+/// would make the book hedge-ratio-neutral rather than dollar-neutral — a larger claim about what
+/// the two legs share than this version can support.
+///
 /// Returns `None` when the short leg would round to zero shares — a symbol priced above the per-leg
 /// budget. That pair cannot be opened dollar-neutral at this account size, and opening the long leg
 /// alone would be a naked directional position rather than a spread.
 pub fn size_pair(candidate: &PairCandidate, notional_per_leg: Dollars) -> Option<SizedPair> {
-    let budget = notional_per_leg.value().to_f64()?;
+    let budget = notional_per_leg.value().as_f64();
     let short_price = candidate.short_price();
     if !short_price.is_finite() || short_price <= 0.0 {
         return None;
@@ -266,6 +268,20 @@ mod tests {
         assert_eq!(SizingParameters::new(0, 1.0), None);
         assert_eq!(SizingParameters::new(10, 0.0), None);
         assert_eq!(SizingParameters::new(10, f64::NAN), None);
+    }
+
+    /// A multiple past `Decimal`'s range is finite and positive, so the two other checks admit it.
+    /// It used to reach `gross_exposure_cap`, whose conversion failed and answered zero — a cap of
+    /// zero refuses every entry, and nothing said why. Rejecting it here is what makes the cap
+    /// infallible.
+    #[test]
+    fn test_parameters_reject_a_multiple_no_decimal_can_hold() {
+        assert!(
+            1e300_f64.is_finite(),
+            "the fixture must clear the other checks"
+        );
+        assert_eq!(SizingParameters::new(10, 1e300), None);
+        assert!(SizingParameters::new(10, 1.5).is_some());
     }
 
     #[test]

--- a/src/portfolio/size.rs
+++ b/src/portfolio/size.rs
@@ -16,6 +16,14 @@ pub const MAXIMUM_CONCURRENT_PAIRS: usize = 10;
 /// the strategy does not ask for it.
 pub const GROSS_EXPOSURE_MULTIPLE: f64 = 1.0;
 
+/// The largest multiple a configuration may ask for.
+///
+/// Reg T allows two and portfolio margin about six, so a hundred is far past anything this book
+/// would run. It is a bound rather than a preference: `equity x multiple` is a bare `Decimal`
+/// product in two places, and a multiple `Decimal` can hold but the product cannot would panic
+/// mid-session — reachable from `GROSS_EXPOSURE_MULTIPLE` in the environment.
+const MAXIMUM_GROSS_EXPOSURE_MULTIPLE: f64 = 100.0;
+
 /// Legs per pair. Named because it is what turns a per-pair budget into a per-leg one, and a stray
 /// factor of two in a sizing calculation is not visible in the result.
 const LEGS_PER_PAIR: u32 = 2;
@@ -30,15 +38,17 @@ pub struct SizingParameters {
 impl SizingParameters {
     /// Constructs parameters, rejecting values that cannot describe a book.
     ///
-    /// The multiple is converted to `Decimal` once, here, and stored that way. Both places that use
-    /// it multiply an equity by it, and a conversion at either would have to decide what an
-    /// unrepresentable value means — `gross_exposure_cap` answered zero, which silently refuses
-    /// every entry rather than reporting anything. Rejecting it at construction removes the choice.
+    /// The multiple is converted to `Decimal` once here and stored that way, so that neither place
+    /// that multiplies an equity by it has to decide what an unrepresentable or overflowing value
+    /// means.
     pub fn new(maximum_concurrent_pairs: usize, gross_exposure_multiple: f64) -> Option<Self> {
         if maximum_concurrent_pairs == 0 {
             return None;
         }
-        if !gross_exposure_multiple.is_finite() || gross_exposure_multiple <= 0.0 {
+        if !gross_exposure_multiple.is_finite()
+            || gross_exposure_multiple <= 0.0
+            || gross_exposure_multiple > MAXIMUM_GROSS_EXPOSURE_MULTIPLE
+        {
             return None;
         }
         Some(Self {
@@ -77,12 +87,9 @@ impl SizingParameters {
 
     /// The dollar notional allocated to one leg of one pair.
     ///
-    /// `equity x multiple / (pairs x 2)`. The denominator is every slot, not the vacant ones, so a
-    /// pair's size does not change when an unrelated pair closes. The consequence is deliberate: a
-    /// book holding three of ten slots runs at roughly three tenths of its exposure target rather
-    /// than concentrating the full target into whichever pairs happen to be open.
-    ///
-    /// Returns `None` for non-positive equity, which is an account that cannot open anything.
+    /// `equity x multiple / (pairs x 2)`, where the denominator counts every slot rather than the
+    /// vacant ones, so a book holding three of ten runs at roughly three tenths of its exposure
+    /// target instead of concentrating it. `None` for non-positive equity.
     pub fn notional_per_leg(&self, equity: Decimal) -> Option<Dollars> {
         if equity <= Decimal::ZERO {
             return None;
@@ -148,14 +155,9 @@ impl SizedPair {
 
 /// Sizes one candidate against a per-leg budget.
 ///
-/// **Both legs get equal notional, not hedge-ratio-weighted notional.** The hedge ratio decides
-/// where the spread's mean is, not how much to buy. Sizing the short at `hedge_ratio x` the long
-/// would make the book hedge-ratio-neutral rather than dollar-neutral — a larger claim about what
-/// the two legs share than this version can support.
-///
-/// Returns `None` when the short leg would round to zero shares — a symbol priced above the per-leg
-/// budget. That pair cannot be opened dollar-neutral at this account size, and opening the long leg
-/// alone would be a naked directional position rather than a spread.
+/// **Both legs get equal notional, not hedge-ratio-weighted notional**, which makes the book
+/// dollar-neutral rather than hedge-ratio-neutral. `None` when the short leg would round to zero
+/// shares, since opening the long alone would be a directional position rather than a spread.
 pub fn size_pair(candidate: &PairCandidate, notional_per_leg: Dollars) -> Option<SizedPair> {
     let budget = notional_per_leg.value().as_f64();
     let short_price = candidate.short_price();
@@ -282,6 +284,27 @@ mod tests {
         );
         assert_eq!(SizingParameters::new(10, 1e300), None);
         assert!(SizingParameters::new(10, 1.5).is_some());
+    }
+
+    /// The window between the two: `Decimal` holds 1e25 comfortably, so it survived construction,
+    /// and then `equity x multiple` overflowed and the bare product panicked mid-session. Reachable
+    /// from `GROSS_EXPOSURE_MULTIPLE` in the environment, which is why the ceiling is a bound at
+    /// construction rather than a checked multiply at each of the two use sites.
+    #[test]
+    fn test_parameters_reject_a_multiple_that_would_overflow_against_equity() {
+        let equity = Decimal::from_str_exact("20097.84").expect("a representable equity");
+        let admitted_by_decimal =
+            Decimal::from_f64_retain(1e25).expect("Decimal holds 1e25 on its own");
+        assert_eq!(
+            equity.checked_mul(admitted_by_decimal),
+            None,
+            "the product is what overflows, not the multiple"
+        );
+
+        assert_eq!(SizingParameters::new(10, 1e25), None);
+        assert_eq!(SizingParameters::new(10, 101.0), None);
+        assert!(SizingParameters::new(10, 100.0).is_some());
+        assert!(SizingParameters::new(10, 6.0).is_some());
     }
 
     #[test]


### PR DESCRIPTION
# Overview

Last of the five modules read against the checklist in `.scratchpad/module_review.md`, after `common/` (#1075), the dashboard (#1076), `data/` (#1077), and `models/` (#1078). Small, and that reflects the module rather than the pass: validated constructors, enums carrying their own numbers, and the observe/decide/apply split with pure `decide` functions were already here.

## Changes

**`SizingParameters.gross_exposure_multiple` becomes a `Decimal`, converted once in `new`.** It was an `f64` that both readers had to convert at the point of use, and `gross_exposure_cap` swallowed a failed conversion into `Decimal::ZERO` — a cap of zero refuses every entry, with nothing recorded to say why. Converting at construction removes the choice: the value is rejected where a rejection is still legible, and both uses are then infallible.

**A broken intra-doc link at `account.rs:34`**, pointing at `windowed_activity_types`, which is `ActivityType::windowed`.

**`account::session_bounds` deleted** — a one-line passthrough to `SessionDate::bounds` with no caller outside its own test.

**`to_f64()?` becomes `as_f64()`** in `size.rs` and `risk.rs`, where `to_f64` is `Some(self.as_f64())` and the `None` arm was unreachable.

Also: four stale "session log" references and the `log` test bindings in `execute.rs` follow the journal rename, and five module headers come down to the three-line ceiling — with the load-bearing content **relocated onto the items it describes** rather than deleted, since a claim like "both legs get equal notional, not hedge-ratio-weighted notional" belongs on the sizing function and not in a header nobody opens.

## Context

Rebased with `--onto master ad52d30b`, replaying only the `portfolio/` commit, as `models-cleanup` needed before it. No conflicts.

One hunk dropped as already-applied: this commit originally carried the fix for the dangling `SessionDate::plus_calendar_days` link that the `data/` review left behind by deleting `TradingCalendar::next_trading_day`. That fix travelled with #1077 instead, so `src/common/types.rs` is no longer in this diff and the commit subject no longer claims it. The paragraph explaining how it was found is kept, because it is why `cargo doc` is now in the checklist's verification list: a build, a lint, and the whole test suite pass with a dangling link.

Verified against the live account and the real database rather than fixtures. Equity 20097.84 and the 2026-08-15 close of 20141.37 came from `/v2/account` and `/v2/account/portfolio/history`; run through the changed arithmetic they give a gross exposure cap of 20097.84, a per-leg notional of 1004.89 across ten slots, and a drawdown of 0.216%. The 13 real closed pairs in `equity_pairs` loaded through `pairs::load_closed_between` and split 3 signal exits to 10 end-of-day, which exercises `CloseReason::is_signal` on stored values.

**Not exercised against real data:** the attribution path in `account.rs`. `account_activities` and `account_snapshots` are both empty locally, so the equity above had to come from Alpaca directly rather than from a stored snapshot, and nothing here drove a real fill.

685 tests pass, `cargo fmt` and `cargo doc` are clean, the sqlx cache is unchanged, and clippy sits at the one pre-existing `redundant_closure` in `tests/test_handlers.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exposure and drawdown calculations for more consistent risk decisions.
  * Invalid or excessively large exposure settings are now rejected.
  * Risk controls continue to allow exits without restriction.

* **Documentation**
  * Clarified portfolio evaluation, execution order, screening, position data, and realized P&L behavior.
  * Updated guidance on position sizing across pair slots and equal allocation between legs.

* **Refactor**
  * Removed the unused session-boundary helper.
  * Improved precision and consistency for exposure and position-sizing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->