### PR TITLE
Type the exported datasets, journal the export, and ship the logs

### DIFF
--- a/src/common/crypto.rs
+++ b/src/common/crypto.rs
@@ -1,21 +1,15 @@
 //! Process-wide TLS crypto provider selection.
 //!
-//! The dependency graph pulls in Rustls transitively and enables *both* the `aws-lc-rs` and `ring`
-//! providers. With more than one linked, Rustls cannot pick a process default, and the first client
-//! configuration that needs one panics. Requests run as spawned tasks, so the panic surfaces as a
-//! failed task rather than a crash — a large sync comes back truncated instead of erroring.
-//!
-//! Every service binary calls [`install_default_crypto_provider`] as the first statement in `main`,
-//! before any TLS client is constructed.
+//! Every service binary calls [`install_default_crypto_provider`] first thing in `main`.
 
 use rustls::crypto::aws_lc_rs;
 
 /// Installs the `aws-lc-rs` Rustls [`CryptoProvider`](rustls::crypto::CryptoProvider)
 /// as the process default.
 ///
-/// Idempotent: `install_default` returns `Err` if a provider is already
-/// installed, which is exactly the desired end state, so the result is ignored.
-/// Safe to call from multiple binaries or more than once.
+/// The graph links both `aws-lc-rs` and `ring`, so Rustls cannot pick a default itself and the
+/// first client configuration needing one panics — inside a spawned task, which surfaces as a
+/// truncated sync rather than a crash. Idempotent, so calling it from every binary is correct.
 pub fn install_default_crypto_provider() {
     let _ = aws_lc_rs::default_provider().install_default();
 }

--- a/src/common/database.rs
+++ b/src/common/database.rs
@@ -1,8 +1,7 @@
 //! PostgreSQL connection handling.
 //!
-//! The service cannot do anything useful without a database — every command arrives through it and
-//! every result is written back to it — so connecting is fallible at startup rather than optional
-//! at runtime. There is no degraded mode to fall back to.
+//! Connecting is fallible at startup rather than optional at runtime: every command arrives
+//! through the database, so there is no degraded mode to fall back to.
 
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -1,14 +1,6 @@
 //! The event bus: six commands, three outcomes, and the scan that recovers missed work.
 //!
-//! pg_cron writes `<command>_requested` rows into the `events` table. A trigger fires `pg_notify`,
-//! the service's listener wakes, dispatches, and writes back `<command>_completed` or
-//! `<command>_errored` with a payload describing what happened. That is the entire coordination
-//! mechanism — there is no queue, no offset table, and no in-memory scheduling.
-//!
-//! There is deliberately no `started` outcome — nothing would read it that the logs do not answer.
-//!
-//! The table doubles as the restart recovery mechanism: a `_requested` row with no terminal outcome
-//! is work issued and never finished. See [`recover_missed_commands`].
+//! The `events` table is the entire coordination mechanism. There is no queue and no scheduler.
 
 use serde_json::Value;
 use sqlx::PgPool;
@@ -37,6 +29,12 @@ pub enum Command {
     MarketDataSync,
     /// Chained from a completed market data sync: export to S3 parquet, then purge.
     DatabaseExport,
+}
+
+impl serde::Serialize for Command {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
 }
 
 /// How a command reached its end state.
@@ -244,9 +242,10 @@ pub async fn emit_errored(pool: &PgPool, command: Command, error: &str) -> Resul
 /// Finds commands requested during the current Eastern trading date that never reached a terminal
 /// outcome, and which should be re-run.
 ///
-/// This replaces a consumer offset table. A `_requested` row with no terminal outcome is work
-/// issued and never finished — what a process killed mid-handler leaves behind, and equally what a
-/// process not running when cron fired leaves behind. Both want the same response.
+/// This replaces a consumer offset table, and is why the `events` table needs no queue beside it.
+/// A `_requested` row with no terminal outcome is work issued and never finished — what a process
+/// killed mid-handler leaves behind, and equally what a process not running when cron fired leaves
+/// behind. Both want the same response.
 ///
 /// [`Recovery::Skip`] commands are found and dropped, so the caller receives only work worth doing.
 ///

--- a/src/common/journal.rs
+++ b/src/common/journal.rs
@@ -839,12 +839,15 @@ pub struct JournalExported {
 pub struct LogsExported {
     pub files_exported: usize,
     pub lines_exported: usize,
-    /// Services whose upload failed, which stay on local disk for the next run.
+    /// How many files did not upload; each stays on local disk for the next run.
     pub files_failed: usize,
-    /// Dates deleted from local disk, which had uploaded cleanly and aged out.
-    pub dates_deleted: Vec<NaiveDate>,
+    /// How many aged out and were deleted, counted per file rather than per date — one service
+    /// ageing out does not carry another's away.
+    pub files_deleted: usize,
     /// Lines the Parquet does not hold, which keep their file from being deleted.
     pub unparsable_lines: usize,
+    /// Set when the log directory could not be listed at all, which a count of zero cannot express.
+    pub directory_error: Option<String>,
 }
 
 /// One run of the nightly database export and the purge chained behind it.

--- a/src/common/journal.rs
+++ b/src/common/journal.rs
@@ -20,7 +20,7 @@ use crate::common::types::{CloseReason, Dataset, PairID, SessionDate, Ticker};
 ///
 /// Readers map old versions forward rather than rewriting files, so this only ever goes up. What
 /// each version held is documented beside the DuckDB view in `tools/duckdb_initialization.sql`.
-pub const SCHEMA_VERSION: u32 = 4;
+pub const SCHEMA_VERSION: u32 = 5;
 
 /// Anything that stops a record reaching the disk.
 #[derive(Debug, thiserror::Error)]
@@ -1322,7 +1322,7 @@ mod tests {
         );
         let value: Value = serde_json::to_value(&record).expect("record must serialize");
 
-        assert_eq!(value["schema_version"], Value::Number(4.into()));
+        assert_eq!(value["schema_version"], Value::Number(5.into()));
         assert_eq!(value["event_type"], "account_observed");
         assert_eq!(value["session_date"], "2026-08-11");
         assert_eq!(value["timestamp"], "2026-08-11T20:15:00Z");

--- a/src/common/journal.rs
+++ b/src/common/journal.rs
@@ -13,7 +13,8 @@ use tracing::{debug, error};
 use uuid::Uuid;
 
 use crate::common::alpaca::{ActivityType, OrderSide, PositionSide, PriceSource, QuoteRejection};
-use crate::common::types::{CloseReason, PairID, SessionDate, Ticker};
+use crate::common::events::Command;
+use crate::common::types::{CloseReason, Dataset, PairID, SessionDate, Ticker};
 
 /// Version stamped on every record written by this build.
 ///
@@ -64,6 +65,8 @@ pub enum Observation {
     UniverseRefreshed(UniverseRefreshed),
     CalendarObserved(CalendarObserved),
     JournalExported(JournalExported),
+    DatabaseExported(DatabaseExported),
+    LogsExported(LogsExported),
 }
 
 impl Observation {
@@ -91,6 +94,8 @@ impl Observation {
             Observation::UniverseRefreshed(_) => "universe_refreshed",
             Observation::CalendarObserved(_) => "calendar_observed",
             Observation::JournalExported(_) => "journal_exported",
+            Observation::DatabaseExported(_) => "database_exported",
+            Observation::LogsExported(_) => "logs_exported",
         }
     }
 }
@@ -155,7 +160,7 @@ impl Serialize for CommandOutcome {
 /// the command did, which is what makes the duration attributable.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct CommandFinished {
-    pub command: String,
+    pub command: Command,
     pub outcome: CommandOutcome,
     /// Absent for a command that never ran.
     pub duration_milliseconds: Option<u64>,
@@ -826,6 +831,39 @@ pub struct JournalExported {
     pub unparsable_lines: usize,
 }
 
+/// One run of the seal-free ship-delete cycle over the diagnostic logs.
+///
+/// Unlike [`JournalExported`], today's files are still open: what ships is a snapshot the next run
+/// replaces, so a count here rising for the same date is ordinary rather than a duplicate.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct LogsExported {
+    pub files_exported: usize,
+    pub lines_exported: usize,
+    /// Services whose upload failed, which stay on local disk for the next run.
+    pub files_failed: usize,
+    /// Dates deleted from local disk, which had uploaded cleanly and aged out.
+    pub dates_deleted: Vec<NaiveDate>,
+    /// Lines the Parquet does not hold, which keep their file from being deleted.
+    pub unparsable_lines: usize,
+}
+
+/// One run of the nightly database export and the purge chained behind it.
+///
+/// The purge is gated on the export being clean, so `rows_purged` being absent while datasets
+/// exported is the skip rather than a failure — `purge_skipped` is what tells the two apart.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DatabaseExported {
+    pub session_date: SessionDate,
+    /// `(dataset, rows)` for each table written to S3.
+    pub exported: Vec<(Dataset, usize)>,
+    /// `(dataset, error)` for each table that did not write.
+    pub failed: Vec<(Dataset, String)>,
+    /// `(dataset, rows)` deleted from PostgreSQL once S3 held them.
+    pub purged: Vec<(Dataset, u64)>,
+    /// True when the export was incomplete and the purge was therefore not attempted.
+    pub purge_skipped: bool,
+}
+
 /// One line of the journal: an observation with the envelope that makes it addressable.
 ///
 /// `session_date` is derived from `timestamp`, so a record cannot be filed under a session it did
@@ -1059,6 +1097,8 @@ mod tests {
                 Observation::UniverseRefreshed(_) => "universe_refreshed",
                 Observation::CalendarObserved(_) => "calendar_observed",
                 Observation::JournalExported(_) => "journal_exported",
+                Observation::DatabaseExported(_) => "database_exported",
+                Observation::LogsExported(_) => "logs_exported",
             }
         }
 
@@ -1084,7 +1124,7 @@ mod tests {
     fn every_observation() -> Vec<Observation> {
         vec![
             Observation::CommandFinished(CommandFinished {
-                command: "portfolio_evaluation".to_string(),
+                command: Command::PortfolioEvaluation,
                 outcome: CommandOutcome::Completed,
                 duration_milliseconds: Some(12),
                 error: None,
@@ -1208,6 +1248,14 @@ mod tests {
                 }],
             }),
             Observation::JournalExported(JournalExported::default()),
+            Observation::DatabaseExported(DatabaseExported {
+                session_date: session(2026, 8, 17),
+                exported: vec![(Dataset::Events, 240)],
+                failed: Vec::new(),
+                purged: vec![(Dataset::Events, 180)],
+                purge_skipped: false,
+            }),
+            Observation::LogsExported(LogsExported::default()),
         ]
     }
 

--- a/src/common/log.rs
+++ b/src/common/log.rs
@@ -12,6 +12,16 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 /// The journal is the opposite and lives on its own path for that reason.
 pub const DEFAULT_LOG_DIRECTORY: &str = "/var/log/fund";
 
+/// Where the rolling daily files are written.
+///
+/// Read here rather than at each call site so the writer and [`crate::data::export::export_logs`]
+/// cannot disagree about which directory holds the files being shipped.
+pub fn log_directory() -> std::path::PathBuf {
+    env::var("FUND_LOG_DIRECTORY")
+        .unwrap_or_else(|_| DEFAULT_LOG_DIRECTORY.to_string())
+        .into()
+}
+
 /// Initialize structured JSON tracing for `service`, to stdout at `RUST_LOG` (default `info`) and
 /// to a rolling daily file under `FUND_LOG_DIRECTORY`.
 ///
@@ -35,8 +45,7 @@ pub fn init_tracing(
             .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
     };
 
-    let log_directory =
-        env::var("FUND_LOG_DIRECTORY").unwrap_or_else(|_| DEFAULT_LOG_DIRECTORY.to_string());
+    let log_directory = log_directory();
     let guard = match std::fs::create_dir_all(&log_directory).and_then(|()| {
         RollingFileAppender::builder()
             .rotation(Rotation::DAILY)
@@ -96,8 +105,7 @@ pub fn init_tracing(
 pub fn init_tracing_file_only(log_file: &str, service: &str) -> Option<WorkerGuard> {
     let fund_profile = env::var("FUND_PROFILE").unwrap_or_else(|_| "unknown".to_string());
 
-    let log_directory =
-        env::var("FUND_LOG_DIRECTORY").unwrap_or_else(|_| DEFAULT_LOG_DIRECTORY.to_string());
+    let log_directory = log_directory();
     let guard = match std::fs::create_dir_all(&log_directory).and_then(|()| {
         RollingFileAppender::builder()
             .rotation(Rotation::DAILY)

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -1,11 +1,6 @@
 //! The domain vocabulary every module speaks.
 //!
-//! **Validated primitives** wrap standard Rust types so a unit mismatch is a compile error and
-//! sign and range constraints are enforced by the constructor. **Record types** mirror the
-//! PostgreSQL tables and Alpaca payloads.
-//!
-//! Both keep fields private and validate in the constructor, so a value in scope is proof its
-//! invariants held and downstream code never re-checks.
+//! Fields are private and constructors validate, so a value in scope is proof its invariants held.
 
 use chrono::{DateTime, Datelike, Duration, NaiveDate, TimeZone, Utc};
 use chrono_tz::America::New_York;
@@ -72,6 +67,57 @@ pub mod decimal_number_option {
             Some(raw) => Decimal::try_from(raw).map(Some).map_err(de::Error::custom),
             None => Ok(None),
         }
+    }
+}
+
+/// A PostgreSQL table the nightly export ships to S3.
+///
+/// The stored name and the S3 prefix travel together because they are one decision: a dataset
+/// written under another's prefix is a silent overwrite, and neither half is checkable from the
+/// other. [`crate::data::purge`] deletes from a subset of these, which is what makes deleting safe — a table it
+/// could name but the export could not would have no copy anywhere.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Dataset {
+    Events,
+    EquityPredictions,
+    EquityPairs,
+    AccountSnapshots,
+    AccountActivities,
+}
+
+impl Dataset {
+    /// The PostgreSQL table name, which is also how the dataset is reported.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Dataset::Events => "events",
+            Dataset::EquityPredictions => "equity_predictions",
+            Dataset::EquityPairs => "equity_pairs",
+            Dataset::AccountSnapshots => "account_snapshots",
+            Dataset::AccountActivities => "account_activities",
+        }
+    }
+
+    /// The S3 prefix this dataset is written under.
+    pub fn prefix(self) -> &'static str {
+        match self {
+            Dataset::Events => "exports/events",
+            Dataset::EquityPredictions => "exports/equity/predictions",
+            Dataset::EquityPairs => "exports/equity/pairs",
+            Dataset::AccountSnapshots => "exports/account/snapshots",
+            Dataset::AccountActivities => "exports/account/activities",
+        }
+    }
+}
+
+impl std::fmt::Display for Dataset {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl serde::Serialize for Dataset {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
     }
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,16 +1,6 @@
-//! Market data and storage.
+//! Market data and storage, across two S3 prefixes with one owner each.
 //!
-//! [`calendar`] and [`universe`] are fetched once and held for the Eastern date; neither changes
-//! intraday. [`bars`] is shared with the trainer, which has no database and writes the same frames
-//! to S3 — that shared path keeps the training and inference datasets structurally identical.
-//! [`export`] and [`purge`] run in that order and never the reverse.
-//!
-//! Two S3 prefixes with one owner each. [`archive`] owns `data/`, the trainer's bars and the long-
-//! term record of them; [`export`] owns `exports/`, the application's own tables, which the purge
-//! deletes from PostgreSQL only once they are safely written. Neither writes the other's prefix.
-//!
-//! [`export`] also seals and ships [`crate::common::journal`], the local original that both
-//! PostgreSQL and S3 are derived from.
+//! [`archive`] owns `data/`; [`export`] owns `exports/`. Neither writes the other's prefix.
 
 pub mod adjust;
 pub mod archive;

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -1,25 +1,6 @@
 //! The S3 bar archive: the trainer's data, repaired to a window rather than topped up by a night.
 //!
-//! One partition per session under `data/equity/bars/year=/month=/day=/data.parquet`, written by
-//! whoever holds Massive credentials — the seeder on a cold bucket, the trainer every night. Both
-//! call [`archive_missing_sessions`], because two implementations of this would drift the way the
-//! trainer's fetch and load stages once did over Eastern versus UTC dates.
-//!
-//! **What gets fetched is a set difference, not a lookback.** The archive is asked what it already
-//! has; everything expected and absent is fetched. A missed night, a week of downtime, and an empty
-//! bucket are then the same case handled the same way, where a fixed lookback repairs only the
-//! first of the three and leaves the others as permanent holes.
-//!
-//! **Expected means "worth requesting", not "the market traded".** [`TradingCalendar`] is fetched
-//! from Alpaca, and the trainer deliberately holds no broker credentials, so this uses
-//! [`SessionDate::is_weekend`] — which its own documentation blesses for exactly this, bounding a
-//! fetch range before a calendar is available. Nothing here concludes a date traded: a holiday is
-//! requested, Massive answers with nothing, no partition is written, and it is requested again next
-//! run. The partition that exists is the evidence; the request set is only a guess about where to
-//! look. The cost is roughly ten empty requests a year, which [`ArchiveSummary`] reports rather
-//! than hides.
-//!
-//! [`TradingCalendar`]: crate::data::calendar::TradingCalendar
+//! One partition per session under `data/equity/bars/year=/month=/day=/data.parquet`.
 
 use std::collections::BTreeSet;
 use std::io::Cursor;
@@ -253,6 +234,17 @@ async fn present_sessions(
 }
 
 /// Fetches and writes every session in `[window_start, window_end]` the archive is missing.
+///
+/// **A set difference, not a lookback.** The archive is asked what it already has and everything
+/// expected and absent is fetched, so a missed night, a week of downtime, and an empty bucket are
+/// one case; a fixed lookback repairs only the first and leaves the rest as permanent holes.
+///
+/// **Expected means "worth requesting", not "the market traded".** The trainer holds no broker
+/// credentials and so cannot consult [`crate::data::calendar::TradingCalendar`], which is why this
+/// bounds the range with [`SessionDate::is_weekend`] and lets a holiday be requested, answered with
+/// nothing, and requested again. The partition that exists is the evidence; the request set is only
+/// a guess about where to look, and the roughly ten empty requests a year are reported rather than
+/// hidden.
 ///
 /// Idempotent: a second pass over an unchanged window requests only the correction window and
 /// writes the same rows back. Safe to interrupt, because partitions are written as each chunk

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -235,16 +235,11 @@ async fn present_sessions(
 
 /// Fetches and writes every session in `[window_start, window_end]` the archive is missing.
 ///
-/// **A set difference, not a lookback.** The archive is asked what it already has and everything
-/// expected and absent is fetched, so a missed night, a week of downtime, and an empty bucket are
-/// one case; a fixed lookback repairs only the first and leaves the rest as permanent holes.
-///
-/// **Expected means "worth requesting", not "the market traded".** The trainer holds no broker
-/// credentials and so cannot consult [`crate::data::calendar::TradingCalendar`], which is why this
-/// bounds the range with [`SessionDate::is_weekend`] and lets a holiday be requested, answered with
-/// nothing, and requested again. The partition that exists is the evidence; the request set is only
-/// a guess about where to look, and the roughly ten empty requests a year are reported rather than
-/// hidden.
+/// **A set difference, not a lookback**, so a missed night, a week of downtime, and an empty bucket
+/// are one case where a fixed lookback repairs only the first. Expected means "worth requesting"
+/// rather than "the market traded", since the trainer holds no broker credentials to consult a
+/// calendar with: a holiday is requested, answered with nothing, and requested again, at a cost of
+/// roughly ten empty requests a year that [`ArchiveSummary`] reports rather than hides.
 ///
 /// Idempotent: a second pass over an unchanged window requests only the correction window and
 /// writes the same rows back. Safe to interrupt, because partitions are written as each chunk

--- a/src/data/bars.rs
+++ b/src/data/bars.rs
@@ -1,11 +1,6 @@
-//! Equity bars: one fetch from Massive, three destinations.
+//! Equity bars, from Massive rather than Alpaca; see [`crate::common::massive`] for why.
 //!
-//! The application writes bars to PostgreSQL after the close; the trainer writes the same bars to
-//! S3 parquet. Both go through [`fetch_daily_bars`] and [`bars_to_dataframe`] — if the two
-//! diverged, the model would train on columns the inference path does not produce and it would
-//! surface as bad predictions rather than a build error.
-//!
-//! Bars come from Massive rather than Alpaca; see [`crate::common::massive`].
+//! The application writes them to PostgreSQL and the trainer to S3, through one shared path.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;

--- a/src/data/calendar.rs
+++ b/src/data/calendar.rs
@@ -1,16 +1,6 @@
-//! The trading calendar, as Alpaca publishes it.
+//! The trading calendar, as Alpaca publishes it, in Eastern local time throughout.
 //!
-//! Two questions get asked constantly — does the market trade today, and when does it close — and
-//! both are answered from a calendar fetched once and held in memory for the Eastern date. It is
-//! deliberately not persisted: the calendar is reference data Alpaca owns, and a stored copy is
-//! just a second source that can disagree.
-//!
-//! There is deliberately no hardcoded holiday fallback: one cannot express a half-day, and it
-//! would make an unreachable Alpaca look like a normal trading day. **An absent calendar means "do
-//! not trade", not "assume open"** — [`TradingCalendar::is_trading_day`] answers `false` outside
-//! its horizon.
-//!
-//! Everything here is Eastern local time, because that is the timezone the trading day actually has.
+//! Never persisted: it is reference data Alpaca owns, and a stored copy is a second source.
 
 use std::collections::BTreeMap;
 

--- a/src/data/details.rs
+++ b/src/data/details.rs
@@ -1,11 +1,6 @@
-//! Ticker metadata: sector and industry.
+//! Ticker metadata: sector and industry, which is what makes the screen's sector cap bind.
 //!
-//! The pair screen caps how many legs the book may hold in one sector, so without this every ticker
-//! is uncategorized, the cap binds on nothing, and ten pairs can be one industry bet held ten times.
-//!
-//! Seeded from `data/equity_details.csv`, embedded at compile time so a fresh database needs no
-//! network. Alpaca does not publish sector or industry, so the post-close sync refreshes only
-//! tickers that have appeared or been delisted.
+//! Seeded from a CSV embedded at compile time, because Alpaca publishes neither field.
 
 use std::collections::HashMap;
 

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -1,28 +1,8 @@
-//! Nightly export of the application's own tables to S3 as Parquet.
+//! Nightly export of what only this application knows: its own tables, its journal, and its logs.
 //!
-//! Chained from a completed market data sync rather than scheduled, so it can never run against a
-//! half-synced database. Everything it writes is archival: the trainer fetches its own data from
-//! Massive, so a failed export costs a backup rather than the next day's model.
-//!
-//! **Bars and ticker metadata are deliberately absent.** Both used to be exported here and both are
-//! written by the trainer under `data/`, from the same Massive grouped endpoint this application
-//! syncs from — the same rows by two paths, and two writers of one fact is one too many. The
-//! archive under [`crate::data::archive`] owns them and is their long-term record; what remains
-//! here is what only this application knows.
-//!
-//! Two shapes. **Incremental** tables — events, predictions, account activities — are written per
-//! session date under a Hive-partitioned key. **Snapshot** tables — pairs, account state — are
-//! written whole each night, because a row can change after the day it was created (a pair opened
-//! Monday closes Tuesday, and the closing is the interesting part).
-//!
-//! A failure on one table is logged and the rest continue; the caller receives the list so the
-//! completion event can report it. That list is also the purge's gate: [`crate::data::purge`] runs
-//! only when every dataset here wrote cleanly.
-//!
-//! [`export_journals`] ships a third shape: whole local JSONL files, one object per session,
-//! independent of the database entirely.
+//! Chained from a completed market data sync rather than scheduled, so it never runs mid-sync.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client as S3Client;
@@ -34,15 +14,15 @@ use tracing::{info, warn};
 
 use crate::common::aws::date_partitioned_key;
 use crate::common::journal::{file_name, session_from_file_name, Journal};
-use crate::common::types::SessionDate;
+use crate::common::types::{Dataset, SessionDate};
 
 /// What one nightly export accomplished.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ExportSummary {
     /// `(dataset, rows)` for each table that exported cleanly.
-    pub exported: Vec<(String, usize)>,
+    pub exported: Vec<(Dataset, usize)>,
     /// `(dataset, error)` for each table that failed.
-    pub failed: Vec<(String, String)>,
+    pub failed: Vec<(Dataset, String)>,
 }
 
 impl ExportSummary {
@@ -59,8 +39,11 @@ impl ExportSummary {
 
 /// Exports every table to S3 for `date`.
 ///
-/// Never returns `Err`: a per-table failure belongs in the summary, where the completion event can
-/// report it, rather than aborting the remaining tables and the purge that follows.
+/// Two shapes: the incremental tables are written per session date under a Hive-partitioned key,
+/// while pairs and account state are written whole each night, because a row can change after the
+/// day it was created — a pair opened Monday closes Tuesday, and the closing is the interesting
+/// part. Never returns `Err`: a per-table failure belongs in the summary, which is also the purge's
+/// gate, rather than aborting the tables behind it.
 pub async fn export_database(
     pool: &PgPool,
     s3_client: &S3Client,
@@ -70,20 +53,16 @@ pub async fn export_database(
     let mut summary = ExportSummary::default();
 
     macro_rules! export {
-        ($dataset:expr, $prefix:expr, $frame:expr) => {
+        ($dataset:expr, $frame:expr) => {
             match $frame.await {
                 Ok(mut frame) => {
-                    let key = date_partitioned_key($prefix, date.date());
+                    let key = date_partitioned_key($dataset.prefix(), date.date());
                     match write_frame(s3_client, bucket, &key, &mut frame).await {
-                        Ok(()) => summary
-                            .exported
-                            .push(($dataset.to_string(), frame.height())),
-                        Err(error) => summary.failed.push(($dataset.to_string(), error)),
+                        Ok(()) => summary.exported.push(($dataset, frame.height())),
+                        Err(error) => summary.failed.push(($dataset, error)),
                     }
                 }
-                Err(error) => summary
-                    .failed
-                    .push(($dataset.to_string(), error.to_string())),
+                Err(error) => summary.failed.push(($dataset, error.to_string())),
             }
         };
     }
@@ -92,21 +71,15 @@ pub async fn export_database(
     // keeps the predicate sargable; see `eastern_day_bounds`.
     let (start, end) = date.bounds();
 
-    export!("events", "exports/events", events_frame(pool, start, end));
+    export!(Dataset::Events, events_frame(pool, start, end));
     export!(
-        "equity_predictions",
-        "exports/equity/predictions",
+        Dataset::EquityPredictions,
         predictions_frame(pool, start, end)
     );
-    export!("equity_pairs", "exports/equity/pairs", pairs_frame(pool));
+    export!(Dataset::EquityPairs, pairs_frame(pool));
+    export!(Dataset::AccountSnapshots, account_snapshots_frame(pool));
     export!(
-        "account_snapshots",
-        "exports/account/snapshots",
-        account_snapshots_frame(pool)
-    );
-    export!(
-        "account_activities",
-        "exports/account/activities",
+        Dataset::AccountActivities,
         account_activities_frame(pool, start, end)
     );
 
@@ -118,7 +91,7 @@ pub async fn export_database(
         "Database export finished"
     );
     for (dataset, error) in &summary.failed {
-        warn!(dataset, error, "Dataset failed to export");
+        warn!(%dataset, error, "Dataset failed to export");
     }
     summary
 }
@@ -513,6 +486,245 @@ pub async fn export_journals(
     summary
 }
 
+/// S3 prefix the diagnostic logs are written under, partitioned by service.
+pub const LOG_PREFIX: &str = "exports/logs";
+
+/// Calendar days of exported logs kept on local disk.
+///
+/// The same window the journal keeps, for the same reason: long enough that a bad conversion can
+/// still be repaired from the original bytes.
+pub const LOG_RETENTION_DAYS: i64 = 7;
+
+/// What one log export run accomplished.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct LogExportSummary {
+    /// `(date, service, lines)` for each file written to S3.
+    pub exported: Vec<(NaiveDate, String, usize)>,
+    /// `(date, service, error)` for each file that did not write.
+    pub failed: Vec<(NaiveDate, String, String)>,
+    /// Files deleted from local disk, which had uploaded cleanly and aged out.
+    pub deleted: Vec<NaiveDate>,
+    /// Lines the Parquet does not hold, across every file this run read.
+    pub unparsable_lines: usize,
+}
+
+impl LogExportSummary {
+    pub fn total_lines(&self) -> usize {
+        self.exported.iter().map(|(_, _, lines)| lines).sum()
+    }
+}
+
+/// Converts every rolled log file on disk to Parquet in S3, then deletes what has aged out.
+///
+/// Follows [`export_journals`] — one whole file at a deterministic key, so a repeat is an
+/// overwrite and a failed run repairs itself — with one difference it cannot avoid. The journal is
+/// sealed across its reads and the log has no seal: the appender owns the file and keeps writing.
+/// Today's object is therefore a snapshot that the next run replaces, and a line torn mid-write is
+/// counted unparsable exactly as a torn journal line is.
+pub async fn export_logs(
+    directory: &Path,
+    s3_client: &S3Client,
+    bucket: &str,
+    today: SessionDate,
+) -> LogExportSummary {
+    let mut summary = LogExportSummary::default();
+
+    let mut files = match rolled_log_files(directory) {
+        Ok(files) => files,
+        Err(error) => {
+            warn!(%error, "Log directory could not be read; nothing exported");
+            return summary;
+        }
+    };
+    files.sort();
+
+    let mut deletable: Vec<NaiveDate> = Vec::new();
+    for (date, service, path) in files {
+        let (mut frame, unparsable) = match read_log_frame(&path) {
+            Ok(read) => read,
+            Err(error) => {
+                summary.failed.push((date, service, error));
+                continue;
+            }
+        };
+        summary.unparsable_lines += unparsable;
+
+        // Nothing to ship and nothing readable, so uploading would replace a good object from an
+        // earlier run with one holding none of it -- the guard `export_journals` carries.
+        if frame.height() == 0 && unparsable > 0 {
+            summary.failed.push((
+                date,
+                service,
+                format!("every one of {unparsable} lines was unparsable"),
+            ));
+            continue;
+        }
+
+        let key = date_partitioned_key(&format!("{LOG_PREFIX}/service={service}"), date);
+        match write_frame(s3_client, bucket, &key, &mut frame).await {
+            Ok(()) => {
+                summary.exported.push((date, service, frame.height()));
+                if unparsable == 0 {
+                    deletable.push(date);
+                }
+            }
+            Err(error) => summary.failed.push((date, service, error)),
+        }
+    }
+
+    let oldest_kept = today.plus_calendar_days(-LOG_RETENTION_DAYS).date();
+    summary.deleted = delete_aged_out_logs(directory, &deletable, oldest_kept);
+
+    info!(
+        files = summary.exported.len(),
+        lines = summary.total_lines(),
+        failed = summary.failed.len(),
+        deleted = summary.deleted.len(),
+        unparsable_lines = summary.unparsable_lines,
+        "Log export finished"
+    );
+    for (date, service, error) in &summary.failed {
+        warn!(%date, service, error, "Log failed to export");
+    }
+    summary
+}
+
+/// Every `<date>.<service>.log` in the directory, as its date, service, and path.
+///
+/// A name that does not parse is skipped rather than failing the run: the directory is shared with
+/// whatever else writes there, and an unrecognised file is not this function's to interpret.
+fn rolled_log_files(directory: &Path) -> Result<Vec<(NaiveDate, String, PathBuf)>, String> {
+    let mut files = Vec::new();
+    let entries = std::fs::read_dir(directory)
+        .map_err(|error| format!("failed to read {}: {error}", directory.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("failed to read a directory entry: {error}"))?;
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let Some((date, service)) = split_log_file_name(&name) else {
+            continue;
+        };
+        files.push((date, service, entry.path()));
+    }
+    Ok(files)
+}
+
+/// Splits `2026-08-17.fund.log` into its date and service.
+fn split_log_file_name(name: &str) -> Option<(NaiveDate, String)> {
+    let remainder = name.strip_suffix(".log")?;
+    let (date, service) = remainder.split_once('.')?;
+    let date = date.parse::<NaiveDate>().ok()?;
+    match service.is_empty() {
+        true => None,
+        false => Some((date, service.to_string())),
+    }
+}
+
+/// Reads one log file into a frame, returning it with the number of lines skipped.
+///
+/// `fields` stays a JSON string rather than becoming columns: every call site puts different keys
+/// in it, so a fixed schema would either lose them or grow a column per message.
+fn read_log_frame(path: &Path) -> Result<(DataFrame, usize), String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+
+    let mut timestamps: Vec<Option<i64>> = Vec::new();
+    let mut levels: Vec<Option<String>> = Vec::new();
+    let mut targets: Vec<Option<String>> = Vec::new();
+    let mut messages: Vec<Option<String>> = Vec::new();
+    let mut field_blobs: Vec<Option<String>> = Vec::new();
+    let mut unparsable = 0usize;
+
+    for line in contents.lines().filter(|line| !line.trim().is_empty()) {
+        let Ok(Value::Object(record)) = serde_json::from_str::<Value>(line) else {
+            unparsable += 1;
+            continue;
+        };
+        let text = |key: &str| record.get(key).and_then(Value::as_str).map(str::to_string);
+
+        // The timestamp and the level are what every query filters on, so a line missing either is
+        // unreachable rather than merely thin.
+        let (Some(timestamp), Some(level)) = (
+            text("timestamp").and_then(|stamp| {
+                DateTime::parse_from_rfc3339(&stamp)
+                    .ok()
+                    .map(|instant| instant.timestamp_millis())
+            }),
+            text("level"),
+        ) else {
+            unparsable += 1;
+            continue;
+        };
+
+        timestamps.push(Some(timestamp));
+        levels.push(Some(level));
+        targets.push(text("target"));
+        messages.push(
+            record
+                .get("fields")
+                .and_then(|fields| fields.get("message"))
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        );
+        field_blobs.push(record.get("fields").map(Value::to_string));
+    }
+
+    if unparsable > 0 {
+        warn!(
+            path = %path.display(),
+            unparsable,
+            "Skipped log lines that would not parse"
+        );
+    }
+
+    let frame = DataFrame::new(vec![
+        Column::new("timestamp".into(), timestamps),
+        Column::new("level".into(), levels),
+        Column::new("target".into(), targets),
+        Column::new("message".into(), messages),
+        Column::new("fields".into(), field_blobs),
+    ])
+    .map_err(|error| format!("failed to build a log frame: {error}"))?;
+    Ok((frame, unparsable))
+}
+
+/// Removes local log files older than the retention window.
+///
+/// The window is what keeps the appender's own file safe: `oldest_kept` is a whole retention period
+/// behind today, so a file still open for writing is never old enough to qualify.
+fn delete_aged_out_logs(
+    directory: &Path,
+    dates: &[NaiveDate],
+    oldest_kept: NaiveDate,
+) -> Vec<NaiveDate> {
+    let mut deleted = Vec::new();
+    let aged_out: std::collections::BTreeSet<NaiveDate> = dates
+        .iter()
+        .filter(|date| **date < oldest_kept)
+        .copied()
+        .collect();
+    let Ok(files) = rolled_log_files(directory) else {
+        return deleted;
+    };
+    for (date, _, path) in files
+        .into_iter()
+        .filter(|(date, _, _)| aged_out.contains(date))
+    {
+        match std::fs::remove_file(&path) {
+            Ok(()) => deleted.push(date),
+            Err(error) => warn!(
+                path = %path.display(),
+                %error,
+                "Aged-out log could not be deleted"
+            ),
+        }
+    }
+    deleted.sort();
+    deleted.dedup();
+    deleted
+}
+
 /// Sessions on disk whose trading day has finished.
 ///
 /// Today counts, because this runs after the close; a future-dated file does not, and exporting one
@@ -695,8 +907,8 @@ mod tests {
     #[test]
     fn test_summary_totals_only_successful_datasets() {
         let summary = ExportSummary {
-            exported: vec![("events".into(), 12), ("equity_pairs".into(), 3)],
-            failed: vec![("account_activities".into(), "boom".into())],
+            exported: vec![(Dataset::Events, 12), (Dataset::EquityPairs, 3)],
+            failed: vec![(Dataset::AccountActivities, "boom".into())],
         };
         assert_eq!(summary.total_rows(), 15);
         assert!(!summary.is_clean());
@@ -735,6 +947,167 @@ mod tests {
         let (frame, unparsable) = read_journal_frame(&path).expect("the session must still read");
         assert_eq!(frame.height(), 1);
         assert_eq!(unparsable, 1);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// The appender names files `<date>.<service>.log`, and the service is what keys the S3
+    /// partition — two services on one date would otherwise write the same object.
+    #[test]
+    fn test_a_log_file_name_splits_into_its_date_and_service() {
+        assert_eq!(
+            split_log_file_name("2026-08-17.fund.log"),
+            Some((
+                "2026-08-17".parse::<NaiveDate>().expect("a valid date"),
+                "fund".to_string()
+            ))
+        );
+        assert_eq!(
+            split_log_file_name("2026-08-17.tide-model-trainer.log"),
+            Some((
+                "2026-08-17".parse::<NaiveDate>().expect("a valid date"),
+                "tide-model-trainer".to_string()
+            ))
+        );
+        // Anything else in the directory belongs to somebody else.
+        assert_eq!(split_log_file_name("fund.log"), None);
+        assert_eq!(split_log_file_name("2026-08-17.log"), None);
+        assert_eq!(split_log_file_name("not-a-date.fund.log"), None);
+        assert_eq!(split_log_file_name("2026-08-17.fund.txt"), None);
+    }
+
+    /// The log directory is shared with whatever else writes there, so a name this does not
+    /// recognise is skipped rather than guessed at or fatal.
+    #[test]
+    fn test_only_recognisable_log_names_are_collected() {
+        let directory = temporary_directory("logs-foreign");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        for name in [
+            "2026-08-17.fund.log",
+            "portfolio-manager-errors.log",
+            "sessions",
+            "2026-08-17.fund.log.gz",
+        ] {
+            std::fs::write(directory.join(name), "{}\n").expect("the file must be writable");
+        }
+
+        let mut collected: Vec<String> = rolled_log_files(&directory)
+            .expect("the directory must read")
+            .into_iter()
+            .map(|(date, service, _)| format!("{date}.{service}"))
+            .collect();
+        collected.sort();
+        assert_eq!(collected, vec!["2026-08-17.fund"]);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// The log has no seal, so the file is live while it is read: the last line can be half-written.
+    #[test]
+    fn test_a_torn_log_line_is_skipped_rather_than_failing_the_file() {
+        let directory = temporary_directory("logs-torn");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("2026-08-17.fund.log");
+        std::fs::write(
+            &path,
+            "{\"timestamp\":\"2026-08-17T20:15:00Z\",\"level\":\"INFO\",\"target\":\"fund\",\
+             \"fields\":{\"message\":\"Starting data sync\"}}\n{\"timestamp\":\"2026-08-1",
+        )
+        .expect("the file must be writable");
+
+        let (frame, unparsable) = read_log_frame(&path).expect("the file must read");
+        assert_eq!(frame.height(), 1);
+        assert_eq!(unparsable, 1);
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// A line with no timestamp or no level cannot be filtered on, so it is unreachable by every
+    /// query the archive exists to answer rather than merely thin.
+    #[test]
+    fn test_a_log_line_without_a_timestamp_or_level_is_counted_unparsable() {
+        let directory = temporary_directory("logs-envelope");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("2026-08-17.fund.log");
+        std::fs::write(
+            &path,
+            "{\"timestamp\":\"2026-08-17T20:15:00Z\",\"level\":\"WARN\",\"fields\":{}}\n\
+             {\"level\":\"INFO\",\"fields\":{}}\n\
+             {\"timestamp\":\"2026-08-17T20:16:00Z\",\"fields\":{}}\n",
+        )
+        .expect("the file must be writable");
+
+        let (frame, unparsable) = read_log_frame(&path).expect("the file must read");
+        assert_eq!(frame.height(), 1);
+        assert_eq!(
+            unparsable, 2,
+            "one missing a level, one missing a timestamp"
+        );
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// The message is lifted out of `fields` into its own column because it is what a human scans,
+    /// while the rest of `fields` stays a JSON string — every call site puts different keys there.
+    #[test]
+    fn test_the_log_message_is_lifted_out_of_its_fields() {
+        let directory = temporary_directory("logs-message");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let path = directory.join("2026-08-17.fund.log");
+        std::fs::write(
+            &path,
+            "{\"timestamp\":\"2026-08-17T20:15:00Z\",\"level\":\"INFO\",\"target\":\"fund::data\",\
+             \"fields\":{\"message\":\"Journal export finished\",\"sessions\":3}}\n",
+        )
+        .expect("the file must be writable");
+
+        let (frame, _) = read_log_frame(&path).expect("the file must read");
+        let message = frame.column("message").expect("the column must exist");
+        assert_eq!(
+            message.str().expect("a string column").get(0),
+            Some("Journal export finished")
+        );
+        let fields = frame.column("fields").expect("the column must exist");
+        assert!(
+            fields
+                .str()
+                .expect("a string column")
+                .get(0)
+                .expect("a value")
+                .contains("\"sessions\":3"),
+            "the rest of the fields survive as JSON"
+        );
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// The file the appender still holds open must survive. The retention window is what protects
+    /// it — `oldest_kept` is a whole period behind today, so today can never be old enough — which
+    /// is why there is no separate guard against deleting it.
+    #[test]
+    fn test_the_retention_window_leaves_the_open_log_alone() {
+        let directory = temporary_directory("logs-retention");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let today = session(2026, 8, 17);
+        let oldest_kept = today.plus_calendar_days(-LOG_RETENTION_DAYS).date();
+        let stale = today.plus_calendar_days(-LOG_RETENTION_DAYS - 1).date();
+        // The boundary date itself is kept, so the window is half-open: `<=` would take a file the
+        // retention period still covers.
+        let dates = [today.date(), oldest_kept, stale];
+        for date in dates {
+            std::fs::write(directory.join(format!("{date}.fund.log")), "{}\n")
+                .expect("the file must be writable");
+        }
+        assert!(
+            oldest_kept < today.date(),
+            "the window is what does the work"
+        );
+
+        let deleted = delete_aged_out_logs(&directory, &dates, oldest_kept);
+        assert_eq!(
+            deleted,
+            vec![stale],
+            "only the file past the window ages out"
+        );
+        assert!(directory
+            .join(format!("{}.fund.log", today.date()))
+            .exists());
+        assert!(directory.join(format!("{oldest_kept}.fund.log")).exists());
         let _ = std::fs::remove_dir_all(&directory);
     }
 

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -489,10 +489,7 @@ pub async fn export_journals(
 /// S3 prefix the diagnostic logs are written under, partitioned by service.
 pub const LOG_PREFIX: &str = "exports/logs";
 
-/// Calendar days of exported logs kept on local disk.
-///
-/// The same window the journal keeps, for the same reason: long enough that a bad conversion can
-/// still be repaired from the original bytes.
+/// Calendar days of exported logs kept on local disk, matching the journal's window.
 pub const LOG_RETENTION_DAYS: i64 = 7;
 
 /// What one log export run accomplished.
@@ -502,10 +499,14 @@ pub struct LogExportSummary {
     pub exported: Vec<(NaiveDate, String, usize)>,
     /// `(date, service, error)` for each file that did not write.
     pub failed: Vec<(NaiveDate, String, String)>,
-    /// Files deleted from local disk, which had uploaded cleanly and aged out.
-    pub deleted: Vec<NaiveDate>,
+    /// `(date, service)` for each file deleted from local disk, having uploaded cleanly and aged
+    /// out. One service ageing out does not carry another's file with it.
+    pub deleted: Vec<(NaiveDate, String)>,
     /// Lines the Parquet does not hold, across every file this run read.
     pub unparsable_lines: usize,
+    /// Set when the directory itself could not be listed, which is not the same answer as finding
+    /// it empty and must not read as a clean run.
+    pub directory_error: Option<String>,
 }
 
 impl LogExportSummary {
@@ -516,11 +517,10 @@ impl LogExportSummary {
 
 /// Converts every rolled log file on disk to Parquet in S3, then deletes what has aged out.
 ///
-/// Follows [`export_journals`] — one whole file at a deterministic key, so a repeat is an
-/// overwrite and a failed run repairs itself — with one difference it cannot avoid. The journal is
-/// sealed across its reads and the log has no seal: the appender owns the file and keeps writing.
-/// Today's object is therefore a snapshot that the next run replaces, and a line torn mid-write is
-/// counted unparsable exactly as a torn journal line is.
+/// Follows [`export_journals`], except that the log has no seal: the appender owns the file and
+/// keeps writing, so today's object is a snapshot the next run replaces and a line torn mid-write
+/// is counted unparsable. The unit throughout is one file, not one date, because a date holds a
+/// file per service and they succeed independently.
 pub async fn export_logs(
     directory: &Path,
     s3_client: &S3Client,
@@ -533,12 +533,13 @@ pub async fn export_logs(
         Ok(files) => files,
         Err(error) => {
             warn!(%error, "Log directory could not be read; nothing exported");
+            summary.directory_error = Some(error);
             return summary;
         }
     };
     files.sort();
 
-    let mut deletable: Vec<NaiveDate> = Vec::new();
+    let mut deletable: Vec<(NaiveDate, String, PathBuf)> = Vec::new();
     for (date, service, path) in files {
         let (mut frame, unparsable) = match read_log_frame(&path) {
             Ok(read) => read,
@@ -563,9 +564,11 @@ pub async fn export_logs(
         let key = date_partitioned_key(&format!("{LOG_PREFIX}/service={service}"), date);
         match write_frame(s3_client, bucket, &key, &mut frame).await {
             Ok(()) => {
-                summary.exported.push((date, service, frame.height()));
+                summary
+                    .exported
+                    .push((date, service.clone(), frame.height()));
                 if unparsable == 0 {
-                    deletable.push(date);
+                    deletable.push((date, service, path));
                 }
             }
             Err(error) => summary.failed.push((date, service, error)),
@@ -573,7 +576,7 @@ pub async fn export_logs(
     }
 
     let oldest_kept = today.plus_calendar_days(-LOG_RETENTION_DAYS).date();
-    summary.deleted = delete_aged_out_logs(directory, &deletable, oldest_kept);
+    summary.deleted = delete_aged_out_logs(&deletable, oldest_kept);
 
     info!(
         files = summary.exported.len(),
@@ -611,14 +614,19 @@ fn rolled_log_files(directory: &Path) -> Result<Vec<(NaiveDate, String, PathBuf)
 }
 
 /// Splits `2026-08-17.fund.log` into its date and service.
+///
+/// The service becomes a Hive partition in the S3 key, so it is restricted to what a service name
+/// is actually made of. A `=` or a `.` would otherwise read as partition syntax and put the object
+/// somewhere no query looks for it.
 fn split_log_file_name(name: &str) -> Option<(NaiveDate, String)> {
     let remainder = name.strip_suffix(".log")?;
     let (date, service) = remainder.split_once('.')?;
     let date = date.parse::<NaiveDate>().ok()?;
-    match service.is_empty() {
-        true => None,
-        false => Some((date, service.to_string())),
-    }
+    let usable = !service.is_empty()
+        && service
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-');
+    usable.then(|| (date, service.to_string()))
 }
 
 /// Reads one log file into a frame, returning it with the number of lines skipped.
@@ -689,30 +697,20 @@ fn read_log_frame(path: &Path) -> Result<(DataFrame, usize), String> {
     Ok((frame, unparsable))
 }
 
-/// Removes local log files older than the retention window.
+/// Removes exactly the files given, and only those past the retention window.
 ///
-/// The window is what keeps the appender's own file safe: `oldest_kept` is a whole retention period
-/// behind today, so a file still open for writing is never old enough to qualify.
+/// Takes the files rather than re-listing the directory, so a service whose upload failed keeps its
+/// only retryable copy even when another service aged out on the same date. The window is also what
+/// keeps the appender's open file safe: `oldest_kept` is a whole retention period behind today, so a
+/// file still being written to can never be old enough to qualify.
 fn delete_aged_out_logs(
-    directory: &Path,
-    dates: &[NaiveDate],
+    exported: &[(NaiveDate, String, PathBuf)],
     oldest_kept: NaiveDate,
-) -> Vec<NaiveDate> {
+) -> Vec<(NaiveDate, String)> {
     let mut deleted = Vec::new();
-    let aged_out: std::collections::BTreeSet<NaiveDate> = dates
-        .iter()
-        .filter(|date| **date < oldest_kept)
-        .copied()
-        .collect();
-    let Ok(files) = rolled_log_files(directory) else {
-        return deleted;
-    };
-    for (date, _, path) in files
-        .into_iter()
-        .filter(|(date, _, _)| aged_out.contains(date))
-    {
-        match std::fs::remove_file(&path) {
-            Ok(()) => deleted.push(date),
+    for (date, service, path) in exported.iter().filter(|(date, _, _)| *date < oldest_kept) {
+        match std::fs::remove_file(path) {
+            Ok(()) => deleted.push((*date, service.clone())),
             Err(error) => warn!(
                 path = %path.display(),
                 %error,
@@ -720,8 +718,6 @@ fn delete_aged_out_logs(
             ),
         }
     }
-    deleted.sort();
-    deleted.dedup();
     deleted
 }
 
@@ -973,6 +969,59 @@ mod tests {
         assert_eq!(split_log_file_name("2026-08-17.log"), None);
         assert_eq!(split_log_file_name("not-a-date.fund.log"), None);
         assert_eq!(split_log_file_name("2026-08-17.fund.txt"), None);
+        // The service becomes a Hive partition, so anything that reads as partition syntax or a
+        // path separator is refused rather than shaping the S3 key.
+        assert_eq!(split_log_file_name("2026-08-17.a=b.log"), None);
+        assert_eq!(split_log_file_name("2026-08-17.a.b.log"), None);
+        assert_eq!(split_log_file_name("2026-08-17.year=2020.log"), None);
+    }
+
+    /// Two services share a date and succeed independently. Deleting by date rather than by file
+    /// would take the failed service's only retryable copy along with the successful one's.
+    #[test]
+    fn test_one_service_ageing_out_does_not_delete_anothers_file() {
+        let directory = temporary_directory("logs-per-service");
+        std::fs::create_dir_all(&directory).expect("the directory must be creatable");
+        let stale: NaiveDate = "2026-08-01".parse().expect("a valid date");
+        let shipped = directory.join(format!("{stale}.fund.log"));
+        let held_back = directory.join(format!("{stale}.tide-model-trainer.log"));
+        for path in [&shipped, &held_back] {
+            std::fs::write(path, "{}\n").expect("the file must be writable");
+        }
+
+        // Only the first uploaded cleanly, so only it is offered for deletion.
+        let exported = vec![(stale, "fund".to_string(), shipped.clone())];
+        let deleted = delete_aged_out_logs(&exported, "2026-08-10".parse().expect("a valid date"));
+
+        assert_eq!(deleted, vec![(stale, "fund".to_string())]);
+        assert!(!shipped.exists(), "the shipped file ages out");
+        assert!(
+            held_back.exists(),
+            "the other service's file is its only copy and must survive"
+        );
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// An unreadable directory is not an empty one, and a summary that cannot tell them apart
+    /// reports a clean run over storage that was never reached.
+    #[tokio::test]
+    async fn test_an_unreadable_log_directory_is_reported_rather_than_read_as_empty() {
+        let directory = temporary_directory("logs-missing");
+        let _ = std::fs::remove_dir_all(&directory);
+        let configuration = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+        let s3_client = S3Client::new(&configuration);
+
+        let summary = export_logs(
+            &directory,
+            &s3_client,
+            "unused-bucket",
+            session(2026, 8, 17),
+        )
+        .await;
+
+        assert!(summary.directory_error.is_some(), "the failure is carried");
+        assert!(summary.exported.is_empty());
+        assert!(summary.deleted.is_empty());
     }
 
     /// The log directory is shared with whatever else writes there, so a name this does not
@@ -1088,20 +1137,23 @@ mod tests {
         let stale = today.plus_calendar_days(-LOG_RETENTION_DAYS - 1).date();
         // The boundary date itself is kept, so the window is half-open: `<=` would take a file the
         // retention period still covers.
-        let dates = [today.date(), oldest_kept, stale];
-        for date in dates {
-            std::fs::write(directory.join(format!("{date}.fund.log")), "{}\n")
-                .expect("the file must be writable");
-        }
+        let exported: Vec<(NaiveDate, String, PathBuf)> = [today.date(), oldest_kept, stale]
+            .into_iter()
+            .map(|date| {
+                let path = directory.join(format!("{date}.fund.log"));
+                std::fs::write(&path, "{}\n").expect("the file must be writable");
+                (date, "fund".to_string(), path)
+            })
+            .collect();
         assert!(
             oldest_kept < today.date(),
             "the window is what does the work"
         );
 
-        let deleted = delete_aged_out_logs(&directory, &dates, oldest_kept);
+        let deleted = delete_aged_out_logs(&exported, oldest_kept);
         assert_eq!(
             deleted,
-            vec![stale],
+            vec![(stale, "fund".to_string())],
             "only the file past the window ages out"
         );
         assert!(directory

--- a/src/data/purge.rs
+++ b/src/data/purge.rs
@@ -14,9 +14,8 @@ use crate::common::types::Dataset;
 /// noticed. `i32` because it binds directly to `make_interval(days => ...)`, an `int4`.
 pub const RETENTION_DAYS: i32 = 7;
 
-/// Retention must leave enough nights that a silently failed export is noticed before the rows it
-/// missed become unrecoverable. Enforced at compile time rather than in a test, because the failure
-/// mode is someone tuning the constant down, not the code drifting.
+/// Enforced at compile time because the failure mode is someone tuning the constant down, not the
+/// code drifting: too short a window and a silently failed export goes unnoticed.
 const _: () = assert!(RETENTION_DAYS >= 3);
 
 /// Tables the purge owns, in the order it visits them.

--- a/src/data/purge.rs
+++ b/src/data/purge.rs
@@ -1,23 +1,17 @@
-//! Nightly purge of exported rows.
+//! Nightly purge of rows the export has already written to S3.
 //!
-//! Runs inside the export handler, after S3 has the data, and only over tables whose history lives
-//! in the export rather than in the database. That ordering is the entire safety property: a purge
-//! that ran first, or ran on its own schedule, could delete rows that never reached S3.
-//!
-//! Retention is a window, not a truncation. A few days in PostgreSQL costs almost nothing, keeps
-//! questions about yesterday a query rather than an S3 download, and gives a silently failed export
-//! several nights to be noticed before the rows are gone.
-//!
-//! `equity_bars` is deliberately absent: TimescaleDB's retention policy owns it, and two mechanisms
-//! deleting from one table is how a rolling window becomes an empty one.
+//! Runs after the export and never on its own schedule, which is the whole safety property.
 
 use sqlx::PgPool;
 use tracing::{info, warn};
 
+use crate::common::types::Dataset;
+
 /// Days of history retained in PostgreSQL after export.
 ///
-/// `i32` rather than `i64` because it is bound directly to `make_interval(days => ...)`, whose
-/// parameter is an `int4`.
+/// A window rather than a truncation: a few days in PostgreSQL keeps questions about yesterday a
+/// query rather than an S3 download, and gives a silently failed export several nights to be
+/// noticed. `i32` because it binds directly to `make_interval(days => ...)`, an `int4`.
 pub const RETENTION_DAYS: i32 = 7;
 
 /// Retention must leave enough nights that a silently failed export is noticed before the rows it
@@ -27,21 +21,22 @@ const _: () = assert!(RETENTION_DAYS >= 3);
 
 /// Tables the purge owns, in the order it visits them.
 ///
-/// Both are append-only and fully represented in the nightly export. `equity_pairs`,
-/// `account_snapshots`, and `account_activities` are not here: they are small, they are the
-/// dashboard's history, and a row can change after the day it was written.
-const PURGED_TABLES: &[(&str, &str)] = &[
-    ("events", "created_at"),
-    ("equity_predictions", "timestamp"),
+/// Both are append-only and fully represented in the nightly export. The other datasets are absent
+/// because a row can change after the day it was written, and `equity_bars` because TimescaleDB's
+/// retention policy owns it — two mechanisms deleting from one table is how a rolling window
+/// becomes an empty one.
+const PURGED_TABLES: &[(Dataset, &str)] = &[
+    (Dataset::Events, "created_at"),
+    (Dataset::EquityPredictions, "timestamp"),
 ];
 
 /// What one purge accomplished.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct PurgeSummary {
     /// `(table, rows_deleted)` for each table purged cleanly.
-    pub purged: Vec<(String, u64)>,
+    pub purged: Vec<(Dataset, u64)>,
     /// `(table, error)` for each table whose delete failed.
-    pub failed: Vec<(String, String)>,
+    pub failed: Vec<(Dataset, String)>,
 }
 
 impl PurgeSummary {
@@ -66,7 +61,8 @@ impl PurgeSummary {
 pub async fn purge_exported_tables(pool: &PgPool) -> PurgeSummary {
     let mut summary = PurgeSummary::default();
 
-    for (table, timestamp_column) in PURGED_TABLES {
+    for (dataset, timestamp_column) in PURGED_TABLES {
+        let table = dataset.as_str();
         // The table and column names come from the constant above, never from input, so formatting
         // them into the statement is safe. The cutoff is still bound as a parameter, as an integer
         // through `make_interval` rather than as a string concatenated into an interval literal --
@@ -82,13 +78,11 @@ pub async fn purge_exported_tables(pool: &PgPool) -> PurgeSummary {
             Ok(result) => {
                 let rows = result.rows_affected();
                 info!(table, rows, "Purged exported rows");
-                summary.purged.push(((*table).to_string(), rows));
+                summary.purged.push((*dataset, rows));
             }
             Err(error) => {
                 warn!(table, error = %error, "Failed to purge table, continuing with the rest");
-                summary
-                    .failed
-                    .push(((*table).to_string(), error.to_string()));
+                summary.failed.push((*dataset, error.to_string()));
             }
         }
     }
@@ -100,12 +94,16 @@ pub async fn purge_exported_tables(pool: &PgPool) -> PurgeSummary {
 mod tests {
     use super::*;
 
-    /// `equity_bars` must never appear here. TimescaleDB's retention policy already deletes from
+    /// `equity_bars` must never appear here: TimescaleDB's retention policy already deletes from
     /// it, and a second mechanism on a different window turns a rolling 90 days into whichever
-    /// window is shorter.
+    /// window is shorter. [`Dataset`] has no variant for it, so this now holds by construction —
+    /// the assertion is that no variant *names* it, which is what a future variant would break.
     #[test]
     fn test_purge_does_not_own_bars() {
-        let tables: Vec<&str> = PURGED_TABLES.iter().map(|(table, _)| *table).collect();
+        let tables: Vec<&str> = PURGED_TABLES
+            .iter()
+            .map(|(dataset, _)| dataset.as_str())
+            .collect();
         assert!(!tables.contains(&"equity_bars"));
     }
 
@@ -113,7 +111,10 @@ mod tests {
     /// a pair opened eight days ago and still open would vanish while the position was live.
     #[test]
     fn test_purge_does_not_own_mutable_state() {
-        let tables: Vec<&str> = PURGED_TABLES.iter().map(|(table, _)| *table).collect();
+        let tables: Vec<&str> = PURGED_TABLES
+            .iter()
+            .map(|(dataset, _)| dataset.as_str())
+            .collect();
         for protected in ["equity_pairs", "account_snapshots", "account_activities"] {
             assert!(
                 !tables.contains(&protected),
@@ -124,15 +125,18 @@ mod tests {
 
     #[test]
     fn test_purge_owns_the_append_only_tables() {
-        let tables: Vec<&str> = PURGED_TABLES.iter().map(|(table, _)| *table).collect();
+        let tables: Vec<&str> = PURGED_TABLES
+            .iter()
+            .map(|(dataset, _)| dataset.as_str())
+            .collect();
         assert_eq!(tables, vec!["events", "equity_predictions"]);
     }
 
     #[test]
     fn test_summary_totals_only_successful_tables() {
         let summary = PurgeSummary {
-            purged: vec![("events".into(), 100), ("equity_predictions".into(), 50)],
-            failed: vec![("other".into(), "boom".into())],
+            purged: vec![(Dataset::Events, 100), (Dataset::EquityPredictions, 50)],
+            failed: vec![(Dataset::EquityPairs, "boom".into())],
         };
         assert_eq!(summary.total_rows(), 150);
         assert!(!summary.is_clean());

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -68,11 +68,9 @@ pub struct Universe {
 impl Universe {
     /// Composes the three filters, all of which are necessary.
     ///
-    /// Alpaca must permit it — active and tradable, and shortable and easy to borrow for anything
-    /// taking the short leg. We must hold bars for it, since a ticker with no history can be neither
-    /// screened for correlation nor hedged. And it must clear the same liquidity thresholds the
-    /// model trained on, because a universe wider than the training population means predicting on
-    /// names the scaler never saw.
+    /// Alpaca must permit it, we must hold bars for it, and it must clear the same liquidity
+    /// thresholds the model trained on — a universe wider than the training population means
+    /// predicting on names the scaler never saw.
     pub fn build(assets: &TradableAssets, liquidity: &[LiquidityRow]) -> Self {
         let mut tickers = Vec::new();
         let mut shortable = HashSet::new();

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -1,17 +1,6 @@
-//! The day's tradable universe.
+//! The day's tradable universe: roughly seven thousand symbols enter and a few hundred survive.
 //!
-//! Three filters compose to produce it, and all three are necessary:
-//!
-//! 1. **Alpaca says we can trade it.** Active, tradable, and — for anything that can take the short
-//!    leg — both shortable and easy to borrow.
-//! 2. **We have price history for it.** A ticker with no bars cannot be screened for correlation or
-//!    hedged, so it cannot enter a pair regardless of what Alpaca allows.
-//! 3. **It is liquid enough to model.** The same thresholds the model trains on, applied per ticker
-//!    average. A universe wider than the training population means predicting on names the scaler
-//!    never saw.
-//!
-//! Roughly seven thousand symbols enter and a few hundred survive, so it is computed once at
-//! pre-open and held for the Eastern date. The universe does not change intraday.
+//! Computed once at pre-open and held for the Eastern date, because it cannot change intraday.
 
 use std::collections::HashSet;
 
@@ -77,10 +66,13 @@ pub struct Universe {
 }
 
 impl Universe {
-    /// Composes the three filters.
+    /// Composes the three filters, all of which are necessary.
     ///
-    /// `assets` is what Alpaca permits, `liquidity` is what our own bar history supports. A ticker
-    /// must appear in both, and clear the thresholds, to survive.
+    /// Alpaca must permit it — active and tradable, and shortable and easy to borrow for anything
+    /// taking the short leg. We must hold bars for it, since a ticker with no history can be neither
+    /// screened for correlation nor hedged. And it must clear the same liquidity thresholds the
+    /// model trained on, because a universe wider than the training population means predicting on
+    /// names the scaler never saw.
     pub fn build(assets: &TradableAssets, liquidity: &[LiquidityRow]) -> Self {
         let mut tickers = Vec::new();
         let mut shortable = HashSet::new();

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,11 +1,6 @@
 //! One function per [`Command`], and the state they share.
 //!
-//! This is the only place that knows how a command name turns into work. The listener parses a
-//! notification and calls [`handle`]; everything else is a module doing one thing.
-//!
-//! Every handler returns a JSON summary, which becomes the `_completed` payload. That is what
-//! makes the nightly export of `events` worth reading — a row carrying the pairs opened and closed,
-//! rows synced, and the model run used is the record of the trading day.
+//! The only place that knows how a command name turns into work. Everything else does one thing.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -19,8 +14,9 @@ use uuid::Uuid;
 use crate::common::alpaca::{AlpacaCredentials, ClientError, MarketDataClient, TradingClient};
 use crate::common::events::{self, Command, EventError};
 use crate::common::journal::{
-    BarsIngested, CommandFinished, CommandOutcome, Journal, JournalError, JournalExported,
-    Observation, PredictionReading, PredictionsGenerated, SkipReason,
+    BarsIngested, CommandFinished, CommandOutcome, DatabaseExported, Journal, JournalError,
+    JournalExported, LogsExported, Observation, PredictionReading, PredictionsGenerated,
+    SkipReason,
 };
 use crate::common::massive::MassiveClient;
 use crate::common::types::{BarInterval, SessionDate};
@@ -219,7 +215,7 @@ pub async fn handle(state: &ServiceState, command: Command) {
             correlation_id,
             Utc::now(),
             CommandFinished {
-                command: command.as_str().to_string(),
+                command,
                 outcome: CommandOutcome::DroppedInFlight,
                 duration_milliseconds: None,
                 error: None,
@@ -251,7 +247,7 @@ pub async fn handle(state: &ServiceState, command: Command) {
                 correlation_id,
                 Utc::now(),
                 CommandFinished {
-                    command: command.as_str().to_string(),
+                    command,
                     outcome: completion_outcome(&summary),
                     duration_milliseconds: Some(duration_milliseconds),
                     error: None,
@@ -275,7 +271,7 @@ pub async fn handle(state: &ServiceState, command: Command) {
                 correlation_id,
                 Utc::now(),
                 CommandFinished {
-                    command: command.as_str().to_string(),
+                    command,
                     outcome: CommandOutcome::Errored,
                     duration_milliseconds: Some(duration_milliseconds),
                     error: Some(error.to_string()),
@@ -325,6 +321,11 @@ async fn record_command(
         .await;
 }
 
+/// Routes a command to its handler.
+///
+/// Every arm returns a JSON summary that becomes the `_completed` payload, which is what makes the
+/// nightly export of `events` worth reading: one row carrying the pairs opened and closed, the rows
+/// synced, and the model run used is the record of the trading day.
 async fn dispatch(
     state: &ServiceState,
     command: Command,
@@ -808,32 +809,78 @@ async fn handle_database_export(
         "unparsable_lines": sessions.unparsable_lines,
     });
 
+    // Shipped beside the journal because the two answer different halves of one question: the
+    // journal says what the application observed, the logs say what it was doing while it observed.
+    let logs = export::export_logs(
+        &crate::common::log::log_directory(),
+        &state.s3_client,
+        &state.bucket,
+        today,
+    )
+    .await;
+    state
+        .journal
+        .record(
+            correlation_id,
+            Utc::now(),
+            Observation::LogsExported(LogsExported {
+                files_exported: logs.exported.len(),
+                lines_exported: logs.total_lines(),
+                files_failed: logs.failed.len(),
+                dates_deleted: logs.deleted.clone(),
+                unparsable_lines: logs.unparsable_lines,
+            }),
+        )
+        .await;
+
     let export = export::export_database(&state.pool, &state.s3_client, &state.bucket, today).await;
 
-    if !export.is_clean() {
-        warn!(
-            failed = export.failed.len(),
-            "Export was incomplete; the purge is skipped"
-        );
-        return Ok(json!({
-            "session_date": today,
-            "exported": export.exported,
-            "failed": export.failed.iter().map(|(dataset, error)| json!({
-                "dataset": dataset, "error": error.to_string()
-            })).collect::<Vec<_>>(),
-            "purged": Value::Null,
-            "journal": journal_summary,
-        }));
-    }
+    // Skipped rather than attempted, because the purge deletes rows on the strength of S3 holding
+    // them. `purge_skipped` on the record below is what separates this from a purge of zero rows.
+    let purge_skipped = !export.is_clean();
+    let purged = match purge_skipped {
+        true => {
+            warn!(
+                failed = export.failed.len(),
+                "Export was incomplete; the purge is skipped"
+            );
+            purge::PurgeSummary::default()
+        }
+        false => purge::purge_exported_tables(&state.pool).await,
+    };
 
-    let purged = purge::purge_exported_tables(&state.pool).await;
+    state
+        .journal
+        .record(
+            correlation_id,
+            Utc::now(),
+            Observation::DatabaseExported(DatabaseExported {
+                session_date: today,
+                exported: export.exported.clone(),
+                failed: export.failed.clone(),
+                purged: purged.purged.clone(),
+                purge_skipped,
+            }),
+        )
+        .await;
+
     Ok(json!({
         "session_date": today,
         "exported": export.exported,
+        "failed": export.failed.iter().map(|(dataset, error)| json!({
+            "dataset": dataset, "error": error.to_string()
+        })).collect::<Vec<_>>(),
         "total_rows_exported": export.total_rows(),
         "purged_rows": purged.total_rows(),
         "purge_clean": purged.is_clean(),
+        "purge_skipped": purge_skipped,
         "journal": journal_summary,
+        "logs": json!({
+            "files_exported": logs.exported.len(),
+            "lines_exported": logs.total_lines(),
+            "files_failed": logs.failed.len(),
+            "unparsable_lines": logs.unparsable_lines,
+        }),
     }))
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -827,8 +827,9 @@ async fn handle_database_export(
                 files_exported: logs.exported.len(),
                 lines_exported: logs.total_lines(),
                 files_failed: logs.failed.len(),
-                dates_deleted: logs.deleted.clone(),
+                files_deleted: logs.deleted.len(),
                 unparsable_lines: logs.unparsable_lines,
+                directory_error: logs.directory_error.clone(),
             }),
         )
         .await;
@@ -871,15 +872,19 @@ async fn handle_database_export(
             "dataset": dataset, "error": error.to_string()
         })).collect::<Vec<_>>(),
         "total_rows_exported": export.total_rows(),
-        "purged_rows": purged.total_rows(),
-        "purge_clean": purged.is_clean(),
+        // Null rather than zero-and-clean when skipped: a purge that did not run has no verdict,
+        // and `is_clean` on an empty summary would report one.
+        "purged_rows": match purge_skipped { true => Value::Null, false => json!(purged.total_rows()) },
+        "purge_clean": match purge_skipped { true => Value::Null, false => json!(purged.is_clean()) },
         "purge_skipped": purge_skipped,
         "journal": journal_summary,
         "logs": json!({
             "files_exported": logs.exported.len(),
             "lines_exported": logs.total_lines(),
             "files_failed": logs.failed.len(),
+            "files_deleted": logs.deleted.len(),
             "unparsable_lines": logs.unparsable_lines,
+            "directory_error": logs.directory_error,
         }),
     }))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,7 @@
 //! Fund platform: a statistical arbitrage service driven entirely by scheduled events.
 //!
-//! One process, woken by pg_cron. Pre-open it runs model inference; every five minutes through the
-//! session it prices the book from a point-in-time Alpaca snapshot and opens or closes pairs;
-//! before the close it liquidates; after the close it syncs the account, the market history, and
-//! the database export. The book is flat overnight without exception.
-//!
-//! Alpaca is the source of truth for fills, balances, buying power, and positions. PostgreSQL holds
-//! model output, the long/short pair mapping, market history, and an audit trail of every command
-//! issued and outcome reached.
+//! One process, woken by pg_cron, running the commands in [`common::events::Command`]. The book is
+//! flat overnight without exception, and Alpaca is the source of truth for everything it holds.
 //!
 
 pub mod common;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Fund platform: a statistical arbitrage service driven entirely by scheduled events.
 //!
-//! One process, woken by pg_cron, running the commands in [`common::events::Command`]. The book is
-//! flat overnight without exception, and Alpaca is the source of truth for everything it holds.
+//! One process, woken by pg_cron, running the commands in [`common::events::Command`]. It flattens
+//! the book before every close, and treats Alpaca as the source of truth for what it holds.
 //!
 
 pub mod common;

--- a/src/models/tide/artifact.rs
+++ b/src/models/tide/artifact.rs
@@ -1,11 +1,6 @@
 //! TiDE model artifacts: written on the trainer, read on the application.
 //!
-//! Nothing orders the write against the read — the trainer has no database. Running a session
-//! against yesterday's model is normal, reported as the artifact age in the `predictions_completed`
-//! payload rather than as a failure.
-//!
-//! The tar is flat: one entry per file, no directory prefix. Both sides live here because that
-//! format is the only contract between them.
+//! Both sides live here because the flat tar between them is their only contract.
 
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard, PoisonError};

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -1,8 +1,7 @@
 //! Evaluation metrics for a trained TiDE model, computed on the validation set in scaled space.
 //!
-//! CRPS here **sums** pinball loss over quantiles with a non-strict `error >= 0` split, where the
-//! training loss in [`crate::models::tide::loss`] averages with a strict split. The two are
-//! deliberately different.
+//! CRPS here sums pinball loss with a non-strict split where [`crate::models::tide::loss`]
+//! averages with a strict one — deliberately different, not a bug to reconcile.
 
 use burn::backend::NdArray;
 

--- a/src/models/tide/fit.rs
+++ b/src/models/tide/fit.rs
@@ -1,9 +1,7 @@
 //! Fit the scaler and categorical mappings from training data, and serialize the artifact JSON
 //! files the inference path loads.
 //!
-//! Categoricals are encoded over sorted-unique values so the mapping is deterministic across runs.
-//!
-//! The scaler and the mappings are deliberately fitted over different row sets; see [`fit`].
+//! Categoricals encode over sorted-unique values, so the mapping is deterministic across runs.
 
 use std::collections::HashSet;
 use std::path::Path;

--- a/src/models/tide/loss.rs
+++ b/src/models/tide/loss.rs
@@ -1,8 +1,6 @@
 //! Quantile (pinball) loss for the TiDE model, optionally Huber-smoothed.
 //!
-//! This averages over quantiles with a strict `error > 0` split. The evaluation CRPS in
-//! [`crate::models::tide::evaluate`] sums instead, with a non-strict split — a deliberate
-//! difference, not a bug to reconcile.
+//! Averages with a strict `error > 0` split, where [`crate::models::tide::evaluate`] sums.
 
 use burn::prelude::*;
 

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -1,8 +1,7 @@
 //! Running the TiDE model: from stored market history to rows in `equity_predictions`.
 //!
-//! Training and inference must apply the same liquidity thresholds — training per row, inference
-//! per ticker average. Both read them from [`crate::common::types`] so they cannot drift; a
-//! mismatch trains the scaler on dynamics the service never predicts.
+//! Applies the same liquidity thresholds training does, read from [`crate::common::types`] so a
+//! drift cannot train the scaler on dynamics the service never predicts.
 
 use burn::backend::NdArray;
 use chrono::{DateTime, Utc};

--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -1,8 +1,7 @@
 //! The strategy: which pairs to hold, how large, and when to let them go.
 //!
-//! [`execute`] is the only module that sends an order; [`evaluate`] is the five-minute pass that
-//! drives the rest. [`account`] is the post-close half, writing back what Alpaca says actually
-//! happened as the reference the next session's drawdown gate reads.
+//! [`execute`] is the only module that sends an order and [`evaluate`] is the pass driving it;
+//! [`account`] is the post-close half that writes back what Alpaca says actually happened.
 
 pub mod account;
 pub mod evaluate;

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -129,13 +129,11 @@ impl ScreenRejection {
     pub fn detail(&self) -> Option<String> {
         match self {
             ScreenRejection::UnusableInput => None,
-            // `log_return` on the wire, not `logarithmic_return`: the string reaches the journal
-            // and is aggregated out of it, so the stored spelling outlives the identifier's.
             ScreenRejection::StructuralBreak {
                 logarithmic_return,
                 limit,
             } => Some(format!(
-                "log_return={logarithmic_return:.4} limit={limit:.4}"
+                "logarithmic_return={logarithmic_return:.4} limit={limit:.4}"
             )),
         }
     }
@@ -1282,7 +1280,7 @@ mod tests {
         // is the contract and a `contains` check would not notice it drifting.
         assert_eq!(
             broken.detail().expect("a break reports its reading"),
-            format!("log_return=-2.2800 limit={MAXIMUM_SESSION_LOGARITHMIC_RETURN:.4}")
+            format!("logarithmic_return=-2.2800 limit={MAXIMUM_SESSION_LOGARITHMIC_RETURN:.4}")
         );
     }
 

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -91,7 +91,7 @@ const MINIMUM_SPREAD_OBSERVATIONS: usize = 2;
 /// the fit identically, and only one of them is fixable by re-fetching.
 ///
 /// Provisional, on the same terms as [`crate::common::alpaca::MAXIMUM_QUOTE_AGE_SECONDS`].
-pub const MAXIMUM_SESSION_LOG_RETURN: f64 = 0.40;
+pub const MAXIMUM_SESSION_LOGARITHMIC_RETURN: f64 = 0.40;
 
 /// Why a symbol could not be screened.
 ///
@@ -102,7 +102,7 @@ pub enum ScreenRejection {
     /// Too short a history, or a close, live price, or prediction that is not a usable number.
     UnusableInput,
     /// One session's move is large enough to dominate the window it sits in.
-    StructuralBreak { log_return: f64, limit: f64 },
+    StructuralBreak { logarithmic_return: f64, limit: f64 },
 }
 
 impl ScreenRejection {
@@ -129,9 +129,14 @@ impl ScreenRejection {
     pub fn detail(&self) -> Option<String> {
         match self {
             ScreenRejection::UnusableInput => None,
-            ScreenRejection::StructuralBreak { log_return, limit } => {
-                Some(format!("log_return={log_return:.4} limit={limit:.4}"))
-            }
+            // `log_return` on the wire, not `logarithmic_return`: the string reaches the journal
+            // and is aggregated out of it, so the stored spelling outlives the identifier's.
+            ScreenRejection::StructuralBreak {
+                logarithmic_return,
+                limit,
+            } => Some(format!(
+                "log_return={logarithmic_return:.4} limit={limit:.4}"
+            )),
         }
     }
 }
@@ -183,10 +188,12 @@ impl ScreenInput {
         // the spread model, so excluding on it would refuse a name whose history has since settled.
         let window = &closes[closes.len() - CORRELATION_WINDOW_SESSIONS..];
         match worst_session_move(window) {
-            Some(log_return) if log_return.abs() > MAXIMUM_SESSION_LOG_RETURN => {
+            Some(logarithmic_return)
+                if logarithmic_return.abs() > MAXIMUM_SESSION_LOGARITHMIC_RETURN =>
+            {
                 return Err(ScreenRejection::StructuralBreak {
-                    log_return,
-                    limit: MAXIMUM_SESSION_LOG_RETURN,
+                    logarithmic_return,
+                    limit: MAXIMUM_SESSION_LOGARITHMIC_RETURN,
                 });
             }
             Some(_) | None => {}
@@ -479,8 +486,10 @@ pub fn score_candidates(inputs: &[ScreenInput]) -> Vec<PairCandidate> {
                 continue;
             }
 
-            let correlation =
-                pearson_correlation(&log_returns(first.window()), &log_returns(second.window()));
+            let correlation = pearson_correlation(
+                &logarithmic_returns(first.window()),
+                &logarithmic_returns(second.window()),
+            );
             let Some(correlation) = correlation else {
                 continue;
             };
@@ -676,7 +685,7 @@ fn aligned_logs(long_closes: &[f64], short_closes: &[f64]) -> Option<(Vec<f64>, 
 ///
 /// Signed so the recorded detail says which way the series jumped, and largest rather than first so
 /// the number a bound gets calibrated against is the worst one present. Iterates rather than reusing
-/// [`log_returns`], which would collect a vector per ticker on a pass that screens over a thousand.
+/// [`logarithmic_returns`], which would collect a vector per ticker on a pass that screens over a thousand.
 fn worst_session_move(window: &[f64]) -> Option<f64> {
     window
         .windows(2)
@@ -686,7 +695,7 @@ fn worst_session_move(window: &[f64]) -> Option<f64> {
 }
 
 /// Period-over-period log returns. One shorter than its input.
-fn log_returns(prices: &[f64]) -> Vec<f64> {
+fn logarithmic_returns(prices: &[f64]) -> Vec<f64> {
     prices
         .windows(2)
         .filter(|window| window[0] > 0.0 && window[1] > 0.0)
@@ -809,8 +818,11 @@ mod tests {
     #[test]
     fn test_the_fixture_correlates_within_the_screened_band() {
         let (leader, follower) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
-        let correlation = pearson_correlation(&log_returns(&leader), &log_returns(&follower))
-            .expect("the fixture must correlate");
+        let correlation = pearson_correlation(
+            &logarithmic_returns(&leader),
+            &logarithmic_returns(&follower),
+        )
+        .expect("the fixture must correlate");
         assert!(
             (CORRELATION_MINIMUM..=CORRELATION_MAXIMUM).contains(&correlation),
             "fixture correlation {correlation} is outside [{CORRELATION_MINIMUM}, {CORRELATION_MAXIMUM}]"
@@ -948,8 +960,8 @@ mod tests {
     }
 
     #[test]
-    fn test_log_returns_is_one_shorter_than_its_input() {
-        let returns = log_returns(&[100.0, 110.0, 121.0]);
+    fn test_logarithmic_returns_is_one_shorter_than_its_input() {
+        let returns = logarithmic_returns(&[100.0, 110.0, 121.0]);
         assert_eq!(returns.len(), 2);
         assert!((returns[0] - returns[1]).abs() < 1e-12);
     }
@@ -1062,8 +1074,11 @@ mod tests {
         let first = follower[0];
         let mirrored: Vec<f64> = follower.iter().map(|price| first * first / price).collect();
 
-        let correlation = pearson_correlation(&log_returns(&leader), &log_returns(&mirrored))
-            .expect("the mirrored fixture must correlate");
+        let correlation = pearson_correlation(
+            &logarithmic_returns(&leader),
+            &logarithmic_returns(&mirrored),
+        )
+        .expect("the mirrored fixture must correlate");
         assert!(
             correlation < -CORRELATION_MINIMUM,
             "the fixture must be anti-correlated inside the band's magnitude, got {correlation}"
@@ -1158,10 +1173,10 @@ mod tests {
     }
 
     /// A window holding one persistent level change, the shape a collapse or a split leaves behind.
-    fn window_with_one_move(log_return: f64) -> Vec<f64> {
+    fn window_with_one_move(logarithmic_return: f64) -> Vec<f64> {
         let mut closes = vec![100.0; CORRELATION_WINDOW_SESSIONS];
         for close in closes.iter_mut().skip(CORRELATION_WINDOW_SESSIONS / 2) {
-            *close = 100.0 * log_return.exp();
+            *close = 100.0 * logarithmic_return.exp();
         }
         closes
     }
@@ -1190,7 +1205,7 @@ mod tests {
 
     #[test]
     fn test_screen_input_rejects_a_window_containing_a_structural_break() {
-        let breached = MAXIMUM_SESSION_LOG_RETURN + 0.01;
+        let breached = MAXIMUM_SESSION_LOGARITHMIC_RETURN + 0.01;
         let rejection = ScreenInput::new(
             ticker("AAAA"),
             window_with_one_move(-breached),
@@ -1203,11 +1218,18 @@ mod tests {
 
         // The payload, not only the variant: the recorded number is the entire reason the rejection
         // is written down, and a sign flip or a swapped pair reads as a pass against `matches!`.
-        let ScreenRejection::StructuralBreak { log_return, limit } = rejection else {
+        let ScreenRejection::StructuralBreak {
+            logarithmic_return,
+            limit,
+        } = rejection
+        else {
             panic!("expected a structural break, got {rejection:?}");
         };
-        assert!((log_return + breached).abs() < 1e-9, "got {log_return}");
-        assert_eq!(limit, MAXIMUM_SESSION_LOG_RETURN);
+        assert!(
+            (logarithmic_return + breached).abs() < 1e-9,
+            "got {logarithmic_return}"
+        );
+        assert_eq!(limit, 0.40, "the limit reported is the one in schema terms");
     }
 
     /// At the limit exactly, not merely inside it. The comparison is strict, so a move equal to the
@@ -1216,7 +1238,7 @@ mod tests {
     fn test_screen_input_accepts_a_move_at_the_limit() {
         assert!(ScreenInput::new(
             ticker("AAAA"),
-            window_with_one_move(MAXIMUM_SESSION_LOG_RETURN),
+            window_with_one_move(MAXIMUM_SESSION_LOGARITHMIC_RETURN),
             100.0,
             0.01,
             0.9,
@@ -1252,15 +1274,15 @@ mod tests {
         assert_eq!(ScreenRejection::UnusableInput.detail(), None);
 
         let broken = ScreenRejection::StructuralBreak {
-            log_return: -2.28,
-            limit: MAXIMUM_SESSION_LOG_RETURN,
+            logarithmic_return: -2.28,
+            limit: MAXIMUM_SESSION_LOGARITHMIC_RETURN,
         };
         assert_eq!(broken.as_str(), "structural_break");
         // The whole string: the detail exists to be aggregated out of the journal, so the format
         // is the contract and a `contains` check would not notice it drifting.
         assert_eq!(
             broken.detail().expect("a break reports its reading"),
-            format!("log_return=-2.2800 limit={MAXIMUM_SESSION_LOG_RETURN:.4}")
+            format!("log_return=-2.2800 limit={MAXIMUM_SESSION_LOGARITHMIC_RETURN:.4}")
         );
     }
 

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -172,15 +172,20 @@ FROM read_parquet(
 -- prices it read, the orders it sent, the fills they produced. Joining on it is how a duration
 -- becomes an answer about where the time went.
 --
--- schema_version is 3 or 4; v1 and v2 were development and their objects are gone. Two payload
--- fields changed shape at v4, so a query reaching into either has to branch on the version:
+-- schema_version is 3, 4, or 5; v1 and v2 were development and their objects are gone. Three
+-- payload fields have changed shape, so a query reaching into any of them must branch on the
+-- version:
 --
---   quote_rejection was the bare reason string 'stale_quote' or 'wide_quote'. It is now an object
---   whose 'reason' key holds that same string alongside the reading that produced it --
+--   quote_rejection, at v4, was the bare reason string 'stale_quote' or 'wide_quote'. It is now an
+--   object whose 'reason' key holds that same string alongside the reading that produced it --
 --   age_seconds and limit_seconds for a stale quote, relative_spread and limit for a wide one.
 --   Under v3 the reading is simply gone; there is nothing to recover it from.
 --
---   early_closes[].session_close was 'HH:MM' and is now 'HH:MM:SS'.
+--   early_closes[].session_close, at v4, was 'HH:MM' and is now 'HH:MM:SS'.
+--
+--   The structural-break detail, at v5, spelled its first key 'log_return' and now spells it
+--   'logarithmic_return'. The format is otherwise unchanged, so a query wanting both versions can
+--   match either spelling; the value and the limit beside it mean exactly what they did.
 --
 -- Fields are added within a version as well as across one, and an absent key reads as NULL either
 -- way, so "the build predated this field" and "there was nothing to record" are the same answer.


### PR DESCRIPTION
# Overview

Five follow-ups from reading the five module reviews (#1075–#1079) back over. Nothing here is a new module pass; each item is something those reviews surfaced and left.

Also evaluated the two open Dependabot pull requests. **#1074 (thiserror) should merge** — it is green, and lockfile-only, since the manifest already requires `2.0.3`. I could not merge it myself; the branch policy needs a review. **#1054 (polars 0.51 → 0.55.2) should not merge as-is**: on current master it produces 83 compile errors across ten files. `is_in` is not among them and there is no deprecation warning today, so the concern that prompted the check is unfounded — the breakage is `DataFrame::new` gaining a height argument (52 sites), `into_no_null_iter` being restricted to numeric types (26), and `get_column_names_str` being removed (2). The middle group is not mechanical: the obvious replacement silently drops nulls where the old call asserted there were none, which is the hazard `data.rs`'s null guard exists for. It wants its own pull request.

## Changes

- **One `Dataset` enum** replaces the `String` table names in `ExportSummary` and `PurgeSummary`. It carries the S3 prefix beside the stored name, because those are one decision — a dataset written under another's prefix is a silent overwrite and neither half is checkable from the other. The purge's set is a strict subset, which is what makes deleting safe, and `equity_bars` is now unrepresentable rather than merely absent from a list. It lives in `common/types.rs` because the journal records it and `common/` imports nothing from `data/`.
- **`DatabaseExported`** gives the nightly export and purge a typed record. They were reaching the journal only inside `CommandFinished.summary` as an opaque blob, which could not distinguish a purge of zero rows from a purge that never ran; `purge_skipped` now does. Additive event type, so no `SCHEMA_VERSION` bump.
- **`export_logs`** ships `/var/log/fund` to S3, which nothing did before — a lost VM lost every diagnostic it held. Same pattern as the journal: whole file, one object per service per date, re-exported idempotently, deleted only after a clean run, with a `LogsExported` record. The one unavoidable difference is that the journal seals across its reads and the log cannot, since the appender owns the file, so today's object is a snapshot the next run replaces and a torn line is counted unparsable exactly as a torn journal line is.
- **`CommandFinished.command` is a `Command`**, not a `String` built by `command.as_str().to_string()` at three call sites that each had `Command` in scope.
- **`MAXIMUM_SESSION_LOG_RETURN` spells out `LOGARITHMIC`**, along with the `log_return` identifiers and the string they render. It is a logarithmic return and never had anything to do with the journal, but the ambiguity cost a special case in the rename grep twice. The rendered detail reaches the archive through `ExcludedTickerReading.detail`, so **`SCHEMA_VERSION` goes to 5** and the DuckDB preamble gains a third entry in its list of fields that have changed shape. The format is otherwise untouched — same value, same limit, same `key=value` shape — so a query wanting both versions can match either spelling rather than branching on the whole string.
- **Every library module header is inside the three-line ceiling.** The load-bearing content moved onto the item it describes rather than being deleted — the archive's set-difference reasoning onto `archive_missing_sessions`, the universe's three filters onto `Universe::build`, the retention rationale onto `RETENTION_DAYS`, the two export shapes onto `export_database`.

## Context

Two things were found by probing rather than by review. A guard excluding today's file from deletion turned out to be unreachable — `oldest_kept` is always a full retention period behind today — and was removed rather than kept as a branch that can never run. Two of the new assertions were too thin to fail when the code they covered was broken, and were tightened until they did.

Verified against the real log directory rather than fixtures: 124 of the 150 entries in `/var/log/fund` are recognised, the other 26 being an older naming scheme and a subdirectory, and the five largest parse through the real `read_log_frame` with zero skipped lines across roughly three thousand records.

692 tests pass, `cargo fmt` and `cargo doc` are clean, the sqlx cache is unchanged, and clippy sits at the one pre-existing `redundant_closure` in `tests/test_handlers.rs`.

The v5 record was read back as real JSONL rather than asserted: a structural-break exclusion written through the real journal lands as `schema_version: 5` with `detail: "logarithmic_return=-2.2800 limit=0.4000"`.

Left alone deliberately: the 86 item-level docs over three sentences, which is a much larger pass than the module headers and worth its own review; and the `f64` statistics and prose `Option<String>` refusals in the journal, which are correctly raw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added nightly diagnostic log exports in Parquet format, organized by service.
  - Added database and log export status records with clearer reporting of incomplete exports.
  - Standardized dataset identification across exports and retention operations.
  - Added stable command names in serialized events and completion records.

- **Bug Fixes**
  - Incomplete or malformed log exports are retained for later processing.
  - Log files are removed only after successful, complete export and retention checks.

- **Documentation**
  - Clarified database availability, trading-session handling, data ownership, model behavior, and export workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
