### PR TITLE
Make a training dataset prove its blocks describe one list of samples

### DIFF
--- a/src/models/tide/batch.rs
+++ b/src/models/tide/batch.rs
@@ -25,9 +25,9 @@ pub fn validate_input_shape(
     let input_length = parameters.input_length();
     let output_length = parameters.output_length();
 
-    let continuous_feature_count = dataset.past_continuous.shape()[2];
-    let categorical_feature_count = dataset.past_categorical.shape()[2];
-    let static_feature_count = dataset.static_categorical.shape()[2];
+    let continuous_feature_count = dataset.past_continuous().shape()[2];
+    let categorical_feature_count = dataset.past_categorical().shape()[2];
+    let static_feature_count = dataset.static_categorical().shape()[2];
 
     let derived = input_length * continuous_feature_count
         + input_length * categorical_feature_count
@@ -49,17 +49,17 @@ pub fn validate_input_shape(
     for (name, available, required) in [
         (
             "past continuous",
-            dataset.past_continuous.shape()[1],
+            dataset.past_continuous().shape()[1],
             input_length,
         ),
         (
             "past categorical",
-            dataset.past_categorical.shape()[1],
+            dataset.past_categorical().shape()[1],
             input_length,
         ),
         (
             "known-future categorical",
-            dataset.future_categorical.shape()[1],
+            dataset.future_categorical().shape()[1],
             output_length,
         ),
         // Always one by construction, and read as `[sample, 0, feature]` regardless — so a dataset
@@ -67,7 +67,7 @@ pub fn validate_input_shape(
         // never looks at.
         (
             "static categorical",
-            dataset.static_categorical.shape()[1],
+            dataset.static_categorical().shape()[1],
             1,
         ),
     ] {
@@ -89,9 +89,9 @@ pub fn build_input_tensor<B: Backend>(
     output_length: usize,
     device: &B::Device,
 ) -> Tensor<B, 2> {
-    let continuous_feature_count = dataset.past_continuous.shape()[2];
-    let categorical_feature_count = dataset.past_categorical.shape()[2];
-    let static_feature_count = dataset.static_categorical.shape()[2];
+    let continuous_feature_count = dataset.past_continuous().shape()[2];
+    let categorical_feature_count = dataset.past_categorical().shape()[2];
+    let static_feature_count = dataset.static_categorical().shape()[2];
     let input_size = input_length * continuous_feature_count
         + input_length * categorical_feature_count
         + output_length * categorical_feature_count
@@ -101,21 +101,21 @@ pub fn build_input_tensor<B: Backend>(
     for &sample in indices {
         for step in 0..input_length {
             for feature in 0..continuous_feature_count {
-                buffer.push(dataset.past_continuous[[sample, step, feature]]);
+                buffer.push(dataset.past_continuous()[[sample, step, feature]]);
             }
         }
         for step in 0..input_length {
             for feature in 0..categorical_feature_count {
-                buffer.push(dataset.past_categorical[[sample, step, feature]] as f32);
+                buffer.push(dataset.past_categorical()[[sample, step, feature]] as f32);
             }
         }
         for step in 0..output_length {
             for feature in 0..categorical_feature_count {
-                buffer.push(dataset.future_categorical[[sample, step, feature]] as f32);
+                buffer.push(dataset.future_categorical()[[sample, step, feature]] as f32);
             }
         }
         for feature in 0..static_feature_count {
-            buffer.push(dataset.static_categorical[[sample, 0, feature]] as f32);
+            buffer.push(dataset.static_categorical()[[sample, 0, feature]] as f32);
         }
     }
 
@@ -132,8 +132,7 @@ pub fn build_target_tensor<B: Backend>(
     device: &B::Device,
 ) -> Tensor<B, 2> {
     let targets = dataset
-        .targets
-        .as_ref()
+        .targets()
         .expect("targets are required to build a target tensor");
     let mut buffer = Vec::with_capacity(indices.len() * output_length);
     for &sample in indices {
@@ -151,13 +150,30 @@ mod tests {
     /// A dataset with the given per-step feature widths. With `input_length` 2 and `output_length`
     /// 1, the derived input size is `2*continuous + 2*categorical + 1*categorical + static`.
     fn dataset(continuous: usize, categorical: usize, static_features: usize) -> TrainingDataset {
-        TrainingDataset {
-            past_continuous: ndarray::Array3::zeros((4, 2, continuous)),
-            past_categorical: ndarray::Array3::zeros((4, 2, categorical)),
-            future_categorical: ndarray::Array3::zeros((4, 1, categorical)),
-            static_categorical: ndarray::Array3::zeros((4, 1, static_features)),
-            targets: None,
-        }
+        blocks(
+            ndarray::Array3::zeros((4, 2, continuous)),
+            ndarray::Array3::zeros((4, 1, categorical)),
+            ndarray::Array3::zeros((4, 1, static_features)),
+            categorical,
+        )
+    }
+
+    /// The same four samples with the past, known-future and static blocks given explicitly, so the
+    /// short-window cases below are built rather than mutated into existence.
+    fn blocks(
+        past_continuous: ndarray::Array3<f32>,
+        future_categorical: ndarray::Array3<i32>,
+        static_categorical: ndarray::Array3<i32>,
+        categorical: usize,
+    ) -> TrainingDataset {
+        TrainingDataset::new(
+            past_continuous,
+            ndarray::Array3::zeros((4, 2, categorical)),
+            future_categorical,
+            static_categorical,
+            None,
+        )
+        .unwrap()
     }
 
     fn parameters(input_size: usize) -> ModelParameters {
@@ -189,9 +205,13 @@ mod tests {
 
     #[test]
     fn test_a_window_shorter_than_the_artifact_needs_is_refused() {
-        let mut short = dataset(7, 5, 3);
         // One past step where the parameters ask for two: indexing step 1 would be out of bounds.
-        short.past_continuous = ndarray::Array3::zeros((4, 1, 7));
+        let short = blocks(
+            ndarray::Array3::zeros((4, 1, 7)),
+            ndarray::Array3::zeros((4, 1, 5)),
+            ndarray::Array3::zeros((4, 1, 3)),
+            5,
+        );
         let error = validate_input_shape(&short, &parameters(32))
             .expect_err("a short window must be refused");
         assert!(error.contains("past continuous"), "got: {error}");
@@ -201,8 +221,12 @@ mod tests {
     /// a zero-length time axis panics on an index the other three checks never look at.
     #[test]
     fn test_a_zero_length_static_axis_is_refused() {
-        let mut degenerate = dataset(7, 5, 3);
-        degenerate.static_categorical = ndarray::Array3::zeros((4, 0, 3));
+        let degenerate = blocks(
+            ndarray::Array3::zeros((4, 2, 7)),
+            ndarray::Array3::zeros((4, 1, 5)),
+            ndarray::Array3::zeros((4, 0, 3)),
+            5,
+        );
         let error = validate_input_shape(&degenerate, &parameters(32))
             .expect_err("a static block with no time axis must be refused");
         assert!(error.contains("static categorical"), "got: {error}");
@@ -210,8 +234,12 @@ mod tests {
 
     #[test]
     fn test_a_short_known_future_window_is_refused() {
-        let mut short = dataset(7, 5, 3);
-        short.future_categorical = ndarray::Array3::zeros((4, 0, 5));
+        let short = blocks(
+            ndarray::Array3::zeros((4, 2, 7)),
+            ndarray::Array3::zeros((4, 0, 5)),
+            ndarray::Array3::zeros((4, 1, 3)),
+            5,
+        );
         assert!(validate_input_shape(&short, &parameters(32)).is_err());
     }
 }

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -208,15 +208,79 @@ impl Scaler {
     }
 }
 
+/// Windowed samples, every block indexed by sample on axis zero.
+///
+/// The blocks are separate arrays describing one list of samples, so `len()` can only speak for all
+/// of them if they agree — which is why they are private and reached through [`TrainingDataset::new`].
 pub struct TrainingDataset {
-    pub past_continuous: ndarray::Array3<f32>,
-    pub past_categorical: ndarray::Array3<i32>,
-    pub future_categorical: ndarray::Array3<i32>,
-    pub static_categorical: ndarray::Array3<i32>,
-    pub targets: Option<ndarray::Array3<f32>>,
+    past_continuous: ndarray::Array3<f32>,
+    past_categorical: ndarray::Array3<i32>,
+    future_categorical: ndarray::Array3<i32>,
+    static_categorical: ndarray::Array3<i32>,
+    targets: Option<ndarray::Array3<f32>>,
 }
 
 impl TrainingDataset {
+    /// Assembles the blocks, refusing any set whose sample counts disagree.
+    ///
+    /// Only axis zero: the per-step widths are checked against the artifact by
+    /// [`crate::models::tide::batch::validate_input_shape`], which is a different question and
+    /// needs the model parameters this does not have.
+    pub fn new(
+        past_continuous: ndarray::Array3<f32>,
+        past_categorical: ndarray::Array3<i32>,
+        future_categorical: ndarray::Array3<i32>,
+        static_categorical: ndarray::Array3<i32>,
+        targets: Option<ndarray::Array3<f32>>,
+    ) -> Result<Self, TideError> {
+        let samples = past_continuous.shape()[0];
+        let blocks = [
+            ("past categorical", past_categorical.shape()[0]),
+            ("known-future categorical", future_categorical.shape()[0]),
+            ("static categorical", static_categorical.shape()[0]),
+        ];
+        for (name, count) in blocks
+            .into_iter()
+            .chain(targets.as_ref().map(|block| ("targets", block.shape()[0])))
+        {
+            if count != samples {
+                return Err(TideError::Data(format!(
+                    "the {name} block carries {count} samples against {samples} past continuous; \
+                     every block describes the same list of samples"
+                )));
+            }
+        }
+
+        Ok(Self {
+            past_continuous,
+            past_categorical,
+            future_categorical,
+            static_categorical,
+            targets,
+        })
+    }
+
+    pub fn past_continuous(&self) -> &ndarray::Array3<f32> {
+        &self.past_continuous
+    }
+
+    pub fn past_categorical(&self) -> &ndarray::Array3<i32> {
+        &self.past_categorical
+    }
+
+    pub fn future_categorical(&self) -> &ndarray::Array3<i32> {
+        &self.future_categorical
+    }
+
+    pub fn static_categorical(&self) -> &ndarray::Array3<i32> {
+        &self.static_categorical
+    }
+
+    pub fn targets(&self) -> Option<&ndarray::Array3<f32>> {
+        self.targets.as_ref()
+    }
+
+    /// How many samples every block carries, which the constructor has already made one number.
     pub fn len(&self) -> usize {
         self.past_continuous.shape()[0]
     }
@@ -641,13 +705,13 @@ fn window_frame(
         None
     };
 
-    Ok(TrainingDataset {
+    TrainingDataset::new(
         past_continuous,
         past_categorical,
         future_categorical,
         static_categorical,
         targets,
-    })
+    )
 }
 
 /// Append one row per ticker carrying `target_session`, so the windowing has a future step to spend
@@ -1273,15 +1337,44 @@ mod tests {
 
     #[test]
     fn test_training_dataset_empty() {
-        let dataset = TrainingDataset {
-            past_continuous: ndarray::Array3::zeros((0, 35, 7)),
-            past_categorical: ndarray::Array3::zeros((0, 35, 5)),
-            future_categorical: ndarray::Array3::zeros((0, 5, 5)),
-            static_categorical: ndarray::Array3::zeros((0, 1, 3)),
-            targets: None,
-        };
+        let dataset = TrainingDataset::new(
+            ndarray::Array3::zeros((0, 35, 7)),
+            ndarray::Array3::zeros((0, 35, 5)),
+            ndarray::Array3::zeros((0, 5, 5)),
+            ndarray::Array3::zeros((0, 1, 3)),
+            None,
+        )
+        .unwrap();
         assert!(dataset.is_empty());
         assert_eq!(dataset.len(), 0);
+    }
+
+    /// The whole reason the blocks are private. A shorter block than the sample count implies is an
+    /// out-of-bounds index deep inside batching, and the identity vector task 3b adds would be
+    /// worse still: it would attribute predictions to the wrong tickers and report a rank
+    /// correlation near zero, which is indistinguishable from the answer that experiment expects.
+    #[test]
+    fn test_blocks_that_disagree_about_the_sample_count_are_refused() {
+        let block = |samples: usize| ndarray::Array3::<i32>::zeros((samples, 1, 3));
+        let build = |static_samples: usize, targets: Option<ndarray::Array3<f32>>| {
+            TrainingDataset::new(
+                ndarray::Array3::zeros((4, 2, 7)),
+                ndarray::Array3::zeros((4, 2, 5)),
+                ndarray::Array3::zeros((4, 1, 5)),
+                block(static_samples),
+                targets,
+            )
+        };
+
+        assert!(build(4, None).is_ok());
+        assert!(
+            build(3, None).is_err(),
+            "a static block one sample short must be refused"
+        );
+        assert!(
+            build(4, Some(ndarray::Array3::zeros((3, 1, 1)))).is_err(),
+            "targets are optional, but a present one still describes the same samples"
+        );
     }
 
     /// Build a minimal, already engineered/scaled/encoded frame (ticker and the

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -211,7 +211,7 @@ impl Scaler {
 /// Windowed samples, every block indexed by sample on axis zero.
 ///
 /// The blocks are separate arrays describing one list of samples, so `len()` can only speak for all
-/// of them if they agree — which is why they are private and reached through [`TrainingDataset::new`].
+/// of them if they agree: [`TrainingDataset::new`] assembles them, and the accessors read them.
 pub struct TrainingDataset {
     past_continuous: ndarray::Array3<f32>,
     past_categorical: ndarray::Array3<i32>,
@@ -1349,10 +1349,8 @@ mod tests {
         assert_eq!(dataset.len(), 0);
     }
 
-    /// The whole reason the blocks are private. A shorter block than the sample count implies is an
-    /// out-of-bounds index deep inside batching, and the identity vector task 3b adds would be
-    /// worse still: it would attribute predictions to the wrong tickers and report a rank
-    /// correlation near zero, which is indistinguishable from the answer that experiment expects.
+    /// The whole reason the blocks are private: a block shorter than the sample count implies is an
+    /// out-of-bounds index deep inside batching rather than a refusal at the boundary.
     #[test]
     fn test_blocks_that_disagree_about_the_sample_count_are_refused() {
         let block = |samples: usize| ndarray::Array3::<i32>::zeros((samples, 1, 3));

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -120,7 +120,7 @@ pub fn evaluate(
     parameters: &ModelParameters,
 ) -> Result<EvaluationMetrics, TideError> {
     let sample_count = dataset.len();
-    let targets = match dataset.targets.as_ref() {
+    let targets = match dataset.targets() {
         Some(targets) if sample_count > 0 => targets,
         _ => return Ok(EvaluationMetrics::zero()),
     };
@@ -489,17 +489,14 @@ mod tests {
     fn make_tiny_dataset(sample_count: usize, with_targets: bool) -> TrainingDataset {
         let input_length = 2_usize;
         let output_length = 1_usize;
-        TrainingDataset {
-            past_continuous: ndarray::Array3::zeros((sample_count, input_length, 7)),
-            past_categorical: ndarray::Array3::zeros((sample_count, input_length, 5)),
-            future_categorical: ndarray::Array3::zeros((sample_count, output_length, 5)),
-            static_categorical: ndarray::Array3::zeros((sample_count, 1, 3)),
-            targets: if with_targets {
-                Some(ndarray::Array3::zeros((sample_count, output_length, 1)))
-            } else {
-                None
-            },
-        }
+        TrainingDataset::new(
+            ndarray::Array3::zeros((sample_count, input_length, 7)),
+            ndarray::Array3::zeros((sample_count, input_length, 5)),
+            ndarray::Array3::zeros((sample_count, output_length, 5)),
+            ndarray::Array3::zeros((sample_count, 1, 3)),
+            with_targets.then(|| ndarray::Array3::zeros((sample_count, output_length, 1))),
+        )
+        .unwrap()
     }
 
     /// Build a TiDEModel that matches `make_tiny_dataset`: input_size=32,

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -393,7 +393,7 @@ pub fn generate_predictions(
 
     let mut results = Vec::with_capacity(sample_count);
     for sample_index in 0..sample_count {
-        let ticker_id = dataset.static_categorical[[sample_index, 0, 0]];
+        let ticker_id = dataset.static_categorical()[[sample_index, 0, 0]];
         // Reported rather than defaulted. This used to fall back to the literal string "UNKNOWN",
         // which is a valid ticker format -- so an unmappable id was stored as a prediction for a
         // symbol called UNKNOWN rather than failing.

--- a/src/models/tide/train.rs
+++ b/src/models/tide/train.rs
@@ -401,13 +401,14 @@ mod tests {
                 targets[[sample_index, step_index, 0]] = 0.5;
             }
         }
-        TrainingDataset {
+        TrainingDataset::new(
             past_continuous,
             past_categorical,
             future_categorical,
             static_categorical,
-            targets: Some(targets),
-        }
+            Some(targets),
+        )
+        .unwrap()
     }
 
     #[test]


### PR DESCRIPTION
# Overview

Gives `TrainingDataset` the invariant it has always assumed. A prerequisite for task 3b rather than a cleanup — see Context for why the ordering matters.

## Changes

- `TrainingDataset` blocks are private and reached through accessors.
- `TrainingDataset::new` refuses any set of blocks whose sample counts disagree, targets included — optional is not the same as exempt.
- Read sites updated in `batch.rs`, `evaluate.rs`, `predict.rs`; construction sites in `data.rs` (`window_frame`) and three test helpers.

Only axis zero is checked here. The per-step widths are a different question, they need the model parameters this constructor does not have, and `validate_input_shape` already answers them against the artifact.

## Context

The struct was four public `Array3`s plus optional targets, all indexed by sample on axis zero, with nothing enforcing that they agree. `len()` read `past_continuous.shape()[0]` and spoke for the rest on trust, while every reader indexes the other blocks out to that length. A disagreement was therefore an out-of-bounds panic deep inside batching rather than a refusal at the boundary.

**Why now, and why its own pull request.** Task 3b scores TiDE cross-sectionally, which requires a per-sample identity carrying the ticker and the session each window forecasts. That is a fifth thing that must stay aligned, and a misaligned identity attributes every prediction to the wrong ticker — which yields a rank correlation near zero. That is *the same answer 3b expects to find anyway*, so the bug's symptom would be indistinguishable from the result. A measurement that cannot fail visibly is not worth running, so the invariant has to precede the thing that depends on it.

It also pays forward independently of what 3b finds: task 14 adds input types, which means more parallel blocks against the same absent invariant.

**Not a change of representation.** The blocks stay contiguous `Array3`s because batching indexes them that way; a `Vec<Sample>` would cost real work for nothing.

**On the three mutated tests.** `batch.rs` built malformed datasets by assigning to a field after construction, which private fields no longer allow. They now pass the odd block at construction, which builds the case under test rather than mutating into it. Their sample counts were always four, so the new constructor accepts them and the short-axis behaviour they cover is untouched.

## Verification

- `devenv tasks run checks:rust` green, exit 0, clippy clean
- 167 tide tests pass, including the 40 in `data.rs` that drive `window_frame` through `get_dataset` — the production construction path, exercised end to end
- The new guard proven load-bearing: disabling the comparison makes `test_blocks_that_disagree_about_the_sample_count_are_refused` fail on the short static block, and restoring it passes
- No real-archive run here, because this changes no behaviour and builds no dataset of its own. The archive exercise belongs to 3b, which needs a fresh train regardless — every published artifact predates the #1081 contiguity fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validated dataset constructor for creating training data safely.
  * Added accessors for retrieving continuous, categorical, static, and target data.

* **Bug Fixes**
  * Dataset creation now rejects mismatched sample counts across data blocks, including optional targets.
  * Updated training, evaluation, prediction, and batch processing to use consistent dataset access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->