### PR TITLE
Test whether the market factor is what starves the ranking

### DIFF
--- a/src/bin/laboratory_tide.rs
+++ b/src/bin/laboratory_tide.rs
@@ -19,11 +19,12 @@ use fund::laboratory::predictor::{
 };
 use fund::laboratory::{dataset, forecast};
 use fund::models::tide::configuration::ModelParameters;
-use fund::models::tide::data::{input_feature_size, DatasetKind, TrainingFraction};
+use fund::models::tide::data::{input_feature_size, DatasetKind, Target, TrainingFraction};
 use fund::models::tide::model::TiDEModel;
 use fund::models::tide::train::{train, TrainBackend, TrainConfiguration};
 
-const USAGE: &str = "Usage: laboratory_tide [LOOKBACK_DAYS] [EPOCHS] [SEED]";
+const USAGE: &str = "Usage: laboratory_tide [LOOKBACK_DAYS] [EPOCHS] [SEED] [TARGET]\n\
+                     TARGET is raw (default) or demeaned";
 
 const INPUT_LENGTH: usize = 35;
 const OUTPUT_LENGTH: usize = 1;
@@ -50,6 +51,7 @@ struct Parameters {
     lookback_days: i64,
     epochs: usize,
     seed: u64,
+    target: Target,
 }
 
 impl Parameters {
@@ -71,13 +73,31 @@ impl Parameters {
                 positive(epochs, "EPOCHS")?,
                 positive(seed, "SEED")?,
             ),
+            [lookback, epochs, seed, _] => (
+                positive(lookback, "LOOKBACK_DAYS")?,
+                positive(epochs, "EPOCHS")?,
+                positive(seed, "SEED")?,
+            ),
             _ => return Err(format!("Too many arguments\n{USAGE}")),
+        };
+        let target = match arguments {
+            [_, _, _, target] => match target.trim() {
+                "raw" => Target::Raw,
+                "demeaned" => Target::CrossSectionallyDemeaned,
+                other => {
+                    return Err(format!(
+                        "TARGET must be raw or demeaned, got {other:?}\n{USAGE}"
+                    ))
+                }
+            },
+            _ => Target::Raw,
         };
         Ok(Self {
             lookback_days,
             epochs: usize::try_from(epochs)
                 .map_err(|_| format!("EPOCHS is larger than this platform can index\n{USAGE}"))?,
             seed: seed as u64,
+            target,
         })
     }
 }
@@ -149,6 +169,7 @@ async fn run(
         lookback_days = parameters.lookback_days,
         epochs = parameters.epochs,
         seed = parameters.seed,
+        target = format!("{:?}", parameters.target),
         %session,
         %run_id,
         "Training a model to score it"
@@ -161,6 +182,7 @@ async fn run(
         parameters.lookback_days,
         session,
         training_fraction,
+        parameters.target,
     )
     .await?;
     let fingerprint = prepared.fingerprint;
@@ -238,8 +260,12 @@ async fn run(
         "Training complete"
     );
 
+    // Named for the arm, so two runs over one window are distinguishable in the journal.
     let scored_model = forecast::score(
-        "tide",
+        match parameters.target {
+            Target::Raw => "tide",
+            Target::CrossSectionallyDemeaned => "tide_demeaned",
+        },
         &best_model.valid(),
         &validation_data,
         &model_parameters,

--- a/src/bin/laboratory_tide.rs
+++ b/src/bin/laboratory_tide.rs
@@ -424,6 +424,27 @@ mod tests {
 
         let parameters = Parameters::parse(&arguments(&["400", "2", "9"])).unwrap();
         assert_eq!(parameters.seed, 9);
+        assert_eq!(parameters.target, Target::Raw);
+    }
+
+    /// The argument that selects the arm, so a regression here would silently compare one target
+    /// against itself — and comparing the two arms is the whole point of running this.
+    #[test]
+    fn test_both_targets_are_accepted_and_raw_is_the_default() {
+        assert_eq!(Parameters::parse(&[]).unwrap().target, Target::Raw);
+        assert_eq!(
+            Parameters::parse(&arguments(&["400", "2", "9", "raw"]))
+                .unwrap()
+                .target,
+            Target::Raw
+        );
+        assert_eq!(
+            Parameters::parse(&arguments(&["400", "2", "9", "demeaned"]))
+                .unwrap()
+                .target,
+            Target::CrossSectionallyDemeaned
+        );
+        assert!(Parameters::parse(&arguments(&["400", "2", "9", "Demeaned"])).is_err());
     }
 
     /// The seed is the whole reason a run is repeatable: initialisation moves the reported

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -29,7 +29,7 @@ use fund::models::tide::artifact::{
     candidate_folders_descending, list_run_folders, package_dir_to_tar_gz, upload_artifact,
 };
 use fund::models::tide::configuration::ModelParameters;
-use fund::models::tide::data::{input_feature_size, DatasetKind, TrainingFraction};
+use fund::models::tide::data::{input_feature_size, DatasetKind, Target, TrainingFraction};
 use fund::models::tide::drift::{check_drift, DriftStatus};
 use fund::models::tide::evaluate::evaluate;
 use fund::models::tide::fit::write_artifact_json;
@@ -206,6 +206,9 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         lookback_days,
         session,
         training_fraction,
+        // The published artifact keeps the raw target; the demeaned one is a laboratory experiment
+        // until it is shown to produce a model that ranks.
+        Target::Raw,
     )
     .await?;
     let fingerprint = prepared.fingerprint;

--- a/src/laboratory/dataset.rs
+++ b/src/laboratory/dataset.rs
@@ -11,7 +11,7 @@ use tracing::warn;
 use crate::common::aws::date_partitioned_key;
 use crate::common::types::{SessionDate, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
 use crate::data::{adjust, archive, bars, details, truncate};
-use crate::models::tide::data::{clean_data, engineer_features, TrainingFraction};
+use crate::models::tide::data::{clean_data, engineer_features, Target, TrainingFraction};
 use crate::models::tide::fit::{filter_training_bars, fit, FitResult};
 use crate::models::tide::predict::consolidate_data;
 use crate::models::tide::TideError;
@@ -114,9 +114,10 @@ pub async fn build(
     lookback_days: i64,
     session: SessionDate,
     training_fraction: TrainingFraction,
+    target: Target,
 ) -> Result<PreparedDataset, DatasetError> {
     let (filtered, fingerprint) = read_window(s3_client, bucket, lookback_days, session).await?;
-    let fit = fit(filtered, training_fraction)?;
+    let fit = fit(filtered, training_fraction, target)?;
 
     Ok(PreparedDataset { fit, fingerprint })
 }

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -925,14 +925,9 @@ pub enum Target {
 
 /// Subtracts each session's equal-weighted mean return from every row in it.
 ///
-/// The mean over a session's cross-section approximates the market's move, because most betas are
-/// near one, so what is left is the part of a return that is specific to the name. A dollar-neutral
-/// book cancels the market out of its profit and loss, so that component of the label is noise with
-/// respect to what is actually traded — and a pointwise loss is minimised by forecasting it.
-///
-/// Equal-weighted, and over every row of the session rather than a subset: weighting by size would
-/// track the largest names instead of the market, and any subset chosen by what is currently held
-/// would put portfolio state into the label.
+/// One constant per session, so it cannot reorder a session's names — only what a pointwise loss
+/// rewards. The mean is taken over every row rather than a subset, because a subset chosen by what
+/// is currently held would put portfolio state into the label.
 pub(crate) fn demean_target(data: DataFrame) -> Result<DataFrame, TideError> {
     let timestamps: Vec<i64> = data
         .column("timestamp")?
@@ -951,8 +946,8 @@ pub(crate) fn demean_target(data: DataFrame) -> Result<DataFrame, TideError> {
 
     let mut totals: HashMap<i64, (f64, usize)> = HashMap::new();
     for (timestamp, value) in timestamps.iter().zip(returns) {
-        // A row with no return contributes nothing to the mean and takes nothing from it. It cannot
-        // be demeaned either, so it stays null and `clean_data` removes it as it always has.
+        // Skipped, so a row with no return neither moves the mean nor draws one. `fit` cleans
+        // before it demeans, so this only bites a caller that demeans an uncleaned frame.
         if let Some(value) = value.filter(|number| number.is_finite()) {
             let entry = totals.entry(*timestamp).or_insert((0.0, 0));
             entry.0 += value;

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -911,6 +911,70 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, TideError>
     Ok(new_data)
 }
 
+/// What the model is trained to predict.
+///
+/// The two differ by a per-session constant, which is invisible to a cross-sectional rank
+/// correlation and decisive for what a pointwise loss rewards — see [`demean_target`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Target {
+    /// The one-session return as the archive reports it.
+    Raw,
+    /// That return less its own session's equal-weighted cross-sectional mean.
+    CrossSectionallyDemeaned,
+}
+
+/// Subtracts each session's equal-weighted mean return from every row in it.
+///
+/// The mean over a session's cross-section approximates the market's move, because most betas are
+/// near one, so what is left is the part of a return that is specific to the name. A dollar-neutral
+/// book cancels the market out of its profit and loss, so that component of the label is noise with
+/// respect to what is actually traded — and a pointwise loss is minimised by forecasting it.
+///
+/// Equal-weighted, and over every row of the session rather than a subset: weighting by size would
+/// track the largest names instead of the market, and any subset chosen by what is currently held
+/// would put portfolio state into the label.
+pub(crate) fn demean_target(data: DataFrame) -> Result<DataFrame, TideError> {
+    let timestamps: Vec<i64> = data
+        .column("timestamp")?
+        .i64()?
+        .into_no_null_iter()
+        .collect();
+    let returns = data.column(TARGET_COLUMN)?.cast(&DataType::Float64)?;
+    let returns = returns.f64()?;
+    if timestamps.len() != data.height() {
+        return Err(TideError::Data(format!(
+            "Equity bars contain null timestamps ({} rows, {} timestamps)",
+            data.height(),
+            timestamps.len()
+        )));
+    }
+
+    let mut totals: HashMap<i64, (f64, usize)> = HashMap::new();
+    for (timestamp, value) in timestamps.iter().zip(returns) {
+        // A row with no return contributes nothing to the mean and takes nothing from it. It cannot
+        // be demeaned either, so it stays null and `clean_data` removes it as it always has.
+        if let Some(value) = value.filter(|number| number.is_finite()) {
+            let entry = totals.entry(*timestamp).or_insert((0.0, 0));
+            entry.0 += value;
+            entry.1 += 1;
+        }
+    }
+
+    let demeaned: Vec<Option<f32>> = timestamps
+        .iter()
+        .zip(returns)
+        .map(|(timestamp, value)| {
+            let value = value.filter(|number| number.is_finite())?;
+            let (sum, count) = totals.get(timestamp)?;
+            (*count > 0).then(|| (value - sum / *count as f64) as f32)
+        })
+        .collect();
+
+    let mut demeaned_data = data;
+    demeaned_data.with_column(Column::new(TARGET_COLUMN.into(), demeaned))?;
+    Ok(demeaned_data)
+}
+
 pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, TideError> {
     // A row with no ticker cannot be attributed to an instrument, and substituting a placeholder
     // would make it indistinguishable from a real symbol of the same spelling. Reject it the way
@@ -1432,6 +1496,135 @@ mod tests {
                 "a window of three past steps cannot forecast earlier than row three, got {session}"
             );
         }
+    }
+
+    /// Three names over two sessions, with a null return that must survive as one.
+    fn demean_frame() -> DataFrame {
+        const DAY: i64 = 86_400_000;
+        DataFrame::new(vec![
+            Column::new(
+                "ticker".into(),
+                vec!["AAA", "BBB", "CCC", "AAA", "BBB", "CCC"],
+            ),
+            Column::new("timestamp".into(), vec![0_i64, 0, 0, DAY, DAY, DAY]),
+            Column::new(
+                "daily_return".into(),
+                vec![
+                    Some(0.01_f32),
+                    Some(0.02),
+                    Some(0.06),
+                    Some(-0.04),
+                    None,
+                    Some(0.02),
+                ],
+            ),
+        ])
+        .unwrap()
+    }
+
+    fn demeaned_returns(frame: &DataFrame) -> Vec<Option<f32>> {
+        frame
+            .column("daily_return")
+            .unwrap()
+            .f32()
+            .unwrap()
+            .into_iter()
+            .collect()
+    }
+
+    /// Compares returns within a tolerance three orders below the smallest difference these
+    /// fixtures care about, so f32 rounding passes and a mean taken from the wrong session does not.
+    fn assert_returns_close(actual: &[Option<f32>], expected: &[Option<f32>], context: &str) {
+        assert_eq!(actual.len(), expected.len(), "{context}");
+        for (actual, expected) in actual.iter().zip(expected) {
+            match (actual, expected) {
+                (Some(actual), Some(expected)) => assert!(
+                    (actual - expected).abs() < 1e-5,
+                    "{context}: expected {expected}, got {actual}"
+                ),
+                (None, None) => {}
+                _ => panic!("{context}: expected {expected:?}, got {actual:?}"),
+            }
+        }
+    }
+
+    /// Session one holds 0.01, 0.02 and 0.06, whose mean is 0.03. Session two holds -0.04 and 0.02
+    /// with one absent, so its mean is -0.01 over the two that traded.
+    #[test]
+    fn test_each_session_is_centred_on_its_own_mean() {
+        let demeaned = demeaned_returns(&demean_target(demean_frame()).unwrap());
+        let expected = [
+            Some(-0.02_f32),
+            Some(-0.01),
+            Some(0.03),
+            Some(-0.03),
+            None,
+            Some(0.03),
+        ];
+
+        assert_returns_close(&demeaned, &expected, "each session centred on its own mean");
+    }
+
+    /// The invariant the whole experiment rests on. Demeaning subtracts one constant from every
+    /// name in a session, so it cannot change their order — which is why a cross-sectional rank
+    /// correlation measures the same thing either side of the change, and only what the model is
+    /// trained to predict differs.
+    #[test]
+    fn test_demeaning_cannot_reorder_a_session() {
+        let raw = demean_frame();
+        let demeaned = demean_target(raw.clone()).unwrap();
+
+        let order = |frame: &DataFrame, session: i64| {
+            let timestamps: Vec<i64> = frame
+                .column("timestamp")
+                .unwrap()
+                .i64()
+                .unwrap()
+                .into_no_null_iter()
+                .collect();
+            let returns = demeaned_returns(frame);
+            let mut rows: Vec<(usize, f32)> = timestamps
+                .iter()
+                .zip(&returns)
+                .enumerate()
+                .filter(|(_, (stamp, value))| **stamp == session && value.is_some())
+                .map(|(index, (_, value))| (index, value.unwrap()))
+                .collect();
+            rows.sort_by(|left, right| left.1.partial_cmp(&right.1).unwrap());
+            rows.into_iter().map(|(index, _)| index).collect::<Vec<_>>()
+        };
+
+        for session in [0, 86_400_000] {
+            assert_eq!(
+                order(&raw, session),
+                order(&demeaned, session),
+                "session {session} was reordered"
+            );
+        }
+    }
+
+    /// A session is centred on itself and nothing else, so a session that moved as a whole does not
+    /// drag its neighbour's rows with it.
+    #[test]
+    fn test_a_sessions_mean_is_taken_from_that_session_alone() {
+        let mut shifted = demean_frame();
+        let returns = shifted.column("daily_return").unwrap().f32().unwrap();
+        let timestamps = shifted.column("timestamp").unwrap().i64().unwrap();
+        // Move every row of the first session up by a whole point, leaving the second untouched.
+        let rewritten: Vec<Option<f32>> = returns
+            .into_iter()
+            .zip(timestamps.into_no_null_iter())
+            .map(|(value, stamp)| value.map(|value| if stamp == 0 { value + 1.0 } else { value }))
+            .collect();
+        shifted
+            .with_column(Column::new("daily_return".into(), rewritten))
+            .unwrap();
+
+        assert_returns_close(
+            &demeaned_returns(&demean_target(shifted).unwrap()),
+            &demeaned_returns(&demean_target(demean_frame()).unwrap()),
+            "a constant added to one session must vanish from it and reach no other",
+        );
     }
 
     /// Build a minimal, already engineered/scaled/encoded frame (ticker and the

--- a/src/models/tide/fit.rs
+++ b/src/models/tide/fit.rs
@@ -10,9 +10,9 @@ use polars::prelude::*;
 
 use crate::models::tide::configuration::ModelParameters;
 use crate::models::tide::data::{
-    apply_scaling, clean_data, encode_categoricals, engineer_features, split_at_cutoff,
-    training_cutoff, CategoryMapping, Data, FeatureMappings, Scaler, TrainingFraction,
-    CATEGORICAL_COLUMNS, CONTINUOUS_COLUMNS, STATIC_CATEGORICAL_COLUMNS,
+    apply_scaling, clean_data, demean_target, encode_categoricals, engineer_features,
+    split_at_cutoff, training_cutoff, CategoryMapping, Data, FeatureMappings, Scaler, Target,
+    TrainingFraction, CATEGORICAL_COLUMNS, CONTINUOUS_COLUMNS, STATIC_CATEGORICAL_COLUMNS,
 };
 use crate::models::tide::TideError;
 
@@ -39,9 +39,20 @@ pub struct FitResult {
 /// instrument first listed (or first clearing the liquidity floors) after the cutoff would vanish
 /// from the validation split, and, since these mappings ship in the artifact as the inference
 /// vocabulary, could not be predicted at all until it had traded the full pre-cutoff window.
-pub fn fit(raw: DataFrame, training_fraction: TrainingFraction) -> Result<FitResult, TideError> {
+///
+/// `target` selects what the model learns to predict. Demeaning happens after cleaning and before
+/// the scaler is fitted, so the statistics describe the label the model is actually given.
+pub fn fit(
+    raw: DataFrame,
+    training_fraction: TrainingFraction,
+    target: Target,
+) -> Result<FitResult, TideError> {
     let engineered = engineer_features(raw)?;
     let cleaned = clean_data(engineered)?;
+    let cleaned = match target {
+        Target::Raw => cleaned,
+        Target::CrossSectionallyDemeaned => demean_target(cleaned)?,
+    };
 
     let cutoff = training_cutoff(&cleaned, training_fraction)?;
     let (training_rows, _) = split_at_cutoff(&cleaned, cutoff)?;
@@ -295,7 +306,7 @@ mod tests {
 
     #[test]
     fn test_fit_mappings_are_sorted_and_deterministic() {
-        let result = fit(raw_frame(), training_fraction()).unwrap();
+        let result = fit(raw_frame(), training_fraction(), Target::Raw).unwrap();
         let tickers = &result.mappings["ticker"];
         // Uppercased and sorted: AAPL -> 0, GOOG -> 1.
         assert_eq!(tickers["AAPL"], 0);
@@ -309,7 +320,7 @@ mod tests {
 
     #[test]
     fn test_fit_scaler_has_all_continuous_columns() {
-        let result = fit(raw_frame(), training_fraction()).unwrap();
+        let result = fit(raw_frame(), training_fraction(), Target::Raw).unwrap();
         for column in CONTINUOUS_COLUMNS {
             assert!(result.scaler.means().contains_key(*column));
             assert!(result.scaler.standard_deviations().contains_key(*column));
@@ -321,7 +332,7 @@ mod tests {
     /// row, so the held-out period set the scale its own predictions were later measured on.
     #[test]
     fn test_the_scaler_is_fitted_only_on_rows_at_or_before_the_training_cutoff() {
-        let result = fit(scale_shifted_frame(), training_fraction()).unwrap();
+        let result = fit(scale_shifted_frame(), training_fraction(), Target::Raw).unwrap();
 
         // Close prices 101 through 108 over the eight training days: mean 104.5, sample standard
         // deviation sqrt(6). Fitted over every row the mean would be 1093.6 instead, dragged there
@@ -355,7 +366,7 @@ mod tests {
     /// mean 0 and sample deviation 1 exactly, so a disagreement of even one session shows up here.
     #[test]
     fn test_the_scaler_window_matches_the_rows_the_training_split_yields() {
-        let result = fit(scale_shifted_frame(), training_fraction()).unwrap();
+        let result = fit(scale_shifted_frame(), training_fraction(), Target::Raw).unwrap();
         let (train, validation) = result.data.split_by_timestamp(training_fraction()).unwrap();
 
         assert_eq!(train.height(), 8, "days 1 through 8 train");
@@ -395,7 +406,7 @@ mod tests {
         rows.push(("ZZZZ", "ENERGY", "SOLAR", 9, 50.0));
         rows.push(("ZZZZ", "ENERGY", "SOLAR", 10, 51.0));
 
-        let result = fit(frame_from_rows(&rows), training_fraction()).unwrap();
+        let result = fit(frame_from_rows(&rows), training_fraction(), Target::Raw).unwrap();
 
         assert!(
             result.mappings["ticker"].contains_key("ZZZZ"),
@@ -480,7 +491,7 @@ mod tests {
     /// exactly the mixed-artifact state the staging exists to prevent.
     #[test]
     fn test_write_artifact_json_leaves_no_staging_files_behind() {
-        let result = fit(raw_frame(), training_fraction()).unwrap();
+        let result = fit(raw_frame(), training_fraction(), Target::Raw).unwrap();
         let parameters = ModelParameters::new(448, 35, 5);
         let directory = tempfile::tempdir().unwrap();
 
@@ -510,7 +521,7 @@ mod tests {
 
     #[test]
     fn test_write_artifact_json_round_trips_via_loader() {
-        let result = fit(raw_frame(), training_fraction()).unwrap();
+        let result = fit(raw_frame(), training_fraction(), Target::Raw).unwrap();
         let parameters = ModelParameters::new(448, 35, 5);
         let directory = tempfile::tempdir().unwrap();
         write_artifact_json(


### PR DESCRIPTION
# Overview

Task 5. The leading explanation for the model's missing signal was an objective mismatch: the raw label carries the market's own move, a pointwise quantile loss is minimised by forecasting it, and a constant added to every name in a session changes no ranking — so the model could score well on what it was trained for while scoring zero on what it is measured by.

**It is not that.** Demeaning the target changed nothing.

## Changes

- `Target` — a two-variant enum, `Raw` or `CrossSectionallyDemeaned`, threaded through `fit` and `dataset::build`. An enum rather than a flag because the arms differ in what the model is trained to predict.
- `demean_target` — subtracts each session's equal-weighted cross-sectional mean from every row in it, applied after `clean_data` and before the scaler is fitted, so the scaler describes the label the model is actually given.
- `laboratory_tide` takes the target as a fourth positional argument and names the predictor for its arm, so both show up distinctly in the journal.
- `tide_model_trainer` passes `Target::Raw` explicitly.

## Context

Six seeds per arm, the same 65 sessions, the same archive fingerprint:

```
raw       +0.010928  +0.009387  +0.008826  +0.011342  +0.003489  -0.006382   mean +0.0063
demeaned  +0.009662  +0.001425  -0.004718  +0.013162  -0.000462  +0.007480   mean +0.0044
```

The difference is **−0.0018 against a standard error of 0.0039 — 0.47 standard errors.** Both arms sit inside their own seed spread and inside zero. The decision rule was written before the numbers landed, and this is the "informative negative" branch of it: the objective mismatch is eliminated, and so is the market factor as an explanation.

**The directional accuracy is where the real content is.** Across the six demeaned seeds it reads 0.5227, 0.5201, 0.5223, 0.5224, 0.5224, 0.5224 — a standard deviation of **0.00099** against the raw arm's **0.00825**, eight times tighter. Six independent weight initialisations landing within 0.0026 of each other means nothing seed-specific is being learned; the model converges to the same output wherever it starts.

And 52.2% needs no learning at all. A demeaned session has mean zero by construction, but returns are right-skewed — most names sit a little below the mean and a few winners sit far above — so more than half of demeaned returns are negative. A forecast that is slightly negative for everything scores exactly the fraction of names that fell. **Demeaning did not make the model rank; it moved the constant the model predicts.** The information coefficient is still measurable rather than `unmeasurable`, so predictions do vary — enough to order names, not enough to change sign, and where they sit is set by the target's skew rather than by any feature.

**Where this points.** Not the objective, and not the market factor. The remaining candidate is that the features carry no usable cross-sectional information about the target, which is exactly what task 4 (mutual information triage) measures.

**Not adopted, deliberately.** There is nothing to adopt, so the confidence-floor replacement that the plan had shipping alongside adoption stays unstarted. It is a runtime percentile gate over the session's score distribution, and that distribution is precisely what the demeaned target would change — calibrating it before knowing whether the target is kept would be work against scores we might not keep.

## Verification

- `devenv tasks run checks:rust` green, exit 0, clippy clean; 655 library tests
- `test_demeaning_cannot_reorder_a_session` is what makes the comparison meaningful: demeaning subtracts one constant from every name in a session, so it cannot change their order, which is why a cross-sectional rank correlation measures the same thing on both arms. Proven load-bearing by dividing by the mean instead of subtracting and watching the order break
- Twelve real runs against the development archive, not fixtures; both arms confirmed to share one dataset fingerprint
- **Caveat found while running this:** seeding makes runs agree within one build, not across rebuilds — raw seed 1 gave +0.009718 on the #1086 binary and +0.010928 here on an identical fingerprint, most likely floating-point reduction order shifting with code layout. Small against the 0.018 seed spread, but a figure should be quoted with its build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting between raw and cross-sectionally demeaned prediction targets.
  * Laboratory runs now accept a target selection and clearly report the active target.
  * Added validation and clear errors for unsupported target values.
  * Added session-level target demeaning while preserving missing or non-finite values.

* **Bug Fixes**
  * Ensured target selection is applied consistently during dataset preparation, model fitting, and scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->