### PR TITLE
Ask whether the inputs carry anything before asking a model to find it

### DIFF
--- a/src/bin/laboratory_information.rs
+++ b/src/bin/laboratory_information.rs
@@ -1,0 +1,384 @@
+//! Ranks the model's inputs by how much each says about the session it precedes.
+//!
+//! Trains nothing. It asks whether there is anything to learn before any architecture is committed to.
+
+use chrono::Utc;
+use tracing::{error, info, warn};
+
+use fund::common::log::init_tracing;
+use fund::common::types::SessionDate;
+use fund::laboratory::information::{self, Outcome, DEFAULT_BINS};
+use fund::laboratory::journal as laboratory;
+use fund::laboratory::metrics::{self, Distribution};
+use fund::laboratory::{dataset, information::Paired};
+
+use polars::prelude::*;
+use rand::{rngs::StdRng, RngExt, SeedableRng};
+
+const USAGE: &str = "Usage: laboratory_information [LOOKBACK_DAYS] [SEED] [OUTCOME]\n\
+                     OUTCOME is signed (default), magnitude or direction";
+
+/// The whole archive, because a feature worth keeping should show over two years and not one month.
+const DEFAULT_LOOKBACK_DAYS: i64 = 730;
+
+/// Seeds the shuffle behind every null. Fixed so a ranking can be got back.
+const DEFAULT_SEED: i64 = 0x4E11;
+
+/// Every feature the model reads that varies across a session's names.
+///
+/// The calendar columns are absent deliberately: `day_of_week`, `month` and the rest hold one value
+/// for every name in a session, so their cross-sectional information is zero by construction rather
+/// than by measurement. `ticker` is absent for the opposite reason — it is unique per name, so every
+/// cell of the table would hold one observation and the statistic would be pure bias.
+const CONTINUOUS_FEATURES: &[&str] = &[
+    "open_price",
+    "high_price",
+    "low_price",
+    "close_price",
+    "volume",
+    "volume_weighted_average_price",
+    "daily_return",
+];
+
+const CATEGORICAL_FEATURES: &[&str] = &["sector", "industry"];
+
+/// A feature with nothing in it, triaged alongside the real ones.
+///
+/// The null is subtracted from every figure below, and this is the row that shows the subtraction
+/// works: a uniform draw must score zero excess bits. Reading a table of positive numbers without
+/// it would leave no way to tell a real dependence from a null that is set too low.
+const CONTROL_FEATURE: &str = "uniform_control";
+
+struct Parameters {
+    lookback_days: i64,
+    seed: u64,
+    outcome: Outcome,
+}
+
+impl Parameters {
+    fn parse(arguments: &[String]) -> Result<Self, String> {
+        let (lookback_days, seed) = match arguments {
+            [] => (DEFAULT_LOOKBACK_DAYS, DEFAULT_SEED),
+            [lookback] => (positive(lookback, "LOOKBACK_DAYS")?, DEFAULT_SEED),
+            [lookback, seed] | [lookback, seed, _] => (
+                positive(lookback, "LOOKBACK_DAYS")?,
+                positive(seed, "SEED")?,
+            ),
+            _ => return Err(format!("Too many arguments\n{USAGE}")),
+        };
+        let outcome = match arguments {
+            [_, _, outcome] => match outcome.trim() {
+                "signed" => Outcome::Signed,
+                "magnitude" => Outcome::Magnitude,
+                "direction" => Outcome::Direction,
+                other => {
+                    return Err(format!(
+                        "OUTCOME must be signed, magnitude or direction, got {other:?}\n{USAGE}"
+                    ))
+                }
+            },
+            _ => Outcome::Signed,
+        };
+        Ok(Self {
+            lookback_days,
+            seed: seed as u64,
+            outcome,
+        })
+    }
+}
+
+fn positive(raw: &str, name: &str) -> Result<i64, String> {
+    let value: i64 = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("{name} must be a positive integer, got {raw:?}\n{USAGE}"))?;
+    if value <= 0 {
+        return Err(format!(
+            "{name} must be greater than zero, got {value}\n{USAGE}"
+        ));
+    }
+    Ok(value)
+}
+
+#[tokio::main]
+async fn main() {
+    fund::common::crypto::install_default_crypto_provider();
+    let tracing_guard = init_tracing(
+        "laboratory-information.log",
+        Some("info"),
+        "laboratory-information",
+    );
+
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let parameters = match Parameters::parse(&arguments) {
+        Ok(parameters) => parameters,
+        Err(message) => {
+            eprintln!("{message}");
+            drop(tracing_guard);
+            std::process::exit(2);
+        }
+    };
+
+    let code = match run(&parameters).await {
+        Ok(triaged) => {
+            println!("{}", render(&triaged));
+            0
+        }
+        Err(error) => {
+            error!(%error, "Triaging the features failed");
+            eprintln!("Triaging the features failed: {error}");
+            1
+        }
+    };
+
+    drop(tracing_guard);
+    std::process::exit(code);
+}
+
+async fn run(
+    parameters: &Parameters,
+) -> Result<Vec<laboratory::FeatureTriaged>, Box<dyn std::error::Error>> {
+    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let s3_client = fund::common::aws::s3_client().await;
+
+    let now = Utc::now();
+    let session = SessionDate::at(now);
+    let run_id = uuid::Uuid::new_v4();
+    let journal = match laboratory::Journal::from_env() {
+        Ok(journal) => Some(journal),
+        Err(error) => {
+            warn!(%error, "No laboratory journal; this run is not recorded");
+            None
+        }
+    };
+
+    info!(
+        bucket,
+        lookback_days = parameters.lookback_days,
+        seed = parameters.seed,
+        bins = DEFAULT_BINS,
+        outcome = format!("{:?}", parameters.outcome),
+        %session,
+        %run_id,
+        "Triaging the model's inputs"
+    );
+
+    let dataset = dataset::returns(&s3_client, &bucket, parameters.lookback_days, session).await?;
+    let fingerprint = dataset.fingerprint.clone();
+    info!(
+        rows = fingerprint.rows,
+        tickers = fingerprint.tickers,
+        "Read the archive window"
+    );
+    if let Some(journal) = journal.as_ref() {
+        journal
+            .record(
+                run_id,
+                Utc::now(),
+                laboratory::Observation::DatasetBuilt(laboratory::DatasetBuilt {
+                    fingerprint,
+                    revision: std::env::var("FUND_REVISION").ok(),
+                }),
+            )
+            .await;
+    }
+
+    // The control is drawn once over the whole frame rather than per session, so it is independent
+    // of everything including the session it lands in.
+    let mut frame = dataset.returns;
+    let mut generator = StdRng::seed_from_u64(parameters.seed);
+    let control: Vec<f64> = (0..frame.height())
+        .map(|_| generator.random::<f64>())
+        .collect();
+    frame.with_column(Column::new(CONTROL_FEATURE.into(), control))?;
+
+    let mut triaged = Vec::new();
+    for feature in CONTINUOUS_FEATURES.iter().chain([&CONTROL_FEATURE]) {
+        let column = *feature;
+        let paired = information::pair_with_next_session(
+            &frame,
+            column,
+            parameters.outcome,
+            move |frame| {
+                Ok(frame
+                    .column(column)?
+                    .cast(&DataType::Float64)?
+                    .f64()?
+                    .into_no_null_iter()
+                    .collect())
+            },
+        )?;
+        triaged.push(triage(column, &paired, parameters.seed));
+    }
+    for feature in CATEGORICAL_FEATURES {
+        let column = *feature;
+        let paired = information::pair_with_next_session(
+            &frame,
+            column,
+            parameters.outcome,
+            move |frame| {
+                let values: Vec<&str> = frame.column(column)?.str()?.into_no_null_iter().collect();
+                Ok(information::category_bins(&values)
+                    .into_iter()
+                    .map(|bin| bin as f64)
+                    .collect())
+            },
+        )?;
+        triaged.push(triage(column, &paired, parameters.seed));
+    }
+
+    // Ranked, because the question is which input carries the most and a table in column order
+    // makes that a search rather than a reading.
+    triaged.sort_by(|left, right| {
+        bits_of(right)
+            .partial_cmp(&bits_of(left))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    for record in &triaged {
+        info!(
+            feature = record.feature,
+            sessions = record.sessions,
+            excess_bits = record.excess_bits.map(|value| value.mean),
+            "Triaged a feature"
+        );
+        if let Some(journal) = journal.as_ref() {
+            journal
+                .record(
+                    run_id,
+                    Utc::now(),
+                    laboratory::Observation::FeatureTriaged(record.clone()),
+                )
+                .await;
+        }
+    }
+
+    Ok(triaged)
+}
+
+/// Measures every session's cross-section and summarizes the three figures across them.
+fn triage(feature: &str, paired: &Paired, seed: u64) -> laboratory::FeatureTriaged {
+    let measured: Vec<Option<information::SessionInformation>> = paired
+        .iter()
+        .map(|(session, (features, targets))| {
+            // Keyed on the session rather than its position, so a run over a different window
+            // shuffles each cross-section the same way this one did.
+            information::measure_session(features, targets, DEFAULT_BINS, seed ^ *session as u64)
+        })
+        .collect();
+
+    laboratory::FeatureTriaged {
+        feature: feature.to_string(),
+        sessions: paired.len(),
+        bits: metrics::summarize(measured.iter().map(|value| value.map(|value| value.bits))),
+        null_bits: metrics::summarize(
+            measured
+                .iter()
+                .map(|value| value.map(|value| value.null_bits)),
+        ),
+        excess_bits: metrics::summarize(
+            measured
+                .iter()
+                .map(|value| value.map(|value| value.excess())),
+        ),
+    }
+}
+
+fn bits_of(record: &laboratory::FeatureTriaged) -> f64 {
+    record
+        .excess_bits
+        .map_or(f64::NEG_INFINITY, |value| value.mean)
+}
+
+fn render(triaged: &[laboratory::FeatureTriaged]) -> String {
+    let mut rendered = format!(
+        "{:<32}{:>10}{:>28}{:>28}{:>28}\n",
+        "feature", "sessions", "excess_bits", "bits", "null_bits"
+    );
+    for record in triaged {
+        rendered.push_str(&format!(
+            "{:<32}{:>10}{:>28}{:>28}{:>28}\n",
+            record.feature,
+            record.sessions,
+            distribution(record.excess_bits),
+            distribution(record.bits),
+            distribution(record.null_bits),
+        ));
+    }
+    rendered
+}
+
+fn distribution(value: Option<Distribution>) -> String {
+    value.map_or_else(
+        || "unmeasurable".to_string(),
+        |distribution| {
+            format!(
+                "{:+.6} ± {:.6} ({})",
+                distribution.mean, distribution.standard_error, distribution.sessions
+            )
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arguments(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn test_arguments_default_from_the_right() {
+        let parameters = Parameters::parse(&[]).unwrap();
+        assert_eq!(parameters.lookback_days, 730);
+        assert_eq!(parameters.seed, DEFAULT_SEED as u64);
+
+        let parameters = Parameters::parse(&arguments(&["365", "3"])).unwrap();
+        assert_eq!(parameters.lookback_days, 365);
+        assert_eq!(parameters.seed, 3);
+        assert_eq!(parameters.outcome, Outcome::Signed);
+
+        let parameters = Parameters::parse(&arguments(&["365", "3", "magnitude"])).unwrap();
+        assert_eq!(parameters.outcome, Outcome::Magnitude);
+        assert_eq!(
+            Parameters::parse(&arguments(&["365", "3", "signed"]))
+                .unwrap()
+                .outcome,
+            Outcome::Signed
+        );
+    }
+
+    #[test]
+    fn test_an_unusable_argument_is_refused() {
+        for value in ["7f", "0", "-1", ""] {
+            assert!(
+                Parameters::parse(&arguments(&[value])).is_err(),
+                "{value:?} must be refused"
+            );
+        }
+        assert!(Parameters::parse(&arguments(&["365", "0"])).is_err());
+        assert!(Parameters::parse(&arguments(&["365", "3", "extra"])).is_err());
+        assert!(Parameters::parse(&arguments(&["365", "3", "signed", "more"])).is_err());
+    }
+
+    /// The calendar columns are excluded because they hold one value for every name in a session,
+    /// so a cross-sectional statistic over them is zero by construction. Naming them here keeps a
+    /// later reader from adding them back and reading the zero as a measurement.
+    #[test]
+    fn test_the_triaged_features_are_the_ones_that_vary_within_a_session() {
+        for constant in [
+            "day_of_week",
+            "day_of_month",
+            "day_of_year",
+            "month",
+            "year",
+        ] {
+            assert!(!CONTINUOUS_FEATURES.contains(&constant));
+            assert!(!CATEGORICAL_FEATURES.contains(&constant));
+        }
+        assert!(!CATEGORICAL_FEATURES.contains(&"ticker"));
+        assert!(CONTINUOUS_FEATURES.contains(&"daily_return"));
+    }
+}

--- a/src/bin/laboratory_information.rs
+++ b/src/bin/laboratory_information.rs
@@ -7,7 +7,7 @@ use tracing::{error, info, warn};
 
 use fund::common::log::init_tracing;
 use fund::common::types::SessionDate;
-use fund::laboratory::information::{self, Outcome, DEFAULT_BINS};
+use fund::laboratory::information::{self, Feature, Outcome, DEFAULT_BINS};
 use fund::laboratory::journal as laboratory;
 use fund::laboratory::metrics::{self, Distribution};
 use fund::laboratory::{dataset, information::Paired};
@@ -45,8 +45,7 @@ const CATEGORICAL_FEATURES: &[&str] = &["sector", "industry"];
 /// A feature with nothing in it, triaged alongside the real ones.
 ///
 /// The null is subtracted from every figure below, and this is the row that shows the subtraction
-/// works: a uniform draw must score zero excess bits. Reading a table of positive numbers without
-/// it would leave no way to tell a real dependence from a null that is set too low.
+/// works: a uniform draw must score zero excess bits.
 const CONTROL_FEATURE: &str = "uniform_control";
 
 struct Parameters {
@@ -201,12 +200,14 @@ async fn run(
             column,
             parameters.outcome,
             move |frame| {
-                Ok(frame
-                    .column(column)?
-                    .cast(&DataType::Float64)?
-                    .f64()?
-                    .into_no_null_iter()
-                    .collect())
+                Ok(Feature::Continuous(
+                    frame
+                        .column(column)?
+                        .cast(&DataType::Float64)?
+                        .f64()?
+                        .into_no_null_iter()
+                        .collect(),
+                ))
             },
         )?;
         triaged.push(triage(column, &paired, parameters.seed));
@@ -219,10 +220,7 @@ async fn run(
             parameters.outcome,
             move |frame| {
                 let values: Vec<&str> = frame.column(column)?.str()?.into_no_null_iter().collect();
-                Ok(information::category_bins(&values)
-                    .into_iter()
-                    .map(|bin| bin as f64)
-                    .collect())
+                Ok(Feature::Nominal(information::category_bins(&values)))
             },
         )?;
         triaged.push(triage(column, &paired, parameters.seed));
@@ -333,7 +331,7 @@ mod tests {
     fn test_arguments_default_from_the_right() {
         let parameters = Parameters::parse(&[]).unwrap();
         assert_eq!(parameters.lookback_days, 730);
-        assert_eq!(parameters.seed, DEFAULT_SEED as u64);
+        assert_eq!(parameters.seed, 19_985);
 
         let parameters = Parameters::parse(&arguments(&["365", "3"])).unwrap();
         assert_eq!(parameters.lookback_days, 365);

--- a/src/laboratory.rs
+++ b/src/laboratory.rs
@@ -5,6 +5,7 @@
 pub mod dataset;
 pub mod export;
 pub mod forecast;
+pub mod information;
 pub mod journal;
 pub mod metrics;
 pub mod predictor;

--- a/src/laboratory/dataset.rs
+++ b/src/laboratory/dataset.rs
@@ -98,7 +98,7 @@ pub struct PreparedDataset {
 
 /// One session's returns per name, and the identity of the window they came from.
 pub struct ReturnsDataset {
-    /// `ticker`, `timestamp`, and an unscaled `daily_return`.
+    /// Every engineered feature alongside `ticker` and `timestamp`, cleaned and unscaled.
     pub returns: DataFrame,
     pub fingerprint: DatasetFingerprint,
 }
@@ -138,10 +138,9 @@ pub async fn returns(
     // non-finite value in any continuous column, so skipping it would measure names the model never
     // sees — a missing vendor VWAP costs a row there and none here.
     let cleaned = clean_data(engineer_features(filtered)?)?;
-    let returns = cleaned.select(["ticker", "timestamp", "daily_return"])?;
 
     Ok(ReturnsDataset {
-        returns,
+        returns: cleaned,
         fingerprint,
     })
 }

--- a/src/laboratory/information.rs
+++ b/src/laboratory/information.rs
@@ -1,0 +1,478 @@
+//! Bits a feature carries about the target, measured against a shuffled null.
+//!
+//! Catches non-linear association a rank correlation misses, before any architecture is committed to.
+
+use polars::prelude::*;
+use rand::seq::SliceRandom;
+use rand::{rngs::StdRng, SeedableRng};
+use serde::Serialize;
+
+use crate::models::tide::data::{session_ranks, TARGET_COLUMN};
+use crate::models::tide::TideError;
+
+/// Bins each side is cut into. Ten matches the decile language the rest of the laboratory uses.
+pub const DEFAULT_BINS: usize = 10;
+
+/// Names a cross-section needs before a hundred-cell table means anything.
+pub const MINIMUM_CROSS_SECTION: usize = 100;
+
+/// What one session's cross-section says about a feature.
+///
+/// Both figures are reported because their difference is the answer and their gap is the reason:
+/// `null_bits` is the bias a hundred-cell table carries at this sample size, and it is not small.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct SessionInformation {
+    pub bits: f64,
+    pub null_bits: f64,
+}
+
+impl SessionInformation {
+    /// Bits above what an unrelated feature scores on the same cross-section.
+    pub fn excess(&self) -> f64 {
+        self.bits - self.null_bits
+    }
+}
+
+/// Cuts values into `bins` roughly equal-count groups, by value rather than by position.
+///
+/// Equal values always land in one bin, so a constant feature yields a single bin and no
+/// information. Splitting ties by sort position would instead manufacture groups whose boundaries
+/// are wherever the rows happened to be ordered.
+pub fn quantile_bins(values: &[f64], bins: usize) -> Option<Vec<usize>> {
+    if bins == 0 || values.is_empty() || !values.iter().all(|value| value.is_finite()) {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|left, right| left.partial_cmp(right).expect("finite values compare"));
+
+    Some(
+        values
+            .iter()
+            .map(|value| {
+                let position = sorted.partition_point(|other| other < value);
+                (position * bins / sorted.len()).min(bins - 1)
+            })
+            .collect(),
+    )
+}
+
+/// Numbers each distinct value, for a feature whose values name groups rather than order them.
+///
+/// A sector has no low and high, so cutting it into quantiles would read its alphabetical position
+/// as a magnitude.
+pub fn category_bins(values: &[&str]) -> Vec<usize> {
+    let mut numbering: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    values
+        .iter()
+        .map(|value| {
+            let next = numbering.len();
+            *numbering.entry(value).or_insert(next)
+        })
+        .collect()
+}
+
+/// Mutual information between two binned variables, in bits.
+///
+/// Zero when the two are independent, and at most the entropy of the coarser side. The estimate is
+/// biased upward at finite sample size, which is what [`measure_session`]'s null exists to remove.
+pub fn mutual_information(feature: &[usize], target: &[usize]) -> Option<f64> {
+    if feature.len() != target.len() || feature.is_empty() {
+        return None;
+    }
+    let total = feature.len() as f64;
+
+    let mut joint: std::collections::HashMap<(usize, usize), f64> =
+        std::collections::HashMap::new();
+    let mut feature_counts: std::collections::HashMap<usize, f64> =
+        std::collections::HashMap::new();
+    let mut target_counts: std::collections::HashMap<usize, f64> = std::collections::HashMap::new();
+    for (left, right) in feature.iter().zip(target) {
+        *joint.entry((*left, *right)).or_default() += 1.0;
+        *feature_counts.entry(*left).or_default() += 1.0;
+        *target_counts.entry(*right).or_default() += 1.0;
+    }
+
+    let bits = joint
+        .into_iter()
+        .map(|((left, right), count)| {
+            let independent = feature_counts[&left] * target_counts[&right];
+            (count / total) * ((count * total) / independent).log2()
+        })
+        .sum();
+    Some(bits)
+}
+
+/// Measures one session's cross-section, and the same cross-section with the feature shuffled.
+///
+/// Shuffling breaks the association while leaving both marginals alone, so what it scores is
+/// exactly the bias — reporting the raw figure without subtracting it is how this technique
+/// produces confident nonsense.
+pub fn measure_session(
+    feature: &[f64],
+    target: &[f64],
+    bins: usize,
+    seed: u64,
+) -> Option<SessionInformation> {
+    if feature.len() != target.len() || feature.len() < MINIMUM_CROSS_SECTION {
+        return None;
+    }
+    let feature_bins = quantile_bins(feature, bins)?;
+    let target_bins = quantile_bins(target, bins)?;
+    let bits = mutual_information(&feature_bins, &target_bins)?;
+
+    let mut shuffled = feature_bins;
+    shuffled.shuffle(&mut StdRng::seed_from_u64(seed));
+    let null_bits = mutual_information(&shuffled, &target_bins)?;
+
+    Some(SessionInformation { bits, null_bits })
+}
+
+/// One session's cross-section: a feature read before the session, and what it forecasts.
+pub type Paired = std::collections::BTreeMap<i64, (Vec<f64>, Vec<f64>)>;
+
+/// Which part of the next session's return is being asked about.
+///
+/// Mutual information counts any dependence, so a feature can say a great deal about how far a name
+/// will move while saying nothing about which way — and only the second is directionally tradeable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The signed return, which is what a directional book acts on.
+    Signed,
+    /// Its magnitude, which is where a volatility relationship shows up.
+    Magnitude,
+    /// Its sign alone, which is the part a directional book can act on and nothing else.
+    Direction,
+}
+
+/// Pairs each name's feature at one session with its own return in the next.
+///
+/// Keyed by the session being forecast, and only where that session immediately follows the one the
+/// feature was read in — a pair spanning a gap would call a multi-session move a forecast. `binned`
+/// receives the feature column already numbered when the feature names groups rather than ordering
+/// them.
+pub fn pair_with_next_session(
+    frame: &DataFrame,
+    feature: &str,
+    outcome: Outcome,
+    binned: impl Fn(&DataFrame) -> Result<Vec<f64>, TideError>,
+) -> Result<Paired, TideError> {
+    let sorted = frame.sort(
+        ["ticker", "timestamp"],
+        SortMultipleOptions::default().with_maintain_order(true),
+    )?;
+    let ranks = session_ranks(&sorted)?;
+
+    let tickers: Vec<&str> = sorted
+        .column("ticker")?
+        .str()?
+        .into_no_null_iter()
+        .collect();
+    let timestamps: Vec<i64> = sorted
+        .column("timestamp")?
+        .i64()?
+        .into_no_null_iter()
+        .collect();
+    let features = binned(&sorted)?;
+    let targets: Vec<f64> = sorted
+        .column(TARGET_COLUMN)?
+        .cast(&DataType::Float64)?
+        .f64()?
+        .into_no_null_iter()
+        .map(|value| match outcome {
+            Outcome::Signed => value,
+            Outcome::Magnitude => value.abs(),
+            Outcome::Direction => value.signum(),
+        })
+        .collect();
+
+    if [
+        tickers.len(),
+        timestamps.len(),
+        features.len(),
+        targets.len(),
+    ]
+    .iter()
+    .any(|length| *length != sorted.height())
+    {
+        return Err(TideError::Data(format!(
+            "column `{feature}` or its neighbours hold nulls the pairing cannot align"
+        )));
+    }
+
+    let mut paired = Paired::new();
+    for index in 0..sorted.height().saturating_sub(1) {
+        let next = index + 1;
+        let follows = tickers[index] == tickers[next]
+            && ranks
+                .get(&timestamps[index])
+                .zip(ranks.get(&timestamps[next]))
+                .is_some_and(|(current, following)| *following == current + 1);
+        if !follows {
+            continue;
+        }
+        let entry = paired.entry(timestamps[next]).or_default();
+        entry.0.push(features[index]);
+        entry.1.push(targets[next]);
+    }
+
+    Ok(paired)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A cross-section large enough to clear the floor, with the target a stated function of the
+    /// feature so the answer is known in advance.
+    fn paired(names: usize, map: impl Fn(usize) -> f64) -> (Vec<f64>, Vec<f64>) {
+        (
+            (0..names).map(|index| index as f64).collect(),
+            (0..names).map(map).collect(),
+        )
+    }
+
+    /// A feature that determines the target carries the full entropy of ten equal bins, which is
+    /// log2(10). Nothing can score higher, so this is the scale everything else is read against.
+    #[test]
+    fn test_a_perfect_association_carries_the_whole_entropy() {
+        let (feature, target) = paired(1000, |index| index as f64);
+        let measured = measure_session(&feature, &target, DEFAULT_BINS, 1).unwrap();
+
+        assert!(
+            (measured.bits - 10.0_f64.log2()).abs() < 1e-9,
+            "expected log2(10) bits, got {}",
+            measured.bits
+        );
+        // The shuffled copy of a perfect association is worth the bias and nothing more.
+        assert!(measured.null_bits < 0.1, "{measured:?}");
+    }
+
+    /// Reversing the target is still a perfect association: mutual information counts shared
+    /// structure and has no sign, which is what makes it catch relationships a correlation misses.
+    #[test]
+    fn test_a_reversed_association_is_worth_as_much_as_a_forward_one() {
+        let (feature, forward) = paired(1000, |index| index as f64);
+        let reversed: Vec<f64> = forward.iter().map(|value| -value).collect();
+
+        let straight = measure_session(&feature, &forward, DEFAULT_BINS, 1).unwrap();
+        let backward = measure_session(&feature, &reversed, DEFAULT_BINS, 1).unwrap();
+        assert!((straight.bits - backward.bits).abs() < 1e-9);
+    }
+
+    /// A relationship no correlation would see. The target is a fold of the feature, so the two are
+    /// close to uncorrelated and yet one determines the other.
+    #[test]
+    fn test_a_folded_relationship_is_visible_where_correlation_is_not() {
+        let names = 1000;
+        let feature: Vec<f64> = (0..names).map(|index| index as f64).collect();
+        let target: Vec<f64> = feature
+            .iter()
+            .map(|value| (value - names as f64 / 2.0).abs())
+            .collect();
+
+        let measured = measure_session(&feature, &target, DEFAULT_BINS, 1).unwrap();
+        assert!(
+            measured.excess() > 1.0,
+            "a fold carries real information: {measured:?}"
+        );
+
+        let correlation = crate::laboratory::metrics::information_coefficient(&feature, &target)
+            .expect("both sides vary");
+        assert!(
+            correlation.abs() < 0.05,
+            "and a rank correlation barely sees it: {correlation}"
+        );
+    }
+
+    /// The bias is the whole reason the null is subtracted, and it is not small: a hundred-cell
+    /// table over a thousand names scores real bits on two unrelated variables.
+    #[test]
+    fn test_an_unrelated_feature_scores_bits_it_has_not_earned() {
+        let names = 1000;
+        let feature: Vec<f64> = (0..names)
+            .map(|index| ((index * 7919) % names) as f64)
+            .collect();
+        let target: Vec<f64> = (0..names)
+            .map(|index| ((index * 104_729) % names) as f64)
+            .collect();
+
+        let measured = measure_session(&feature, &target, DEFAULT_BINS, 1).unwrap();
+        assert!(
+            measured.bits > 0.0,
+            "the raw estimate is biased upward: {measured:?}"
+        );
+        assert!(
+            measured.excess().abs() < 0.2,
+            "and the null removes almost all of it: {measured:?}"
+        );
+    }
+
+    /// A constant feature has one bin, not ten. Splitting its ties by sort position would invent
+    /// groups whose boundaries are wherever the rows happened to be ordered — the same error as
+    /// reading a decile spread off a tie-broken sort.
+    #[test]
+    fn test_a_constant_feature_yields_one_bin_and_no_information() {
+        let feature = vec![0.5_f64; 1000];
+        let target: Vec<f64> = (0..1000).map(|index| index as f64).collect();
+
+        let bins = quantile_bins(&feature, DEFAULT_BINS).unwrap();
+        assert!(bins.iter().all(|bin| *bin == 0));
+
+        let measured = measure_session(&feature, &target, DEFAULT_BINS, 1).unwrap();
+        assert!(measured.bits.abs() < 1e-12, "{measured:?}");
+        assert!(measured.excess().abs() < 1e-12, "{measured:?}");
+    }
+
+    /// Equal values share a bin even when they straddle what would otherwise be a boundary.
+    #[test]
+    fn test_ties_are_not_split_across_a_boundary() {
+        let values = vec![1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0];
+        let bins = quantile_bins(&values, DEFAULT_BINS).unwrap();
+
+        assert_eq!(
+            bins[..5]
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            1
+        );
+        assert_eq!(
+            bins[5..]
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            1
+        );
+        assert_ne!(bins[0], bins[5]);
+    }
+
+    const DAY: i64 = 86_400_000;
+
+    /// Two names over four sessions, with the third session missing for BBB so its pair would span
+    /// a gap. Feature and target are distinct columns so a pairing off by one is visible.
+    fn gapped_frame() -> DataFrame {
+        let rows: Vec<(&str, i64, f64, f64)> = vec![
+            ("AAA", 0, 10.0, 0.01),
+            ("AAA", DAY, 20.0, 0.02),
+            ("AAA", 2 * DAY, 30.0, 0.03),
+            ("AAA", 3 * DAY, 40.0, 0.04),
+            ("BBB", 0, 50.0, 0.05),
+            ("BBB", DAY, 60.0, 0.06),
+            // No session two for BBB, so its next row is two sessions on.
+            ("BBB", 3 * DAY, 70.0, 0.07),
+        ];
+        DataFrame::new(vec![
+            Column::new(
+                "ticker".into(),
+                rows.iter().map(|row| row.0).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "timestamp".into(),
+                rows.iter().map(|row| row.1).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "close_price".into(),
+                rows.iter().map(|row| row.2).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                TARGET_COLUMN.into(),
+                rows.iter().map(|row| row.3).collect::<Vec<_>>(),
+            ),
+        ])
+        .unwrap()
+    }
+
+    fn continuous(column: &'static str) -> impl Fn(&DataFrame) -> Result<Vec<f64>, TideError> {
+        move |frame: &DataFrame| {
+            Ok(frame
+                .column(column)?
+                .cast(&DataType::Float64)?
+                .f64()?
+                .into_no_null_iter()
+                .collect())
+        }
+    }
+
+    /// The feature is read before the session it forecasts, never in it. Pairing a session with
+    /// itself would score the model against an outcome it was given as input.
+    #[test]
+    fn test_a_feature_is_paired_with_the_following_session() {
+        let paired = pair_with_next_session(
+            &gapped_frame(),
+            "close_price",
+            Outcome::Signed,
+            continuous("close_price"),
+        )
+        .unwrap();
+
+        // Session one is forecast by session zero: AAA's 10.0 against its own next return, and
+        // BBB's 50.0 against its own.
+        let (features, targets) = &paired[&DAY];
+        assert_eq!(features, &vec![10.0, 50.0]);
+        assert_eq!(targets, &vec![0.02, 0.06]);
+    }
+
+    /// BBB does not trade in session two, so its session-one row and its session-three row are not
+    /// adjacent. Pairing them would call a two-session move a one-session forecast.
+    #[test]
+    fn test_a_pair_is_not_formed_across_a_session_gap() {
+        let paired = pair_with_next_session(
+            &gapped_frame(),
+            "close_price",
+            Outcome::Signed,
+            continuous("close_price"),
+        )
+        .unwrap();
+
+        assert_eq!(paired[&(2 * DAY)].0, vec![20.0], "AAA alone");
+        assert_eq!(
+            paired[&(3 * DAY)].0,
+            vec![30.0],
+            "BBB's jump over session two is refused"
+        );
+    }
+
+    #[test]
+    fn test_categories_are_numbered_rather_than_ordered() {
+        let bins = category_bins(&["ENERGY", "HEALTH", "ENERGY", "UTILITIES"]);
+        assert_eq!(bins[0], bins[2], "one sector is one bin");
+        assert_ne!(bins[0], bins[1]);
+        assert_eq!(
+            bins.iter().collect::<std::collections::HashSet<_>>().len(),
+            3
+        );
+    }
+
+    /// The market's own move is a constant across a session, and the bins are cut by rank, so it
+    /// is already absent from every figure here. Measured before this was understood: an outcome
+    /// that demeaned the target returned bit-identical numbers, because it could not do otherwise.
+    #[test]
+    fn test_the_sessions_own_move_is_already_out_of_the_measurement() {
+        let (feature, target) = paired(1000, |index| ((index * 37) % 1000) as f64);
+        let shifted: Vec<f64> = target.iter().map(|value| value + 12.5).collect();
+
+        let plain = measure_session(&feature, &target, DEFAULT_BINS, 1).unwrap();
+        let moved = measure_session(&feature, &shifted, DEFAULT_BINS, 1).unwrap();
+        // Equal to floating point rather than bitwise: the bins are identical, and what is left is
+        // the last place of a sum over a hundred cells.
+        assert!(
+            (plain.bits - moved.bits).abs() < 1e-12,
+            "{plain:?} {moved:?}"
+        );
+        assert!((plain.excess() - moved.excess()).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_a_cross_section_too_thin_to_fill_the_table_is_refused() {
+        let (feature, target) = paired(MINIMUM_CROSS_SECTION - 1, |index| index as f64);
+        assert_eq!(measure_session(&feature, &target, DEFAULT_BINS, 1), None);
+    }
+
+    #[test]
+    fn test_mismatched_or_unusable_input_is_refused() {
+        assert_eq!(mutual_information(&[0, 1], &[0]), None);
+        assert_eq!(mutual_information(&[], &[]), None);
+        assert_eq!(quantile_bins(&[1.0, f64::NAN], DEFAULT_BINS), None);
+        assert_eq!(quantile_bins(&[1.0, 2.0], 0), None);
+    }
+}

--- a/src/laboratory/information.rs
+++ b/src/laboratory/information.rs
@@ -13,8 +13,11 @@ use crate::models::tide::TideError;
 /// Bins each side is cut into. Ten matches the decile language the rest of the laboratory uses.
 pub const DEFAULT_BINS: usize = 10;
 
-/// Names a cross-section needs before a hundred-cell table means anything.
-pub const MINIMUM_CROSS_SECTION: usize = 100;
+/// Names a cross-section needs for every cell of the table before a count means anything.
+///
+/// One apiece, so the ten-by-ten table the continuous features use asks for a hundred names, and a
+/// feature naming more groups than that asks for proportionally more.
+pub const NAMES_PER_CELL: usize = 1;
 
 /// What one session's cross-section says about a feature.
 ///
@@ -71,6 +74,78 @@ pub fn category_bins(values: &[&str]) -> Vec<usize> {
         .collect()
 }
 
+/// Renumbers an already-grouped column so its bins run from zero with no gaps.
+///
+/// Every distinct value keeps a bin of its own however many there are, which is the whole point:
+/// quantile-cutting a hundred and fifty industries into ten would merge them by their numbering.
+fn nominal_bins(values: &[usize]) -> Option<Vec<usize>> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut distinct = values.to_vec();
+    distinct.sort_unstable();
+    distinct.dedup();
+
+    Some(
+        values
+            .iter()
+            .map(|value| distinct.partition_point(|other| other < value))
+            .collect(),
+    )
+}
+
+/// A feature's values for one cross-section, carrying how they are cut into bins.
+///
+/// The two travel together because separating them is what lets a sector be quantile-cut: nothing
+/// downstream can tell an ordered scale from a numbering once the values are bare.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Feature {
+    /// Values ordering names on a scale, cut into equal-count groups within each session.
+    Continuous(Vec<f64>),
+    /// Values naming groups, already numbered, each group its own bin.
+    Nominal(Vec<usize>),
+}
+
+impl Feature {
+    /// How many names the column covers.
+    pub fn len(&self) -> usize {
+        match self {
+            Feature::Continuous(values) => values.len(),
+            Feature::Nominal(values) => values.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The values at `indices`, cut the same way this column is.
+    fn select(&self, indices: &[usize]) -> Self {
+        match self {
+            Feature::Continuous(values) => {
+                Feature::Continuous(indices.iter().map(|index| values[*index]).collect())
+            }
+            Feature::Nominal(values) => {
+                Feature::Nominal(indices.iter().map(|index| values[*index]).collect())
+            }
+        }
+    }
+
+    /// The bin each name falls in, `bins` of them for a continuous column and one per group for a
+    /// nominal one.
+    fn bins(&self, bins: usize) -> Option<Vec<usize>> {
+        match self {
+            Feature::Continuous(values) => quantile_bins(values, bins),
+            Feature::Nominal(values) => nominal_bins(values),
+        }
+    }
+}
+
+/// How many bins a column actually occupies, which is what sets the size of the table.
+fn occupied(bins: &[usize]) -> usize {
+    bins.iter().collect::<std::collections::BTreeSet<_>>().len()
+}
+
 /// Mutual information between two binned variables, in bits.
 ///
 /// Zero when the two are independent, and at most the entropy of the coarser side. The estimate is
@@ -81,11 +156,14 @@ pub fn mutual_information(feature: &[usize], target: &[usize]) -> Option<f64> {
     }
     let total = feature.len() as f64;
 
-    let mut joint: std::collections::HashMap<(usize, usize), f64> =
-        std::collections::HashMap::new();
-    let mut feature_counts: std::collections::HashMap<usize, f64> =
-        std::collections::HashMap::new();
-    let mut target_counts: std::collections::HashMap<usize, f64> = std::collections::HashMap::new();
+    // Ordered rather than hashed: a hundred cells cost nothing to keep sorted, and the sum below
+    // is over floats, so a randomly seeded iteration order would move its last digits every run.
+    let mut joint: std::collections::BTreeMap<(usize, usize), f64> =
+        std::collections::BTreeMap::new();
+    let mut feature_counts: std::collections::BTreeMap<usize, f64> =
+        std::collections::BTreeMap::new();
+    let mut target_counts: std::collections::BTreeMap<usize, f64> =
+        std::collections::BTreeMap::new();
     for (left, right) in feature.iter().zip(target) {
         *joint.entry((*left, *right)).or_default() += 1.0;
         *feature_counts.entry(*left).or_default() += 1.0;
@@ -108,16 +186,23 @@ pub fn mutual_information(feature: &[usize], target: &[usize]) -> Option<f64> {
 /// exactly the bias — reporting the raw figure without subtracting it is how this technique
 /// produces confident nonsense.
 pub fn measure_session(
-    feature: &[f64],
+    feature: &Feature,
     target: &[f64],
     bins: usize,
     seed: u64,
 ) -> Option<SessionInformation> {
-    if feature.len() != target.len() || feature.len() < MINIMUM_CROSS_SECTION {
+    if feature.len() != target.len() {
         return None;
     }
-    let feature_bins = quantile_bins(feature, bins)?;
+    let feature_bins = feature.bins(bins)?;
     let target_bins = quantile_bins(target, bins)?;
+
+    // A nominal feature sets its own width, so the table can outgrow the cross-section: a hundred
+    // and fifty industries against ten return bins wants more names than a session holds.
+    let cells = occupied(&feature_bins) * occupied(&target_bins);
+    if target.len() < cells * NAMES_PER_CELL {
+        return None;
+    }
     let bits = mutual_information(&feature_bins, &target_bins)?;
 
     let mut shuffled = feature_bins;
@@ -128,7 +213,7 @@ pub fn measure_session(
 }
 
 /// One session's cross-section: a feature read before the session, and what it forecasts.
-pub type Paired = std::collections::BTreeMap<i64, (Vec<f64>, Vec<f64>)>;
+pub type Paired = std::collections::BTreeMap<i64, (Feature, Vec<f64>)>;
 
 /// Which part of the next session's return is being asked about.
 ///
@@ -147,21 +232,32 @@ pub enum Outcome {
 /// Pairs each name's feature at one session with its own return in the next.
 ///
 /// Keyed by the session being forecast, and only where that session immediately follows the one the
-/// feature was read in — a pair spanning a gap would call a multi-session move a forecast. `binned`
-/// receives the feature column already numbered when the feature names groups rather than ordering
-/// them.
+/// feature was read in — a pair spanning a gap would call a multi-session move a forecast. `read`
+/// returns the whole sorted column, and which [`Feature`] it returns is what decides how the column
+/// is binned.
 pub fn pair_with_next_session(
     frame: &DataFrame,
     feature: &str,
     outcome: Outcome,
-    binned: impl Fn(&DataFrame) -> Result<Vec<f64>, TideError>,
+    read: impl Fn(&DataFrame) -> Result<Feature, TideError>,
 ) -> Result<Paired, TideError> {
     let sorted = frame.sort(
         ["ticker", "timestamp"],
         SortMultipleOptions::default().with_maintain_order(true),
     )?;
-    let ranks = session_ranks(&sorted)?;
 
+    // Checked here rather than by counting values back: the readers below take the physical slot
+    // whether or not it holds one, so a null arrives as whatever the slot happened to contain.
+    for name in ["ticker", "timestamp", TARGET_COLUMN, feature] {
+        let nulls = sorted.column(name)?.null_count();
+        if nulls > 0 {
+            return Err(TideError::Data(format!(
+                "column `{name}` holds {nulls} nulls the pairing cannot align"
+            )));
+        }
+    }
+
+    let ranks = session_ranks(&sorted)?;
     let tickers: Vec<&str> = sorted
         .column("ticker")?
         .str()?
@@ -172,7 +268,7 @@ pub fn pair_with_next_session(
         .i64()?
         .into_no_null_iter()
         .collect();
-    let features = binned(&sorted)?;
+    let features = read(&sorted)?;
     let targets: Vec<f64> = sorted
         .column(TARGET_COLUMN)?
         .cast(&DataType::Float64)?
@@ -181,25 +277,23 @@ pub fn pair_with_next_session(
         .map(|value| match outcome {
             Outcome::Signed => value,
             Outcome::Magnitude => value.abs(),
+            // Signum calls both zeroes a move, so a name that closed unchanged would be recorded
+            // as a rise in the one outcome a directional book can act on.
+            Outcome::Direction if value == 0.0 => 0.0,
             Outcome::Direction => value.signum(),
         })
         .collect();
 
-    if [
-        tickers.len(),
-        timestamps.len(),
-        features.len(),
-        targets.len(),
-    ]
-    .iter()
-    .any(|length| *length != sorted.height())
-    {
+    if features.len() != sorted.height() {
         return Err(TideError::Data(format!(
-            "column `{feature}` or its neighbours hold nulls the pairing cannot align"
+            "column `{feature}` read {} values for {} rows",
+            features.len(),
+            sorted.height()
         )));
     }
 
-    let mut paired = Paired::new();
+    let mut rows: std::collections::BTreeMap<i64, (Vec<usize>, Vec<f64>)> =
+        std::collections::BTreeMap::new();
     for index in 0..sorted.height().saturating_sub(1) {
         let next = index + 1;
         let follows = tickers[index] == tickers[next]
@@ -210,12 +304,15 @@ pub fn pair_with_next_session(
         if !follows {
             continue;
         }
-        let entry = paired.entry(timestamps[next]).or_default();
-        entry.0.push(features[index]);
+        let entry = rows.entry(timestamps[next]).or_default();
+        entry.0.push(index);
         entry.1.push(targets[next]);
     }
 
-    Ok(paired)
+    Ok(rows
+        .into_iter()
+        .map(|(session, (indices, targets))| (session, (features.select(&indices), targets)))
+        .collect())
 }
 
 #[cfg(test)]
@@ -224,9 +321,9 @@ mod tests {
 
     /// A cross-section large enough to clear the floor, with the target a stated function of the
     /// feature so the answer is known in advance.
-    fn paired(names: usize, map: impl Fn(usize) -> f64) -> (Vec<f64>, Vec<f64>) {
+    fn paired(names: usize, map: impl Fn(usize) -> f64) -> (Feature, Vec<f64>) {
         (
-            (0..names).map(|index| index as f64).collect(),
+            Feature::Continuous((0..names).map(|index| index as f64).collect()),
             (0..names).map(map).collect(),
         )
     }
@@ -270,7 +367,13 @@ mod tests {
             .map(|value| (value - names as f64 / 2.0).abs())
             .collect();
 
-        let measured = measure_session(&feature, &target, DEFAULT_BINS, 1).unwrap();
+        let measured = measure_session(
+            &Feature::Continuous(feature.clone()),
+            &target,
+            DEFAULT_BINS,
+            1,
+        )
+        .unwrap();
         assert!(
             measured.excess() > 1.0,
             "a fold carries real information: {measured:?}"
@@ -296,7 +399,8 @@ mod tests {
             .map(|index| ((index * 104_729) % names) as f64)
             .collect();
 
-        let measured = measure_session(&feature, &target, DEFAULT_BINS, 1).unwrap();
+        let measured =
+            measure_session(&Feature::Continuous(feature), &target, DEFAULT_BINS, 1).unwrap();
         assert!(
             measured.bits > 0.0,
             "the raw estimate is biased upward: {measured:?}"
@@ -318,7 +422,8 @@ mod tests {
         let bins = quantile_bins(&feature, DEFAULT_BINS).unwrap();
         assert!(bins.iter().all(|bin| *bin == 0));
 
-        let measured = measure_session(&feature, &target, DEFAULT_BINS, 1).unwrap();
+        let measured =
+            measure_session(&Feature::Continuous(feature), &target, DEFAULT_BINS, 1).unwrap();
         assert!(measured.bits.abs() < 1e-12, "{measured:?}");
         assert!(measured.excess().abs() < 1e-12, "{measured:?}");
     }
@@ -382,14 +487,16 @@ mod tests {
         .unwrap()
     }
 
-    fn continuous(column: &'static str) -> impl Fn(&DataFrame) -> Result<Vec<f64>, TideError> {
+    fn continuous(column: &'static str) -> impl Fn(&DataFrame) -> Result<Feature, TideError> {
         move |frame: &DataFrame| {
-            Ok(frame
-                .column(column)?
-                .cast(&DataType::Float64)?
-                .f64()?
-                .into_no_null_iter()
-                .collect())
+            Ok(Feature::Continuous(
+                frame
+                    .column(column)?
+                    .cast(&DataType::Float64)?
+                    .f64()?
+                    .into_no_null_iter()
+                    .collect(),
+            ))
         }
     }
 
@@ -408,7 +515,7 @@ mod tests {
         // Session one is forecast by session zero: AAA's 10.0 against its own next return, and
         // BBB's 50.0 against its own.
         let (features, targets) = &paired[&DAY];
-        assert_eq!(features, &vec![10.0, 50.0]);
+        assert_eq!(features, &Feature::Continuous(vec![10.0, 50.0]));
         assert_eq!(targets, &vec![0.02, 0.06]);
     }
 
@@ -424,10 +531,14 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(paired[&(2 * DAY)].0, vec![20.0], "AAA alone");
+        assert_eq!(
+            paired[&(2 * DAY)].0,
+            Feature::Continuous(vec![20.0]),
+            "AAA alone"
+        );
         assert_eq!(
             paired[&(3 * DAY)].0,
-            vec![30.0],
+            Feature::Continuous(vec![30.0]),
             "BBB's jump over session two is refused"
         );
     }
@@ -462,10 +573,87 @@ mod tests {
         assert!((plain.excess() - moved.excess()).abs() < 1e-12);
     }
 
+    /// Ten bins a side is a hundred cells, so ninety-nine names is one short of the floor and a
+    /// hundred clears it. Pinned to literals: built from the rule, the input would move with it.
     #[test]
     fn test_a_cross_section_too_thin_to_fill_the_table_is_refused() {
-        let (feature, target) = paired(MINIMUM_CROSS_SECTION - 1, |index| index as f64);
+        let (feature, target) = paired(99, |index| index as f64);
         assert_eq!(measure_session(&feature, &target, DEFAULT_BINS, 1), None);
+
+        let (feature, target) = paired(100, |index| index as f64);
+        assert!(measure_session(&feature, &target, DEFAULT_BINS, 1).is_some());
+    }
+
+    /// A nominal feature sets the width of the table itself, so the floor rises with the number of
+    /// groups rather than sitting at the hundred a ten-by-ten table asks for.
+    #[test]
+    fn test_a_nominal_feature_wider_than_the_cross_section_is_refused() {
+        let names = 1000;
+        let target: Vec<f64> = (0..names).map(|index| index as f64).collect();
+
+        // A hundred groups against ten return bins is a thousand cells, which a thousand names
+        // fills exactly.
+        let hundred = Feature::Nominal((0..names).map(|index| index % 100).collect());
+        assert!(measure_session(&hundred, &target, DEFAULT_BINS, 1).is_some());
+
+        // A hundred and one does not.
+        let hundred_and_one = Feature::Nominal((0..names).map(|index| index % 101).collect());
+        assert_eq!(
+            measure_session(&hundred_and_one, &target, DEFAULT_BINS, 1),
+            None
+        );
+    }
+
+    /// The defect this replaced: a nominal column cut into ten quantiles merges its groups by
+    /// nothing but their numbering, and the data has thirteen sectors and a hundred and fifty-one
+    /// industries.
+    #[test]
+    fn test_more_groups_than_bins_stay_apart() {
+        let values: Vec<usize> = (0..40).map(|index| index % 20).collect();
+
+        let quantiles = quantile_bins(
+            &values.iter().map(|value| *value as f64).collect::<Vec<_>>(),
+            DEFAULT_BINS,
+        )
+        .unwrap();
+        assert_eq!(
+            quantiles[0], quantiles[1],
+            "groups zero and one share a quantile bin"
+        );
+
+        let nominal = nominal_bins(&values).unwrap();
+        assert_ne!(nominal[0], nominal[1], "and stay apart when numbered");
+        assert_eq!(occupied(&nominal), 20, "one bin per group");
+        assert_eq!(nominal[0], nominal[20], "and one bin for each group");
+    }
+
+    /// A feature that determines the target is worth more measured as groups than merged into ten
+    /// bins, which is the size of what the quantile cut was throwing away.
+    ///
+    /// The target is scrambled across the groups deliberately: neighbouring group numbers mean
+    /// nothing to each other, which is the property a sector has and a price does not.
+    #[test]
+    fn test_merging_groups_costs_information() {
+        let names = 1000;
+        let groups: Vec<usize> = (0..names).map(|index| index % 25).collect();
+        let target: Vec<f64> = groups
+            .iter()
+            .map(|group| ((group * 7) % 25) as f64)
+            .collect();
+
+        let merged = measure_session(
+            &Feature::Continuous(groups.iter().map(|group| *group as f64).collect()),
+            &target,
+            DEFAULT_BINS,
+            1,
+        )
+        .unwrap();
+        let kept = measure_session(&Feature::Nominal(groups), &target, DEFAULT_BINS, 1).unwrap();
+
+        assert!(
+            kept.excess() > merged.excess() + 1.0,
+            "merging unrelated groups throws information away: {kept:?} {merged:?}"
+        );
     }
 
     #[test]
@@ -474,5 +662,63 @@ mod tests {
         assert_eq!(mutual_information(&[], &[]), None);
         assert_eq!(quantile_bins(&[1.0, f64::NAN], DEFAULT_BINS), None);
         assert_eq!(quantile_bins(&[1.0, 2.0], 0), None);
+        assert_eq!(nominal_bins(&[]), None);
+    }
+
+    /// `into_no_null_iter` takes the physical slot whether or not it holds a value, so a null read
+    /// through it arrives as whatever the slot contained rather than as a missing row.
+    #[test]
+    fn test_a_null_is_refused_rather_than_read_as_a_value() {
+        let mut frame = gapped_frame();
+        let mut prices: Vec<Option<f64>> = frame
+            .column("close_price")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .into_iter()
+            .collect();
+        prices[2] = None;
+        frame
+            .with_column(Column::new("close_price".into(), prices))
+            .unwrap();
+
+        let error = pair_with_next_session(
+            &frame,
+            "close_price",
+            Outcome::Signed,
+            continuous("close_price"),
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("close_price"),
+            "the column is named: {error}"
+        );
+    }
+
+    /// A name that closed unchanged did not rise, and `f64::signum` says it did.
+    #[test]
+    fn test_an_unchanged_close_is_not_a_direction() {
+        let mut frame = gapped_frame();
+        let mut returns: Vec<f64> = frame
+            .column(TARGET_COLUMN)
+            .unwrap()
+            .f64()
+            .unwrap()
+            .into_no_null_iter()
+            .collect();
+        // AAA's session-one return, which is the one session zero forecasts.
+        returns[1] = 0.0;
+        frame
+            .with_column(Column::new(TARGET_COLUMN.into(), returns))
+            .unwrap();
+
+        let paired = pair_with_next_session(
+            &frame,
+            "close_price",
+            Outcome::Direction,
+            continuous("close_price"),
+        )
+        .unwrap();
+        assert_eq!(paired[&DAY].1, vec![0.0, 1.0], "flat is neither way");
     }
 }

--- a/src/laboratory/journal.rs
+++ b/src/laboratory/journal.rs
@@ -273,8 +273,8 @@ mod tests {
         })
     }
 
-    /// The export partitions on this name, so the two variants must not collide and neither may
-    /// drift from the tag `rename_all` generates for it.
+    /// The export partitions on this name, so no two variants may collide and none may drift from
+    /// the tag `rename_all` generates for it.
     #[test]
     fn test_each_observation_exports_under_its_own_partition() {
         let forecast = Observation::ForecastScored(ForecastScored {
@@ -292,6 +292,23 @@ mod tests {
         );
         assert_eq!(forecast.experiment_type(), "forecast_scored");
         assert_ne!(forecast.experiment_type(), observation().experiment_type());
+
+        let triaged = Observation::FeatureTriaged(FeatureTriaged {
+            feature: "daily_return".to_string(),
+            sessions: 499,
+            bits: None,
+            null_bits: None,
+            excess_bits: None,
+        });
+        let value: serde_json::Value = serde_json::to_value(&triaged).unwrap();
+
+        assert_eq!(
+            value["experiment_type"],
+            serde_json::json!("feature_triaged")
+        );
+        assert_eq!(triaged.experiment_type(), "feature_triaged");
+        assert_ne!(triaged.experiment_type(), forecast.experiment_type());
+        assert_ne!(triaged.experiment_type(), observation().experiment_type());
     }
 
     /// Two different counts, and conflating them would read a forecast that ranked twice out of

--- a/src/laboratory/journal.rs
+++ b/src/laboratory/journal.rs
@@ -46,6 +46,7 @@ pub enum JournalError {
 pub enum Observation {
     DatasetBuilt(DatasetBuilt),
     ForecastScored(ForecastScored),
+    FeatureTriaged(FeatureTriaged),
 }
 
 impl Observation {
@@ -54,8 +55,22 @@ impl Observation {
         match self {
             Observation::DatasetBuilt(_) => "dataset_built",
             Observation::ForecastScored(_) => "forecast_scored",
+            Observation::FeatureTriaged(_) => "feature_triaged",
         }
     }
+}
+
+/// How much one feature says about the session it precedes.
+///
+/// `excess_bits` is the answer and the other two are why it should be believed: the raw estimate is
+/// biased upward at this sample size, and `null_bits` is that bias measured on the same rows.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct FeatureTriaged {
+    pub feature: String,
+    pub sessions: usize,
+    pub bits: Option<Distribution>,
+    pub null_bits: Option<Distribution>,
+    pub excess_bits: Option<Distribution>,
 }
 
 /// One frame prepared for an experiment to read.

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -515,7 +515,7 @@ pub(crate) fn split_at_cutoff(
 /// Adjacency is therefore relative to the sessions this frame contains, not to a trading calendar:
 /// a session missing for some tickers is a gap, and one missing across the whole universe is
 /// invisible here and belongs to whatever checks the archive's completeness.
-fn session_ranks(data: &DataFrame) -> Result<HashMap<i64, usize>, TideError> {
+pub(crate) fn session_ranks(data: &DataFrame) -> Result<HashMap<i64, usize>, TideError> {
     let timestamps = data.column("timestamp")?.i64()?;
     // Skipping these would leave fewer sessions than rows, and the windows are counted from the
     // row height.


### PR DESCRIPTION
# Overview

Task 4, the last diagnostic in the arc. It measures how many bits each of the model's inputs carries about the session it precedes, before any architecture is committed to.

**They all carry something.** The hypothesis this task existed to test — that the features hold no usable cross-sectional information — is refuted.

## Changes

- `laboratory::information` — `mutual_information` over binned variables, `quantile_bins` and `nominal_bins` behind a `Feature` enum, `measure_session` with its shuffled null, and `pair_with_next_session` to form the cross-sections.
- `src/bin/laboratory_information.rs` — ranks every feature and journals each under a new `feature_triaged` record. Takes an outcome argument: `signed`, `magnitude`, or `direction`.
- `dataset::returns` now hands back the whole cleaned frame rather than three columns, so a second near-duplicate accessor was not needed. `Panel::from_frame` reads its columns by name and is unaffected.

## Context

730 days, 499 sessions, ten bins a side for a continuous feature and one bin per group for a nominal one, every figure measured against a shuffled null on the same rows:

```
feature                          signed             direction
industry                    unmeasurable             +0.125917
sector                        +0.140213              +0.065330
daily_return                  +0.068955              +0.017366
low / close / vwap / open     ~+0.0213               ~+0.00544
volume                        +0.011124              +0.002517
uniform_control               -0.000163              -0.000090
```

**The control row is what makes the rest readable.** A uniform draw carried through the same pipeline scores −0.000163 ± 0.000644, and its raw bits equal its null to four decimals. A hundred-cell table over ~1,150 names carries about **0.065 bits of pure bias** — larger than most real figures above it. Without a feature known to hold nothing, this table is a column of positive numbers with no way to tell which were earned. That row is not decoration; it is the measurement's own control.

**Two rows are not what the first version of this pull request reported, and review is why.** `sector` and `industry` were quantile-cut along with everything else, which merges groups by nothing but the order they were numbered in — the archive holds 13 sectors and 151 industries against ten bins. Measured as groups, `sector` rises from +0.108051 to +0.140213 signed, so the merge was discarding about a third of it. `industry` at 152 groups against ten signed-return bins is a 1,520-cell table over ~1,150 names — fewer observations than cells — and now reads `unmeasurable` rather than the +0.069696 the merge manufactured. Against a three-way direction the same feature is 456 cells, which the cross-section clears, and there it carries the most of anything measured; read that row alongside its null of +0.1158 bits, by far the largest in the table. The continuous rows are unchanged to six decimals.

**What this does not establish, and the reason is the statistic rather than the data.** Mutual information has no sign. A relationship whose direction reverses between sessions — high-beta names leading on an up day and trailing on a down day — scores every session and averages positive, while a rank correlation averages to zero. The baselines already show exactly that shape: persistence's per-session information coefficients have a standard deviation near **0.16** around a mean of **−0.007**. This measurement sees the 0.16; the coefficient sees the mean.

So: structure exists within sessions, and whether any of it is directionally stable enough to forecast is still open. That is a real narrowing rather than an answer — the remaining candidate is stability across sessions, not the presence of signal.

**Three things fell out of building it.** The market's own move is already absent from every figure, because bins are cut by rank within a session and a session's move is a constant added to every name — an `Outcome::Demeaned` written to test that returned bit-identical numbers and became a test rather than a shipped option. It is the same invariant #1087 relied on, reached from the other side. The joint and marginal counts accumulate in ordered maps, because the cells are summed in floating point and iteration order would move the last digits between runs; no test can catch that, since a process fixes its hasher seed once, which is why three reviewers found it and the suite did not. And a nominal feature sets the width of its own table, so the floor on a cross-section is one name per cell rather than a flat hundred — ten by ten still asks for a hundred names, and 152 industries against ten return bins asks for 1,520.

**A stated limitation.** The standard errors are understated. `summarize` treats 499 sessions as independent when they share names, and `sector` and `industry` are constant per ticker for the whole window. Trust the ordering; treat the significance as decorative until a block bootstrap over sessions says otherwise.

**Where the arc now points.** Unlearnable target refuted here, contaminated data by task 1, wrong objective by #1087. What is left is capacity and architecture — task 16, promoted to next, with a specific question rather than a sweep: can a model hold a relationship that reverses between sessions?

## Verification

- `devenv tasks run checks:rust` green, exit 0, clippy clean
- The statistic pinned against known answers: a perfect association returns exactly log2(10), a reversed one the same (it has no sign), a folded one over 1.0 bits where a rank correlation sees under 0.05, and a constant feature exactly zero
- The gap guard proven load-bearing by dropping the contiguity requirement and watching a pair form across a missing session
- The nominal binning, the cell-count floor, the zero-direction fix and the null guard each proven load-bearing the same way — reverted one at a time, each failing exactly its own test and nothing else
- Six real runs against the development archive across three outcomes, not fixtures; the control at zero in every one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added information-ranking analysis for laboratory datasets.
  * Supports signed, magnitude, and directional outcome analysis.
  * Added a command-line tool to rank features and display results in a table.
  * Added optional dataset and feature observation journaling.

* **Bug Fixes**
  * Cleaned laboratory datasets now retain all engineered features for analysis.

* **Tests**
  * Added coverage for argument validation, feature selection, information calculations, categorical data, and session gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
