### PR TITLE
Score the model by the order it puts names in

### DIFF
--- a/src/bin/laboratory_tide.rs
+++ b/src/bin/laboratory_tide.rs
@@ -1,7 +1,6 @@
 //! Trains one model and scores it against the baselines, over the same sessions.
 //!
-//! Publishes nothing. The artifact exists for the length of the run, because the question is what
-//! the model orders rather than what it should trade.
+//! Publishes nothing: the question is what the model orders, not what it should trade.
 
 use std::collections::BTreeSet;
 
@@ -24,7 +23,7 @@ use fund::models::tide::data::{input_feature_size, DatasetKind, TrainingFraction
 use fund::models::tide::model::TiDEModel;
 use fund::models::tide::train::{train, TrainBackend, TrainConfiguration};
 
-const USAGE: &str = "Usage: laboratory_tide [LOOKBACK_DAYS] [EPOCHS]";
+const USAGE: &str = "Usage: laboratory_tide [LOOKBACK_DAYS] [EPOCHS] [SEED]";
 
 const INPUT_LENGTH: usize = 35;
 const OUTPUT_LENGTH: usize = 1;
@@ -40,19 +39,37 @@ const DEFAULT_EPOCHS: i64 = 5;
 const MOMENTUM_SESSIONS: usize = 20;
 const RANDOM_SEED: u64 = 0x5EED;
 
+/// Seeds the weight initialiser, so two runs of one configuration produce one model.
+///
+/// `train` already seeds its own batch shuffle; the weights went through the backend's global
+/// generator, and two runs of the same configuration scored 0.008 apart — a whole standard error.
+/// Settable, because one seed measures one model and the question is about the architecture.
+const DEFAULT_TRAINING_SEED: i64 = 0x7A1D;
+
 struct Parameters {
     lookback_days: i64,
     epochs: usize,
+    seed: u64,
 }
 
 impl Parameters {
     fn parse(arguments: &[String]) -> Result<Self, String> {
-        let (lookback_days, epochs) = match arguments {
-            [] => (DEFAULT_LOOKBACK_DAYS, DEFAULT_EPOCHS),
-            [lookback] => (positive(lookback, "LOOKBACK_DAYS")?, DEFAULT_EPOCHS),
+        let (lookback_days, epochs, seed) = match arguments {
+            [] => (DEFAULT_LOOKBACK_DAYS, DEFAULT_EPOCHS, DEFAULT_TRAINING_SEED),
+            [lookback] => (
+                positive(lookback, "LOOKBACK_DAYS")?,
+                DEFAULT_EPOCHS,
+                DEFAULT_TRAINING_SEED,
+            ),
             [lookback, epochs] => (
                 positive(lookback, "LOOKBACK_DAYS")?,
                 positive(epochs, "EPOCHS")?,
+                DEFAULT_TRAINING_SEED,
+            ),
+            [lookback, epochs, seed] => (
+                positive(lookback, "LOOKBACK_DAYS")?,
+                positive(epochs, "EPOCHS")?,
+                positive(seed, "SEED")?,
             ),
             _ => return Err(format!("Too many arguments\n{USAGE}")),
         };
@@ -60,6 +77,7 @@ impl Parameters {
             lookback_days,
             epochs: usize::try_from(epochs)
                 .map_err(|_| format!("EPOCHS is larger than this platform can index\n{USAGE}"))?,
+            seed: seed as u64,
         })
     }
 }
@@ -130,6 +148,7 @@ async fn run(
         bucket,
         lookback_days = parameters.lookback_days,
         epochs = parameters.epochs,
+        seed = parameters.seed,
         %session,
         %run_id,
         "Training a model to score it"
@@ -180,6 +199,8 @@ async fn run(
     let input_size = input_feature_size(INPUT_LENGTH, OUTPUT_LENGTH);
     let model_parameters = ModelParameters::new(input_size, INPUT_LENGTH, OUTPUT_LENGTH);
     let device = <TrainBackend as Backend>::Device::default();
+    // Before the weights are drawn, not after.
+    <TrainBackend as Backend>::seed(parameters.seed);
     let model = TiDEModel::<TrainBackend>::new(
         &device,
         input_size,
@@ -238,7 +259,21 @@ async fn run(
         "Scored the model over its validation window"
     );
 
+    // A second read of the same window, because `build` consumed the first into the fit. The
+    // archive is written nightly, so a partition landing between the two would measure the
+    // baselines over a snapshot the model never saw — which is the one comparison this binary is for.
     let returns = dataset::returns(&s3_client, &bucket, parameters.lookback_days, session).await?;
+    if returns.fingerprint != fingerprint {
+        return Err(format!(
+            "the archive moved between the two reads of this window: the model was fitted on {} \
+             rows over {} tickers and the baselines would be measured on {} over {}",
+            fingerprint.rows,
+            fingerprint.tickers,
+            returns.fingerprint.rows,
+            returns.fingerprint.tickers
+        )
+        .into());
+    }
     let panel = Panel::from_frame(&returns.returns)?;
     let baselines: Vec<Box<dyn Predictor>> = vec![
         Box::new(CrossSectionalMean),
@@ -354,10 +389,25 @@ mod tests {
         let parameters = Parameters::parse(&[]).unwrap();
         assert_eq!(parameters.lookback_days, 365);
         assert_eq!(parameters.epochs, 5);
+        assert_eq!(parameters.seed, DEFAULT_TRAINING_SEED as u64);
 
         let parameters = Parameters::parse(&arguments(&["400", "2"])).unwrap();
         assert_eq!(parameters.lookback_days, 400);
         assert_eq!(parameters.epochs, 2);
+        assert_eq!(parameters.seed, DEFAULT_TRAINING_SEED as u64);
+
+        let parameters = Parameters::parse(&arguments(&["400", "2", "9"])).unwrap();
+        assert_eq!(parameters.seed, 9);
+    }
+
+    /// The seed is the whole reason a run is repeatable: initialisation moves the reported
+    /// coefficient by more than the tradeable threshold, so a run that did not name its seed would
+    /// report a number nobody could get back.
+    #[test]
+    fn test_the_seed_is_read_and_refused_like_the_others() {
+        assert!(Parameters::parse(&arguments(&["365", "5", "0"])).is_err());
+        assert!(Parameters::parse(&arguments(&["365", "5", "x"])).is_err());
+        assert!(Parameters::parse(&arguments(&["365", "5", "9", "1"])).is_err());
     }
 
     #[test]

--- a/src/bin/laboratory_tide.rs
+++ b/src/bin/laboratory_tide.rs
@@ -1,0 +1,373 @@
+//! Trains one model and scores it against the baselines, over the same sessions.
+//!
+//! Publishes nothing. The artifact exists for the length of the run, because the question is what
+//! the model orders rather than what it should trade.
+
+use std::collections::BTreeSet;
+
+use burn::module::AutodiffModule;
+use burn::tensor::backend::Backend;
+use chrono::Utc;
+use tracing::{error, info, warn};
+
+use fund::common::log::init_tracing;
+use fund::common::types::SessionDate;
+use fund::laboratory::journal as laboratory;
+use fund::laboratory::metrics::{self, Distribution};
+use fund::laboratory::predictor::{
+    evaluate, CrossSectionalMean, Evaluation, Momentum, Panel, Persistence, Predictor,
+    RandomRanking,
+};
+use fund::laboratory::{dataset, forecast};
+use fund::models::tide::configuration::ModelParameters;
+use fund::models::tide::data::{input_feature_size, DatasetKind, TrainingFraction};
+use fund::models::tide::model::TiDEModel;
+use fund::models::tide::train::{train, TrainBackend, TrainConfiguration};
+
+const USAGE: &str = "Usage: laboratory_tide [LOOKBACK_DAYS] [EPOCHS]";
+
+const INPUT_LENGTH: usize = 35;
+const OUTPUT_LENGTH: usize = 1;
+const TRAINING_FRACTION: f64 = 0.8;
+
+/// The trainer's own window, so the model being scored is the model the trainer would publish.
+const DEFAULT_LOOKBACK_DAYS: i64 = 365;
+
+/// Fewer than the trainer runs. The question is what the model orders, not its best score, and a
+/// rehearsal that takes an hour is one nobody repeats.
+const DEFAULT_EPOCHS: i64 = 5;
+
+const MOMENTUM_SESSIONS: usize = 20;
+const RANDOM_SEED: u64 = 0x5EED;
+
+struct Parameters {
+    lookback_days: i64,
+    epochs: usize,
+}
+
+impl Parameters {
+    fn parse(arguments: &[String]) -> Result<Self, String> {
+        let (lookback_days, epochs) = match arguments {
+            [] => (DEFAULT_LOOKBACK_DAYS, DEFAULT_EPOCHS),
+            [lookback] => (positive(lookback, "LOOKBACK_DAYS")?, DEFAULT_EPOCHS),
+            [lookback, epochs] => (
+                positive(lookback, "LOOKBACK_DAYS")?,
+                positive(epochs, "EPOCHS")?,
+            ),
+            _ => return Err(format!("Too many arguments\n{USAGE}")),
+        };
+        Ok(Self {
+            lookback_days,
+            epochs: usize::try_from(epochs)
+                .map_err(|_| format!("EPOCHS is larger than this platform can index\n{USAGE}"))?,
+        })
+    }
+}
+
+fn positive(raw: &str, name: &str) -> Result<i64, String> {
+    let value: i64 = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("{name} must be a positive integer, got {raw:?}\n{USAGE}"))?;
+    if value <= 0 {
+        return Err(format!(
+            "{name} must be greater than zero, got {value}\n{USAGE}"
+        ));
+    }
+    Ok(value)
+}
+
+#[tokio::main]
+async fn main() {
+    fund::common::crypto::install_default_crypto_provider();
+    let tracing_guard = init_tracing("laboratory-tide.log", Some("info"), "laboratory-tide");
+
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let parameters = match Parameters::parse(&arguments) {
+        Ok(parameters) => parameters,
+        Err(message) => {
+            eprintln!("{message}");
+            drop(tracing_guard);
+            std::process::exit(2);
+        }
+    };
+
+    let code = match run(&parameters).await {
+        Ok(scored) => {
+            println!("{}", render(&scored));
+            0
+        }
+        Err(error) => {
+            error!(%error, "Scoring the model failed");
+            eprintln!("Scoring the model failed: {error}");
+            1
+        }
+    };
+
+    drop(tracing_guard);
+    std::process::exit(code);
+}
+
+async fn run(
+    parameters: &Parameters,
+) -> Result<Vec<laboratory::ForecastScored>, Box<dyn std::error::Error>> {
+    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let s3_client = fund::common::aws::s3_client().await;
+
+    let now = Utc::now();
+    let session = SessionDate::at(now);
+    let run_id = uuid::Uuid::new_v4();
+    let journal = match laboratory::Journal::from_env() {
+        Ok(journal) => Some(journal),
+        Err(error) => {
+            warn!(%error, "No laboratory journal; this run is not recorded");
+            None
+        }
+    };
+
+    info!(
+        bucket,
+        lookback_days = parameters.lookback_days,
+        epochs = parameters.epochs,
+        %session,
+        %run_id,
+        "Training a model to score it"
+    );
+
+    let training_fraction = TrainingFraction::new(TRAINING_FRACTION)?;
+    let prepared = dataset::build(
+        &s3_client,
+        &bucket,
+        parameters.lookback_days,
+        session,
+        training_fraction,
+    )
+    .await?;
+    let fingerprint = prepared.fingerprint;
+    if let Some(journal) = journal.as_ref() {
+        journal
+            .record(
+                run_id,
+                Utc::now(),
+                laboratory::Observation::DatasetBuilt(laboratory::DatasetBuilt {
+                    fingerprint: fingerprint.clone(),
+                    revision: std::env::var("FUND_REVISION").ok(),
+                }),
+            )
+            .await;
+    }
+
+    let training_data = prepared.fit.data.get_dataset(
+        DatasetKind::Train(training_fraction),
+        INPUT_LENGTH,
+        OUTPUT_LENGTH,
+    )?;
+    let validation_data = prepared.fit.data.get_dataset(
+        DatasetKind::Validate(training_fraction),
+        INPUT_LENGTH,
+        OUTPUT_LENGTH,
+    )?;
+    if training_data.is_empty() || validation_data.is_empty() {
+        return Err("the lookback window produced no training or validation samples".into());
+    }
+    info!(
+        train_samples = training_data.len(),
+        validation_samples = validation_data.len(),
+        "Built windowed datasets"
+    );
+
+    let input_size = input_feature_size(INPUT_LENGTH, OUTPUT_LENGTH);
+    let model_parameters = ModelParameters::new(input_size, INPUT_LENGTH, OUTPUT_LENGTH);
+    let device = <TrainBackend as Backend>::Device::default();
+    let model = TiDEModel::<TrainBackend>::new(
+        &device,
+        input_size,
+        model_parameters.hidden_size(),
+        model_parameters.encoder_layer_count(),
+        model_parameters.decoder_layer_count(),
+        model_parameters.output_length(),
+        model_parameters.quantiles().len(),
+        model_parameters.dropout_rate(),
+    );
+
+    // Through the validated constructor rather than by assigning a field, as the trainer does: an
+    // epoch count of zero would otherwise run no epochs and score an untrained model.
+    let defaults = TrainConfiguration::default();
+    let configuration = TrainConfiguration::new(
+        defaults.learning_rate(),
+        parameters.epochs,
+        defaults.batch_size(),
+        defaults.early_stopping_patience(),
+        defaults.min_delta(),
+    )?;
+    let started = tokio::time::Instant::now();
+    let (best_model, losses) = train(
+        model,
+        &training_data,
+        Some(&validation_data),
+        &model_parameters,
+        &configuration,
+        &device,
+    );
+    info!(
+        epochs = losses.len(),
+        final_train_loss = losses.last().copied().unwrap_or_default(),
+        seconds = started.elapsed().as_secs(),
+        "Training complete"
+    );
+
+    let scored_model = forecast::score(
+        "tide",
+        &best_model.valid(),
+        &validation_data,
+        &model_parameters,
+        &prepared.fit.scaler,
+    )?;
+
+    // The sessions the model was actually measured over. Every baseline is then cut to the same
+    // set, because comparing a forecast scored on fifty sessions against one scored on five hundred
+    // compares two stretches of calendar rather than two forecasts.
+    let measured: BTreeSet<i64> = validation_data
+        .forecast_sessions()
+        .iter()
+        .copied()
+        .collect();
+    info!(
+        sessions = measured.len(),
+        "Scored the model over its validation window"
+    );
+
+    let returns = dataset::returns(&s3_client, &bucket, parameters.lookback_days, session).await?;
+    let panel = Panel::from_frame(&returns.returns)?;
+    let baselines: Vec<Box<dyn Predictor>> = vec![
+        Box::new(CrossSectionalMean),
+        Box::new(Persistence),
+        Box::new(Momentum {
+            sessions: MOMENTUM_SESSIONS,
+        }),
+        Box::new(RandomRanking { seed: RANDOM_SEED }),
+    ];
+
+    let mut scored = vec![scored_model];
+    for baseline in &baselines {
+        // Evaluated over the whole panel and cut afterwards, so each baseline still reads the
+        // history before its first measured session — momentum needs twenty sessions of it.
+        scored.push(restrict(
+            evaluate(baseline.as_ref(), &panel),
+            &panel,
+            &measured,
+        ));
+    }
+
+    let mut records = Vec::with_capacity(scored.len());
+    for evaluation in &scored {
+        let record = laboratory::ForecastScored::from(evaluation);
+        info!(
+            predictor = record.predictor,
+            sessions = record.sessions,
+            information_coefficient = record
+                .information_coefficient
+                .map(|distribution| distribution.mean),
+            "Scored a forecast"
+        );
+        if let Some(journal) = journal.as_ref() {
+            journal
+                .record(
+                    run_id,
+                    Utc::now(),
+                    laboratory::Observation::ForecastScored(record.clone()),
+                )
+                .await;
+        }
+        records.push(record);
+    }
+
+    Ok(records)
+}
+
+/// Keeps only the sessions in `measured`, then re-summarizes what is left.
+fn restrict(evaluation: Evaluation, panel: &Panel, measured: &BTreeSet<i64>) -> Evaluation {
+    let sessions: Vec<metrics::SessionMetrics> = evaluation
+        .sessions
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| measured.contains(&panel.session_at(*index)))
+        .map(|(_, session)| *session)
+        .collect();
+
+    Evaluation {
+        predictor: evaluation.predictor,
+        information_coefficient: metrics::summarize(
+            sessions
+                .iter()
+                .map(|session| session.information_coefficient),
+        ),
+        decile_spread: metrics::summarize(sessions.iter().map(|session| session.decile_spread)),
+        directional_accuracy: metrics::summarize(
+            sessions.iter().map(|session| session.directional_accuracy),
+        ),
+        sessions,
+    }
+}
+
+fn render(scored: &[laboratory::ForecastScored]) -> String {
+    let mut rendered = format!(
+        "{:<22}{:>10}{:>30}{:>30}{:>30}\n",
+        "predictor", "sessions", "information_coefficient", "decile_spread", "directional_accuracy"
+    );
+    for record in scored {
+        rendered.push_str(&format!(
+            "{:<22}{:>10}{:>30}{:>30}{:>30}\n",
+            record.predictor,
+            record.sessions,
+            distribution(record.information_coefficient),
+            distribution(record.decile_spread),
+            distribution(record.directional_accuracy),
+        ));
+    }
+    rendered
+}
+
+fn distribution(value: Option<Distribution>) -> String {
+    value.map_or_else(
+        || "unmeasurable".to_string(),
+        |distribution| {
+            format!(
+                "{:+.6} ± {:.6} ({})",
+                distribution.mean, distribution.standard_error, distribution.sessions
+            )
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arguments(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn test_arguments_default_from_the_right() {
+        let parameters = Parameters::parse(&[]).unwrap();
+        assert_eq!(parameters.lookback_days, 365);
+        assert_eq!(parameters.epochs, 5);
+
+        let parameters = Parameters::parse(&arguments(&["400", "2"])).unwrap();
+        assert_eq!(parameters.lookback_days, 400);
+        assert_eq!(parameters.epochs, 2);
+    }
+
+    #[test]
+    fn test_an_unusable_argument_is_refused() {
+        for value in ["1o", "0", "-1", ""] {
+            assert!(
+                Parameters::parse(&arguments(&[value])).is_err(),
+                "{value:?} must be refused"
+            );
+        }
+        assert!(Parameters::parse(&arguments(&["365", "0"])).is_err());
+    }
+}

--- a/src/laboratory.rs
+++ b/src/laboratory.rs
@@ -4,6 +4,7 @@
 
 pub mod dataset;
 pub mod export;
+pub mod forecast;
 pub mod journal;
 pub mod metrics;
 pub mod predictor;

--- a/src/laboratory/forecast.rs
+++ b/src/laboratory/forecast.rs
@@ -1,7 +1,6 @@
 //! Scores a trained model the way a baseline is scored: by the order it puts names in.
 //!
-//! Cross-sectional, so it answers a different question than CRPS — not how close each prediction
-//! lands, but whether the ranking a dollar-neutral book would act on is the right one.
+//! Cross-sectional, so it asks what CRPS cannot: is the ranking a neutral book acts on the right one?
 
 use std::collections::BTreeMap;
 
@@ -124,7 +123,9 @@ fn forward(
 ) -> Result<Vec<f32>, TideError> {
     let device = Default::default();
     let indices: Vec<usize> = (0..dataset.len()).collect();
-    let mut predictions: Vec<f32> = Vec::new();
+    let mut predictions: Vec<f32> = Vec::with_capacity(
+        dataset.len() * parameters.output_length() * parameters.quantiles().len(),
+    );
     for chunk in indices.chunks(BATCH_SIZE) {
         let input = build_input_tensor::<NdArray>(
             dataset,
@@ -254,6 +255,48 @@ mod tests {
             upper.decile_spread, None,
             "the spread is in return units and does move"
         );
+    }
+
+    /// A dataset shaped for a different artifact is refused before the forward pass, where burn
+    /// would otherwise raise a tensor-dimension panic naming neither the artifact nor the columns.
+    #[test]
+    fn test_a_dataset_the_artifact_cannot_read_is_refused() {
+        let device = Default::default();
+        let model = TiDEModel::<NdArray>::new(&device, 32, 8, 1, 1, 1, 3, 0.0);
+        // The fixture carries two past steps of seven continuous features; these parameters expect
+        // an input the fixture cannot produce.
+        let parameters =
+            ModelParameters::for_tests(64, 8, 1, 1, 1, 2, 0.0, vec![0.1, 0.5, 0.9], 0.5);
+        assert!(matches!(
+            score(
+                "mismatched",
+                &model,
+                &dataset(2, 12),
+                &parameters,
+                &scaler()
+            ),
+            Err(TideError::Artifact(_))
+        ));
+    }
+
+    /// Unreachable in production — `ModelParameters::new` installs the served quantiles and `load`
+    /// validates them, so only `for_tests` can build this. Kept because a model that emits no
+    /// quantiles has nothing to rank names by, and the alternative is indexing into an empty row.
+    #[test]
+    fn test_a_model_emitting_no_quantiles_has_nothing_to_rank_by() {
+        let device = Default::default();
+        let model = TiDEModel::<NdArray>::new(&device, 32, 8, 1, 1, 1, 3, 0.0);
+        let parameters = ModelParameters::for_tests(32, 8, 1, 1, 1, 2, 0.0, Vec::new(), 0.5);
+        assert!(matches!(
+            score(
+                "quantile-less",
+                &model,
+                &dataset(2, 12),
+                &parameters,
+                &scaler()
+            ),
+            Err(TideError::Artifact(_))
+        ));
     }
 
     #[test]

--- a/src/laboratory/forecast.rs
+++ b/src/laboratory/forecast.rs
@@ -1,0 +1,278 @@
+//! Scores a trained model the way a baseline is scored: by the order it puts names in.
+//!
+//! Cross-sectional, so it answers a different question than CRPS — not how close each prediction
+//! lands, but whether the ranking a dollar-neutral book would act on is the right one.
+
+use std::collections::BTreeMap;
+
+use burn::backend::NdArray;
+
+use crate::laboratory::metrics;
+use crate::laboratory::predictor::Evaluation;
+use crate::models::tide::batch::{build_input_tensor, validate_input_shape};
+use crate::models::tide::configuration::ModelParameters;
+use crate::models::tide::data::{Scaler, TrainingDataset, TARGET_COLUMN};
+use crate::models::tide::evaluate::QuantileIndices;
+use crate::models::tide::model::TiDEModel;
+use crate::models::tide::TideError;
+
+/// Samples per forward pass, matching the evaluation path.
+const BATCH_SIZE: usize = 4096;
+
+/// Runs `model` over `dataset` and measures the cross-section it produces each session.
+///
+/// Both sides come out of the same dataset — the median quantile against the target the sample was
+/// built with — so a prediction is matched to its own outcome by construction rather than by a join
+/// that could silently mismatch. Returns are unscaled first: the rank correlation would not notice,
+/// but the decile spread is a return and would otherwise be quoted in standard deviations.
+pub fn score(
+    name: &str,
+    model: &TiDEModel<NdArray>,
+    dataset: &TrainingDataset,
+    parameters: &ModelParameters,
+    scaler: &Scaler,
+) -> Result<Evaluation, TideError> {
+    validate_input_shape(dataset, parameters).map_err(TideError::Artifact)?;
+
+    let quantiles = parameters.quantiles();
+    let quantile_count = quantiles.len();
+    if quantile_count == 0 {
+        return Err(TideError::Artifact(
+            "the model emits no quantiles, so it has nothing to rank names by".to_string(),
+        ));
+    }
+    let median = QuantileIndices::locate(quantiles).median;
+    let output_length = parameters.output_length();
+
+    let predictions = forward(model, dataset, parameters)?;
+    measure(
+        name,
+        &predictions,
+        dataset,
+        scaler,
+        median,
+        quantile_count,
+        output_length,
+    )
+}
+
+/// Groups the model's output into one cross-section per session and measures each.
+///
+/// Separated from the forward pass so a known forecast can be measured without a network, which is
+/// the only way to show the instrument reports a signal when one is there.
+fn measure(
+    name: &str,
+    predictions: &[f32],
+    dataset: &TrainingDataset,
+    scaler: &Scaler,
+    median: usize,
+    quantile_count: usize,
+    output_length: usize,
+) -> Result<Evaluation, TideError> {
+    let targets = dataset.targets().ok_or_else(|| {
+        TideError::Data(
+            "scoring a forecast needs the realized returns the samples were built with".to_string(),
+        )
+    })?;
+    let expected = dataset.len() * output_length * quantile_count;
+    if predictions.len() < expected {
+        return Err(TideError::Artifact(format!(
+            "the model returned {} values against {expected} for {} samples",
+            predictions.len(),
+            dataset.len()
+        )));
+    }
+
+    // Step zero only. The book flattens every position the same session, so a longer horizon
+    // describes a holding period this strategy never has — the same step `predict` trades on.
+    let mut by_session: BTreeMap<i64, (Vec<f64>, Vec<f64>)> = BTreeMap::new();
+    for sample in 0..dataset.len() {
+        let scaled = predictions[sample * output_length * quantile_count + median] as f64;
+        let (scores, realized) = by_session
+            .entry(dataset.forecast_sessions()[sample])
+            .or_default();
+        scores.push(scaler.inverse_transform_value(TARGET_COLUMN, scaled));
+        realized
+            .push(scaler.inverse_transform_value(TARGET_COLUMN, targets[[sample, 0, 0]] as f64));
+    }
+
+    let sessions: Vec<metrics::SessionMetrics> = by_session
+        .into_values()
+        .map(|(scores, realized)| metrics::measure_session(&scores, &realized))
+        .collect();
+
+    Ok(Evaluation {
+        predictor: name.to_string(),
+        information_coefficient: metrics::summarize(
+            sessions
+                .iter()
+                .map(|session| session.information_coefficient),
+        ),
+        decile_spread: metrics::summarize(sessions.iter().map(|session| session.decile_spread)),
+        directional_accuracy: metrics::summarize(
+            sessions.iter().map(|session| session.directional_accuracy),
+        ),
+        sessions,
+    })
+}
+
+/// Every sample's quantiles, in sample order.
+fn forward(
+    model: &TiDEModel<NdArray>,
+    dataset: &TrainingDataset,
+    parameters: &ModelParameters,
+) -> Result<Vec<f32>, TideError> {
+    let device = Default::default();
+    let indices: Vec<usize> = (0..dataset.len()).collect();
+    let mut predictions: Vec<f32> = Vec::new();
+    for chunk in indices.chunks(BATCH_SIZE) {
+        let input = build_input_tensor::<NdArray>(
+            dataset,
+            chunk,
+            parameters.input_length(),
+            parameters.output_length(),
+            &device,
+        );
+        let mut values: Vec<f32> = model
+            .forward(input)
+            .to_data()
+            .to_vec()
+            .map_err(|error| TideError::Artifact(format!("{error:?}")))?;
+        predictions.append(&mut values);
+    }
+    Ok(predictions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::tide::data::Scaler;
+
+    const DAY: i64 = 86_400_000;
+    const QUANTILES: usize = 3;
+    const MEDIAN: usize = 1;
+
+    /// Twelve names across two sessions, with the realized return rising through each session.
+    fn dataset(sessions: usize, names: usize) -> TrainingDataset {
+        let samples = sessions * names;
+        let mut targets = ndarray::Array3::<f32>::zeros((samples, 1, 1));
+        let mut forecast_sessions = Vec::with_capacity(samples);
+        for session in 0..sessions {
+            for name in 0..names {
+                targets[[session * names + name, 0, 0]] = name as f32 * 0.01;
+                forecast_sessions.push(session as i64 * DAY);
+            }
+        }
+        TrainingDataset::new(
+            ndarray::Array3::zeros((samples, 2, 7)),
+            ndarray::Array3::zeros((samples, 2, 5)),
+            ndarray::Array3::zeros((samples, 1, 5)),
+            ndarray::Array3::zeros((samples, 1, 3)),
+            Some(targets),
+            forecast_sessions,
+        )
+        .unwrap()
+    }
+
+    /// The identity scaler, so the assertions below read in the units the targets were written in.
+    fn scaler() -> Scaler {
+        Scaler::new(
+            std::collections::HashMap::from([(TARGET_COLUMN.to_string(), 0.0)]),
+            std::collections::HashMap::from([(TARGET_COLUMN.to_string(), 1.0)]),
+        )
+        .unwrap()
+    }
+
+    /// Predictions laid out as the model emits them: one row of quantiles per sample.
+    fn quantiles_from(medians: &[f32]) -> Vec<f32> {
+        medians
+            .iter()
+            .flat_map(|median| [median - 1.0, *median, median + 1.0])
+            .collect()
+    }
+
+    /// A forecast that is the outcome must score exactly +1, and its reverse exactly -1.
+    ///
+    /// Without this the reported zero would be untestable: a measurement that cannot report a
+    /// signal when one is handed to it says nothing when it reports none. It also pins the sample
+    /// ordering, since a forecast misaligned against its own session would score neither.
+    #[test]
+    fn test_a_perfect_forecast_scores_one_and_its_reverse_minus_one() {
+        let sessions = 2;
+        let names = 12;
+        let data = dataset(sessions, names);
+        let realized: Vec<f32> = (0..sessions)
+            .flat_map(|_| (0..names).map(|name| name as f32 * 0.01))
+            .collect();
+
+        let perfect = measure(
+            "perfect",
+            &quantiles_from(&realized),
+            &data,
+            &scaler(),
+            MEDIAN,
+            QUANTILES,
+            1,
+        )
+        .unwrap();
+        assert_eq!(perfect.sessions.len(), sessions);
+        let coefficient = perfect.information_coefficient.unwrap();
+        assert!(
+            (coefficient.mean - 1.0).abs() < 1e-9,
+            "a forecast equal to the outcome must rank perfectly, got {coefficient:?}"
+        );
+
+        let reversed: Vec<f32> = realized.iter().map(|value| -value).collect();
+        let inverted = measure(
+            "inverted",
+            &quantiles_from(&reversed),
+            &data,
+            &scaler(),
+            MEDIAN,
+            QUANTILES,
+            1,
+        )
+        .unwrap();
+        assert!((inverted.information_coefficient.unwrap().mean + 1.0).abs() < 1e-9);
+    }
+
+    /// The median is the traded quantile, so reading a neighbouring one would score a forecast the
+    /// book never acts on — and the two bracket the median by construction here.
+    #[test]
+    fn test_the_median_quantile_is_the_one_scored() {
+        let data = dataset(2, 12);
+        let realized: Vec<f32> = (0..2)
+            .flat_map(|_| (0..12).map(|name| name as f32 * 0.01))
+            .collect();
+        let predictions = quantiles_from(&realized);
+
+        let upper = measure("upper", &predictions, &data, &scaler(), 2, QUANTILES, 1).unwrap();
+        // Every median is offset by the same constant to build the upper quantile, so the ordering
+        // survives and only the level moves — the rank correlation cannot see the difference.
+        assert!((upper.information_coefficient.unwrap().mean - 1.0).abs() < 1e-9);
+        assert_ne!(
+            upper.decile_spread, None,
+            "the spread is in return units and does move"
+        );
+    }
+
+    #[test]
+    fn test_a_dataset_without_outcomes_cannot_be_scored() {
+        let bare = TrainingDataset::new(
+            ndarray::Array3::zeros((4, 2, 7)),
+            ndarray::Array3::zeros((4, 2, 5)),
+            ndarray::Array3::zeros((4, 1, 5)),
+            ndarray::Array3::zeros((4, 1, 3)),
+            None,
+            vec![0; 4],
+        )
+        .unwrap();
+        assert!(measure("bare", &[0.0; 12], &bare, &scaler(), MEDIAN, QUANTILES, 1).is_err());
+    }
+
+    #[test]
+    fn test_a_short_prediction_buffer_is_refused_rather_than_indexed() {
+        let data = dataset(2, 12);
+        assert!(measure("short", &[0.0; 6], &data, &scaler(), MEDIAN, QUANTILES, 1).is_err());
+    }
+}

--- a/src/models/tide/batch.rs
+++ b/src/models/tide/batch.rs
@@ -172,6 +172,7 @@ mod tests {
             future_categorical,
             static_categorical,
             None,
+            vec![0; 4],
         )
         .unwrap()
     }

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -572,6 +572,15 @@ fn window_frame(
             "A window needs a non-zero input or output length".to_string(),
         ));
     }
+    // A window that forecasts nothing has no session to name, and the row it would read for one is
+    // the first past the ticker's own rows. `ModelParameters::load` refuses a zero output length on
+    // the same grounds, at the other end of the same pipeline.
+    if output_length == 0 {
+        return Err(TideError::Data(
+            "A window needs a non-zero output length; one with no future step forecasts nothing"
+                .to_string(),
+        ));
+    }
     let ranks = session_ranks(frame)?;
     let continuous_feature_count = CONTINUOUS_COLUMNS.len();
     let categorical_feature_count = CATEGORICAL_COLUMNS.len();
@@ -1627,6 +1636,28 @@ mod tests {
             matches!(result, Err(TideError::Data(_))),
             "a zero-length window must be an error, not a panic"
         );
+    }
+
+    /// A window with past steps but no future one is the case the guard above misses: the sum is
+    /// non-zero, so it passes, and the last window then reads one position past the ticker's final
+    /// row to name the session it forecasts. A window that forecasts nothing has no such session.
+    #[test]
+    fn test_a_window_with_no_future_step_is_refused_rather_than_indexed() {
+        let data = Data::from_parts(
+            prepared_and_encoded(raw_gapped_frame()),
+            return_scaler(),
+            FeatureMappings::new(),
+        );
+        for kind in [
+            DatasetKind::Predict,
+            DatasetKind::Train(fraction_of(0.8)),
+            DatasetKind::Validate(fraction_of(0.8)),
+        ] {
+            assert!(
+                matches!(data.get_dataset(kind, 3, 0), Err(TideError::Data(_))),
+                "an output length of zero must be an error, not a panic"
+            );
+        }
     }
 
     /// `session_ranks` skips nulls while the windows are counted from the row height, so one null

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -218,6 +218,7 @@ pub struct TrainingDataset {
     future_categorical: ndarray::Array3<i32>,
     static_categorical: ndarray::Array3<i32>,
     targets: Option<ndarray::Array3<f32>>,
+    forecast_sessions: Vec<i64>,
 }
 
 impl TrainingDataset {
@@ -232,12 +233,14 @@ impl TrainingDataset {
         future_categorical: ndarray::Array3<i32>,
         static_categorical: ndarray::Array3<i32>,
         targets: Option<ndarray::Array3<f32>>,
+        forecast_sessions: Vec<i64>,
     ) -> Result<Self, TideError> {
         let samples = past_continuous.shape()[0];
         let blocks = [
             ("past categorical", past_categorical.shape()[0]),
             ("known-future categorical", future_categorical.shape()[0]),
             ("static categorical", static_categorical.shape()[0]),
+            ("forecast session", forecast_sessions.len()),
         ];
         for (name, count) in blocks
             .into_iter()
@@ -257,6 +260,7 @@ impl TrainingDataset {
             future_categorical,
             static_categorical,
             targets,
+            forecast_sessions,
         })
     }
 
@@ -278,6 +282,14 @@ impl TrainingDataset {
 
     pub fn targets(&self) -> Option<&ndarray::Array3<f32>> {
         self.targets.as_ref()
+    }
+
+    /// The session each sample forecasts, as a millisecond timestamp.
+    ///
+    /// The encoded ticker is already reachable at `static_categorical[[sample, 0, 0]]`, so this is
+    /// the other half of a sample's identity and the half a cross-section cannot be grouped without.
+    pub fn forecast_sessions(&self) -> &[i64] {
+        &self.forecast_sessions
     }
 
     /// How many samples every block carries, which the constructor has already made one number.
@@ -585,6 +597,7 @@ fn window_frame(
     let mut all_future_categorical: Vec<Vec<i32>> = Vec::new();
     let mut all_static_categorical: Vec<Vec<i32>> = Vec::new();
     let mut all_targets: Vec<Vec<f32>> = Vec::new();
+    let mut all_forecast_sessions: Vec<i64> = Vec::new();
 
     for ticker in &tickers {
         let mask = frame.column("ticker")?.i32()?.equal(*ticker);
@@ -593,6 +606,12 @@ fn window_frame(
         if ticker_data.height() < window_size {
             continue;
         }
+
+        let timestamps: Vec<i64> = ticker_data
+            .column("timestamp")?
+            .i64()?
+            .into_no_null_iter()
+            .collect();
 
         let continuous_column_values = get_float_columns(&ticker_data, CONTINUOUS_COLUMNS)?;
         let categorical_column_values = get_int_columns(&ticker_data, CATEGORICAL_COLUMNS)?;
@@ -645,6 +664,9 @@ fn window_frame(
             all_past_categorical.push(past_categorical_window);
             all_future_categorical.push(future_categorical_window);
             all_static_categorical.push(static_categorical_window);
+            // The first future step, which is the session the sample forecasts. Taken here rather
+            // than derived later, because this loop is what decides which windows exist.
+            all_forecast_sessions.push(timestamps[start + input_length]);
 
             if with_targets {
                 let returns = &continuous_column_values[target_index];
@@ -711,6 +733,7 @@ fn window_frame(
         future_categorical,
         static_categorical,
         targets,
+        all_forecast_sessions,
     )
 }
 
@@ -1343,6 +1366,7 @@ mod tests {
             ndarray::Array3::zeros((0, 5, 5)),
             ndarray::Array3::zeros((0, 1, 3)),
             None,
+            Vec::new(),
         )
         .unwrap();
         assert!(dataset.is_empty());
@@ -1361,6 +1385,7 @@ mod tests {
                 ndarray::Array3::zeros((4, 1, 5)),
                 block(static_samples),
                 targets,
+                vec![0; 4],
             )
         };
 
@@ -1373,6 +1398,31 @@ mod tests {
             build(4, Some(ndarray::Array3::zeros((3, 1, 1)))).is_err(),
             "targets are optional, but a present one still describes the same samples"
         );
+    }
+
+    /// The session a sample forecasts is the first *future* step, not the last past one. Off by one
+    /// the wrong way, every prediction would be scored against the outcome it was given as input,
+    /// and the rank correlation would read as a signal nobody could trade.
+    #[test]
+    fn test_a_sample_names_the_session_it_forecasts() {
+        const DAY: i64 = 86_400_000;
+        let data = empty_data(make_encoded_frame(1, 6));
+        // Input 3, output 1: the windows start at rows 0, 1 and 2, so they forecast rows 3, 4, 5.
+        let dataset = data.get_dataset(DatasetKind::Predict, 3, 1).unwrap();
+
+        // Predict mode keeps only the last window per ticker, which forecasts the final row.
+        assert_eq!(dataset.forecast_sessions(), &[5 * DAY]);
+
+        let training = data
+            .get_dataset(DatasetKind::Train(fraction_of(0.8)), 3, 1)
+            .unwrap();
+        assert_eq!(training.forecast_sessions().len(), training.len());
+        for session in training.forecast_sessions() {
+            assert!(
+                *session >= 3 * DAY,
+                "a window of three past steps cannot forecast earlier than row three, got {session}"
+            );
+        }
     }
 
     /// Build a minimal, already engineered/scaled/encoded frame (ticker and the

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -43,14 +43,14 @@ impl EvaluationMetrics {
 /// The quantiles arrive from the artifact in whatever order training wrote them, so "lowest",
 /// "highest", and "the median" are positions to be found rather than indices 0, 1, and 2.
 #[derive(Debug, Clone, Copy)]
-struct QuantileIndices {
+pub(crate) struct QuantileIndices {
     lower: usize,
-    median: usize,
+    pub(crate) median: usize,
     upper: usize,
 }
 
 impl QuantileIndices {
-    fn locate(quantiles: &[f64]) -> Self {
+    pub(crate) fn locate(quantiles: &[f64]) -> Self {
         Self {
             lower: argmin(quantiles),
             median: closest_to(quantiles, 0.5),
@@ -495,6 +495,7 @@ mod tests {
             ndarray::Array3::zeros((sample_count, output_length, 5)),
             ndarray::Array3::zeros((sample_count, 1, 3)),
             with_targets.then(|| ndarray::Array3::zeros((sample_count, output_length, 1))),
+            vec![0; sample_count],
         )
         .unwrap()
     }

--- a/src/models/tide/train.rs
+++ b/src/models/tide/train.rs
@@ -407,6 +407,7 @@ mod tests {
             future_categorical,
             static_categorical,
             Some(targets),
+            vec![0; sample_count],
         )
         .unwrap()
     }

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -484,25 +484,22 @@ async fn test_predictions_are_bounded_to_the_session_window() {
 
 /// One row per ticker, the newest. A re-run leaves two predictions for the same symbol, and feeding
 /// both into the screen would let one ticker appear on both legs of the same pair.
+///
+/// Both rows are placed relative to the session's own start rather than to the clock. Offsets back
+/// from `now` land in the *previous* session whenever the suite runs within that many hours of
+/// Eastern midnight, and the window query then returns nothing.
 #[tokio::test]
 #[serial]
 async fn test_predictions_return_the_newest_row_per_ticker() {
     let pool = fresh_pool().await;
-    let now = Utc::now();
-    let (start, end) = SessionDate::at(now).bounds();
+    let (start, end) = SessionDate::at(Utc::now()).bounds();
 
-    common::seed_predictions(
-        &pool,
-        "run-early",
-        &[("AAAA", 0.01)],
-        now - Duration::hours(2),
-    )
-    .await;
+    common::seed_predictions(&pool, "run-early", &[("AAAA", 0.01)], start).await;
     common::seed_predictions(
         &pool,
         "run-late",
         &[("AAAA", 0.05)],
-        now - Duration::minutes(5),
+        start + Duration::hours(1),
     )
     .await;
 


### PR DESCRIPTION
# Overview

Task 3b: train one model and score it the way a baseline is scored — cross-sectionally, by the ranking a dollar-neutral book would act on. Publishes nothing; the artifact exists for the length of the run.

**The result: no detectable signal — but only a seed sweep can say so, and finding that out was the most useful part of the review.**

## Changes

- `src/bin/laboratory_tide.rs` — trains one model, scores it, then scores the four baselines over the identical sessions and journals every result under `forecast_scored`.
- `laboratory::forecast` — runs the model over a dataset, takes the median quantile at horizon zero, inverse-scales to return units, and forms one cross-section per session.
- `TrainingDataset` carries the session each sample forecasts, emitted by `window_frame` in the loop that filters windows for contiguity.
- `QuantileIndices` is `pub(crate)` so the median selection has one implementation rather than two.

## Context

Over a 730-day window, 206,391 training and 50,637 validation samples, 65 measured sessions. One run at the default seed:

```
predictor              information_coefficient      decile_spread          directional_accuracy
tide                   -0.000632 ± 0.008908         +0.000899 ± 0.001411   +0.5064 ± 0.0149
cross_sectional_mean   unmeasurable                 unmeasurable           +0.4964 ± 0.0151
persistence            +0.001229 ± 0.025432         +0.001176 ± 0.003656   +0.4930 ± 0.0098
momentum (20)          -0.035651 ± 0.023359         -0.003099 ± 0.003999   +0.4866 ± 0.0085
random_ranking         -0.003957 ± 0.003081         -0.001175 ± 0.000500   unmeasurable
```

**A single run does not measure the architecture, it measures one draw of the weights.** Review verification caught this: the baselines came back bit-identical while the model moved from -0.000632 to -0.009056 on an identical configuration. `train` seeds its batch shuffle, but the weights came from the backend's global generator, which nothing seeded.

The weights are seeded now — the seed is the third positional argument, and two runs of one configuration agree bit for bit. Six seeds over the identical 65 sessions:

```
seed 1  +0.009718     seed 4  +0.012468
seed 2  +0.007028     seed 5  +0.002871
seed 3  -0.005788     seed 6  -0.001511
```

Mean **+0.0041**, range **0.018** — comparable to the tradeable bar of 0.021 all by itself. Against a within-run session standard error of about 0.009, that average sits roughly **0.45 standard errors from zero**.

So the conclusion holds and my first statement of it does not. "0.07 standard errors from zero, stable across epoch settings" described one arbitrary draw; three runs landed near each other and I read that as stability. The stronger claim goes too: two standard errors on the seed mean reaches about +0.022, so the tradeable bar of 0.021 sits at the *edge* of what 65 sessions can exclude rather than outside it. No signal is detectable here; a signal of tradeable size has not been ruled out.

**The prediction was half wrong, and that half matters.** The expected answer was `unmeasurable` — the same result `cross_sectional_mean` gives, on the grounds that a constant forecast has no ordering to be right about. Instead TiDE *ranks*: its predictions vary across the cross-section enough for a rank correlation to exist, and the ordering is simply uninformative. The earlier observation that every prediction sits positive within 19bps describes their level, not their spread. Session-to-session variation in the coefficient runs random 0.0031 < **tide 0.0089** < momentum 0.0234 ≈ persistence 0.0254 — nearly as flat as a uniform draw, where a forecast with real factor exposure swings with the market.

**Only the session had to be added.** The encoded ticker was already reachable at `static_categorical[[sample, 0, 0]]`, which `predict.rs` has always used. What no sample carried was the session it forecasts, because predict mode emits one window per ticker and knows the session globally, while a validation window has many per ticker each forecasting a different day.

**TiDE does not implement `Predictor`, deliberately.** `History` exposes daily returns and nothing else, which is what makes the lookahead guarantee structural for the cheap rules. Widening it to carry a feature frame, scaler, mappings and artifact would dissolve that guarantee for every implementor to accommodate one caller.

**Why 65 sessions.** A 365-day window leaves about 50 validation sessions and each sample spends 35 of them on burn-in, so the first run measured 15 sessions at a standard error of 0.0106 — too wide to conclude anything from, and re-run wider. 65 is the ceiling at the trainer's own 0.8 split, kept because changing it changes the model being scored.

**This drops task 3c.** The permutation test asks whether the real coefficient clears the 95th percentile of a shuffled null. There is no signal to attribute to a leak. Incidentally, the cost worry behind splitting it off was unfounded: training runs at 4 seconds per epoch, so twenty retrains would have been about fifteen minutes.

## Verification

- `devenv tasks run checks:rust` green, exit 0, clippy clean; 649 library tests
- **The instrument is tested, which is what makes the zero meaningful.** `measure` is separated from the forward pass so a known forecast can be scored without a network: handed the outcome it returns exactly +1, handed the reverse exactly −1
- Both new guards proven load-bearing — a one-sample shift in the prediction buffer breaks the perfect-forecast assertion, and reading the last past step instead of the first future step breaks the forecast-session assertion
- Run against the real development archive across six seeds, not fixtures; journal records read back from the written JSONL
- The `output_length == 0` panic reproduced first as `index out of bounds: the len is 10 but the index is 10`, then guarded
- Two seeded runs of one configuration confirmed bit-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TiDE forecasting evaluation with median-quantile predictions and session-level metrics.
  * Added a command-line training and validation workflow with configurable lookback and epoch settings.
  * Added baseline comparisons, including persistence, momentum, mean, and seeded random predictors.
  * Forecast results can be recorded when journaling is available.

* **Bug Fixes**
  * Improved validation for invalid settings, missing data, malformed model outputs, and forecast-session alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

