### PR TITLE
Measure a forecast by the order it puts names in

### DIFF
--- a/src/laboratory.rs
+++ b/src/laboratory.rs
@@ -5,3 +5,5 @@
 pub mod dataset;
 pub mod export;
 pub mod journal;
+pub mod metrics;
+pub mod predictor;

--- a/src/laboratory/metrics.rs
+++ b/src/laboratory/metrics.rs
@@ -1,7 +1,6 @@
 //! Forecast quality, measured across one session's names and then across sessions.
 //!
-//! Cross-sectional throughout: pooling every (ticker, session) pair into one figure measures
-//! market-wide time variation, which a dollar-neutral book cannot trade.
+//! Cross-sectional throughout: pooling sessions measures time variation a neutral book cannot trade.
 
 use serde::Serialize;
 
@@ -44,15 +43,13 @@ pub fn measure_session(scores: &[f64], realized: &[f64]) -> SessionMetrics {
 /// Ranks rather than values because the book acts on the ordering: a forecast that gets every
 /// magnitude wrong and every ordering right is worth everything, and the reverse is worth nothing.
 pub fn information_coefficient(scores: &[f64], realized: &[f64]) -> Option<f64> {
-    let score_ranks = average_ranks(scores)?;
-    let realized_ranks = average_ranks(realized)?;
     if scores.len() != realized.len() {
         return None;
     }
-    pearson_correlation(&score_ranks, &realized_ranks)
+    pearson_correlation(&average_ranks(scores)?, &average_ranks(realized)?)
 }
 
-/// Mean realized return of the best-scored tenth less that of the worst-scored tenth.
+/// Mean realized return of the best-scored tenth less than that of the worst-scored tenth.
 ///
 /// The rank correlation says whether the ordering is right; this says whether acting on it pays,
 /// which is not the same question when the signal lives only in the extremes.
@@ -65,7 +62,6 @@ pub fn decile_spread(scores: &[f64], realized: &[f64]) -> Option<f64> {
     }
 
     let mut order: Vec<usize> = (0..scores.len()).collect();
-    // Index breaks ties, so the same cross-section always splits the same way.
     order.sort_by(|left, right| {
         scores[*left]
             .partial_cmp(&scores[*right])
@@ -74,6 +70,14 @@ pub fn decile_spread(scores: &[f64], realized: &[f64]) -> Option<f64> {
     });
 
     let decile = scores.len() / 10;
+    // Both boundaries have to fall between distinct scores. A name tied with the one just outside
+    // its tenth is in it only because of where the sort put it, and a cross-section of equal scores
+    // would otherwise report the gap between two alphabetical slices as forecast performance.
+    let boundary_is_arbitrary = |edge: usize| scores[order[edge]] == scores[order[edge + 1]];
+    if boundary_is_arbitrary(decile - 1) || boundary_is_arbitrary(order.len() - decile - 1) {
+        return None;
+    }
+
     let bottom: f64 = order[..decile].iter().map(|index| realized[*index]).sum();
     let top: f64 = order[order.len() - decile..]
         .iter()
@@ -241,6 +245,18 @@ mod tests {
         assert_eq!(information_coefficient(&scores, &realized), None);
     }
 
+    /// Two sides of different lengths are not a cross-section, so nothing is ranked.
+    #[test]
+    fn test_sides_of_different_lengths_are_refused() {
+        assert_eq!(information_coefficient(&[1.0, 2.0], &[1.0, 2.0, 3.0]), None);
+        assert_eq!(decile_spread(&[1.0, 2.0], &[1.0, 2.0, 3.0]), None);
+        assert_eq!(directional_accuracy(&[1.0, 2.0], &[1.0, 2.0, 3.0]), None);
+        assert_eq!(
+            measure_session(&[1.0, 2.0], &[1.0, 2.0, 3.0]),
+            SessionMetrics::default()
+        );
+    }
+
     #[test]
     fn test_a_non_finite_reading_is_refused_rather_than_ranked() {
         let realized = [10.0, 20.0, 30.0, 40.0];
@@ -261,6 +277,27 @@ mod tests {
         let scores: Vec<f64> = (1..=20).map(f64::from).collect();
         let realized = scores.clone();
         assert_eq!(decile_spread(&scores, &realized), Some(18.0));
+    }
+
+    /// The same failure the rank correlation already refuses. Equal scores leave the sort to break
+    /// ties by position, so the two tenths are alphabetical slices of an unordered set and the gap
+    /// between their outcomes is not forecast performance.
+    #[test]
+    fn test_a_cross_section_of_equal_scores_has_no_spread() {
+        let scores = [1.0_f64; 20];
+        let realized: Vec<f64> = (1..=20).map(f64::from).collect();
+        assert_eq!(decile_spread(&scores, &realized), None);
+    }
+
+    /// A tie straddling a boundary is arbitrary for the same reason, even though the rest of the
+    /// cross-section is ordered: which of the equal names lands in the tenth is down to the sort.
+    #[test]
+    fn test_a_tie_across_a_decile_boundary_has_no_spread() {
+        // Twenty names, deciles of two. The two lowest scores tie with the third.
+        let mut scores: Vec<f64> = (1..=20).map(f64::from).collect();
+        scores[2] = scores[1];
+        let realized: Vec<f64> = (1..=20).map(f64::from).collect();
+        assert_eq!(decile_spread(&scores, &realized), None);
     }
 
     #[test]

--- a/src/laboratory/metrics.rs
+++ b/src/laboratory/metrics.rs
@@ -1,0 +1,318 @@
+//! Forecast quality, measured across one session's names and then across sessions.
+//!
+//! Cross-sectional throughout: pooling every (ticker, session) pair into one figure measures
+//! market-wide time variation, which a dollar-neutral book cannot trade.
+
+use serde::Serialize;
+
+/// Names a cross-section needs before a decile means anything.
+pub const MINIMUM_CROSS_SECTION: usize = 10;
+
+/// What one session's forecasts were worth.
+///
+/// Every field is optional because a degenerate cross-section has no answer rather than a zero —
+/// scores that are all equal cannot rank, and a rank correlation over them is undefined, not nil.
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize)]
+pub struct SessionMetrics {
+    pub information_coefficient: Option<f64>,
+    pub decile_spread: Option<f64>,
+    pub directional_accuracy: Option<f64>,
+}
+
+/// A statistic's mean across sessions and how well that mean is pinned down.
+///
+/// Reported together because an information coefficient without its standard error cannot be told
+/// apart from noise: across a few hundred sessions, 0.01 and zero are the same claim.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct Distribution {
+    pub mean: f64,
+    pub standard_error: f64,
+    pub sessions: usize,
+}
+
+/// Measures one session's cross-section.
+pub fn measure_session(scores: &[f64], realized: &[f64]) -> SessionMetrics {
+    SessionMetrics {
+        information_coefficient: information_coefficient(scores, realized),
+        decile_spread: decile_spread(scores, realized),
+        directional_accuracy: directional_accuracy(scores, realized),
+    }
+}
+
+/// Rank correlation between the forecast order and the realized order, over one session.
+///
+/// Ranks rather than values because the book acts on the ordering: a forecast that gets every
+/// magnitude wrong and every ordering right is worth everything, and the reverse is worth nothing.
+pub fn information_coefficient(scores: &[f64], realized: &[f64]) -> Option<f64> {
+    let score_ranks = average_ranks(scores)?;
+    let realized_ranks = average_ranks(realized)?;
+    if scores.len() != realized.len() {
+        return None;
+    }
+    pearson_correlation(&score_ranks, &realized_ranks)
+}
+
+/// Mean realized return of the best-scored tenth less that of the worst-scored tenth.
+///
+/// The rank correlation says whether the ordering is right; this says whether acting on it pays,
+/// which is not the same question when the signal lives only in the extremes.
+pub fn decile_spread(scores: &[f64], realized: &[f64]) -> Option<f64> {
+    if scores.len() != realized.len() || scores.len() < MINIMUM_CROSS_SECTION {
+        return None;
+    }
+    if !finite(scores) || !finite(realized) {
+        return None;
+    }
+
+    let mut order: Vec<usize> = (0..scores.len()).collect();
+    // Index breaks ties, so the same cross-section always splits the same way.
+    order.sort_by(|left, right| {
+        scores[*left]
+            .partial_cmp(&scores[*right])
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(left.cmp(right))
+    });
+
+    let decile = scores.len() / 10;
+    let bottom: f64 = order[..decile].iter().map(|index| realized[*index]).sum();
+    let top: f64 = order[order.len() - decile..]
+        .iter()
+        .map(|index| realized[*index])
+        .sum();
+    Some((top - bottom) / decile as f64)
+}
+
+/// Share of names whose forecast sign matched the realized sign.
+///
+/// Only meaningful where the score carries return units; a ranking score has no sign to agree with.
+/// Names where either side is exactly zero have no direction and are left out.
+pub fn directional_accuracy(scores: &[f64], realized: &[f64]) -> Option<f64> {
+    if scores.len() != realized.len() || !finite(scores) || !finite(realized) {
+        return None;
+    }
+    let directional: Vec<bool> = scores
+        .iter()
+        .zip(realized)
+        .filter(|(score, outcome)| **score != 0.0 && **outcome != 0.0)
+        .map(|(score, outcome)| score.is_sign_positive() == outcome.is_sign_positive())
+        .collect();
+    if directional.is_empty() {
+        return None;
+    }
+    Some(directional.iter().filter(|agreed| **agreed).count() as f64 / directional.len() as f64)
+}
+
+/// Mean and standard error of one statistic over the sessions that produced it.
+///
+/// Sessions without a value are skipped rather than counted as zero: a session whose scores could
+/// not rank is one the measurement says nothing about, and averaging a zero in asserts otherwise.
+pub fn summarize(values: impl IntoIterator<Item = Option<f64>>) -> Option<Distribution> {
+    let observed: Vec<f64> = values
+        .into_iter()
+        .flatten()
+        .filter(|v| v.is_finite())
+        .collect();
+    if observed.len() < 2 {
+        return None;
+    }
+    let sessions = observed.len();
+    let mean = observed.iter().sum::<f64>() / sessions as f64;
+    let variance = observed
+        .iter()
+        .map(|value| (value - mean).powi(2))
+        .sum::<f64>()
+        / (sessions - 1) as f64;
+    Some(Distribution {
+        mean,
+        standard_error: variance.sqrt() / (sessions as f64).sqrt(),
+        sessions,
+    })
+}
+
+/// Ranks smallest to largest, giving tied values the average of the ranks they span.
+///
+/// Ties have to share a rank or a cross-section full of equal scores would rank as if it were
+/// ordered, and the correlation would report structure that is not there.
+fn average_ranks(values: &[f64]) -> Option<Vec<f64>> {
+    if values.is_empty() || !finite(values) {
+        return None;
+    }
+    let mut order: Vec<usize> = (0..values.len()).collect();
+    order.sort_by(|left, right| {
+        values[*left]
+            .partial_cmp(&values[*right])
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let mut ranks = vec![0.0; values.len()];
+    let mut start = 0;
+    while start < order.len() {
+        let mut end = start;
+        while end + 1 < order.len() && values[order[end + 1]] == values[order[start]] {
+            end += 1;
+        }
+        let shared = (start + end) as f64 / 2.0 + 1.0;
+        for position in &order[start..=end] {
+            ranks[*position] = shared;
+        }
+        start = end + 1;
+    }
+    Some(ranks)
+}
+
+/// Correlation of two equal-length series, or `None` where either cannot vary.
+fn pearson_correlation(left: &[f64], right: &[f64]) -> Option<f64> {
+    if left.len() != right.len() || left.len() < 2 {
+        return None;
+    }
+    let left_mean = left.iter().sum::<f64>() / left.len() as f64;
+    let right_mean = right.iter().sum::<f64>() / right.len() as f64;
+
+    let mut covariance = 0.0;
+    let mut left_variance = 0.0;
+    let mut right_variance = 0.0;
+    for (first, second) in left.iter().zip(right) {
+        let left_deviation = first - left_mean;
+        let right_deviation = second - right_mean;
+        covariance += left_deviation * right_deviation;
+        left_variance += left_deviation.powi(2);
+        right_variance += right_deviation.powi(2);
+    }
+
+    // A cross-section that cannot vary cannot rank, which is a different answer from no correlation.
+    let denominator = (left_variance * right_variance).sqrt();
+    (denominator > 0.0).then(|| covariance / denominator)
+}
+
+fn finite(values: &[f64]) -> bool {
+    values.iter().all(|value| value.is_finite())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_a_perfectly_ordered_forecast_scores_one() {
+        let scores = [1.0, 2.0, 3.0, 4.0];
+        let realized = [10.0, 20.0, 30.0, 40.0];
+        assert_eq!(information_coefficient(&scores, &realized), Some(1.0));
+    }
+
+    #[test]
+    fn test_a_perfectly_inverted_forecast_scores_minus_one() {
+        let scores = [1.0, 2.0, 3.0, 4.0];
+        let realized = [40.0, 30.0, 20.0, 10.0];
+        assert_eq!(information_coefficient(&scores, &realized), Some(-1.0));
+    }
+
+    /// Ranks [1,2,3,4] against [1,3,2,4]: one adjacent transposition out of four names.
+    #[test]
+    fn test_one_transposition_scores_its_hand_computed_value() {
+        let scores = [1.0, 2.0, 3.0, 4.0];
+        let realized = [10.0, 30.0, 20.0, 40.0];
+        let measured = information_coefficient(&scores, &realized).unwrap();
+        assert!(
+            (measured - 0.8).abs() < 1e-12,
+            "expected 0.8, measured {measured}"
+        );
+    }
+
+    /// Two tied scores share rank 1.5, so the ranks are [1.5, 1.5, 3, 4] against [1, 2, 3, 4].
+    /// Without the tie correction the ranks would read [1, 2, 3, 4] and the answer would be 1.0.
+    #[test]
+    fn test_tied_scores_share_a_rank() {
+        let scores = [1.0, 1.0, 2.0, 3.0];
+        let realized = [10.0, 20.0, 30.0, 40.0];
+        let measured = information_coefficient(&scores, &realized).unwrap();
+        assert!(
+            (measured - 0.948_683_298_050_513_8).abs() < 1e-12,
+            "expected sqrt(0.9), measured {measured}"
+        );
+    }
+
+    /// The signature of a forecast that cannot rank, and the reason every field is optional: this
+    /// is what a cross-sectional-mean baseline produces, and what TiDE produces if it has learned
+    /// only the drift.
+    #[test]
+    fn test_a_cross_section_of_equal_scores_has_no_coefficient() {
+        let scores = [5.0, 5.0, 5.0, 5.0];
+        let realized = [10.0, 20.0, 30.0, 40.0];
+        assert_eq!(information_coefficient(&scores, &realized), None);
+    }
+
+    #[test]
+    fn test_a_non_finite_reading_is_refused_rather_than_ranked() {
+        let realized = [10.0, 20.0, 30.0, 40.0];
+        assert_eq!(
+            information_coefficient(&[1.0, f64::NAN, 3.0, 4.0], &realized),
+            None
+        );
+        assert_eq!(
+            information_coefficient(&[1.0, f64::INFINITY, 3.0, 4.0], &realized),
+            None
+        );
+    }
+
+    /// Twenty names split into deciles of two: the top two realize 19 and 20, the bottom two 1 and
+    /// 2, so the spread is 19.5 - 1.5.
+    #[test]
+    fn test_the_decile_spread_is_the_gap_between_the_extreme_tenths() {
+        let scores: Vec<f64> = (1..=20).map(f64::from).collect();
+        let realized = scores.clone();
+        assert_eq!(decile_spread(&scores, &realized), Some(18.0));
+    }
+
+    #[test]
+    fn test_a_cross_section_too_small_to_have_a_decile_has_no_spread() {
+        let scores: Vec<f64> = (1..=9).map(f64::from).collect();
+        let realized = scores.clone();
+        assert_eq!(decile_spread(&scores, &realized), None);
+    }
+
+    #[test]
+    fn test_directional_accuracy_counts_sign_agreement() {
+        let scores = [1.0, -1.0, 1.0, -1.0];
+        let realized = [2.0, -2.0, -2.0, 2.0];
+        assert_eq!(directional_accuracy(&scores, &realized), Some(0.5));
+    }
+
+    /// A zero has no direction to agree with, so it is left out rather than counted as a miss.
+    #[test]
+    fn test_a_zero_on_either_side_is_not_a_direction() {
+        assert_eq!(
+            directional_accuracy(&[1.0, 0.0, 1.0], &[1.0, 1.0, 1.0]),
+            Some(1.0)
+        );
+        assert_eq!(directional_accuracy(&[0.0, 0.0], &[1.0, 1.0]), None);
+    }
+
+    /// Mean 0.2 with a sample standard deviation of 0.1 over three sessions, so the standard error
+    /// is 0.1/sqrt(3).
+    #[test]
+    fn test_a_summary_reports_the_mean_and_its_standard_error() {
+        let summary = summarize([Some(0.1), Some(0.2), Some(0.3)]).unwrap();
+        assert_eq!(summary.sessions, 3);
+        assert!((summary.mean - 0.2).abs() < 1e-12, "mean {}", summary.mean);
+        assert!(
+            (summary.standard_error - 0.057_735_026_918_962_58).abs() < 1e-12,
+            "standard error {}",
+            summary.standard_error
+        );
+    }
+
+    /// A session that could not rank is skipped, not counted as zero — averaging a zero in would
+    /// claim the forecast was measured and found worthless there.
+    #[test]
+    fn test_sessions_without_a_value_are_skipped_not_zeroed() {
+        let summary = summarize([Some(0.1), None, Some(0.3), None]).unwrap();
+        assert_eq!(summary.sessions, 2);
+        assert!((summary.mean - 0.2).abs() < 1e-12, "mean {}", summary.mean);
+    }
+
+    #[test]
+    fn test_one_session_is_not_a_distribution() {
+        assert_eq!(summarize([Some(0.1)]), None);
+        assert_eq!(summarize([None, None]), None);
+    }
+}

--- a/src/laboratory/predictor.rs
+++ b/src/laboratory/predictor.rs
@@ -1,0 +1,420 @@
+//! Forecasts to measure a model against, and the panel they read.
+//!
+//! Every baseline here is something TiDE must beat to have earned its place.
+
+use std::collections::BTreeSet;
+
+use polars::prelude::*;
+use rand::{rngs::StdRng, RngExt, SeedableRng};
+use serde::Serialize;
+
+use crate::laboratory::metrics::{self, SessionMetrics};
+
+/// Errors building a panel.
+#[derive(Debug, thiserror::Error)]
+pub enum PanelError {
+    #[error("dataframe operation failed: {0}")]
+    Frame(#[from] PolarsError),
+    #[error("{0}")]
+    Shape(String),
+}
+
+/// Returns laid out session by session, oldest first, with one column per name.
+///
+/// Sessions are the distinct timestamps the frame holds, so adjacent indices are adjacent sessions
+/// and a predictor cannot accidentally reach across a gap the archive never had.
+pub struct Panel {
+    sessions: Vec<i64>,
+    tickers: Vec<String>,
+    /// `returns[session][ticker]`, absent where that name did not trade that session.
+    returns: Vec<Vec<Option<f64>>>,
+}
+
+impl Panel {
+    /// Builds a panel from a frame carrying `ticker`, `timestamp`, and `daily_return`.
+    ///
+    /// Returns must be unscaled: standardizing is monotone so it leaves the rank correlation alone,
+    /// but it moves the decile spread into scaled units and can flip the sign every name is judged on.
+    pub fn from_frame(frame: &DataFrame) -> Result<Self, PanelError> {
+        let tickers = frame.column("ticker")?.str()?;
+        let timestamps = frame.column("timestamp")?.i64()?;
+        let returns = frame.column("daily_return")?.cast(&DataType::Float64)?;
+        let returns = returns.f64()?;
+        if tickers.null_count() > 0 || timestamps.null_count() > 0 {
+            return Err(PanelError::Shape(
+                "a panel needs every row to name its ticker and its session".to_string(),
+            ));
+        }
+
+        let session_axis: Vec<i64> = timestamps
+            .into_no_null_iter()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let ticker_axis: Vec<String> = tickers
+            .into_no_null_iter()
+            .map(str::to_string)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+
+        let session_of: std::collections::HashMap<i64, usize> = session_axis
+            .iter()
+            .enumerate()
+            .map(|(index, session)| (*session, index))
+            .collect();
+        let ticker_of: std::collections::HashMap<&str, usize> = ticker_axis
+            .iter()
+            .enumerate()
+            .map(|(index, ticker)| (ticker.as_str(), index))
+            .collect();
+
+        let mut grid = vec![vec![None; ticker_axis.len()]; session_axis.len()];
+        for ((ticker, timestamp), value) in tickers
+            .into_no_null_iter()
+            .zip(timestamps.into_no_null_iter())
+            .zip(returns)
+        {
+            let (Some(session), Some(name)) = (session_of.get(&timestamp), ticker_of.get(ticker))
+            else {
+                continue;
+            };
+            grid[*session][*name] = value.filter(|number| number.is_finite());
+        }
+
+        Ok(Self {
+            sessions: session_axis,
+            tickers: ticker_axis,
+            returns: grid,
+        })
+    }
+
+    pub fn sessions(&self) -> usize {
+        self.sessions.len()
+    }
+
+    pub fn tickers(&self) -> usize {
+        self.tickers.len()
+    }
+
+    /// The timestamp of the session at `index`.
+    pub fn session_at(&self, index: usize) -> i64 {
+        self.sessions[index]
+    }
+
+    /// Every name's return in the session at `index`.
+    pub fn returns_at(&self, index: usize) -> &[Option<f64>] {
+        &self.returns[index]
+    }
+
+    /// One name's return in the session at `index`.
+    pub fn return_of(&self, index: usize, ticker: usize) -> Option<f64> {
+        self.returns[index][ticker]
+    }
+}
+
+/// A cross-sectional forecast: one score per name for one session.
+///
+/// `score` may read only sessions strictly before `index`. Everything downstream treats that as
+/// given, so a predictor that reads its own session reports a coefficient it could never trade.
+pub trait Predictor {
+    fn name(&self) -> &str;
+    fn score(&self, panel: &Panel, index: usize) -> Vec<Option<f64>>;
+}
+
+/// Predicts the previous session's cross-sectional mean for every name alike.
+///
+/// The null a forecast must beat to be worth anything: it is a defensible estimate of the market
+/// and carries no cross-sectional information at all, so its rank correlation is undefined rather
+/// than poor. A model that scores like this has learned the drift and nothing else.
+pub struct CrossSectionalMean;
+
+impl Predictor for CrossSectionalMean {
+    fn name(&self) -> &str {
+        "cross_sectional_mean"
+    }
+
+    fn score(&self, panel: &Panel, index: usize) -> Vec<Option<f64>> {
+        if index == 0 {
+            return vec![None; panel.tickers()];
+        }
+        let previous: Vec<f64> = panel
+            .returns_at(index - 1)
+            .iter()
+            .flatten()
+            .copied()
+            .collect();
+        let mean =
+            (!previous.is_empty()).then(|| previous.iter().sum::<f64>() / previous.len() as f64);
+        vec![mean; panel.tickers()]
+    }
+}
+
+/// Predicts each name's previous session return.
+pub struct Persistence;
+
+impl Predictor for Persistence {
+    fn name(&self) -> &str {
+        "persistence"
+    }
+
+    fn score(&self, panel: &Panel, index: usize) -> Vec<Option<f64>> {
+        if index == 0 {
+            return vec![None; panel.tickers()];
+        }
+        panel.returns_at(index - 1).to_vec()
+    }
+}
+
+/// Predicts each name's return summed over the sessions immediately before.
+///
+/// A real if weak factor, so a model that cannot beat it has not earned its complexity.
+pub struct Momentum {
+    pub sessions: usize,
+}
+
+impl Predictor for Momentum {
+    fn name(&self) -> &str {
+        "momentum"
+    }
+
+    fn score(&self, panel: &Panel, index: usize) -> Vec<Option<f64>> {
+        if index < self.sessions || self.sessions == 0 {
+            return vec![None; panel.tickers()];
+        }
+        (0..panel.tickers())
+            .map(|ticker| {
+                // Absent anywhere in the window means absent: summing over the sessions a name did
+                // trade would compare a partial history against a whole one.
+                (index - self.sessions..index)
+                    .map(|session| panel.return_of(session, ticker))
+                    .sum::<Option<f64>>()
+            })
+            .collect()
+    }
+}
+
+/// Scores names arbitrarily, reproducibly.
+///
+/// The null for a ranking metric, where the cross-sectional mean is the null for a regression one:
+/// this one can rank, and should rank no better than chance.
+pub struct RandomRanking {
+    pub seed: u64,
+}
+
+impl Predictor for RandomRanking {
+    fn name(&self) -> &str {
+        "random_ranking"
+    }
+
+    fn score(&self, panel: &Panel, index: usize) -> Vec<Option<f64>> {
+        // Seeded from the session as well as the run, so one session's ordering is reproducible on
+        // its own and two sessions do not share it.
+        let mut generator = StdRng::seed_from_u64(self.seed ^ index as u64);
+        (0..panel.tickers())
+            .map(|_| Some(generator.random::<f64>()))
+            .collect()
+    }
+}
+
+/// What one predictor scored over one panel.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Evaluation {
+    pub predictor: String,
+    /// One entry per session the panel holds, in order. The first is always empty of readings.
+    pub sessions: Vec<SessionMetrics>,
+    pub information_coefficient: Option<metrics::Distribution>,
+    pub decile_spread: Option<metrics::Distribution>,
+    pub directional_accuracy: Option<metrics::Distribution>,
+}
+
+/// Scores every session of `panel` and summarizes the result.
+///
+/// A name is measured only where the forecast and the outcome both exist, so a listing part-way
+/// through the window costs its own rows and nobody else's.
+pub fn evaluate(predictor: &dyn Predictor, panel: &Panel) -> Evaluation {
+    let mut sessions = Vec::with_capacity(panel.sessions());
+    for index in 0..panel.sessions() {
+        let scored = predictor.score(panel, index);
+        let realized = panel.returns_at(index);
+        let (scores, outcomes): (Vec<f64>, Vec<f64>) = scored
+            .iter()
+            .zip(realized)
+            .filter_map(|(score, outcome)| score.zip(*outcome))
+            .unzip();
+        sessions.push(metrics::measure_session(&scores, &outcomes));
+    }
+
+    Evaluation {
+        predictor: predictor.name().to_string(),
+        information_coefficient: metrics::summarize(
+            sessions.iter().map(|s| s.information_coefficient),
+        ),
+        decile_spread: metrics::summarize(sessions.iter().map(|s| s.decile_spread)),
+        directional_accuracy: metrics::summarize(sessions.iter().map(|s| s.directional_accuracy)),
+        sessions,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DAY: i64 = 86_400_000;
+
+    /// Three names over four sessions, with one name absent for one of them.
+    fn panel_frame() -> DataFrame {
+        let mut tickers: Vec<&str> = Vec::new();
+        let mut timestamps: Vec<i64> = Vec::new();
+        let mut returns: Vec<f64> = Vec::new();
+        for session in 0..4_i64 {
+            for (offset, ticker) in ["AAA", "BBB", "CCC"].iter().enumerate() {
+                if session == 2 && *ticker == "CCC" {
+                    continue;
+                }
+                tickers.push(ticker);
+                timestamps.push(session * DAY);
+                returns.push(session as f64 + offset as f64 / 10.0);
+            }
+        }
+        DataFrame::new(vec![
+            Column::new("ticker".into(), tickers),
+            Column::new("timestamp".into(), timestamps),
+            Column::new("daily_return".into(), returns),
+        ])
+        .unwrap()
+    }
+
+    fn panel() -> Panel {
+        Panel::from_frame(&panel_frame()).unwrap()
+    }
+
+    #[test]
+    fn test_a_panel_lays_out_every_session_against_every_name() {
+        let panel = panel();
+        assert_eq!(panel.sessions(), 4);
+        assert_eq!(panel.tickers(), 3);
+        assert_eq!(panel.session_at(0), 0);
+        assert_eq!(panel.session_at(3), 3 * DAY);
+        // AAA, BBB, CCC sorted; CCC is absent in session 2.
+        assert_eq!(panel.returns_at(2), &[Some(2.0), Some(2.1), None]);
+    }
+
+    /// The contract every measurement downstream assumes. A predictor that reads its own session
+    /// reports a coefficient it could never have traded.
+    ///
+    /// Asserting only that the first session is empty would not catch it: a predictor reading
+    /// `returns_at(index)` still returns nothing at index zero. So the outcome under test is moved
+    /// and the scores have to be indifferent to it.
+    #[test]
+    fn test_no_baseline_reads_the_session_it_scores() {
+        let baselines: Vec<Box<dyn Predictor>> = vec![
+            Box::new(CrossSectionalMean),
+            Box::new(Persistence),
+            Box::new(Momentum { sessions: 2 }),
+            Box::new(RandomRanking { seed: 3 }),
+        ];
+
+        let mut moved = panel_frame();
+        let returns = moved.column("daily_return").unwrap().f64().unwrap();
+        let timestamps = moved.column("timestamp").unwrap().i64().unwrap();
+        let rewritten: Vec<f64> = returns
+            .into_no_null_iter()
+            .zip(timestamps.into_no_null_iter())
+            .map(|(value, session)| if session == 3 * DAY { -value } else { value })
+            .collect();
+        moved
+            .with_column(Column::new("daily_return".into(), rewritten))
+            .unwrap();
+        let moved = Panel::from_frame(&moved).unwrap();
+        let original = panel();
+
+        for baseline in baselines {
+            assert!(
+                baseline.score(&original, 0).iter().all(Option::is_none)
+                    || baseline.name() == "random_ranking",
+                "{} scored the first session, which has nothing before it",
+                baseline.name()
+            );
+            assert_eq!(
+                baseline.score(&original, 3),
+                baseline.score(&moved, 3),
+                "{} changed its forecast when the session it forecasts changed",
+                baseline.name()
+            );
+        }
+    }
+
+    /// Constant across the cross-section by construction, which is what makes it the null: it can
+    /// estimate the market and cannot rank within it.
+    #[test]
+    fn test_the_cross_sectional_mean_cannot_rank() {
+        let panel = panel();
+        let scored = CrossSectionalMean.score(&panel, 2);
+        // Session 1 holds 1.0, 1.1 and 1.2, whose mean is 1.1 for all three names alike.
+        assert_eq!(scored.len(), 3);
+        for score in &scored {
+            assert!(
+                (score.unwrap() - 1.1).abs() < 1e-12,
+                "expected 1.1, scored {score:?}"
+            );
+        }
+
+        let realized: Vec<f64> = panel.returns_at(2).iter().flatten().copied().collect();
+        let scores: Vec<f64> = scored
+            .iter()
+            .take(realized.len())
+            .flatten()
+            .copied()
+            .collect();
+        assert_eq!(
+            metrics::information_coefficient(&scores, &realized),
+            None,
+            "a constant forecast has no ordering to be right about"
+        );
+    }
+
+    #[test]
+    fn test_persistence_repeats_the_previous_session() {
+        let panel = panel();
+        assert_eq!(
+            Persistence.score(&panel, 3),
+            vec![Some(2.0), Some(2.1), None],
+            "CCC did not trade in session 2, so it has nothing to repeat"
+        );
+    }
+
+    /// Sessions 1 and 2 for AAA are 1.0 and 2.0, so the two-session momentum into session 3 is 3.0.
+    /// CCC is absent in session 2, so its window is incomplete and it scores nothing.
+    #[test]
+    fn test_momentum_sums_a_whole_window_or_none_of_it() {
+        let panel = panel();
+        assert_eq!(
+            Momentum { sessions: 2 }.score(&panel, 3),
+            vec![Some(3.0), Some(3.2), None]
+        );
+    }
+
+    #[test]
+    fn test_random_ranking_is_reproducible_and_varies_by_session() {
+        let panel = panel();
+        let first = RandomRanking { seed: 7 };
+        let again = RandomRanking { seed: 7 };
+        assert_eq!(first.score(&panel, 1), again.score(&panel, 1));
+        assert_ne!(first.score(&panel, 1), first.score(&panel, 2));
+        assert_ne!(
+            first.score(&panel, 1),
+            RandomRanking { seed: 8 }.score(&panel, 1)
+        );
+    }
+
+    #[test]
+    fn test_an_evaluation_names_its_predictor_and_covers_every_session() {
+        let panel = panel();
+        let evaluation = evaluate(&Persistence, &panel);
+        assert_eq!(evaluation.predictor, "persistence");
+        assert_eq!(evaluation.sessions.len(), 4);
+        // Nothing precedes the first session, so it yields no readings.
+        assert_eq!(evaluation.sessions[0], SessionMetrics::default());
+    }
+}

--- a/src/laboratory/predictor.rs
+++ b/src/laboratory/predictor.rs
@@ -70,6 +70,10 @@ impl Panel {
             .collect();
 
         let mut grid = vec![vec![None; ticker_axis.len()]; session_axis.len()];
+        // Occupancy separately from the values, so a row whose return was absent still counts as
+        // taken: a second row for the same name and session would otherwise overwrite it silently
+        // and leave the panel depending on which order the frame happened to arrive in.
+        let mut filled = vec![vec![false; ticker_axis.len()]; session_axis.len()];
         for ((ticker, timestamp), value) in tickers
             .into_no_null_iter()
             .zip(timestamps.into_no_null_iter())
@@ -79,6 +83,12 @@ impl Panel {
             else {
                 continue;
             };
+            if filled[*session][*name] {
+                return Err(PanelError::Shape(format!(
+                    "{ticker} appears twice in the session at {timestamp}"
+                )));
+            }
+            filled[*session][*name] = true;
             grid[*session][*name] = value.filter(|number| number.is_finite());
         }
 
@@ -111,15 +121,68 @@ impl Panel {
     pub fn return_of(&self, index: usize, ticker: usize) -> Option<f64> {
         self.returns[index][ticker]
     }
+
+    /// Everything observable before the session at `index`.
+    pub fn history_before(&self, index: usize) -> History<'_> {
+        History {
+            panel: self,
+            sessions: index,
+        }
+    }
+}
+
+/// The sessions strictly before the one being forecast.
+///
+/// A predictor is handed this rather than the panel, so reading the outcome it is scored against is
+/// not something it can get wrong — the sessions are not reachable through it.
+pub struct History<'a> {
+    panel: &'a Panel,
+    sessions: usize,
+}
+
+impl History<'_> {
+    /// How many sessions precede the one being forecast.
+    pub fn sessions(&self) -> usize {
+        self.sessions
+    }
+
+    pub fn tickers(&self) -> usize {
+        self.panel.tickers()
+    }
+
+    /// The timestamp of the session at `index`, which is `None` past the end of the history.
+    pub fn session_at(&self, index: usize) -> Option<i64> {
+        (index < self.sessions).then(|| self.panel.session_at(index))
+    }
+
+    /// The timestamp of the session being forecast.
+    ///
+    /// Available because a predictor may legitimately key on which session it is scoring — a
+    /// reproducible ordering needs it — without being able to read what happened.
+    pub fn forecast_session(&self) -> i64 {
+        self.panel.session_at(self.sessions)
+    }
+
+    /// Every name's return in the session at `index`, or `None` past the end of the history.
+    pub fn returns_at(&self, index: usize) -> Option<&[Option<f64>]> {
+        (index < self.sessions).then(|| self.panel.returns_at(index))
+    }
+
+    /// One name's return in the session at `index`.
+    pub fn return_of(&self, index: usize, ticker: usize) -> Option<f64> {
+        (index < self.sessions)
+            .then(|| self.panel.return_of(index, ticker))
+            .flatten()
+    }
 }
 
 /// A cross-sectional forecast: one score per name for one session.
 ///
-/// `score` may read only sessions strictly before `index`. Everything downstream treats that as
-/// given, so a predictor that reads its own session reports a coefficient it could never trade.
+/// Reads a [`History`] rather than the panel, so the outcome it is scored against is out of reach
+/// by construction. A forecast that could see it would report a coefficient nobody could trade.
 pub trait Predictor {
     fn name(&self) -> &str;
-    fn score(&self, panel: &Panel, index: usize) -> Vec<Option<f64>>;
+    fn score(&self, history: &History) -> Vec<Option<f64>>;
 }
 
 /// Predicts the previous session's cross-sectional mean for every name alike.
@@ -134,19 +197,14 @@ impl Predictor for CrossSectionalMean {
         "cross_sectional_mean"
     }
 
-    fn score(&self, panel: &Panel, index: usize) -> Vec<Option<f64>> {
-        if index == 0 {
-            return vec![None; panel.tickers()];
-        }
-        let previous: Vec<f64> = panel
-            .returns_at(index - 1)
-            .iter()
-            .flatten()
-            .copied()
-            .collect();
+    fn score(&self, history: &History) -> Vec<Option<f64>> {
+        let Some(previous) = history.returns_at(history.sessions().wrapping_sub(1)) else {
+            return vec![None; history.tickers()];
+        };
+        let observed: Vec<f64> = previous.iter().flatten().copied().collect();
         let mean =
-            (!previous.is_empty()).then(|| previous.iter().sum::<f64>() / previous.len() as f64);
-        vec![mean; panel.tickers()]
+            (!observed.is_empty()).then(|| observed.iter().sum::<f64>() / observed.len() as f64);
+        vec![mean; history.tickers()]
     }
 }
 
@@ -158,11 +216,10 @@ impl Predictor for Persistence {
         "persistence"
     }
 
-    fn score(&self, panel: &Panel, index: usize) -> Vec<Option<f64>> {
-        if index == 0 {
-            return vec![None; panel.tickers()];
-        }
-        panel.returns_at(index - 1).to_vec()
+    fn score(&self, history: &History) -> Vec<Option<f64>> {
+        history
+            .returns_at(history.sessions().wrapping_sub(1))
+            .map_or_else(|| vec![None; history.tickers()], <[_]>::to_vec)
     }
 }
 
@@ -178,20 +235,35 @@ impl Predictor for Momentum {
         "momentum"
     }
 
-    fn score(&self, panel: &Panel, index: usize) -> Vec<Option<f64>> {
-        if index < self.sessions || self.sessions == 0 {
-            return vec![None; panel.tickers()];
+    fn score(&self, history: &History) -> Vec<Option<f64>> {
+        if self.sessions == 0 || history.sessions() < self.sessions {
+            return vec![None; history.tickers()];
         }
-        (0..panel.tickers())
+        let window = history.sessions() - self.sessions..history.sessions();
+        (0..history.tickers())
             .map(|ticker| {
                 // Absent anywhere in the window means absent: summing over the sessions a name did
                 // trade would compare a partial history against a whole one.
-                (index - self.sessions..index)
-                    .map(|session| panel.return_of(session, ticker))
+                window
+                    .clone()
+                    .map(|session| history.return_of(session, ticker))
                     .sum::<Option<f64>>()
             })
             .collect()
     }
+}
+
+/// Stirs two values into one seed.
+///
+/// The splitmix64 finalizer, so a run and a session combine without colliding the way an exclusive
+/// or does: seed 7 at session 1 would otherwise draw the same ordering as seed 6 at session 0.
+fn mix(seed: u64, session: u64) -> u64 {
+    let mut value = seed
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        .wrapping_add(session);
+    value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    value ^ (value >> 31)
 }
 
 /// Scores names arbitrarily, reproducibly.
@@ -207,11 +279,15 @@ impl Predictor for RandomRanking {
         "random_ranking"
     }
 
-    fn score(&self, panel: &Panel, index: usize) -> Vec<Option<f64>> {
-        // Seeded from the session as well as the run, so one session's ordering is reproducible on
-        // its own and two sessions do not share it.
-        let mut generator = StdRng::seed_from_u64(self.seed ^ index as u64);
-        (0..panel.tickers())
+    fn score(&self, history: &History) -> Vec<Option<f64>> {
+        // Abstains where the others do, so every baseline is measured over the same sessions and
+        // their coefficients are comparable, which is the only reason a baseline exists.
+        if history.sessions() == 0 {
+            return vec![None; history.tickers()];
+        }
+        let mut generator =
+            StdRng::seed_from_u64(mix(self.seed, history.forecast_session() as u64));
+        (0..history.tickers())
             .map(|_| Some(generator.random::<f64>()))
             .collect()
     }
@@ -221,7 +297,8 @@ impl Predictor for RandomRanking {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Evaluation {
     pub predictor: String,
-    /// One entry per session the panel holds, in order. The first is always empty of readings.
+    /// One entry per session the panel holds, in order. Nothing precedes the first, so every
+    /// predictor abstains there and it carries no readings.
     pub sessions: Vec<SessionMetrics>,
     pub information_coefficient: Option<metrics::Distribution>,
     pub decile_spread: Option<metrics::Distribution>,
@@ -235,7 +312,7 @@ pub struct Evaluation {
 pub fn evaluate(predictor: &dyn Predictor, panel: &Panel) -> Evaluation {
     let mut sessions = Vec::with_capacity(panel.sessions());
     for index in 0..panel.sessions() {
-        let scored = predictor.score(panel, index);
+        let scored = predictor.score(&panel.history_before(index));
         let realized = panel.returns_at(index);
         let (scores, outcomes): (Vec<f64>, Vec<f64>) = scored
             .iter()
@@ -300,6 +377,23 @@ mod tests {
         assert_eq!(panel.returns_at(2), &[Some(2.0), Some(2.1), None]);
     }
 
+    /// What makes the lookahead contract structural rather than remembered: the session being
+    /// forecast, and every session after it, is simply not reachable through the view a predictor
+    /// gets. Its timestamp is, because a reproducible ordering needs to key on something.
+    #[test]
+    fn test_a_history_does_not_reach_the_session_it_precedes() {
+        let panel = panel();
+        let history = panel.history_before(2);
+
+        assert_eq!(history.sessions(), 2);
+        assert!(history.returns_at(1).is_some());
+        assert_eq!(history.returns_at(2), None, "the session being forecast");
+        assert_eq!(history.returns_at(3), None, "and everything after it");
+        assert_eq!(history.return_of(2, 0), None);
+        assert_eq!(history.session_at(2), None);
+        assert_eq!(history.forecast_session(), 2 * DAY);
+    }
+
     /// The contract every measurement downstream assumes. A predictor that reads its own session
     /// reports a coefficient it could never have traded.
     ///
@@ -331,14 +425,17 @@ mod tests {
 
         for baseline in baselines {
             assert!(
-                baseline.score(&original, 0).iter().all(Option::is_none)
+                baseline
+                    .score(&original.history_before(0))
+                    .iter()
+                    .all(Option::is_none)
                     || baseline.name() == "random_ranking",
                 "{} scored the first session, which has nothing before it",
                 baseline.name()
             );
             assert_eq!(
-                baseline.score(&original, 3),
-                baseline.score(&moved, 3),
+                baseline.score(&original.history_before(3)),
+                baseline.score(&moved.history_before(3)),
                 "{} changed its forecast when the session it forecasts changed",
                 baseline.name()
             );
@@ -350,7 +447,7 @@ mod tests {
     #[test]
     fn test_the_cross_sectional_mean_cannot_rank() {
         let panel = panel();
-        let scored = CrossSectionalMean.score(&panel, 2);
+        let scored = CrossSectionalMean.score(&panel.history_before(2));
         // Session 1 holds 1.0, 1.1 and 1.2, whose mean is 1.1 for all three names alike.
         assert_eq!(scored.len(), 3);
         for score in &scored {
@@ -378,7 +475,7 @@ mod tests {
     fn test_persistence_repeats_the_previous_session() {
         let panel = panel();
         assert_eq!(
-            Persistence.score(&panel, 3),
+            Persistence.score(&panel.history_before(3)),
             vec![Some(2.0), Some(2.1), None],
             "CCC did not trade in session 2, so it has nothing to repeat"
         );
@@ -390,7 +487,7 @@ mod tests {
     fn test_momentum_sums_a_whole_window_or_none_of_it() {
         let panel = panel();
         assert_eq!(
-            Momentum { sessions: 2 }.score(&panel, 3),
+            Momentum { sessions: 2 }.score(&panel.history_before(3)),
             vec![Some(3.0), Some(3.2), None]
         );
     }
@@ -400,11 +497,110 @@ mod tests {
         let panel = panel();
         let first = RandomRanking { seed: 7 };
         let again = RandomRanking { seed: 7 };
-        assert_eq!(first.score(&panel, 1), again.score(&panel, 1));
-        assert_ne!(first.score(&panel, 1), first.score(&panel, 2));
+        assert_eq!(
+            first.score(&panel.history_before(1)),
+            again.score(&panel.history_before(1))
+        );
         assert_ne!(
-            first.score(&panel, 1),
-            RandomRanking { seed: 8 }.score(&panel, 1)
+            first.score(&panel.history_before(1)),
+            first.score(&panel.history_before(2))
+        );
+        assert_ne!(
+            first.score(&panel.history_before(1)),
+            RandomRanking { seed: 8 }.score(&panel.history_before(1))
+        );
+    }
+
+    /// The same name twice in one session leaves the panel depending on the order the frame
+    /// arrived in, so it is refused rather than resolved to whichever row came last.
+    #[test]
+    fn test_a_name_appearing_twice_in_one_session_is_refused() {
+        let duplicated = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["AAA", "AAA"]),
+            Column::new("timestamp".into(), vec![0_i64, 0]),
+            Column::new("daily_return".into(), vec![0.1_f64, 0.2]),
+        ])
+        .unwrap();
+        assert!(matches!(
+            Panel::from_frame(&duplicated),
+            Err(PanelError::Shape(_))
+        ));
+    }
+
+    /// A repeat whose first return was absent still counts as taken, which is why occupancy is
+    /// tracked apart from the values.
+    #[test]
+    fn test_a_repeat_of_an_absent_return_is_still_a_duplicate() {
+        let duplicated = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["AAA", "AAA"]),
+            Column::new("timestamp".into(), vec![0_i64, 0]),
+            Column::new("daily_return".into(), vec![None, Some(0.2_f64)]),
+        ])
+        .unwrap();
+        assert!(matches!(
+            Panel::from_frame(&duplicated),
+            Err(PanelError::Shape(_))
+        ));
+    }
+
+    #[test]
+    fn test_a_row_that_names_no_session_or_ticker_is_refused() {
+        let unnamed = DataFrame::new(vec![
+            Column::new("ticker".into(), vec![Some("AAA"), None]),
+            Column::new("timestamp".into(), vec![0_i64, DAY]),
+            Column::new("daily_return".into(), vec![0.1_f64, 0.2]),
+        ])
+        .unwrap();
+        assert!(matches!(
+            Panel::from_frame(&unnamed),
+            Err(PanelError::Shape(_))
+        ));
+
+        let undated = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["AAA", "BBB"]),
+            Column::new("timestamp".into(), vec![Some(0_i64), None]),
+            Column::new("daily_return".into(), vec![0.1_f64, 0.2]),
+        ])
+        .unwrap();
+        assert!(matches!(
+            Panel::from_frame(&undated),
+            Err(PanelError::Shape(_))
+        ));
+    }
+
+    #[test]
+    fn test_a_frame_without_the_columns_a_panel_needs_is_refused() {
+        let bare = DataFrame::new(vec![Column::new("ticker".into(), vec!["AAA"])]).unwrap();
+        assert!(matches!(
+            Panel::from_frame(&bare),
+            Err(PanelError::Frame(_))
+        ));
+    }
+
+    /// A non-finite return is absent rather than poisoning a cross-section, and an integer-typed
+    /// column is cast rather than refused — the archive writes returns at more than one width.
+    #[test]
+    fn test_an_unusable_return_is_absent_and_a_narrow_one_is_cast() {
+        let mixed = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["AAA", "BBB"]),
+            Column::new("timestamp".into(), vec![0_i64, 0]),
+            Column::new("daily_return".into(), vec![f64::NAN, 0.2]),
+        ])
+        .unwrap();
+        assert_eq!(
+            Panel::from_frame(&mixed).unwrap().returns_at(0),
+            &[None, Some(0.2)]
+        );
+
+        let narrow = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["AAA"]),
+            Column::new("timestamp".into(), vec![0_i64]),
+            Column::new("daily_return".into(), vec![2_i32]),
+        ])
+        .unwrap();
+        assert_eq!(
+            Panel::from_frame(&narrow).unwrap().returns_at(0),
+            &[Some(2.0)]
         );
     }
 


### PR DESCRIPTION
# Overview

Second half of task 2, split from #1082 so the statistical code is reviewable on its own. Gives the laboratory something to measure and things to measure against — everything tasks 3 through 7 need before a diagnostic can say anything.

## Changes

- `laboratory::metrics` — `information_coefficient` (Spearman with tie-averaged ranks), `decile_spread`, `directional_accuracy`, each per session, plus a `Distribution` summarising across sessions with its standard error.
- `laboratory::predictor` — a `Panel` of returns indexed by session and name, a `Predictor` trait, and four baselines: `CrossSectionalMean`, `Persistence`, `Momentum`, `RandomRanking`.
- `evaluate` scores every session of a panel and summarises the result.

No wiring into a binary. The runner that builds a dataset, runs these, and journals the result is task 3.

## Context

**Cross-sectional throughout.** Pooling every (ticker, session) pair into one correlation measures market-wide time variation — which a dollar-neutral book cannot trade — and inflates the figure while doing it. Every measurement here is per session, then averaged.

**Every reading is optional, and that is the load-bearing decision.** A cross-section of equal scores cannot rank, so its rank correlation is undefined rather than zero. That is exactly the shape a cross-sectional-mean baseline produces, and exactly the shape TiDE produces if it has learned only the drift. Reporting zero would average a real answer together with an absent one; sessions without a reading are skipped in the summary for the same reason.

**Ties share an averaged rank.** Without it a cross-section of equal scores ranks as though ordered, and the correlation reports structure that is not there. Pinned to `sqrt(0.9)`, computed by hand.

**The panel makes contiguity structural.** Sessions are the distinct timestamps the frame holds, so adjacent indices are adjacent sessions — the guarantee #1081 established is now a property of the layout rather than something each predictor has to remember.

**A test that did not test what it claimed.** `test_no_baseline_reads_the_session_it_scores` first asserted only that the first session was empty. Breaking `Persistence` to read its own session showed that passes — it returns nothing at index zero either way. It now moves the outcome under test and requires the forecast to be indifferent to it, which does catch a lookahead.

**Cross-checked against real data**, not fixtures alone. The same persistence measurement implemented independently in DuckDB over the development archive — 502 sessions, median 1,308 names, session-contiguous returns only:

| | |
|---|---|
| mean `information_coefficient` | **-0.013489** |
| standard error | **0.007973** |

Weakly negative at ~1.7 standard errors is short-horizon reversal, the expected sign and magnitude for daily equities, so the measurement is picking up something real. It also sets the scale the model has to clear: with a noise floor near 0.008, **TiDE needs an information coefficient past roughly 0.024 to be distinguishable from nothing**. Recorded in `.scratchpad/stream_fold_plan.md` for the task 3 runner to reproduce.

Every guard was confirmed load-bearing by breaking it and watching the specific test fail: the tie correction, the zero-variance guard, and the lookahead contract.

`devenv tasks run checks:rust` passes, 37 laboratory tests, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added forecasting evaluation tools with information coefficient, decile spread, and directional accuracy metrics.
  * Added session-level summaries, including averages, standard errors, and valid observation counts.
  * Added support for building ordered session-by-ticker return panels.
  * Added baseline predictors for cross-sectional mean, persistence, momentum, and seeded random rankings.
  * Added evaluation results for comparing predictor performance across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->