### PR TITLE
Measure a session's return and window against the session before it

### DIFF
--- a/.sqlx/query-88dd6cda793c7db3901d1ab580ed898bead0454332d56d1904ac54ecd70cd2b2.json
+++ b/.sqlx/query-88dd6cda793c7db3901d1ab580ed898bead0454332d56d1904ac54ecd70cd2b2.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT ticker AS \"ticker!\",\n               AVG(close_price) AS \"average_close_price!\",\n               AVG(volume::double precision) AS \"average_volume!\"\n        FROM equity_bars\n        WHERE bar_interval = $1\n          AND timestamp >= $2\n        GROUP BY ticker\n        ",
+  "query": "\n        SELECT ticker AS \"ticker!\",\n               MIN(close_price) AS \"minimum_close_price!\",\n               AVG(volume::double precision) AS \"average_volume!\"\n        FROM equity_bars\n        WHERE bar_interval = $1\n          AND timestamp >= $2\n        GROUP BY ticker\n        ",
   "describe": {
     "columns": [
       {
@@ -10,7 +10,7 @@
       },
       {
         "ordinal": 1,
-        "name": "average_close_price!",
+        "name": "minimum_close_price!",
         "type_info": "Float8"
       },
       {
@@ -31,5 +31,5 @@
       null
     ]
   },
-  "hash": "9d6a9a572f6c09ddd75c075e1fceb24ed4b819c62ca21d650fd680ea0c42f749"
+  "hash": "88dd6cda793c7db3901d1ab580ed898bead0454332d56d1904ac54ecd70cd2b2"
 }

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -30,26 +30,32 @@ pub enum UniverseError {
     Database(#[from] sqlx::Error),
 }
 
-/// One ticker's average liquidity over the trailing window.
+/// One ticker's liquidity over the trailing window.
+///
+/// Price is summarised by its minimum and volume by its average, because the two are different
+/// kinds of quantity. A price is a level: a name that traded below the floor at any point in the
+/// window was not the kind of instrument this universe is for, and averaging across the fall admits
+/// it on the strength of what it used to cost. Volume is a flow that varies session to session, and
+/// one quiet day says nothing about tradability.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LiquidityRow {
     ticker: Ticker,
-    average_close_price: f64,
+    minimum_close_price: f64,
     average_volume: f64,
 }
 
 impl LiquidityRow {
-    pub fn new(ticker: Ticker, average_close_price: f64, average_volume: f64) -> Self {
+    pub fn new(ticker: Ticker, minimum_close_price: f64, average_volume: f64) -> Self {
         Self {
             ticker,
-            average_close_price,
+            minimum_close_price,
             average_volume,
         }
     }
 
     /// Whether this ticker clears both liquidity thresholds.
     fn is_liquid(&self) -> bool {
-        self.average_close_price >= MINIMUM_CLOSE_PRICE && self.average_volume >= MINIMUM_VOLUME
+        self.minimum_close_price >= MINIMUM_CLOSE_PRICE && self.average_volume >= MINIMUM_VOLUME
     }
 }
 
@@ -138,11 +144,11 @@ impl Universe {
     }
 }
 
-/// Reads per-ticker average close and volume over the trailing window.
+/// Reads per-ticker minimum close and average volume over the trailing window.
 ///
-/// Averaged over daily bars specifically: the liquidity thresholds are calibrated on daily
-/// dynamics, and averaging intraday bars would compare a per-minute volume against a per-day
-/// threshold and reject the entire universe.
+/// Read over daily bars specifically: the liquidity thresholds are calibrated on daily dynamics,
+/// and averaging intraday bars would compare a per-minute volume against a per-day threshold and
+/// reject the entire universe.
 pub async fn load_liquidity(
     pool: &PgPool,
     as_of: SessionDate,
@@ -151,7 +157,7 @@ pub async fn load_liquidity(
     let rows = sqlx::query!(
         r#"
         SELECT ticker AS "ticker!",
-               AVG(close_price) AS "average_close_price!",
+               MIN(close_price) AS "minimum_close_price!",
                AVG(volume::double precision) AS "average_volume!"
         FROM equity_bars
         WHERE bar_interval = $1
@@ -168,7 +174,7 @@ pub async fn load_liquidity(
         .into_iter()
         .filter_map(|row| {
             Ticker::new(&row.ticker).map(|ticker| {
-                LiquidityRow::new(ticker, row.average_close_price, row.average_volume)
+                LiquidityRow::new(ticker, row.minimum_close_price, row.average_volume)
             })
         })
         .collect())

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -32,11 +32,9 @@ pub enum UniverseError {
 
 /// One ticker's liquidity over the trailing window.
 ///
-/// Price is summarised by its minimum and volume by its average, because the two are different
-/// kinds of quantity. A price is a level: a name that traded below the floor at any point in the
-/// window was not the kind of instrument this universe is for, and averaging across the fall admits
-/// it on the strength of what it used to cost. Volume is a flow that varies session to session, and
-/// one quiet day says nothing about tradability.
+/// Price is summarised by its minimum and volume by its average. A price is a level, so one that
+/// ever fell below the floor disqualifies the name; volume is a flow, where one quiet session says
+/// nothing about tradability.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LiquidityRow {
     ticker: Ticker,

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -436,14 +436,21 @@ pub(crate) fn split_at_cutoff(
 /// additionally extracts the future `daily_return` window as the target.
 /// Maps every session the frame holds to its position in the sorted set of them.
 ///
-/// Adjacency is read off the sessions present rather than a trading calendar, which is both what
-/// keeps this module free of one and what makes a session the archive never fetched count as a gap
-/// instead of a silent splice. It holds because the frame spans the whole universe: some
-/// instrument traded on every session the archive has.
+/// Adjacency is therefore relative to the sessions this frame contains, not to a trading calendar:
+/// a session missing for some tickers is a gap, and one missing across the whole universe is
+/// invisible here and belongs to whatever checks the archive's completeness.
 fn session_ranks(data: &DataFrame) -> Result<HashMap<i64, usize>, TideError> {
-    let mut sessions: Vec<i64> = data
-        .column("timestamp")?
-        .i64()?
+    let timestamps = data.column("timestamp")?.i64()?;
+    // Skipping these would leave fewer sessions than rows, and the windows are counted from the
+    // row height.
+    if timestamps.null_count() > 0 {
+        return Err(TideError::Data(format!(
+            "Equity bars contain {} null timestamp values out of {} rows",
+            timestamps.null_count(),
+            data.height()
+        )));
+    }
+    let mut sessions: Vec<i64> = timestamps
         .into_no_null_iter()
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
@@ -483,6 +490,12 @@ fn window_frame(
     with_targets: bool,
 ) -> Result<TrainingDataset, TideError> {
     let window_size = input_length + output_length;
+    // An empty window has no last row for the span check below to read.
+    if window_size == 0 {
+        return Err(TideError::Data(
+            "A window needs a non-zero input or output length".to_string(),
+        ));
+    }
     let ranks = session_ranks(frame)?;
     let continuous_feature_count = CONTINUOUS_COLUMNS.len();
     let categorical_feature_count = CATEGORICAL_COLUMNS.len();
@@ -522,10 +535,8 @@ fn window_frame(
         let static_column_values = get_int_columns(&ticker_data, STATIC_CATEGORICAL_COLUMNS)?;
 
         let sessions = ticker_sessions(&ticker_data, &ranks)?;
-        // Session positions rise strictly within a ticker, so a window spans exactly its own
-        // length only when every step inside it is one session. A window that fails this teaches
-        // a transition that never happened -- in the archive the widest such splice covers 462
-        // sessions -- and in predict mode it would forecast from one.
+        // Positions rise strictly within a ticker, so spanning exactly the window's own length is
+        // the same as every step inside it being one session.
         let is_contiguous = |start: usize| {
             sessions[start + window_size - 1].saturating_sub(sessions[start]) == window_size - 1
         };
@@ -712,11 +723,8 @@ pub(crate) fn append_forecast_session_rows(
 }
 
 pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, TideError> {
-    // Sort by [ticker, timestamp] so daily returns and the downstream windowing are chronological
-    // within each ticker, independent of the order rows arrived in. Chronological is not
-    // contiguous: sorting cannot conjure a session the frame does not hold, which is why the
-    // return below is measured against `session_ranks` and not against the previous row.
-    // Each ticker's first row gets a null return; clean_data drops it.
+    // Sort by [ticker, timestamp] so the return below is chronological whatever order rows arrived
+    // in. Chronological is not contiguous, which is why it is measured against `session_ranks`.
     let data = data.sort(
         ["ticker", "timestamp"],
         SortMultipleOptions::default().with_maintain_order(true),
@@ -1464,6 +1472,46 @@ mod tests {
     ///
     /// The dense ticker is what makes the gap visible: session adjacency is read off the sessions
     /// the frame contains, so a gap is only a gap when some instrument traded through it.
+    /// Both lengths zero makes the window empty, and an empty window has no contiguity to check.
+    /// Refused rather than indexed: the span check reads the window's last row.
+    #[test]
+    fn test_a_zero_length_window_is_refused_rather_than_indexed() {
+        let data = Data::from_parts(
+            prepared_and_encoded(raw_gapped_frame()),
+            return_scaler(),
+            FeatureMappings::new(),
+        );
+        let result = data.get_dataset(DatasetKind::Predict, 0, 0);
+        assert!(
+            matches!(result, Err(TideError::Data(_))),
+            "a zero-length window must be an error, not a panic"
+        );
+    }
+
+    /// `session_ranks` skips nulls while the windows are counted from the row height, so one null
+    /// timestamp leaves fewer sessions than rows and the span check reads past the end.
+    #[test]
+    fn test_a_null_timestamp_is_refused_rather_than_skipped() {
+        let mut frame = prepared_and_encoded(raw_gapped_frame());
+        let height = frame.height();
+        let mut timestamps: Vec<Option<i64>> = frame
+            .column("timestamp")
+            .unwrap()
+            .i64()
+            .unwrap()
+            .into_iter()
+            .collect();
+        timestamps[height - 1] = None;
+        frame
+            .with_column(Column::new("timestamp".into(), timestamps))
+            .unwrap();
+
+        assert!(
+            matches!(session_ranks(&frame), Err(TideError::Data(_))),
+            "a null timestamp must be an error, not a silently shorter session list"
+        );
+    }
+
     fn raw_gapped_frame() -> DataFrame {
         const DAY: i64 = 86_400_000;
         let gapped_days: Vec<i64> = vec![0, 1, 2, 3, 8, 9, 10];

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -434,6 +434,47 @@ pub(crate) fn split_at_cutoff(
 ///
 /// `predict_mode` keeps only the final window per ticker; `with_targets`
 /// additionally extracts the future `daily_return` window as the target.
+/// Maps every session the frame holds to its position in the sorted set of them.
+///
+/// Adjacency is read off the sessions present rather than a trading calendar, which is both what
+/// keeps this module free of one and what makes a session the archive never fetched count as a gap
+/// instead of a silent splice. It holds because the frame spans the whole universe: some
+/// instrument traded on every session the archive has.
+fn session_ranks(data: &DataFrame) -> Result<HashMap<i64, usize>, TideError> {
+    let mut sessions: Vec<i64> = data
+        .column("timestamp")?
+        .i64()?
+        .into_no_null_iter()
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+    sessions.sort_unstable();
+    Ok(sessions
+        .into_iter()
+        .enumerate()
+        .map(|(rank, timestamp)| (timestamp, rank))
+        .collect())
+}
+
+/// One ticker's rows as session positions, in row order.
+fn ticker_sessions(
+    ticker_data: &DataFrame,
+    ranks: &HashMap<i64, usize>,
+) -> Result<Vec<usize>, TideError> {
+    ticker_data
+        .column("timestamp")?
+        .i64()?
+        .into_no_null_iter()
+        .map(|timestamp| {
+            ranks.get(&timestamp).copied().ok_or_else(|| {
+                TideError::Data(format!(
+                    "timestamp {timestamp} is not a session of this frame"
+                ))
+            })
+        })
+        .collect()
+}
+
 fn window_frame(
     frame: &DataFrame,
     input_length: usize,
@@ -442,6 +483,7 @@ fn window_frame(
     with_targets: bool,
 ) -> Result<TrainingDataset, TideError> {
     let window_size = input_length + output_length;
+    let ranks = session_ranks(frame)?;
     let continuous_feature_count = CONTINUOUS_COLUMNS.len();
     let categorical_feature_count = CATEGORICAL_COLUMNS.len();
     let static_feature_count = STATIC_CATEGORICAL_COLUMNS.len();
@@ -479,13 +521,22 @@ fn window_frame(
         let categorical_column_values = get_int_columns(&ticker_data, CATEGORICAL_COLUMNS)?;
         let static_column_values = get_int_columns(&ticker_data, STATIC_CATEGORICAL_COLUMNS)?;
 
+        let sessions = ticker_sessions(&ticker_data, &ranks)?;
+        // Session positions rise strictly within a ticker, so a window spans exactly its own
+        // length only when every step inside it is one session. A window that fails this teaches
+        // a transition that never happened -- in the archive the widest such splice covers 462
+        // sessions -- and in predict mode it would forecast from one.
+        let is_contiguous = |start: usize| {
+            sessions[start + window_size - 1].saturating_sub(sessions[start]) == window_size - 1
+        };
+
         let windows: Vec<usize> = if predict_mode {
             vec![ticker_data.height() - window_size]
         } else {
             (0..=ticker_data.height() - window_size).collect()
         };
 
-        for start in windows {
+        for start in windows.into_iter().filter(|start| is_contiguous(*start)) {
             let mut past_continuous_window =
                 Vec::with_capacity(input_length * continuous_feature_count);
             for row in start..start + input_length {
@@ -661,13 +712,16 @@ pub(crate) fn append_forecast_session_rows(
 }
 
 pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, TideError> {
-    // Sort by [ticker, timestamp] so daily returns and the downstream windowing
-    // are chronological and contiguous within each ticker, independent of the
-    // order rows arrived in. Each ticker's first row gets a null return; clean_data drops it.
+    // Sort by [ticker, timestamp] so daily returns and the downstream windowing are chronological
+    // within each ticker, independent of the order rows arrived in. Chronological is not
+    // contiguous: sorting cannot conjure a session the frame does not hold, which is why the
+    // return below is measured against `session_ranks` and not against the previous row.
+    // Each ticker's first row gets a null return; clean_data drops it.
     let data = data.sort(
         ["ticker", "timestamp"],
         SortMultipleOptions::default().with_maintain_order(true),
     )?;
+    let ranks = session_ranks(&data)?;
 
     let timestamps = data.column("timestamp")?;
     let height = data.height();
@@ -725,8 +779,15 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, TideError>
         month.push(date.month() as i32);
         year.push(date.year());
 
-        let same_ticker = index > 0 && tickers[index] == tickers[index - 1];
-        if same_ticker && close_prices[index - 1] != 0.0 {
+        // A *daily* return or nothing. Measured across a gap it is a multi-session return wearing
+        // a one-session label, and it is the column the model is trained to predict.
+        let follows_previous_session = index > 0
+            && tickers[index] == tickers[index - 1]
+            && ranks
+                .get(&timestamp_milliseconds)
+                .zip(ranks.get(&timestamp_values[index - 1]))
+                .is_some_and(|(current, previous)| *current == previous + 1);
+        if follows_previous_session && close_prices[index - 1] != 0.0 {
             daily_return.push(Some(
                 ((close_prices[index] / close_prices[index - 1]) - 1.0) as f32,
             ));
@@ -1399,6 +1460,91 @@ mod tests {
 
     /// Two tickers, two days each, unsorted on input; close prices chosen so
     /// each ticker's second-day return is 0.1.
+    /// One ticker missing four sessions in the middle, alongside one that trades every session.
+    ///
+    /// The dense ticker is what makes the gap visible: session adjacency is read off the sessions
+    /// the frame contains, so a gap is only a gap when some instrument traded through it.
+    fn raw_gapped_frame() -> DataFrame {
+        const DAY: i64 = 86_400_000;
+        let gapped_days: Vec<i64> = vec![0, 1, 2, 3, 8, 9, 10];
+        let dense_days: Vec<i64> = (0..=10).collect();
+
+        let mut tickers: Vec<&str> = vec!["GAPPY"; gapped_days.len()];
+        tickers.extend(vec!["DENSE"; dense_days.len()]);
+
+        let mut timestamps: Vec<i64> = gapped_days.iter().map(|day| day * DAY).collect();
+        timestamps.extend(dense_days.iter().map(|day| day * DAY));
+
+        // Distinct per row, so a window's contents identify the rows it drew from.
+        let closes: Vec<f64> = (0..timestamps.len())
+            .map(|row| 100.0 + row as f64)
+            .collect();
+        let height = timestamps.len();
+
+        DataFrame::new(vec![
+            Column::new("ticker".into(), tickers),
+            Column::new("timestamp".into(), timestamps),
+            Column::new("open_price".into(), vec![1.0_f64; height]),
+            Column::new("high_price".into(), vec![1.0_f64; height]),
+            Column::new("low_price".into(), vec![1.0_f64; height]),
+            Column::new("close_price".into(), closes),
+            Column::new("volume".into(), vec![1.0_f64; height]),
+            Column::new(
+                "volume_weighted_average_price".into(),
+                vec![1.0_f64; height],
+            ),
+            Column::new("sector".into(), vec!["S"; height]),
+            Column::new("industry".into(), vec!["I"; height]),
+        ])
+        .unwrap()
+    }
+
+    /// A return is a *daily* return or it is not the target. Measured across a gap it is a
+    /// multi-session return wearing a one-session label, and the model is trained to predict it.
+    #[test]
+    fn test_engineer_features_nulls_a_return_measured_across_a_session_gap() {
+        let engineered = engineer_features(raw_gapped_frame()).unwrap();
+        let tickers: Vec<String> = engineered
+            .column("ticker")
+            .unwrap()
+            .str()
+            .unwrap()
+            .into_no_null_iter()
+            .map(str::to_string)
+            .collect();
+        let returns: Vec<Option<f32>> = engineered
+            .column("daily_return")
+            .unwrap()
+            .f32()
+            .unwrap()
+            .into_iter()
+            .collect();
+
+        // Sorted by [ticker, timestamp]: DENSE days 0..10 occupy rows 0..10, then GAPPY days
+        // 0, 1, 2, 3, 8, 9, 10 occupy rows 11..17. GAPPY's day 8 is row 15.
+        assert_eq!(tickers[15], "GAPPY");
+        assert_eq!(
+            returns[15], None,
+            "GAPPY's day 8 follows its day 3, so its return spans five sessions"
+        );
+        // The rows on either side of the gap are ordinary and must survive.
+        assert!(returns[14].is_some(), "GAPPY day 3 follows day 2");
+        assert!(returns[16].is_some(), "GAPPY day 9 follows day 8");
+    }
+
+    /// A window is 36 consecutive sessions or it teaches a transition that never happened.
+    #[test]
+    fn test_window_frame_skips_a_window_spanning_a_session_gap() {
+        let encoded = prepared_and_encoded(raw_gapped_frame());
+        let dataset = window_frame(&encoded, 2, 1, false, true).unwrap();
+
+        // DENSE keeps days 1..10 after its first row is nulled and dropped: 10 rows, 8 windows of
+        // three, every one contiguous. GAPPY keeps days 1, 2, 3, 9, 10 -- day 0 is its first row
+        // and day 8 is nulled by the gap -- which is 3 windows by index, of which only [1, 2, 3]
+        // is contiguous. [2, 3, 9] and [3, 9, 10] both cross the gap.
+        assert_eq!(dataset.past_continuous.shape()[0], 9);
+    }
+
     fn raw_two_ticker_frame() -> DataFrame {
         DataFrame::new(vec![
             Column::new("ticker".into(), vec!["BBB", "AAA", "BBB", "AAA"]),

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -182,11 +182,10 @@ fn duplicated_tickers(bars: &DataFrame) -> Result<Vec<String>, PredictionError> 
 
 /// Drops tickers whose trailing averages fall below the liquidity thresholds.
 ///
-/// **Both bounds are inclusive**, matching [`crate::models::tide::fit::filter_training_bars`] and
-/// [`crate::data::universe::LiquidityRow`]'s liquidity test. The three read the same two constants, so a
-/// difference in the comparison alone is enough to reopen the train/serve gap those constants were
-/// introduced to close: an exclusive test here would admit a ticker to the universe, train on it,
-/// and then refuse to predict for it at exactly the threshold.
+/// **Both bounds are inclusive**, matching [`crate::models::tide::fit::filter_training_bars`]: an
+/// exclusive test here would train on a ticker and then refuse to predict for it at exactly the
+/// threshold. [`crate::data::universe::LiquidityRow`] screens price on the window's *minimum*, which
+/// is the stricter test, so every name the universe admits still reaches this one.
 pub fn filter_equity_bars(
     data: DataFrame,
     minimum_average_close_price: f64,

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -20,6 +20,7 @@ use fund::common::types::{BarInterval, PairID, SessionDate, Ticker};
 use fund::data::adjust::SplitTable;
 use fund::data::bars;
 use fund::data::truncate::BoundaryTable;
+use fund::data::universe;
 
 use fund::common::types::CloseReason;
 use fund::models::tide::predict;
@@ -396,6 +397,31 @@ async fn test_aligned_closes_drops_a_ticker_with_a_gap() {
 
 /// The interval is part of the primary key, so a daily and a one-minute bar for the same ticker and
 /// instant coexist. A query that ignored the interval would mix sampling rates into one series.
+#[tokio::test]
+#[serial]
+async fn test_liquidity_reports_the_window_low_not_its_average() {
+    // A name that fell from $13.00 to $1.38 averages $10.68 and clears a $10 floor on the strength
+    // of what it used to cost. The minimum is what says where it trades now. This lives here
+    // because the difference is the aggregate the query asks for, which no unit test can see.
+    let pool = fresh_pool().await;
+    let today = SessionDate::at(Utc::now());
+    for (offset, close) in [(-4, 13.0), (-3, 13.0), (-2, 13.0), (-1, 13.0), (0, 1.38)] {
+        common::seed_bar(&pool, "AAAA", today.plus_calendar_days(offset), close).await;
+    }
+
+    let liquidity = universe::load_liquidity(&pool, today).await.unwrap();
+
+    assert_eq!(
+        liquidity,
+        vec![universe::LiquidityRow::new(
+            ticker("AAAA"),
+            1.38,
+            5_000_000.0
+        )],
+        "the averaged close would have reported 10.676 and passed the floor"
+    );
+}
+
 #[tokio::test]
 #[serial]
 async fn test_aligned_closes_reads_only_the_requested_interval() {


### PR DESCRIPTION
# Overview

Nothing in the training path checked that two rows sit on adjacent sessions. Two separate things leaned on the assumption that they do, and both were wrong for roughly two in five training samples.

Found while starting the data-correctness work: the structural-break guard that task was meant to add already exists (`screen.rs:94`), and the bar archive was already current at 503 partitions through 2026-08-17. The defect was elsewhere.

## Changes

- `engineer_features` nulls `daily_return` unless the row follows the preceding session. The liquidity filter runs before it and drops rows per bar, so for any ticker that dipped under $10 or traded thinly the previous surviving row is not the previous session — and the "daily" return spanned the gap. That column is the model's target.
- `window_frame` emits a window only when it spans exactly its own length. It sliced by row index; its docstring already asserted "one contiguous block", and the sort above it claimed to deliver contiguity, which sorting cannot do when rows are missing.
- Both read adjacency from one new `session_ranks` map, built from the sessions the frame holds.
- `load_liquidity` admits on `MIN(close_price)` rather than `AVG(close_price)`. Volume stays averaged.
- Two unit tests in `models/tide/data.rs` and one database test in `tests/test_database.rs`.

## Context

**Measured with DuckDB over the development S3 parquet**, inside the trainer's real 365-day lookback (251 sessions):

| | before | after |
|---|---|---|
| training windows | 327,530 | 201,459 |
| of those, spanning a session gap | 123,868 (37.8%) | 0 |
| tickers contributing windows | 2,402 | 1,521 |

865 tickers contributed nothing but contaminated windows. Over the full 503-session archive the widest single splice covered 462 sessions inside a nominal 35-day window.

Adjacency is read off the data rather than a `TradingCalendar` for two reasons: it keeps the model module free of one (the trainer runs without a database), and it makes a session the archive never fetched count as a gap rather than a silent splice.

The universe had the same bug from the other side. A name that fell from $13.00 to $1.38 averages $10.68 and cleared the $10 floor on the strength of what it used to cost. The asymmetry between the two thresholds is deliberate: a price is a level, and one that ever fell below the floor says the name is not what this universe is for, while volume is a flow where one quiet session says nothing about tradability. Requiring the minimum of both would have cut 765 names, 670 of them on volume alone; requiring it of price alone cuts 95, leaving 1,723.

Every test was confirmed load-bearing before being trusted. The two windowing tests failed at 12 windows against an expected 9 and at `Some(0.0097)` against `None`. The database test was re-run with the query reverted to `AVG` and reported `minimum_close_price: 10.676`, exactly the value that used to pass the floor.

`devenv tasks run checks:rust` passes, and `cargo sqlx prepare --check -- --all-features` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Liquidity screening now uses the lowest closing price within the selected period while preserving average-volume calculations.
  * Daily return calculations no longer span missing trading sessions.
  * Time windows that include gaps in session data are now excluded for more accurate analysis.

* **Tests**
  * Added coverage for minimum-price liquidity screening, session gaps, and contiguous window handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->