### PR TITLE
Give the laboratory a frame to read and a journal to write

### DIFF
--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -15,19 +15,16 @@
 use burn::module::AutodiffModule;
 use burn::tensor::backend::Backend;
 use chrono::Utc;
-use polars::prelude::*;
 use tracing::{error, info, warn};
 
 use fund::common::alpaca::{AlpacaCredentials, MarketDataClient};
-use fund::common::aws::date_partitioned_key;
 use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
-use fund::common::types::{SessionDate, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
-use fund::data::adjust;
+use fund::common::types::SessionDate;
 use fund::data::archive;
-use fund::data::bars;
 use fund::data::details;
-use fund::data::truncate;
+use fund::laboratory::dataset;
+use fund::laboratory::journal as laboratory;
 use fund::models::tide::artifact::{
     candidate_folders_descending, list_run_folders, package_dir_to_tar_gz, upload_artifact,
 };
@@ -35,9 +32,8 @@ use fund::models::tide::configuration::ModelParameters;
 use fund::models::tide::data::{input_feature_size, DatasetKind, TrainingFraction};
 use fund::models::tide::drift::{check_drift, DriftStatus};
 use fund::models::tide::evaluate::evaluate;
-use fund::models::tide::fit::{filter_training_bars, fit, write_artifact_json};
+use fund::models::tide::fit::write_artifact_json;
 use fund::models::tide::model::TiDEModel;
-use fund::models::tide::predict::consolidate_data;
 use fund::models::tide::train::{train, TrainBackend, TrainConfiguration};
 
 const INPUT_LENGTH: usize = 35;
@@ -93,11 +89,23 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let now = Utc::now();
     let session = SessionDate::at(now);
 
+    // One identity for every record this run emits, so a later result can be joined back to the
+    // frame it was measured on. A journal that will not open is warned about, never fatal.
+    let run_id = uuid::Uuid::new_v4();
+    let laboratory_journal = match laboratory::Journal::from_env() {
+        Ok(journal) => Some(journal),
+        Err(error) => {
+            warn!(%error, "No laboratory journal; this run is not recorded");
+            None
+        }
+    };
+
     info!(
         bucket,
         artifact_prefix,
         lookback_days,
         %session,
+        %run_id,
         "Starting tide training"
     );
 
@@ -187,63 +195,39 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         Err(error) => warn!(%error, "No Alpaca credentials; the boundary table is not refreshed"),
     }
 
-    // Fatal where the archive repair above was not: the stored bars are raw, so training without
-    // this table fits a two-for-one split as a genuine fifty percent fall.
-    let splits =
-        match archive::read_partition(&s3_client, &bucket, archive::SPLITS_ARCHIVE_KEY).await? {
-            Some(frame) => adjust::SplitTable::from_dataframe(&frame)?,
-            None => {
-                return Err(format!(
-                    "no splits table at {}; refusing to train on unadjusted prices",
-                    archive::SPLITS_ARCHIVE_KEY
-                )
-                .into())
-            }
-        };
-
-    // Not fatal where the splits table is: an absent boundary table costs a guard on a handful of
-    // names, where an absent splits table makes every price wrong by whole factors.
-    let boundaries = match archive::read_partition(
-        &s3_client,
-        &bucket,
-        archive::BOUNDARIES_ARCHIVE_KEY,
-    )
-    .await?
-    {
-        Some(frame) => truncate::BoundaryTable::from_dataframe(&frame)?,
-        None => {
-            warn!(
-                key = archive::BOUNDARIES_ARCHIVE_KEY,
-                "No boundary table in the archive; training on unbounded series"
-            );
-            truncate::BoundaryTable::default()
-        }
-    };
-
-    let equity_bars = load_archived_bars(
-        &s3_client,
-        &bucket,
-        lookback_days,
-        session,
-        &splits,
-        &boundaries,
-    )
-    .await?;
-    info!(rows = equity_bars.height(), "Loaded equity bars from S3");
-
-    let equity_details = details::details_to_dataframe(&details::parse_embedded_details()?)?;
-    info!(rows = equity_details.height(), "Loaded equity details");
-
-    let consolidated = consolidate_data(equity_bars, equity_details)?;
-    let filtered = filter_training_bars(consolidated, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME)?;
-    info!(rows = filtered.height(), "Consolidated and filtered");
-
     // The same fraction reaches preprocessing and windowing, because the scaler is fitted on the
     // rows at or before its cutoff. Passing one value here and another below would fit statistics
     // over a window other than the one the model trains on.
     let training_fraction = TrainingFraction::new(TRAINING_FRACTION)?;
 
-    let fit_result = fit(filtered, training_fraction)?;
+    let prepared = dataset::build(
+        &s3_client,
+        &bucket,
+        lookback_days,
+        session,
+        training_fraction,
+    )
+    .await?;
+    let fingerprint = prepared.fingerprint;
+    let fit_result = prepared.fit;
+    info!(
+        rows = fingerprint.rows,
+        tickers = fingerprint.tickers,
+        "Prepared the training frame"
+    );
+
+    if let Some(journal) = laboratory_journal.as_ref() {
+        journal
+            .record(
+                run_id,
+                now,
+                laboratory::Observation::DatasetBuilt(laboratory::DatasetBuilt {
+                    fingerprint,
+                    revision: std::env::var("FUND_REVISION").ok(),
+                }),
+            )
+            .await;
+    }
 
     let train_dataset = fit_result.data.get_dataset(
         DatasetKind::Train(training_fraction),
@@ -542,75 +526,6 @@ fn training_configuration() -> Result<TrainConfiguration, Box<dyn std::error::Er
 /// a request for one is a guaranteed 404 — about a hundred of them per run. Skipping them here uses
 /// the same predicate the archive scan does, which is what keeps reader and writer agreeing about
 /// which days the archive can hold at all.
-async fn load_archived_bars(
-    s3_client: &aws_sdk_s3::Client,
-    bucket: &str,
-    lookback_days: i64,
-    session: SessionDate,
-    splits: &adjust::SplitTable,
-    boundaries: &truncate::BoundaryTable,
-) -> Result<DataFrame, Box<dyn std::error::Error>> {
-    let end_date = session;
-    let start_date = end_date.plus_calendar_days(-lookback_days);
-
-    let mut frames: Vec<LazyFrame> = Vec::new();
-    let mut unreadable = 0usize;
-    let mut date = start_date;
-    while date <= end_date {
-        if date.is_weekend() {
-            date = date.plus_calendar_days(1);
-            continue;
-        }
-        let key = date_partitioned_key(archive::BAR_ARCHIVE_PREFIX, date.date());
-        if let Some(frame) = archive::read_partition(s3_client, bucket, &key).await? {
-            match bars::project_bar_frame(frame) {
-                Ok(projected) => frames.push(projected.lazy()),
-                Err(error) => {
-                    unreadable += 1;
-                    warn!(key, %error, "Skipping a partition the training schema cannot read");
-                }
-            }
-        }
-        date = date.plus_calendar_days(1);
-    }
-
-    if frames.is_empty() {
-        return Err("No equity-bar parquet files found in the lookback window".into());
-    }
-    if unreadable > 0 {
-        warn!(
-            unreadable,
-            loaded = frames.len(),
-            "Some partitions were skipped; training on the rest"
-        );
-    }
-    // Stepping over a bad partition is the point of the projection, but stepping over most of them
-    // is a different event wearing the same clothes. The sample-count guards downstream only catch a
-    // window that collapsed entirely; this catches one that quietly lost half its history and would
-    // otherwise publish a model trained on the remainder.
-    if unreadable > frames.len() {
-        return Err(format!(
-            "{unreadable} partitions could not be read against {} that could; refusing to train on \
-             the remainder",
-            frames.len()
-        )
-        .into());
-    }
-    // Folded once over the concatenated window rather than per partition: the factor depends on
-    // where a bar sits relative to today, not on which file it came out of.
-    // Stitched, bounded, then folded, in the order the PostgreSQL loader uses and for the same
-    // reasons: the stitch rescues the bars truncation would drop, and the fold keys on the symbol a
-    // bar carries after both.
-    let stitched =
-        truncate::stitch_bars(concat(frames, UnionArgs::default())?.collect()?, boundaries)?;
-    let bounded = truncate::truncate_bars(stitched, boundaries, session)?;
-    Ok(adjust::adjust_bars(
-        bounded,
-        &splits.following_renames(boundaries),
-        session,
-    )?)
-}
-
 /// The bar columns training consumes, in the types [`fund::data::bars::bars_to_dataframe`] writes.
 ///
 /// Deliberately a subset of what the archive holds: `bar_interval` and `transactions` are written
@@ -802,78 +717,5 @@ mod tests {
             .and_then(|(_, tail)| tail.trim_end_matches('.').parse().ok())
             .expect("the rejection must end with a suggested day count");
         assert!(validate_lookback_window(suggested, session).is_ok());
-    }
-
-    /// A partition written before `bar_interval` joined the frame, and one written after. Both must
-    /// project to the same schema, because `concat` rejects the window when one member differs.
-    #[test]
-    fn test_partitions_from_either_writer_project_to_one_schema() {
-        let legacy = df![
-            "ticker" => ["AAPL"],
-            "timestamp" => [1_724_000_000_000i64],
-            "open_price" => [100.0],
-            "high_price" => [101.0],
-            "low_price" => [99.0],
-            "close_price" => [100.5],
-            "volume" => [1_000i64],
-            "volume_weighted_average_price" => [100.2],
-        ]
-        .unwrap();
-        let current = df![
-            "ticker" => ["AAPL"],
-            "bar_interval" => ["one_day"],
-            "timestamp" => [1_724_086_400_000i64],
-            "open_price" => [100.5],
-            "high_price" => [102.0],
-            "low_price" => [100.0],
-            "close_price" => [101.5],
-            "volume" => [1_100i64],
-            "volume_weighted_average_price" => [101.0],
-            "transactions" => [42i64],
-        ]
-        .unwrap();
-
-        let legacy = bars::project_bar_frame(legacy).unwrap();
-        let current = bars::project_bar_frame(current).unwrap();
-        assert_eq!(legacy.schema(), current.schema());
-
-        let combined = concat([legacy.lazy(), current.lazy()], UnionArgs::default())
-            .unwrap()
-            .collect()
-            .unwrap();
-        assert_eq!(combined.height(), 2);
-    }
-
-    /// A column of the right name but the wrong type is refused rather than nulled.
-    ///
-    /// The non-strict cast would accept this and leave `clean_data` to drop the rows much later,
-    /// reporting a thin session instead of a corrupt partition.
-    #[test]
-    fn test_a_partition_with_an_uncastable_column_is_refused() {
-        let frame = df![
-            "ticker" => ["AAPL"],
-            "timestamp" => [1_724_000_000_000i64],
-            "open_price" => ["not a number"],
-            "high_price" => [101.0],
-            "low_price" => [99.0],
-            "close_price" => [100.5],
-            "volume" => [1_000i64],
-            "volume_weighted_average_price" => [100.2],
-        ]
-        .unwrap();
-        assert!(bars::project_bar_frame(frame).is_err());
-    }
-
-    /// A partition genuinely missing a price column is skipped, not silently null-filled — the
-    /// caller counts the skip and trains on the rest.
-    #[test]
-    fn test_a_partition_missing_a_price_column_is_refused() {
-        let frame = df![
-            "ticker" => ["AAPL"],
-            "timestamp" => [1_724_000_000_000i64],
-            "open_price" => [100.0],
-        ]
-        .unwrap();
-        assert!(bars::project_bar_frame(frame).is_err());
     }
 }

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -217,10 +217,12 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     if let Some(journal) = laboratory_journal.as_ref() {
+        // Stamped when it is recorded, not when the run began. Preparation takes minutes, and a run
+        // that crosses UTC midnight would otherwise file this into a day the exporter has sealed.
         journal
             .record(
                 run_id,
-                now,
+                Utc::now(),
                 laboratory::Observation::DatasetBuilt(laboratory::DatasetBuilt {
                     fingerprint,
                     revision: std::env::var("FUND_REVISION").ok(),

--- a/src/laboratory.rs
+++ b/src/laboratory.rs
@@ -1,0 +1,7 @@
+//! Where models, features, and strategies are tried: stateful, offline, and never on the trading path.
+//!
+//! Everything here reads the archive and writes its own journal. Nothing here decides a trade.
+
+pub mod dataset;
+pub mod export;
+pub mod journal;

--- a/src/laboratory/dataset.rs
+++ b/src/laboratory/dataset.rs
@@ -1,0 +1,340 @@
+//! The frame every laboratory experiment reads, and the identity that makes two runs comparable.
+//!
+//! Lifted out of the trainer binary because baselines need this frame and no model.
+
+use aws_sdk_s3::Client as S3Client;
+use chrono::{DateTime, Utc};
+use polars::prelude::*;
+use serde::Serialize;
+use tracing::warn;
+
+use crate::common::aws::date_partitioned_key;
+use crate::common::types::{SessionDate, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
+use crate::data::{adjust, archive, bars, details, truncate};
+use crate::models::tide::data::TrainingFraction;
+use crate::models::tide::fit::{filter_training_bars, fit, FitResult};
+use crate::models::tide::predict::consolidate_data;
+use crate::models::tide::TideError;
+
+/// Errors building a dataset.
+#[derive(Debug, thiserror::Error)]
+pub enum DatasetError {
+    #[error("failed to read the archive: {0}")]
+    Archive(#[from] archive::ArchiveError),
+    #[error("dataframe operation failed: {0}")]
+    Frame(#[from] PolarsError),
+    #[error("preprocessing failed: {0}")]
+    Tide(#[from] TideError),
+    #[error("failed to read the embedded ticker details: {0}")]
+    Details(#[from] crate::data::details::DetailsError),
+    #[error("failed to consolidate bars with details: {0}")]
+    Consolidation(#[from] crate::models::tide::predict::PredictionError),
+    /// A window that cannot produce a dataset, named rather than returned empty.
+    #[error("{0}")]
+    Window(String),
+}
+
+/// What a dataset was built from, recorded so two runs can be told apart.
+///
+/// Counts and spans catch a different window; the two table sizes catch the case they cannot, where
+/// the archive holds the same raw bars and the read-time fold restates them.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DatasetFingerprint {
+    pub session: SessionDate,
+    pub lookback_days: i64,
+    pub rows: usize,
+    pub tickers: usize,
+    pub first_timestamp: Option<DateTime<Utc>>,
+    pub last_timestamp: Option<DateTime<Utc>>,
+    /// Rows in the splits table the prices were folded against.
+    pub splits: usize,
+    /// Rows in the boundary table the series were stitched and bounded against.
+    pub boundaries: usize,
+}
+
+/// A prepared dataset and the identity of what it was prepared from.
+pub struct PreparedDataset {
+    pub fit: FitResult,
+    pub fingerprint: DatasetFingerprint,
+}
+
+/// Reads the archive for `lookback_days` back from `session` and prepares it for windowing.
+///
+/// The splits table is fatal where the boundary table is not: stored prices are raw, so training
+/// without splits fits a two-for-one as a genuine fifty percent fall, while an absent boundary
+/// table costs a guard on a handful of names.
+pub async fn build(
+    s3_client: &S3Client,
+    bucket: &str,
+    lookback_days: i64,
+    session: SessionDate,
+    training_fraction: TrainingFraction,
+) -> Result<PreparedDataset, DatasetError> {
+    let splits_frame = archive::read_partition(s3_client, bucket, archive::SPLITS_ARCHIVE_KEY)
+        .await?
+        .ok_or_else(|| {
+            DatasetError::Window(format!(
+                "no splits table at {}; refusing to build on unadjusted prices",
+                archive::SPLITS_ARCHIVE_KEY
+            ))
+        })?;
+    let splits_rows = splits_frame.height();
+    let splits = adjust::SplitTable::from_dataframe(&splits_frame)?;
+
+    let boundaries_frame =
+        archive::read_partition(s3_client, bucket, archive::BOUNDARIES_ARCHIVE_KEY).await?;
+    let boundaries_rows = boundaries_frame.as_ref().map_or(0, DataFrame::height);
+    let boundaries = match boundaries_frame {
+        Some(frame) => truncate::BoundaryTable::from_dataframe(&frame)?,
+        None => {
+            warn!(
+                key = archive::BOUNDARIES_ARCHIVE_KEY,
+                "No boundary table in the archive; building on unbounded series"
+            );
+            truncate::BoundaryTable::default()
+        }
+    };
+
+    let equity_bars = load_archived_bars(
+        s3_client,
+        bucket,
+        lookback_days,
+        session,
+        &splits,
+        &boundaries,
+    )
+    .await?;
+
+    let equity_details = details::details_to_dataframe(&details::parse_embedded_details()?)?;
+    let consolidated = consolidate_data(equity_bars, equity_details)?;
+    let filtered = filter_training_bars(consolidated, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME)?;
+
+    let fingerprint = fingerprint_of(
+        &filtered,
+        session,
+        lookback_days,
+        splits_rows,
+        boundaries_rows,
+    )?;
+    let fit = fit(filtered, training_fraction)?;
+
+    Ok(PreparedDataset { fit, fingerprint })
+}
+
+/// Describes the frame the model will be fitted on, before fitting consumes it.
+fn fingerprint_of(
+    frame: &DataFrame,
+    session: SessionDate,
+    lookback_days: i64,
+    splits: usize,
+    boundaries: usize,
+) -> Result<DatasetFingerprint, DatasetError> {
+    let timestamps = frame.column("timestamp")?.i64()?;
+    let tickers = frame.column("ticker")?.str()?;
+
+    Ok(DatasetFingerprint {
+        session,
+        lookback_days,
+        rows: frame.height(),
+        tickers: tickers
+            .into_no_null_iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len(),
+        first_timestamp: timestamps.min().and_then(DateTime::from_timestamp_millis),
+        last_timestamp: timestamps.max().and_then(DateTime::from_timestamp_millis),
+        splits,
+        boundaries,
+    })
+}
+
+/// Reads every weekday partition in the window, then stitches, bounds, and folds it once.
+///
+/// Folded over the concatenated window rather than per partition, because the factor depends on
+/// where a bar sits relative to `session` and not on which file it came out of.
+async fn load_archived_bars(
+    s3_client: &S3Client,
+    bucket: &str,
+    lookback_days: i64,
+    session: SessionDate,
+    splits: &adjust::SplitTable,
+    boundaries: &truncate::BoundaryTable,
+) -> Result<DataFrame, DatasetError> {
+    let mut frames: Vec<LazyFrame> = Vec::new();
+    let mut unreadable = 0usize;
+    let mut date = session.plus_calendar_days(-lookback_days);
+    while date <= session {
+        if date.is_weekend() {
+            date = date.plus_calendar_days(1);
+            continue;
+        }
+        let key = date_partitioned_key(archive::BAR_ARCHIVE_PREFIX, date.date());
+        if let Some(frame) = archive::read_partition(s3_client, bucket, &key).await? {
+            match bars::project_bar_frame(frame) {
+                Ok(projected) => frames.push(projected.lazy()),
+                Err(error) => {
+                    unreadable += 1;
+                    warn!(key, %error, "Skipping a partition the training schema cannot read");
+                }
+            }
+        }
+        date = date.plus_calendar_days(1);
+    }
+
+    if frames.is_empty() {
+        return Err(DatasetError::Window(
+            "No equity-bar parquet files found in the lookback window".to_string(),
+        ));
+    }
+    if unreadable > 0 {
+        warn!(
+            unreadable,
+            loaded = frames.len(),
+            "Some partitions were skipped; building on the rest"
+        );
+    }
+    // Stepping over a bad partition is the point of the projection; stepping over most of them is a
+    // different event wearing the same clothes, which the downstream sample counts cannot see.
+    if unreadable > frames.len() {
+        return Err(DatasetError::Window(format!(
+            "{unreadable} partitions could not be read against {} that could; refusing to build on \
+             the remainder",
+            frames.len()
+        )));
+    }
+
+    // Stitched, bounded, then folded, in the order the PostgreSQL loader uses: the stitch rescues
+    // the bars truncation would drop, and the fold keys on the symbol a bar carries after both.
+    let stitched =
+        truncate::stitch_bars(concat(frames, UnionArgs::default())?.collect()?, boundaries)?;
+    let bounded = truncate::truncate_bars(stitched, boundaries, session)?;
+    Ok(adjust::adjust_bars(
+        bounded,
+        &splits.following_renames(boundaries),
+        session,
+    )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A partition written before `bar_interval` joined the frame, and one written after. Both must
+    /// project to the same schema, because `concat` rejects the window when one member differs.
+    #[test]
+    fn test_partitions_from_either_writer_project_to_one_schema() {
+        let legacy = df![
+            "ticker" => ["AAPL"],
+            "timestamp" => [1_724_000_000_000i64],
+            "open_price" => [100.0],
+            "high_price" => [101.0],
+            "low_price" => [99.0],
+            "close_price" => [100.5],
+            "volume" => [1_000i64],
+            "volume_weighted_average_price" => [100.2],
+        ]
+        .unwrap();
+        let current = df![
+            "ticker" => ["AAPL"],
+            "bar_interval" => ["one_day"],
+            "timestamp" => [1_724_086_400_000i64],
+            "open_price" => [100.5],
+            "high_price" => [102.0],
+            "low_price" => [100.0],
+            "close_price" => [101.5],
+            "volume" => [1_100i64],
+            "volume_weighted_average_price" => [101.0],
+            "transactions" => [42i64],
+        ]
+        .unwrap();
+
+        let legacy = bars::project_bar_frame(legacy).unwrap();
+        let current = bars::project_bar_frame(current).unwrap();
+        assert_eq!(legacy.schema(), current.schema());
+
+        let combined = concat([legacy.lazy(), current.lazy()], UnionArgs::default())
+            .unwrap()
+            .collect()
+            .unwrap();
+        assert_eq!(combined.height(), 2);
+    }
+
+    /// A column of the right name but the wrong type is refused rather than nulled.
+    ///
+    /// The non-strict cast would accept this and leave `clean_data` to drop the rows much later,
+    /// reporting a thin session instead of a corrupt partition.
+    #[test]
+    fn test_a_partition_with_an_uncastable_column_is_refused() {
+        let frame = df![
+            "ticker" => ["AAPL"],
+            "timestamp" => [1_724_000_000_000i64],
+            "open_price" => ["not a number"],
+            "high_price" => [101.0],
+            "low_price" => [99.0],
+            "close_price" => [100.5],
+            "volume" => [1_000i64],
+            "volume_weighted_average_price" => [100.2],
+        ]
+        .unwrap();
+        assert!(bars::project_bar_frame(frame).is_err());
+    }
+
+    /// A partition genuinely missing a price column is skipped, not silently null-filled — the
+    /// caller counts the skip and trains on the rest.
+    #[test]
+    fn test_a_partition_missing_a_price_column_is_refused() {
+        let frame = df![
+            "ticker" => ["AAPL"],
+            "timestamp" => [1_724_000_000_000i64],
+            "open_price" => [100.0],
+        ]
+        .unwrap();
+        assert!(bars::project_bar_frame(frame).is_err());
+    }
+
+    fn frame(tickers: Vec<&str>, timestamps: Vec<i64>) -> DataFrame {
+        DataFrame::new(vec![
+            Column::new("ticker".into(), tickers),
+            Column::new("timestamp".into(), timestamps),
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn test_fingerprint_counts_distinct_tickers_not_rows() {
+        const DAY: i64 = 86_400_000;
+        let fingerprint = fingerprint_of(
+            &frame(vec!["AAA", "AAA", "BBB"], vec![0, DAY, DAY]),
+            SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 8, 17).unwrap()),
+            365,
+            12,
+            3,
+        )
+        .unwrap();
+
+        assert_eq!(fingerprint.rows, 3);
+        assert_eq!(fingerprint.tickers, 2);
+        assert_eq!(
+            fingerprint.first_timestamp,
+            DateTime::from_timestamp_millis(0)
+        );
+        assert_eq!(
+            fingerprint.last_timestamp,
+            DateTime::from_timestamp_millis(DAY)
+        );
+        assert_eq!(fingerprint.splits, 12);
+        assert_eq!(fingerprint.boundaries, 3);
+    }
+
+    /// The two table sizes are the whole reason the fingerprint is not just a row count: a
+    /// re-adjustment restates prices while the window, the rows, and the tickers all stay put.
+    #[test]
+    fn test_a_restated_fold_changes_the_fingerprint() {
+        let session = SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 8, 17).unwrap());
+        let rows = frame(vec!["AAA", "BBB"], vec![0, 0]);
+
+        let before = fingerprint_of(&rows, session, 365, 12, 3).unwrap();
+        let after = fingerprint_of(&rows, session, 365, 13, 3).unwrap();
+
+        assert_ne!(before, after, "one more split must not read as one dataset");
+    }
+}

--- a/src/laboratory/dataset.rs
+++ b/src/laboratory/dataset.rs
@@ -36,8 +36,8 @@ pub enum DatasetError {
 
 /// What a dataset was built from, recorded so two runs can be told apart.
 ///
-/// Counts and spans catch a different window; the two table sizes catch the case they cannot, where
-/// the archive holds the same raw bars and the read-time fold restates them.
+/// Counts and spans catch a different window; the two digests catch the case they cannot, where the
+/// archive holds the same raw bars and a table revised in place restates them at read time.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct DatasetFingerprint {
     pub session: SessionDate,
@@ -46,10 +46,48 @@ pub struct DatasetFingerprint {
     pub tickers: usize,
     pub first_timestamp: Option<DateTime<Utc>>,
     pub last_timestamp: Option<DateTime<Utc>>,
-    /// Rows in the splits table the prices were folded against.
-    pub splits: usize,
-    /// Rows in the boundary table the series were stitched and bounded against.
-    pub boundaries: usize,
+    /// Content of the splits table the prices were folded against.
+    pub splits_digest: u64,
+    /// Content of the boundary table the series were stitched and bounded against.
+    pub boundaries_digest: u64,
+}
+
+/// Folds a frame's contents into one value that changes when any cell does.
+///
+/// FNV-1a over the sorted rows rather than Polars' own row hash, which is seeded randomly per call
+/// and so cannot answer whether two runs read the same table. Sorting makes the row order irrelevant.
+fn digest_of(frame: &DataFrame) -> Result<u64, DatasetError> {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    let columns: Vec<String> = frame
+        .get_column_names()
+        .iter()
+        .map(|name| name.to_string())
+        .collect();
+    let sorted = frame.sort(&columns, SortMultipleOptions::default())?;
+
+    let mut digest = OFFSET_BASIS;
+    let mut fold = |bytes: &[u8]| {
+        for byte in bytes {
+            digest = (digest ^ u64::from(*byte)).wrapping_mul(PRIME);
+        }
+    };
+    // Names as well as values: a column renamed in place changes what the table means.
+    for name in &columns {
+        fold(name.as_bytes());
+        fold(b"\x1f");
+    }
+    let mut rendered = String::new();
+    for index in 0..sorted.height() {
+        rendered.clear();
+        for value in &sorted.get_row(index)?.0 {
+            use std::fmt::Write;
+            let _ = write!(rendered, "{value}\u{1f}");
+        }
+        fold(rendered.as_bytes());
+    }
+    Ok(digest)
 }
 
 /// A prepared dataset and the identity of what it was prepared from.
@@ -78,12 +116,16 @@ pub async fn build(
                 archive::SPLITS_ARCHIVE_KEY
             ))
         })?;
-    let splits_rows = splits_frame.height();
+    let splits_digest = digest_of(&splits_frame)?;
     let splits = adjust::SplitTable::from_dataframe(&splits_frame)?;
 
     let boundaries_frame =
         archive::read_partition(s3_client, bucket, archive::BOUNDARIES_ARCHIVE_KEY).await?;
-    let boundaries_rows = boundaries_frame.as_ref().map_or(0, DataFrame::height);
+    let boundaries_digest = boundaries_frame
+        .as_ref()
+        .map(digest_of)
+        .transpose()?
+        .unwrap_or(0);
     let boundaries = match boundaries_frame {
         Some(frame) => truncate::BoundaryTable::from_dataframe(&frame)?,
         None => {
@@ -113,8 +155,8 @@ pub async fn build(
         &filtered,
         session,
         lookback_days,
-        splits_rows,
-        boundaries_rows,
+        splits_digest,
+        boundaries_digest,
     )?;
     let fit = fit(filtered, training_fraction)?;
 
@@ -126,8 +168,8 @@ fn fingerprint_of(
     frame: &DataFrame,
     session: SessionDate,
     lookback_days: i64,
-    splits: usize,
-    boundaries: usize,
+    splits_digest: u64,
+    boundaries_digest: u64,
 ) -> Result<DatasetFingerprint, DatasetError> {
     let timestamps = frame.column("timestamp")?.i64()?;
     let tickers = frame.column("ticker")?.str()?;
@@ -142,8 +184,8 @@ fn fingerprint_of(
             .len(),
         first_timestamp: timestamps.min().and_then(DateTime::from_timestamp_millis),
         last_timestamp: timestamps.max().and_then(DateTime::from_timestamp_millis),
-        splits,
-        boundaries,
+        splits_digest,
+        boundaries_digest,
     })
 }
 
@@ -180,10 +222,17 @@ async fn load_archived_bars(
         date = date.plus_calendar_days(1);
     }
 
+    // Two different failures wearing one message otherwise: an empty archive sends the operator to
+    // the fetch stage, where a window of partitions that all failed projection is a schema problem.
     if frames.is_empty() {
-        return Err(DatasetError::Window(
-            "No equity-bar parquet files found in the lookback window".to_string(),
-        ));
+        return Err(DatasetError::Window(if unreadable > 0 {
+            format!(
+                "all {unreadable} partitions in the lookback window failed projection; none could \
+                 be read"
+            )
+        } else {
+            "No equity-bar parquet files found in the lookback window".to_string()
+        }));
     }
     if unreadable > 0 {
         warn!(
@@ -306,8 +355,8 @@ mod tests {
             &frame(vec!["AAA", "AAA", "BBB"], vec![0, DAY, DAY]),
             SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 8, 17).unwrap()),
             365,
-            12,
-            3,
+            0xAB,
+            0xCD,
         )
         .unwrap();
 
@@ -321,8 +370,8 @@ mod tests {
             fingerprint.last_timestamp,
             DateTime::from_timestamp_millis(DAY)
         );
-        assert_eq!(fingerprint.splits, 12);
-        assert_eq!(fingerprint.boundaries, 3);
+        assert_eq!(fingerprint.splits_digest, 0xAB);
+        assert_eq!(fingerprint.boundaries_digest, 0xCD);
     }
 
     /// The two table sizes are the whole reason the fingerprint is not just a row count: a
@@ -332,9 +381,44 @@ mod tests {
         let session = SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 8, 17).unwrap());
         let rows = frame(vec!["AAA", "BBB"], vec![0, 0]);
 
-        let before = fingerprint_of(&rows, session, 365, 12, 3).unwrap();
-        let after = fingerprint_of(&rows, session, 365, 13, 3).unwrap();
+        // One ratio revised in place: same table, same row count, different adjusted prices. This
+        // is the case a count cannot see, and the whole reason the digest is here.
+        let splits = |ratio: f64| {
+            DataFrame::new(vec![
+                Column::new("ticker".into(), vec!["AAA", "BBB"]),
+                Column::new("ratio".into(), vec![2.0_f64, ratio]),
+            ])
+            .unwrap()
+        };
+        let before = splits(3.0);
+        let after = splits(4.0);
+        assert_eq!(before.height(), after.height());
 
-        assert_ne!(before, after, "one more split must not read as one dataset");
+        let before = fingerprint_of(&rows, session, 365, digest_of(&before).unwrap(), 0).unwrap();
+        let after = fingerprint_of(&rows, session, 365, digest_of(&after).unwrap(), 0).unwrap();
+
+        assert_ne!(
+            before, after,
+            "a revised ratio must not read as one dataset"
+        );
+    }
+
+    /// The digest is what two runs compare, so the same table must produce the same value however
+    /// its rows happen to be ordered on the way back out of the archive.
+    #[test]
+    fn test_the_digest_is_stable_and_order_independent() {
+        let ordered = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["AAA", "BBB"]),
+            Column::new("ratio".into(), vec![2.0_f64, 3.0]),
+        ])
+        .unwrap();
+        let reversed = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["BBB", "AAA"]),
+            Column::new("ratio".into(), vec![3.0_f64, 2.0]),
+        ])
+        .unwrap();
+
+        assert_eq!(digest_of(&ordered).unwrap(), digest_of(&ordered).unwrap());
+        assert_eq!(digest_of(&ordered).unwrap(), digest_of(&reversed).unwrap());
     }
 }

--- a/src/laboratory/export.rs
+++ b/src/laboratory/export.rs
@@ -1,0 +1,360 @@
+//! Ships sealed laboratory journal days to S3, one object per experiment type per UTC date.
+//!
+//! Triggered explicitly: the laboratory has no scheduled pass to hang this off.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::Client as S3Client;
+use chrono::{DateTime, NaiveDate};
+use polars::prelude::*;
+use serde_json::Value;
+use tracing::{info, warn};
+
+use crate::common::aws::date_partitioned_key;
+use crate::laboratory::journal::{date_from_file_name, file_name, Journal};
+
+/// S3 prefix the laboratory writes under.
+///
+/// Its own, and not the application's `exports/journal`: both partition by date, so one prefix
+/// would mean two producers overwriting each other's object for the same day.
+pub const EXPERIMENT_PREFIX: &str = "exports/laboratory/experiments";
+
+/// Days a local file is kept once it has been shipped.
+pub const RETENTION_DAYS: i64 = 7;
+
+/// What one export run shipped, and what it could not.
+#[derive(Debug, Default, PartialEq)]
+pub struct ExportSummary {
+    /// `(experiment_type, date, rows)` for each object written.
+    pub written: Vec<(String, NaiveDate, usize)>,
+    pub failed: Vec<String>,
+    pub files_deleted: usize,
+    /// Lines the Parquet does not hold, which keep their file from being deleted.
+    pub unparsable_lines: usize,
+}
+
+/// Writes every sealed day to S3, then deletes the local files that have aged out.
+///
+/// A day is sealed once `today` has moved past it. The key is derived from the record, so a repeat
+/// run overwrites byte-identically and a failed run repairs itself.
+pub async fn export_journals(
+    journal: &Journal,
+    s3_client: &S3Client,
+    bucket: &str,
+    today: NaiveDate,
+) -> ExportSummary {
+    let mut summary = ExportSummary::default();
+
+    let dates = match sealed_dates(journal.directory(), today) {
+        Ok(dates) => dates,
+        Err(error) => {
+            summary.failed.push(format!(
+                "could not list {}: {error}",
+                journal.directory().display()
+            ));
+            return summary;
+        }
+    };
+
+    let mut shipped: Vec<NaiveDate> = Vec::new();
+    for date in dates {
+        // Held only for the read, so a long upload does not block an experiment mid-run.
+        let frames = {
+            let _sealed = journal.seal().await;
+            read_day(&journal.directory().join(file_name(date)))
+        };
+        let (frames, unparsable) = match frames {
+            Ok(read) => read,
+            Err(error) => {
+                summary.failed.push(error);
+                continue;
+            }
+        };
+        summary.unparsable_lines += unparsable;
+
+        let mut day_written = true;
+        for (experiment_type, mut frame) in frames {
+            let prefix = format!("{EXPERIMENT_PREFIX}/experiment_type={experiment_type}");
+            let key = date_partitioned_key(&prefix, date);
+            match write_frame(s3_client, bucket, &key, &mut frame).await {
+                Ok(()) => summary
+                    .written
+                    .push((experiment_type, date, frame.height())),
+                Err(error) => {
+                    summary.failed.push(error);
+                    day_written = false;
+                }
+            }
+        }
+        // A file with unparsable lines is kept whole: those lines reach no object, and deleting the
+        // file would destroy the only copy of them.
+        if day_written && unparsable == 0 {
+            shipped.push(date);
+        }
+    }
+
+    summary.files_deleted = delete_aged_out(journal.directory(), &shipped, today);
+    summary
+}
+
+/// Every UTC date in the directory that `today` has moved past.
+fn sealed_dates(directory: &Path, today: NaiveDate) -> Result<Vec<NaiveDate>, std::io::Error> {
+    let mut dates = Vec::new();
+    for entry in std::fs::read_dir(directory)? {
+        let Some(name) = entry?.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let Some(date) = date_from_file_name(&name) else {
+            continue;
+        };
+        if date >= today {
+            continue;
+        }
+        dates.push(date);
+    }
+    dates.sort_unstable();
+    Ok(dates)
+}
+
+/// One day's records as a frame per experiment type, keyed by that type.
+///
+/// Grouped here rather than at the query surface because the type is a partition, so a day holding
+/// three kinds of record writes three objects.
+fn read_day(path: &Path) -> Result<(BTreeMap<String, DataFrame>, usize), String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+
+    let mut grouped: BTreeMap<String, Vec<Value>> = BTreeMap::new();
+    let mut unparsable = 0usize;
+    for line in contents.lines().filter(|line| !line.trim().is_empty()) {
+        let Ok(Value::Object(record)) = serde_json::from_str::<Value>(line) else {
+            unparsable += 1;
+            continue;
+        };
+        match record.get("experiment_type").and_then(Value::as_str) {
+            Some(experiment_type) => grouped
+                .entry(experiment_type.to_string())
+                .or_default()
+                .push(Value::Object(record)),
+            None => unparsable += 1,
+        }
+    }
+
+    if unparsable > 0 {
+        warn!(path = %path.display(), unparsable, "Skipped laboratory lines that would not parse");
+    }
+
+    let mut frames = BTreeMap::new();
+    for (experiment_type, records) in grouped {
+        let (frame, rejected) = records_to_frame(&records, path)?;
+        unparsable += rejected;
+        frames.insert(experiment_type, frame);
+    }
+    Ok((frames, unparsable))
+}
+
+/// The envelope as columns and the payload as one JSON string.
+///
+/// Every envelope column or no row at all: `run_id` is the join and `timestamp` orders the runs, so
+/// a row missing either is unreachable by the queries this archive exists to answer.
+fn records_to_frame(records: &[Value], path: &Path) -> Result<(DataFrame, usize), String> {
+    let mut schema_versions: Vec<Option<i64>> = Vec::new();
+    let mut event_ids: Vec<Option<String>> = Vec::new();
+    let mut run_ids: Vec<Option<String>> = Vec::new();
+    let mut timestamps: Vec<Option<i64>> = Vec::new();
+    let mut payloads: Vec<Option<String>> = Vec::new();
+    let mut rejected = 0usize;
+
+    for record in records {
+        let text = |key: &str| record.get(key).and_then(Value::as_str).map(str::to_string);
+        let (Some(schema_version), Some(event_id), Some(run_id), Some(timestamp)) = (
+            record.get("schema_version").and_then(Value::as_i64),
+            text("event_id"),
+            text("run_id"),
+            text("timestamp").and_then(|stamp| {
+                DateTime::parse_from_rfc3339(&stamp)
+                    .ok()
+                    .map(|instant| instant.timestamp_millis())
+            }),
+        ) else {
+            rejected += 1;
+            continue;
+        };
+
+        schema_versions.push(Some(schema_version));
+        event_ids.push(Some(event_id));
+        run_ids.push(Some(run_id));
+        timestamps.push(Some(timestamp));
+        payloads.push(record.get("payload").map(Value::to_string));
+    }
+
+    let frame = DataFrame::new(vec![
+        Column::new("schema_version".into(), schema_versions),
+        Column::new("event_id".into(), event_ids),
+        Column::new("run_id".into(), run_ids),
+        Column::new("timestamp".into(), timestamps),
+        Column::new("payload".into(), payloads),
+    ])
+    .map_err(|error| format!("failed to build frame for {}: {error}", path.display()))?;
+
+    Ok((frame, rejected))
+}
+
+/// Serializes a frame to Parquet and puts it at `key`.
+async fn write_frame(
+    s3_client: &S3Client,
+    bucket: &str,
+    key: &str,
+    frame: &mut DataFrame,
+) -> Result<(), String> {
+    let mut buffer: Vec<u8> = Vec::new();
+    ParquetWriter::new(&mut buffer)
+        .finish(frame)
+        .map_err(|error| format!("failed to serialize Parquet: {error}"))?;
+
+    s3_client
+        .put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(ByteStream::from(buffer))
+        .content_type("application/vnd.apache.parquet")
+        .send()
+        .await
+        .map_err(|error| format!("failed to write s3://{bucket}/{key}: {error}"))?;
+
+    info!(key, rows = frame.height(), "Experiment records exported");
+    Ok(())
+}
+
+/// Deletes shipped files older than the retention window.
+fn delete_aged_out(directory: &Path, shipped: &[NaiveDate], today: NaiveDate) -> usize {
+    let oldest_kept = today - chrono::Duration::days(RETENTION_DAYS);
+    let mut deleted = 0usize;
+    for date in shipped {
+        if *date >= oldest_kept {
+            continue;
+        }
+        let path = directory.join(file_name(*date));
+        match std::fs::remove_file(&path) {
+            Ok(()) => deleted += 1,
+            Err(error) => warn!(path = %path.display(), %error, "Could not delete a shipped file"),
+        }
+    }
+    deleted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::types::SessionDate;
+    use crate::laboratory::dataset::DatasetFingerprint;
+    use crate::laboratory::journal::{DatasetBuilt, Observation, Record};
+    use uuid::Uuid;
+
+    fn record(run_id: Uuid, milliseconds: i64) -> Record {
+        Record::new(
+            run_id,
+            DateTime::from_timestamp_millis(milliseconds).unwrap(),
+            Observation::DatasetBuilt(DatasetBuilt {
+                fingerprint: DatasetFingerprint {
+                    session: SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 8, 17).unwrap()),
+                    lookback_days: 365,
+                    rows: 10,
+                    tickers: 2,
+                    first_timestamp: DateTime::from_timestamp_millis(0),
+                    last_timestamp: DateTime::from_timestamp_millis(86_400_000),
+                    splits: 12,
+                    boundaries: 3,
+                },
+                revision: None,
+            }),
+        )
+    }
+
+    fn write_day(directory: &Path, date: NaiveDate, lines: &[String]) {
+        std::fs::write(directory.join(file_name(date)), lines.join("\n") + "\n").unwrap();
+    }
+
+    #[test]
+    fn test_today_is_not_yet_sealed() {
+        let directory = tempfile::tempdir().unwrap();
+        let today = NaiveDate::from_ymd_opt(2026, 8, 18).unwrap();
+        let yesterday = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        for date in [today, yesterday] {
+            write_day(directory.path(), date, &[]);
+        }
+
+        let sealed = sealed_dates(directory.path(), today).unwrap();
+
+        assert_eq!(
+            sealed,
+            vec![yesterday],
+            "a day still being written to is not sealed"
+        );
+    }
+
+    /// Experiment type is a partition, so a day holding two kinds writes two objects rather than
+    /// one frame with a mostly-null union schema.
+    #[test]
+    fn test_a_day_groups_into_one_frame_per_experiment_type() {
+        let directory = tempfile::tempdir().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        let run_id = Uuid::new_v4();
+
+        let mut lines: Vec<String> = (0..2)
+            .map(|index| serde_json::to_string(&record(run_id, 1_755_400_000_000 + index)).unwrap())
+            .collect();
+        // A second type, spelled directly because only one variant exists so far.
+        let mut other: Value = serde_json::from_str(&lines[0]).unwrap();
+        other["experiment_type"] = Value::String("model_trained".to_string());
+        lines.push(other.to_string());
+        write_day(directory.path(), date, &lines);
+
+        let (frames, unparsable) = read_day(&directory.path().join(file_name(date))).unwrap();
+
+        assert_eq!(unparsable, 0);
+        assert_eq!(frames.len(), 2);
+        assert_eq!(frames["dataset_built"].height(), 2);
+        assert_eq!(frames["model_trained"].height(), 1);
+    }
+
+    #[test]
+    fn test_a_line_without_an_experiment_type_is_counted_not_filed() {
+        let directory = tempfile::tempdir().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        write_day(
+            directory.path(),
+            date,
+            &[
+                serde_json::to_string(&record(Uuid::new_v4(), 1_755_400_000_000)).unwrap(),
+                "{\"run_id\":\"nope\"}".to_string(),
+                "not json at all".to_string(),
+            ],
+        );
+
+        let (frames, unparsable) = read_day(&directory.path().join(file_name(date))).unwrap();
+
+        assert_eq!(unparsable, 2);
+        assert_eq!(frames["dataset_built"].height(), 1);
+    }
+
+    /// The whole reason for a separate prefix: the application's journal key for the same date must
+    /// not be the one this produces.
+    #[test]
+    fn test_the_key_does_not_collide_with_the_application_journal() {
+        let date = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        let laboratory = date_partitioned_key(
+            &format!("{EXPERIMENT_PREFIX}/experiment_type=dataset_built"),
+            date,
+        );
+        let application = date_partitioned_key(crate::data::export::JOURNAL_PREFIX, date);
+
+        assert_ne!(laboratory, application);
+        assert_eq!(
+            laboratory,
+            "exports/laboratory/experiments/experiment_type=dataset_built/year=2026/month=08/day=17/data.parquet"
+        );
+    }
+}

--- a/src/laboratory/export.rs
+++ b/src/laboratory/export.rs
@@ -21,7 +21,9 @@ use crate::laboratory::journal::{date_from_file_name, file_name, Journal};
 /// would mean two producers overwriting each other's object for the same day.
 pub const EXPERIMENT_PREFIX: &str = "exports/laboratory/experiments";
 
-/// Days a local file is kept once it has been shipped.
+/// Age, in days, past which a shipped file is deleted.
+///
+/// A file exactly this old is kept, matching `data::export::JOURNAL_RETENTION_DAYS`.
 pub const RETENTION_DAYS: i64 = 7;
 
 /// What one export run shipped, and what it could not.
@@ -76,6 +78,12 @@ pub async fn export_journals(
 
         let mut day_written = true;
         for (experiment_type, mut frame) in frames {
+            // Every run re-exports the sealed days inside the retention window, so writing a frame
+            // whose records were all rejected would replace a complete object with an empty one.
+            if frame.is_empty() {
+                day_written = false;
+                continue;
+            }
             let prefix = format!("{EXPERIMENT_PREFIX}/experiment_type={experiment_type}");
             let key = date_partitioned_key(&prefix, date);
             match write_frame(s3_client, bucket, &key, &mut frame).await {
@@ -265,8 +273,8 @@ mod tests {
                     tickers: 2,
                     first_timestamp: DateTime::from_timestamp_millis(0),
                     last_timestamp: DateTime::from_timestamp_millis(86_400_000),
-                    splits: 12,
-                    boundaries: 3,
+                    splits_digest: 0xAB,
+                    boundaries_digest: 0xCD,
                 },
                 revision: None,
             }),
@@ -318,6 +326,69 @@ mod tests {
         assert_eq!(frames.len(), 2);
         assert_eq!(frames["dataset_built"].height(), 2);
         assert_eq!(frames["model_trained"].height(), 1);
+
+        // The reader rebuilds the envelope from JSON keys the producer names, so this is what
+        // catches a field renamed on `Record` — without it the failure is only a row count.
+        for column in [
+            "schema_version",
+            "event_id",
+            "run_id",
+            "timestamp",
+            "payload",
+        ] {
+            assert_eq!(
+                frames["dataset_built"].column(column).unwrap().null_count(),
+                0,
+                "{column} did not survive the round trip from Record"
+            );
+        }
+    }
+
+    /// Pinned to literal dates rather than to `RETENTION_DAYS`: an expectation derived from the
+    /// constant under test moves with it and can never fail.
+    #[test]
+    fn test_only_files_older_than_the_retention_window_are_deleted() {
+        let directory = tempfile::tempdir().unwrap();
+        let today = NaiveDate::from_ymd_opt(2026, 8, 18).unwrap();
+        let too_old = NaiveDate::from_ymd_opt(2026, 8, 10).unwrap();
+        let exactly_at_the_edge = NaiveDate::from_ymd_opt(2026, 8, 11).unwrap();
+        let recent = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        for date in [too_old, exactly_at_the_edge, recent] {
+            write_day(directory.path(), date, &[]);
+        }
+
+        let deleted = delete_aged_out(
+            directory.path(),
+            &[too_old, exactly_at_the_edge, recent],
+            today,
+        );
+
+        assert_eq!(deleted, 1);
+        assert!(!directory.path().join(file_name(too_old)).exists());
+        assert!(directory
+            .path()
+            .join(file_name(exactly_at_the_edge))
+            .exists());
+        assert!(directory.path().join(file_name(recent)).exists());
+    }
+
+    /// A day whose records were all rejected must not ship. Every run re-exports the sealed days in
+    /// the window, so writing that frame would replace a complete object with an empty one.
+    #[test]
+    fn test_a_type_whose_records_were_all_rejected_yields_an_empty_frame() {
+        let directory = tempfile::tempdir().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        // A well-formed experiment_type over an envelope missing run_id: grouped, then rejected.
+        let mut broken: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&record(Uuid::new_v4(), 1)).unwrap())
+                .unwrap();
+        broken.as_object_mut().unwrap().remove("run_id");
+        write_day(directory.path(), date, &[broken.to_string()]);
+
+        let (frames, unparsable) = read_day(&directory.path().join(file_name(date))).unwrap();
+
+        assert_eq!(unparsable, 1);
+        assert!(frames["dataset_built"].is_empty());
     }
 
     #[test]

--- a/src/laboratory/journal.rs
+++ b/src/laboratory/journal.rs
@@ -1,0 +1,295 @@
+//! The laboratory's own append-only record of what it ran.
+//!
+//! Separate from the application's journal because an experiment happens at an instant, not on a
+//! trading day, so it is keyed by run and partitioned by the UTC date.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::Serialize;
+use tokio::io::AsyncWriteExt;
+use tracing::{debug, error};
+use uuid::Uuid;
+
+use crate::laboratory::dataset::DatasetFingerprint;
+
+/// The shape of a laboratory record, versioned independently of the application journal.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Where the laboratory writes when `FUND_LABORATORY_JOURNAL_DIRECTORY` says nothing.
+const DEFAULT_JOURNAL_DIRECTORY: &str = "/var/journal/fund/laboratory";
+
+/// Errors writing the laboratory journal.
+#[derive(Debug, thiserror::Error)]
+pub enum JournalError {
+    #[error("failed to create the journal directory {directory}: {source}")]
+    Directory {
+        directory: String,
+        source: std::io::Error,
+    },
+    #[error("failed to write the journal: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("failed to serialize a record: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+/// One thing the laboratory did.
+///
+/// Named `<subject>_<past participle>`, the convention the application journal already uses.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(
+    tag = "experiment_type",
+    content = "payload",
+    rename_all = "snake_case"
+)]
+pub enum Observation {
+    DatasetBuilt(DatasetBuilt),
+}
+
+impl Observation {
+    /// The stable name this observation serializes under, and the partition it exports into.
+    pub fn experiment_type(&self) -> &'static str {
+        match self {
+            Observation::DatasetBuilt(_) => "dataset_built",
+        }
+    }
+}
+
+/// One frame prepared for an experiment to read.
+///
+/// The fingerprint is what makes a later result comparable, so it is recorded once here and
+/// referenced by `run_id` rather than repeated on every result the run goes on to produce.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DatasetBuilt {
+    pub fingerprint: DatasetFingerprint,
+    /// The commit this ran from, so a number can be traced to the code that produced it.
+    pub revision: Option<String>,
+}
+
+/// One line of the laboratory journal: an observation with the envelope that addresses it.
+///
+/// `run_id` sits where the application's record carries `session_date`, and threads every record
+/// one run emits. An experiment spans hundreds of sessions and belongs to none of them.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Record {
+    pub schema_version: u32,
+    pub event_id: Uuid,
+    pub run_id: Uuid,
+    pub timestamp: DateTime<Utc>,
+    #[serde(flatten)]
+    pub observation: Observation,
+}
+
+impl Record {
+    /// Stamps an observation with a fresh identity at `timestamp`.
+    pub fn new(run_id: Uuid, timestamp: DateTime<Utc>, observation: Observation) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            event_id: Uuid::new_v4(),
+            run_id,
+            timestamp,
+            observation,
+        }
+    }
+}
+
+/// The file the writer currently holds open, and the UTC date it belongs to.
+struct OpenDate {
+    date: NaiveDate,
+    file: tokio::fs::File,
+}
+
+/// Appends records to the current UTC date's file.
+///
+/// The date comes from the record rather than from construction, so the file rolls at UTC midnight
+/// whatever the process was doing at the time.
+pub struct Journal {
+    directory: PathBuf,
+    open_date: tokio::sync::Mutex<Option<OpenDate>>,
+}
+
+impl Journal {
+    /// Opens a journal against `directory`, creating it if needed.
+    pub fn new(directory: impl Into<PathBuf>) -> Result<Self, JournalError> {
+        let directory = directory.into();
+        std::fs::create_dir_all(&directory).map_err(|source| JournalError::Directory {
+            directory: directory.display().to_string(),
+            source,
+        })?;
+        Ok(Self {
+            directory,
+            open_date: tokio::sync::Mutex::new(None),
+        })
+    }
+
+    /// Opens a journal at `FUND_LABORATORY_JOURNAL_DIRECTORY`, or the default beneath it.
+    pub fn from_env() -> Result<Self, JournalError> {
+        let directory = std::env::var("FUND_LABORATORY_JOURNAL_DIRECTORY")
+            .unwrap_or_else(|_| DEFAULT_JOURNAL_DIRECTORY.to_string());
+        Self::new(directory)
+    }
+
+    pub fn directory(&self) -> &Path {
+        &self.directory
+    }
+
+    /// Appends one record and returns once it is fsynced to the disk.
+    pub async fn append(&self, record: &Record) -> Result<(), JournalError> {
+        let mut line = serde_json::to_vec(record)?;
+        line.push(b'\n');
+        let date = record.timestamp.date_naive();
+
+        let mut open_date = self.open_date.lock().await;
+        let open = match open_date.as_mut() {
+            Some(open) if open.date == date => open,
+            _ => {
+                let file = tokio::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(self.directory.join(file_name(date)))
+                    .await?;
+                open_date.insert(OpenDate { date, file })
+            }
+        };
+
+        open.file.write_all(&line).await?;
+        open.file.flush().await?;
+        open.file.sync_all().await?;
+        Ok(())
+    }
+
+    /// Appends a record, reporting a failure without propagating it.
+    ///
+    /// A journal write must not become a new way for an experiment to fail, so running unobserved
+    /// beats refusing to run.
+    pub async fn record(&self, run_id: Uuid, timestamp: DateTime<Utc>, observation: Observation) {
+        let record = Record::new(run_id, timestamp, observation);
+        let experiment_type = record.observation.experiment_type();
+        match self.append(&record).await {
+            Ok(()) => debug!(experiment_type, %run_id, "Laboratory record written"),
+            Err(error) => error!(
+                experiment_type,
+                %run_id,
+                %error,
+                "Laboratory record could not be written; the run proceeds unobserved"
+            ),
+        }
+    }
+
+    /// Blocks appends for as long as the returned guard is held.
+    pub async fn seal(&self) -> JournalGuard<'_> {
+        let mut open_date = self.open_date.lock().await;
+        *open_date = None;
+        JournalGuard {
+            _appends_blocked: open_date,
+        }
+    }
+}
+
+/// Proof that no append can run while it is alive.
+pub struct JournalGuard<'a> {
+    _appends_blocked: tokio::sync::MutexGuard<'a, Option<OpenDate>>,
+}
+
+/// The file one UTC date's records are written to.
+pub fn file_name(date: NaiveDate) -> String {
+    format!("laboratory-{date}.jsonl")
+}
+
+/// Recovers the UTC date from a name built by [`file_name`], or `None` if it does not have that
+/// shape.
+pub fn date_from_file_name(name: &str) -> Option<NaiveDate> {
+    name.strip_prefix("laboratory-")
+        .and_then(|rest| rest.strip_suffix(".jsonl"))
+        .and_then(|date| NaiveDate::parse_from_str(date, "%Y-%m-%d").ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::types::SessionDate;
+
+    fn fingerprint() -> DatasetFingerprint {
+        DatasetFingerprint {
+            session: SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 8, 17).unwrap()),
+            lookback_days: 365,
+            rows: 10,
+            tickers: 2,
+            first_timestamp: DateTime::from_timestamp_millis(0),
+            last_timestamp: DateTime::from_timestamp_millis(86_400_000),
+            splits: 12,
+            boundaries: 3,
+        }
+    }
+
+    fn observation() -> Observation {
+        Observation::DatasetBuilt(DatasetBuilt {
+            fingerprint: fingerprint(),
+            revision: Some("abc1234".to_string()),
+        })
+    }
+
+    #[test]
+    fn test_file_names_round_trip_through_their_date() {
+        let date = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        assert_eq!(file_name(date), "laboratory-2026-08-17.jsonl");
+        assert_eq!(date_from_file_name(&file_name(date)), Some(date));
+    }
+
+    /// The application's journal names its files by session date. Reading one of those as a
+    /// laboratory file would file an instant under a trading day.
+    #[test]
+    fn test_an_application_journal_file_name_is_not_a_laboratory_one() {
+        assert_eq!(date_from_file_name("fund-2026-08-17.jsonl"), None);
+        assert_eq!(date_from_file_name("laboratory-2026-08-17.txt"), None);
+    }
+
+    /// The envelope is what the export partitions and joins on, so every field of it must survive
+    /// serialization even though the payload is flattened alongside.
+    #[test]
+    fn test_a_record_serializes_its_envelope_and_its_payload() {
+        let run_id = Uuid::new_v4();
+        let timestamp = DateTime::from_timestamp_millis(1_755_000_000_000).unwrap();
+        let record = Record::new(run_id, timestamp, observation());
+
+        let value: serde_json::Value = serde_json::to_value(&record).unwrap();
+
+        assert_eq!(value["schema_version"], serde_json::json!(1));
+        assert_eq!(value["run_id"], serde_json::json!(run_id.to_string()));
+        assert_eq!(value["experiment_type"], serde_json::json!("dataset_built"));
+        assert_eq!(
+            value["payload"]["fingerprint"]["rows"],
+            serde_json::json!(10)
+        );
+        assert_eq!(
+            value["payload"]["fingerprint"]["splits"],
+            serde_json::json!(12)
+        );
+        assert!(
+            value.get("session_date").is_none(),
+            "an experiment belongs to no trading day"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_records_roll_into_the_file_for_their_utc_date() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = Journal::new(directory.path()).unwrap();
+        let run_id = Uuid::new_v4();
+
+        let first = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        let second = NaiveDate::from_ymd_opt(2026, 8, 18).unwrap();
+
+        // 23:30 on the 17th and 00:30 on the 18th: an hour apart, either side of UTC midnight.
+        for (date, hour, minute) in [(first, 23, 30), (second, 0, 30)] {
+            let timestamp = date.and_hms_opt(hour, minute, 0).unwrap().and_utc();
+            journal
+                .append(&Record::new(run_id, timestamp, observation()))
+                .await
+                .unwrap();
+        }
+
+        assert!(directory.path().join(file_name(first)).exists());
+        assert!(directory.path().join(file_name(second)).exists());
+    }
+}

--- a/src/laboratory/journal.rs
+++ b/src/laboratory/journal.rs
@@ -1,7 +1,6 @@
 //! The laboratory's own append-only record of what it ran.
 //!
-//! Separate from the application's journal because an experiment happens at an instant, not on a
-//! trading day, so it is keyed by run and partitioned by the UTC date.
+//! Keyed by run and rolled on the UTC date: an experiment happens at an instant, not on a session.
 
 use std::path::{Path, PathBuf};
 
@@ -217,8 +216,8 @@ mod tests {
             tickers: 2,
             first_timestamp: DateTime::from_timestamp_millis(0),
             last_timestamp: DateTime::from_timestamp_millis(86_400_000),
-            splits: 12,
-            boundaries: 3,
+            splits_digest: 0xAB,
+            boundaries_digest: 0xCD,
         }
     }
 
@@ -234,6 +233,19 @@ mod tests {
         let date = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
         assert_eq!(file_name(date), "laboratory-2026-08-17.jsonl");
         assert_eq!(date_from_file_name(&file_name(date)), Some(date));
+    }
+
+    /// `experiment_type()` restates what `rename_all` generates for the variant. Left unpinned, a
+    /// rename would move the export partition while the logged name kept the old spelling.
+    #[test]
+    fn test_the_reported_experiment_type_is_the_tag_that_serializes() {
+        let value: serde_json::Value = serde_json::to_value(observation()).unwrap();
+        assert_eq!(value["experiment_type"], serde_json::json!("dataset_built"));
+        assert_eq!(observation().experiment_type(), "dataset_built");
+        assert_eq!(
+            value["experiment_type"].as_str(),
+            Some(observation().experiment_type())
+        );
     }
 
     /// The application's journal names its files by session date. Reading one of those as a
@@ -262,8 +274,8 @@ mod tests {
             serde_json::json!(10)
         );
         assert_eq!(
-            value["payload"]["fingerprint"]["splits"],
-            serde_json::json!(12)
+            value["payload"]["fingerprint"]["splits_digest"],
+            serde_json::json!(0xAB)
         );
         assert!(
             value.get("session_date").is_none(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,6 @@ pub mod common;
 pub mod dashboard;
 pub mod data;
 pub mod handlers;
+pub mod laboratory;
 pub mod models;
 pub mod portfolio;


### PR DESCRIPTION
# Overview

First half of task 2 of the stream/fold plan, split from the metrics work so the statistical code lands separately.

Nothing outside the trainer binary could build the frame a model trains on, and the trainer had no way to say which frame it had built. Both block the diagnostics that come next: a baseline needs this frame and no model, and comparing two runs needs to know they saw the same data.

## Changes

- `laboratory::dataset::build` lifts the read-and-prepare path out of `tide_model_trainer` unchanged — splits, boundaries, the windowed partition walk, consolidation, the liquidity filter, and the fit.
- `DatasetFingerprint` records what a frame was built from: session, lookback, row and ticker counts, timestamp span, and the sizes of the splits and boundary tables.
- `laboratory::journal` — the laboratory's own append-only record, with a `run_id` envelope and UTC-date file rolling.
- `laboratory::export` — ships sealed days to `exports/laboratory/experiments`, partitioned by experiment type then date.
- The trainer now emits a `dataset_built` record and carries one `run_id` for everything a run will go on to record.
- The three partition-projection tests moved with the code they cover.

## Context

**Why the fingerprint is not just a row count.** Prices are stored raw and folded at read time, so a restated split changes every value while the window, the rows, and the tickers all stay exactly where they were. The two table sizes are what catch that case, and there is a test pinning it.

**Why the laboratory journal is not the application's.** It reuses the mechanism — fsynced appends, a seal that blocks writers while a reader runs, a tagged observation enum carrying an opaque payload — and deliberately not the key. An experiment happens at an instant and spans hundreds of sessions, so the envelope carries `run_id` where the application carries `session_date` and the file rolls on the UTC date. Filing an instant under a trading day is the mistake the log export already made once.

**Why its own S3 prefix.** The application's `exports/journal` is keyed by date alone, so two producers would overwrite each other's object for the same day. Grouping by experiment type at write time also means a day holding three kinds of record writes three objects, each with its own natural schema, rather than one with a mostly-null union. There is no scheduled pass to hang the export off, so the trigger is explicit.

**Verified against the development bucket**, not fixtures. A full training run prepared 316,108 rows across 3,092 tickers spanning 2025-08-18 to 2026-08-18 and wrote the record:

```json
{"schema_version":1,"run_id":"5e869394-...","timestamp":"2026-08-18T18:49:32Z",
 "experiment_type":"dataset_built",
 "payload":{"fingerprint":{"session":"2026-08-18","lookback_days":365,"rows":316108,
   "tickers":3092,"first_timestamp":"2025-08-18T20:00:00Z",
   "last_timestamp":"2026-08-18T20:00:00Z","splits":28091,"boundaries":814}}}
```

The 2026-08-16 run under the same 365-day lookback prepared 314,512 rows; the difference is the two sessions the window gained. Its training samples fell from 180,529 to 109,239 — a 39.5% drop against the 37.8% predicted for #1081 from the archive, so that is the contiguity fix arriving rather than this change.

`devenv tasks run checks:rust` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added laboratory tools for building and validating training datasets.
  * Training runs now receive unique IDs and record dataset fingerprints and revisions for reproducibility.
  * Added append-only experiment journaling with timestamps and run details.
  * Added journal export to date-partitioned Parquet files for analysis and archival.
  * Added safeguards for incomplete data, invalid records, and failed exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->