### PR TITLE
Measure the baselines a forecast has to beat

### DIFF
--- a/src/bin/laboratory_baselines.rs
+++ b/src/bin/laboratory_baselines.rs
@@ -1,0 +1,331 @@
+//! Measures the forecasts a model has to beat, over the archive and nothing else.
+//!
+//! Trains nothing: every forecast here is a rule, so a run is one archive read and some arithmetic.
+//! That is what makes it the thing to run first — it says what the data alone is worth.
+
+use chrono::Utc;
+use tracing::{error, info, warn};
+
+use fund::common::log::init_tracing;
+use fund::common::types::SessionDate;
+use fund::laboratory::dataset;
+use fund::laboratory::journal as laboratory;
+use fund::laboratory::metrics::Distribution;
+use fund::laboratory::predictor::{
+    evaluate, CrossSectionalMean, Momentum, Panel, Persistence, Predictor, RandomRanking,
+};
+
+const USAGE: &str = "Usage: laboratory_baselines [LOOKBACK_DAYS] [MOMENTUM_SESSIONS]";
+
+/// Calendar days of archive to measure over by default.
+///
+/// Twice the trainer's window, because nothing here is trained and a standard error over one year
+/// of sessions is wide enough to call a real weak effect nothing.
+const DEFAULT_LOOKBACK_DAYS: i64 = 730;
+
+/// Sessions the momentum baseline sums over by default.
+const DEFAULT_MOMENTUM_SESSIONS: i64 = 20;
+
+/// Fixed, so two runs over one archive draw the same orderings and differ only where the data does.
+const RANDOM_SEED: u64 = 0x5EED;
+
+/// What to measure, and over how much.
+struct Parameters {
+    lookback_days: i64,
+    momentum_sessions: usize,
+}
+
+impl Parameters {
+    /// Reads the two positional arguments, each falling back to its default.
+    fn parse(arguments: &[String]) -> Result<Self, String> {
+        let (lookback_days, momentum_sessions) = match arguments {
+            [] => (DEFAULT_LOOKBACK_DAYS, DEFAULT_MOMENTUM_SESSIONS),
+            [lookback] => (
+                positive(lookback, "LOOKBACK_DAYS")?,
+                DEFAULT_MOMENTUM_SESSIONS,
+            ),
+            [lookback, momentum] => (
+                positive(lookback, "LOOKBACK_DAYS")?,
+                positive(momentum, "MOMENTUM_SESSIONS")?,
+            ),
+            _ => return Err(format!("Too many arguments\n{USAGE}")),
+        };
+        Ok(Self {
+            lookback_days,
+            momentum_sessions: momentum_sessions as usize,
+        })
+    }
+}
+
+/// Parses a positive integer, refusing a typo rather than falling back to the default.
+///
+/// An operator who passed a window is asking for that window; quietly measuring a different one
+/// would put a number in the journal against a fingerprint nobody chose.
+fn positive(raw: &str, name: &str) -> Result<i64, String> {
+    let value: i64 = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("{name} must be a positive integer, got {raw:?}\n{USAGE}"))?;
+    if value <= 0 {
+        return Err(format!(
+            "{name} must be greater than zero, got {value}\n{USAGE}"
+        ));
+    }
+    Ok(value)
+}
+
+#[tokio::main]
+async fn main() {
+    fund::common::crypto::install_default_crypto_provider();
+    let tracing_guard = init_tracing(
+        "laboratory-baselines.log",
+        Some("info"),
+        "laboratory-baselines",
+    );
+
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let parameters = match Parameters::parse(&arguments) {
+        Ok(parameters) => parameters,
+        Err(message) => {
+            eprintln!("{message}");
+            drop(tracing_guard);
+            std::process::exit(2);
+        }
+    };
+
+    let code = match run(&parameters).await {
+        Ok(scored) => {
+            println!("{}", render(&scored));
+            0
+        }
+        Err(error) => {
+            error!(%error, "Measuring the baselines failed");
+            eprintln!("Measuring the baselines failed: {error}");
+            1
+        }
+    };
+
+    // `std::process::exit` runs no destructors, so the non-blocking appender's guard would never
+    // drop and its buffered lines would be lost — exactly when the failure log matters.
+    drop(tracing_guard);
+    std::process::exit(code);
+}
+
+/// Reads the window, lays out the panel, and scores every baseline against it.
+///
+/// Reads `AWS_S3_BUCKET_NAME` and writes to the laboratory journal. Nothing is fetched and nothing
+/// is published: this measures what the archive already holds.
+async fn run(
+    parameters: &Parameters,
+) -> Result<Vec<laboratory::ForecastScored>, Box<dyn std::error::Error>> {
+    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let s3_client = fund::common::aws::s3_client().await;
+
+    // One instant for the run, resolved once to its Eastern session, as the trainer does: the window
+    // is bounded by a trading day and the journal is stamped with an instant.
+    let now = Utc::now();
+    let session = SessionDate::at(now);
+
+    let run_id = uuid::Uuid::new_v4();
+    let journal = match laboratory::Journal::from_env() {
+        Ok(journal) => Some(journal),
+        Err(error) => {
+            warn!(%error, "No laboratory journal; this run is not recorded");
+            None
+        }
+    };
+
+    info!(
+        bucket,
+        lookback_days = parameters.lookback_days,
+        momentum_sessions = parameters.momentum_sessions,
+        %session,
+        %run_id,
+        "Measuring the baselines"
+    );
+
+    let dataset = dataset::returns(&s3_client, &bucket, parameters.lookback_days, session).await?;
+    let fingerprint = dataset.fingerprint;
+    info!(
+        rows = fingerprint.rows,
+        tickers = fingerprint.tickers,
+        "Read the archive window"
+    );
+
+    if let Some(journal) = journal.as_ref() {
+        // The same record the trainer writes, so a baseline and a model measured over one window
+        // share a fingerprint and their results can be put side by side.
+        journal
+            .record(
+                run_id,
+                Utc::now(),
+                laboratory::Observation::DatasetBuilt(laboratory::DatasetBuilt {
+                    fingerprint,
+                    revision: std::env::var("FUND_REVISION").ok(),
+                }),
+            )
+            .await;
+    }
+
+    let panel = Panel::from_frame(&dataset.returns)?;
+    info!(
+        sessions = panel.sessions(),
+        tickers = panel.tickers(),
+        "Laid the window out session by session"
+    );
+
+    let baselines: Vec<Box<dyn Predictor>> = vec![
+        Box::new(CrossSectionalMean),
+        Box::new(Persistence),
+        Box::new(Momentum {
+            sessions: parameters.momentum_sessions,
+        }),
+        Box::new(RandomRanking { seed: RANDOM_SEED }),
+    ];
+
+    let mut scored = Vec::with_capacity(baselines.len());
+    for baseline in &baselines {
+        let evaluation = evaluate(baseline.as_ref(), &panel);
+        let record = laboratory::ForecastScored::from(&evaluation);
+        info!(
+            predictor = record.predictor,
+            sessions = record.sessions,
+            information_coefficient = record
+                .information_coefficient
+                .map(|distribution| distribution.mean),
+            "Scored a baseline"
+        );
+
+        if let Some(journal) = journal.as_ref() {
+            journal
+                .record(
+                    run_id,
+                    Utc::now(),
+                    laboratory::Observation::ForecastScored(record.clone()),
+                )
+                .await;
+        }
+        scored.push(record);
+    }
+
+    Ok(scored)
+}
+
+/// One row per baseline, for the operator who ran it.
+fn render(scored: &[laboratory::ForecastScored]) -> String {
+    let mut rendered = format!(
+        "{:<22}{:>10}{:>30}{:>30}{:>30}\n",
+        "predictor", "sessions", "information_coefficient", "decile_spread", "directional_accuracy"
+    );
+    for record in scored {
+        rendered.push_str(&format!(
+            "{:<22}{:>10}{:>30}{:>30}{:>30}\n",
+            record.predictor,
+            record.sessions,
+            distribution(record.information_coefficient),
+            distribution(record.decile_spread),
+            distribution(record.directional_accuracy),
+        ));
+    }
+    rendered
+}
+
+/// A statistic with its standard error, or why there is none.
+///
+/// Rendered together because the mean alone invites reading 0.01 over a few hundred sessions as a
+/// signal, and an absent distribution is a measurement that could not be made rather than a zero.
+fn distribution(value: Option<Distribution>) -> String {
+    value.map_or_else(
+        || "unmeasurable".to_string(),
+        |distribution| {
+            format!(
+                "{:+.6} ± {:.6} ({})",
+                distribution.mean, distribution.standard_error, distribution.sessions
+            )
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arguments(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn test_no_arguments_measures_the_default_window() {
+        let parameters = Parameters::parse(&[]).unwrap();
+        assert_eq!(parameters.lookback_days, 730);
+        assert_eq!(parameters.momentum_sessions, 20);
+    }
+
+    #[test]
+    fn test_arguments_are_read_in_order_and_default_from_the_right() {
+        let parameters = Parameters::parse(&arguments(&["365"])).unwrap();
+        assert_eq!(parameters.lookback_days, 365);
+        assert_eq!(parameters.momentum_sessions, 20);
+
+        let parameters = Parameters::parse(&arguments(&["365", "5"])).unwrap();
+        assert_eq!(parameters.lookback_days, 365);
+        assert_eq!(parameters.momentum_sessions, 5);
+    }
+
+    /// A typo must stop the run rather than fall back. A baseline that quietly measured a different
+    /// window would journal a number against a fingerprint nobody asked for, and the fingerprint is
+    /// the only thing that makes two results comparable.
+    #[test]
+    fn test_an_unusable_argument_is_refused() {
+        for value in ["3o5", "0", "-5", ""] {
+            assert!(
+                Parameters::parse(&arguments(&[value])).is_err(),
+                "{value:?} must be refused"
+            );
+        }
+        assert!(Parameters::parse(&arguments(&["365", "0"])).is_err());
+        assert!(Parameters::parse(&arguments(&["365", "20", "7"])).is_err());
+    }
+
+    fn scored(
+        predictor: &str,
+        information_coefficient: Option<Distribution>,
+    ) -> laboratory::ForecastScored {
+        laboratory::ForecastScored {
+            predictor: predictor.to_string(),
+            sessions: 502,
+            information_coefficient,
+            decile_spread: None,
+            directional_accuracy: None,
+        }
+    }
+
+    /// The sign is what a reader acts on, and a negative coefficient is the expected result for a
+    /// daily persistence forecast — so it must not be rendered bare, where it reads as a minus sign
+    /// in a table of positives.
+    #[test]
+    fn test_a_rendered_statistic_carries_its_sign_and_its_error() {
+        let rendered = render(&[scored(
+            "persistence",
+            Some(Distribution {
+                mean: -0.013489,
+                standard_error: 0.007973,
+                sessions: 502,
+            }),
+        )]);
+        assert!(
+            rendered.contains("-0.013489 ± 0.007973 (502)"),
+            "{rendered}"
+        );
+    }
+
+    /// The cross-sectional mean cannot rank, so it has no information coefficient at all. Rendering
+    /// that as `0.000000` would read as a forecast that ranked and got it exactly wrong-by-nothing.
+    #[test]
+    fn test_a_statistic_that_could_not_be_measured_is_not_rendered_as_zero() {
+        let rendered = render(&[scored("cross_sectional_mean", None)]);
+        assert!(rendered.contains("unmeasurable"), "{rendered}");
+        assert!(!rendered.contains("0.000000"), "{rendered}");
+    }
+}

--- a/src/bin/laboratory_baselines.rs
+++ b/src/bin/laboratory_baselines.rs
@@ -1,7 +1,6 @@
 //! Measures the forecasts a model has to beat, over the archive and nothing else.
 //!
-//! Trains nothing: every forecast here is a rule, so a run is one archive read and some arithmetic.
-//! That is what makes it the thing to run first — it says what the data alone is worth.
+//! Trains nothing, so a run is one archive read and some arithmetic: what the data alone is worth.
 
 use chrono::Utc;
 use tracing::{error, info, warn};
@@ -52,7 +51,11 @@ impl Parameters {
         };
         Ok(Self {
             lookback_days,
-            momentum_sessions: momentum_sessions as usize,
+            // Checked rather than cast: `as usize` truncates a value past the pointer width, and a
+            // momentum window that truncated to zero would abstain on every session in silence.
+            momentum_sessions: usize::try_from(momentum_sessions).map_err(|_| {
+                format!("MOMENTUM_SESSIONS is larger than this platform can index\n{USAGE}")
+            })?,
         })
     }
 }

--- a/src/laboratory/dataset.rs
+++ b/src/laboratory/dataset.rs
@@ -11,7 +11,7 @@ use tracing::warn;
 use crate::common::aws::date_partitioned_key;
 use crate::common::types::{SessionDate, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
 use crate::data::{adjust, archive, bars, details, truncate};
-use crate::models::tide::data::{engineer_features, TrainingFraction};
+use crate::models::tide::data::{clean_data, engineer_features, TrainingFraction};
 use crate::models::tide::fit::{filter_training_bars, fit, FitResult};
 use crate::models::tide::predict::consolidate_data;
 use crate::models::tide::TideError;
@@ -123,9 +123,9 @@ pub async fn build(
 
 /// Reads the same window as [`build`] and engineers returns from it, fitting nothing.
 ///
-/// Returns are unscaled because a baseline is measured in the units a book earns. Standardizing is
-/// monotone, so it would leave the rank correlation alone and quietly denominate the decile spread
-/// in standard deviations of a window that has not happened yet.
+/// The rows are the rows the model would train on, because a baseline measured over a wider
+/// universe is not a baseline for it. Returns stay unscaled: standardizing is monotone, so it would
+/// leave the rank correlation alone and denominate the decile spread in units nobody earns.
 pub async fn returns(
     s3_client: &S3Client,
     bucket: &str,
@@ -133,10 +133,11 @@ pub async fn returns(
     session: SessionDate,
 ) -> Result<ReturnsDataset, DatasetError> {
     let (filtered, fingerprint) = read_window(s3_client, bucket, lookback_days, session).await?;
-    // The model's own feature step, so a baseline and the model it is a baseline for are measured
-    // against the same target — including its refusal to call a return across a session gap daily.
-    let engineered = engineer_features(filtered)?;
-    let returns = engineered.select(["ticker", "timestamp", "daily_return"])?;
+    // The model's own two steps, not just the first: `clean_data` drops any row holding a null or
+    // non-finite value in any continuous column, so skipping it would measure names the model never
+    // sees — a missing vendor VWAP costs a row there and none here.
+    let cleaned = clean_data(engineer_features(filtered)?)?;
+    let returns = cleaned.select(["ticker", "timestamp", "daily_return"])?;
 
     Ok(ReturnsDataset {
         returns,

--- a/src/laboratory/dataset.rs
+++ b/src/laboratory/dataset.rs
@@ -11,7 +11,7 @@ use tracing::warn;
 use crate::common::aws::date_partitioned_key;
 use crate::common::types::{SessionDate, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
 use crate::data::{adjust, archive, bars, details, truncate};
-use crate::models::tide::data::TrainingFraction;
+use crate::models::tide::data::{engineer_features, TrainingFraction};
 use crate::models::tide::fit::{filter_training_bars, fit, FitResult};
 use crate::models::tide::predict::consolidate_data;
 use crate::models::tide::TideError;
@@ -96,6 +96,13 @@ pub struct PreparedDataset {
     pub fingerprint: DatasetFingerprint,
 }
 
+/// One session's returns per name, and the identity of the window they came from.
+pub struct ReturnsDataset {
+    /// `ticker`, `timestamp`, and an unscaled `daily_return`.
+    pub returns: DataFrame,
+    pub fingerprint: DatasetFingerprint,
+}
+
 /// Reads the archive for `lookback_days` back from `session` and prepares it for windowing.
 ///
 /// The splits table is fatal where the boundary table is not: stored prices are raw, so training
@@ -108,6 +115,45 @@ pub async fn build(
     session: SessionDate,
     training_fraction: TrainingFraction,
 ) -> Result<PreparedDataset, DatasetError> {
+    let (filtered, fingerprint) = read_window(s3_client, bucket, lookback_days, session).await?;
+    let fit = fit(filtered, training_fraction)?;
+
+    Ok(PreparedDataset { fit, fingerprint })
+}
+
+/// Reads the same window as [`build`] and engineers returns from it, fitting nothing.
+///
+/// Returns are unscaled because a baseline is measured in the units a book earns. Standardizing is
+/// monotone, so it would leave the rank correlation alone and quietly denominate the decile spread
+/// in standard deviations of a window that has not happened yet.
+pub async fn returns(
+    s3_client: &S3Client,
+    bucket: &str,
+    lookback_days: i64,
+    session: SessionDate,
+) -> Result<ReturnsDataset, DatasetError> {
+    let (filtered, fingerprint) = read_window(s3_client, bucket, lookback_days, session).await?;
+    // The model's own feature step, so a baseline and the model it is a baseline for are measured
+    // against the same target — including its refusal to call a return across a session gap daily.
+    let engineered = engineer_features(filtered)?;
+    let returns = engineered.select(["ticker", "timestamp", "daily_return"])?;
+
+    Ok(ReturnsDataset {
+        returns,
+        fingerprint,
+    })
+}
+
+/// Everything both paths share: the archive read, the folds applied to it, and its identity.
+///
+/// The fingerprint is taken here rather than in either caller, so a baseline run and a training run
+/// over the same window report the same one and their journal records join.
+async fn read_window(
+    s3_client: &S3Client,
+    bucket: &str,
+    lookback_days: i64,
+    session: SessionDate,
+) -> Result<(DataFrame, DatasetFingerprint), DatasetError> {
     let splits_frame = archive::read_partition(s3_client, bucket, archive::SPLITS_ARCHIVE_KEY)
         .await?
         .ok_or_else(|| {
@@ -158,9 +204,8 @@ pub async fn build(
         splits_digest,
         boundaries_digest,
     )?;
-    let fit = fit(filtered, training_fraction)?;
 
-    Ok(PreparedDataset { fit, fingerprint })
+    Ok((filtered, fingerprint))
 }
 
 /// Describes the frame the model will be fitted on, before fitting consumes it.

--- a/src/laboratory/journal.rs
+++ b/src/laboratory/journal.rs
@@ -11,6 +11,8 @@ use tracing::{debug, error};
 use uuid::Uuid;
 
 use crate::laboratory::dataset::DatasetFingerprint;
+use crate::laboratory::metrics::Distribution;
+use crate::laboratory::predictor::Evaluation;
 
 /// The shape of a laboratory record, versioned independently of the application journal.
 pub const SCHEMA_VERSION: u32 = 1;
@@ -43,6 +45,7 @@ pub enum JournalError {
 )]
 pub enum Observation {
     DatasetBuilt(DatasetBuilt),
+    ForecastScored(ForecastScored),
 }
 
 impl Observation {
@@ -50,6 +53,7 @@ impl Observation {
     pub fn experiment_type(&self) -> &'static str {
         match self {
             Observation::DatasetBuilt(_) => "dataset_built",
+            Observation::ForecastScored(_) => "forecast_scored",
         }
     }
 }
@@ -63,6 +67,31 @@ pub struct DatasetBuilt {
     pub fingerprint: DatasetFingerprint,
     /// The commit this ran from, so a number can be traced to the code that produced it.
     pub revision: Option<String>,
+}
+
+/// What one forecast was worth over one dataset.
+///
+/// Summarized rather than per session: `sessions` is what the panel held and each distribution
+/// counts what it could measure, so a forecast that never ranked reads as absent and not as zero.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ForecastScored {
+    pub predictor: String,
+    pub sessions: usize,
+    pub information_coefficient: Option<Distribution>,
+    pub decile_spread: Option<Distribution>,
+    pub directional_accuracy: Option<Distribution>,
+}
+
+impl From<&Evaluation> for ForecastScored {
+    fn from(evaluation: &Evaluation) -> Self {
+        Self {
+            predictor: evaluation.predictor.clone(),
+            sessions: evaluation.sessions.len(),
+            information_coefficient: evaluation.information_coefficient,
+            decile_spread: evaluation.decile_spread,
+            directional_accuracy: evaluation.directional_accuracy,
+        }
+    }
 }
 
 /// One line of the laboratory journal: an observation with the envelope that addresses it.
@@ -207,6 +236,7 @@ pub fn date_from_file_name(name: &str) -> Option<NaiveDate> {
 mod tests {
     use super::*;
     use crate::common::types::SessionDate;
+    use crate::laboratory::metrics::SessionMetrics;
 
     fn fingerprint() -> DatasetFingerprint {
         DatasetFingerprint {
@@ -226,6 +256,62 @@ mod tests {
             fingerprint: fingerprint(),
             revision: Some("abc1234".to_string()),
         })
+    }
+
+    /// The export partitions on this name, so the two variants must not collide and neither may
+    /// drift from the tag `rename_all` generates for it.
+    #[test]
+    fn test_each_observation_exports_under_its_own_partition() {
+        let forecast = Observation::ForecastScored(ForecastScored {
+            predictor: "persistence".to_string(),
+            sessions: 4,
+            information_coefficient: None,
+            decile_spread: None,
+            directional_accuracy: None,
+        });
+        let value: serde_json::Value = serde_json::to_value(&forecast).unwrap();
+
+        assert_eq!(
+            value["experiment_type"],
+            serde_json::json!("forecast_scored")
+        );
+        assert_eq!(forecast.experiment_type(), "forecast_scored");
+        assert_ne!(forecast.experiment_type(), observation().experiment_type());
+    }
+
+    /// Two different counts, and conflating them would read a forecast that ranked twice out of
+    /// five hundred sessions as one that ranked throughout.
+    #[test]
+    fn test_a_scored_forecast_separates_the_panel_from_what_it_could_measure() {
+        let measurable = SessionMetrics {
+            information_coefficient: Some(0.02),
+            ..SessionMetrics::default()
+        };
+        let evaluation = Evaluation {
+            predictor: "persistence".to_string(),
+            sessions: vec![
+                SessionMetrics::default(),
+                SessionMetrics::default(),
+                measurable,
+                measurable,
+            ],
+            information_coefficient: Some(Distribution {
+                mean: 0.02,
+                standard_error: 0.0,
+                sessions: 2,
+            }),
+            decile_spread: None,
+            directional_accuracy: None,
+        };
+
+        let record = ForecastScored::from(&evaluation);
+
+        assert_eq!(record.sessions, 4, "every session the panel held");
+        assert_eq!(
+            record.information_coefficient.unwrap().sessions,
+            2,
+            "and only the ones that yielded a reading"
+        );
     }
 
     #[test]

--- a/src/laboratory/predictor.rs
+++ b/src/laboratory/predictor.rs
@@ -183,6 +183,14 @@ impl History<'_> {
 pub trait Predictor {
     fn name(&self) -> &str;
     fn score(&self, history: &History) -> Vec<Option<f64>>;
+
+    /// Whether a score is a return rather than only a place in an ordering.
+    ///
+    /// Directional accuracy compares the two signs, so a score that merely orders names has no
+    /// sign to be right about and the statistic is withheld rather than computed.
+    fn scores_are_returns(&self) -> bool {
+        true
+    }
 }
 
 /// Predicts the previous session's cross-sectional mean for every name alike.
@@ -279,6 +287,13 @@ impl Predictor for RandomRanking {
         "random_ranking"
     }
 
+    /// A uniform draw is positive everywhere, so its directional accuracy would be the share of
+    /// names that rose — a fact about the market reported in the column where the other baselines
+    /// report a forecast, and the highest number in it.
+    fn scores_are_returns(&self) -> bool {
+        false
+    }
+
     fn score(&self, history: &History) -> Vec<Option<f64>> {
         // Abstains where the others do, so every baseline is measured over the same sessions and
         // their coefficients are comparable, which is the only reason a baseline exists.
@@ -319,7 +334,11 @@ pub fn evaluate(predictor: &dyn Predictor, panel: &Panel) -> Evaluation {
             .zip(realized)
             .filter_map(|(score, outcome)| score.zip(*outcome))
             .unzip();
-        sessions.push(metrics::measure_session(&scores, &outcomes));
+        let mut measured = metrics::measure_session(&scores, &outcomes);
+        if !predictor.scores_are_returns() {
+            measured.directional_accuracy = None;
+        }
+        sessions.push(measured);
     }
 
     Evaluation {
@@ -601,6 +620,77 @@ mod tests {
         assert_eq!(
             Panel::from_frame(&narrow).unwrap().returns_at(0),
             &[Some(2.0)]
+        );
+    }
+
+    /// The whole measurement end to end, on a cross-section whose answer can be read off by hand.
+    ///
+    /// Persistence scores each session with the one before it, so a session that exactly reverses
+    /// its predecessor's order must come back at -1 and one that repeats it at +1. This is the
+    /// contract the DuckDB cross-check compares against: same pairing, same per-session correlation,
+    /// same refusal to measure a session with nothing before it.
+    #[test]
+    fn test_persistence_scores_a_reversal_at_minus_one_and_a_repeat_at_plus_one() {
+        let names = ["AAA", "BBB", "CCC", "DDD"];
+        let by_session = [
+            [0.01, 0.02, 0.03, 0.04],
+            // Reversed against the session before it.
+            [0.04, 0.03, 0.02, 0.01],
+            // And in the same order as the session before it.
+            [0.05, 0.04, 0.03, 0.02],
+        ];
+
+        let mut tickers: Vec<&str> = Vec::new();
+        let mut timestamps: Vec<i64> = Vec::new();
+        let mut returns: Vec<f64> = Vec::new();
+        for (session, row) in by_session.iter().enumerate() {
+            for (name, value) in names.iter().zip(row) {
+                tickers.push(name);
+                timestamps.push(session as i64 * DAY);
+                returns.push(*value);
+            }
+        }
+        let frame = DataFrame::new(vec![
+            Column::new("ticker".into(), tickers),
+            Column::new("timestamp".into(), timestamps),
+            Column::new("daily_return".into(), returns),
+        ])
+        .unwrap();
+
+        let evaluation = evaluate(&Persistence, &Panel::from_frame(&frame).unwrap());
+
+        assert_eq!(evaluation.sessions[0].information_coefficient, None);
+        assert_eq!(evaluation.sessions[1].information_coefficient, Some(-1.0));
+        assert_eq!(evaluation.sessions[2].information_coefficient, Some(1.0));
+        let summarized = evaluation.information_coefficient.unwrap();
+        assert_eq!(summarized.sessions, 2, "the first session has no forecast");
+        assert!(summarized.mean.abs() < 1e-12, "{summarized:?}");
+    }
+
+    /// Measured over the real archive, `random_ranking` reported the highest directional accuracy
+    /// of the four baselines — because a uniform draw is positive everywhere, so the statistic was
+    /// the share of names that rose and had nothing to do with the forecast. It still ranks, so its
+    /// rank correlation stands; only the statistic that reads a sign is withheld.
+    #[test]
+    fn test_a_ranking_score_reports_no_directional_accuracy() {
+        let panel = panel();
+
+        let ranking = evaluate(&RandomRanking { seed: 3 }, &panel);
+        assert!(ranking
+            .sessions
+            .iter()
+            .all(|session| session.directional_accuracy.is_none()));
+        assert_eq!(ranking.directional_accuracy, None);
+        assert!(
+            ranking.sessions[3].information_coefficient.is_some(),
+            "a ranking score still orders names"
+        );
+
+        assert!(
+            evaluate(&Persistence, &panel).sessions[3]
+                .directional_accuracy
+                .is_some(),
+            "a score in return units does have a sign to be right about"
         );
     }
 


### PR DESCRIPTION
# Overview

Adds `laboratory_baselines`, the runner that establishes what any model has to beat. It reads an archive window, lays it out session by session, scores the four baselines against it, and journals each result. Nothing is trained — every forecast here is a rule, so a run is one archive read and some arithmetic.

## Changes

- `src/bin/laboratory_baselines.rs` — reads a window, builds the panel, scores `cross_sectional_mean`, `persistence`, `momentum` and `random_ranking`, journals each under a new `forecast_scored` record, and prints a table. Takes positional arguments rather than environment variables, following `seed_equity_bars_s3`: this is an operator-run experiment, not a scheduled job.
- `laboratory::dataset::returns` — baselines need the unscaled `daily_return`, and `build` only returns the scaled frame `fit` produces. Standardizing is monotone, so it would leave the rank correlation untouched and quietly denominate the decile spread in standard deviations of a window that has not happened yet. `build` and `returns` now share `read_window`, and both run `engineer_features` then `clean_data`, so the two paths agree on the window *and* the rows.
- `laboratory::journal::ForecastScored` — keeps two counts apart: sessions the panel held, and sessions that yielded a reading. Conflating them would read a forecast that ranked twice out of five hundred sessions as one that ranked throughout.
- `Predictor::scores_are_returns` — withholds directional accuracy from a score that only orders names.

## Context

**A guard the real run forced.** `random_ranking` came back with the highest directional accuracy of the four baselines. Not a signal: a uniform draw is positive everywhere, so the statistic was the share of names that rose, reported in the column where the other baselines report a forecast. Same class of error as the decile spread fabricating a gap out of tie-broken order — a number computed from an ordering, presented as though computed from a forecast. Its rank correlation still stands, because it does genuinely rank.

**The measurement**, over the development archive, 500 sessions and 2,678 names:

```
predictor              information_coefficient       decile_spread          directional_accuracy
cross_sectional_mean   unmeasurable                  unmeasurable           +0.4963 ± 0.0079
persistence            -0.006785 ± 0.007128 (499)    -0.000110 ± 0.000825   +0.4939 ± 0.0041
momentum (20)          -0.007186 ± 0.008229 (480)    +0.000111 ± 0.000977   +0.4955 ± 0.0041
random_ranking         +0.001644 ± 0.001339 (499)    +0.000133 ± 0.000240   unmeasurable
```

Three of these check the measurement rather than report a result. `random_ranking` at +0.0016 ± 0.0013 is well inside noise, which says the machinery carries no bias of its own. `cross_sectional_mean` reporting nothing is the constant-forecast guard firing on real data — both the rank correlation and the decile spread refuse it rather than returning zero. And `momentum` covers 480 sessions against persistence's 499, which is the twenty-session warm-up it needs.

**Persistence is less than one standard error from zero.** An earlier DuckDB cross-check over the same archive gave -0.013489 ± 0.007973, and the gap is universe rather than arithmetic: that query covered every name, while the runner covers only those present in the embedded details CSV, which `consolidate_data` inner-joins against. Splitting the DuckDB query on that predicate gives kept -0.007299 ± 0.007086 and absent -0.034712 ± 0.013790, and the kept arm agrees with the runner to within a tenth of a standard error. The absent names are ETFs — the CSV is a Nasdaq common-stock screener export — so their stronger reversal is redundancy between leveraged and inverse products rather than missed alpha. Split adjustment was the first suspect and is refuted: capping returns at ±50%, ±30% and ±20% moves the all-names figure by less than 0.0003.

So there is no weak-but-real baseline beneath the model to beat, only zero, and the bar is the noise floor alone — roughly 0.021 for three standard errors.

## Verification

- `devenv tasks run checks:rust` green, exit 0, clippy clean
- 50 laboratory tests and 5 in the binary
- Every new guard proven load-bearing by breaking it and watching the specific test fail: the persistence offset, the two session counts, the unmeasurable rendering, the argument refusal, and the ranking-score suppression
- Run against the real development archive, not fixtures; journal records read back from the written JSONL
- Aligning the row sets was measurement-neutral, as expected: persistence moved -0.006830 to -0.006785 and both runs measure the same 499 sessions. The panel loses its oldest session, which could never carry a return because nothing precedes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)