### PR TITLE
Ask whether a session's reading survives to the next session

### DIFF
--- a/src/bin/laboratory_stability.rs
+++ b/src/bin/laboratory_stability.rs
@@ -1,0 +1,347 @@
+//! Asks whether a forecast's per-session reading says anything about the next session's.
+//!
+//! Trains nothing. It measures the one thing a cross-sectional statistic is blind to: time.
+
+use chrono::Utc;
+use tracing::{error, info, warn};
+
+use fund::common::log::init_tracing;
+use fund::common::types::SessionDate;
+use fund::laboratory::dataset;
+use fund::laboratory::journal as laboratory;
+use fund::laboratory::predictor::{
+    evaluate, CrossSectionalMean, Momentum, Panel, Persistence, Predictor, RandomRanking,
+};
+use fund::laboratory::stability::{self, DEFAULT_LAGS};
+
+const USAGE: &str = "Usage: laboratory_stability [LOOKBACK_DAYS] [MOMENTUM_SESSIONS]";
+
+/// Calendar days of archive to measure over by default, matching the baselines runner.
+const DEFAULT_LOOKBACK_DAYS: i64 = 730;
+
+/// Sessions the momentum baseline sums over by default.
+const DEFAULT_MOMENTUM_SESSIONS: i64 = 20;
+
+/// Fixed, so the control draws the same orderings every run.
+const RANDOM_SEED: u64 = 0x5EED;
+
+/// The per-session statistic followed through time.
+///
+/// The information coefficient and nothing else: it is the ordering the book acts on, and it is the
+/// statistic whose per-session spread of 0.16 against a mean of zero raised the question.
+const STATISTIC: &str = "information_coefficient";
+
+struct Parameters {
+    lookback_days: i64,
+    momentum_sessions: usize,
+}
+
+impl Parameters {
+    fn parse(arguments: &[String]) -> Result<Self, String> {
+        let (lookback_days, momentum_sessions) = match arguments {
+            [] => (DEFAULT_LOOKBACK_DAYS, DEFAULT_MOMENTUM_SESSIONS),
+            [lookback] => (
+                positive(lookback, "LOOKBACK_DAYS")?,
+                DEFAULT_MOMENTUM_SESSIONS,
+            ),
+            [lookback, momentum] => (
+                positive(lookback, "LOOKBACK_DAYS")?,
+                positive(momentum, "MOMENTUM_SESSIONS")?,
+            ),
+            _ => return Err(format!("Too many arguments\n{USAGE}")),
+        };
+        Ok(Self {
+            lookback_days,
+            momentum_sessions: usize::try_from(momentum_sessions).map_err(|_| {
+                format!("MOMENTUM_SESSIONS is larger than this platform can index\n{USAGE}")
+            })?,
+        })
+    }
+}
+
+fn positive(raw: &str, name: &str) -> Result<i64, String> {
+    let value: i64 = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("{name} must be a positive integer, got {raw:?}\n{USAGE}"))?;
+    if value <= 0 {
+        return Err(format!(
+            "{name} must be greater than zero, got {value}\n{USAGE}"
+        ));
+    }
+    Ok(value)
+}
+
+#[tokio::main]
+async fn main() {
+    fund::common::crypto::install_default_crypto_provider();
+    let tracing_guard = init_tracing(
+        "laboratory-stability.log",
+        Some("info"),
+        "laboratory-stability",
+    );
+
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let parameters = match Parameters::parse(&arguments) {
+        Ok(parameters) => parameters,
+        Err(message) => {
+            eprintln!("{message}");
+            drop(tracing_guard);
+            std::process::exit(2);
+        }
+    };
+
+    let code = match run(&parameters).await {
+        Ok(measured) => {
+            println!("{}", render(&measured));
+            0
+        }
+        Err(error) => {
+            error!(%error, "Measuring session stability failed");
+            eprintln!("Measuring session stability failed: {error}");
+            1
+        }
+    };
+
+    drop(tracing_guard);
+    std::process::exit(code);
+}
+
+/// Scores every baseline session by session, then follows each one's readings through time.
+async fn run(
+    parameters: &Parameters,
+) -> Result<Vec<laboratory::StabilityMeasured>, Box<dyn std::error::Error>> {
+    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let s3_client = fund::common::aws::s3_client().await;
+
+    let now = Utc::now();
+    let session = SessionDate::at(now);
+    let run_id = uuid::Uuid::new_v4();
+    let journal = match laboratory::Journal::from_env() {
+        Ok(journal) => Some(journal),
+        Err(error) => {
+            warn!(%error, "No laboratory journal; this run is not recorded");
+            None
+        }
+    };
+
+    info!(
+        bucket,
+        lookback_days = parameters.lookback_days,
+        momentum_sessions = parameters.momentum_sessions,
+        lags = DEFAULT_LAGS,
+        %session,
+        %run_id,
+        "Measuring session stability"
+    );
+
+    let dataset = dataset::returns(&s3_client, &bucket, parameters.lookback_days, session).await?;
+    let fingerprint = dataset.fingerprint.clone();
+    info!(
+        rows = fingerprint.rows,
+        tickers = fingerprint.tickers,
+        "Read the archive window"
+    );
+    if let Some(journal) = journal.as_ref() {
+        journal
+            .record(
+                run_id,
+                Utc::now(),
+                laboratory::Observation::DatasetBuilt(laboratory::DatasetBuilt {
+                    fingerprint,
+                    revision: std::env::var("FUND_REVISION").ok(),
+                }),
+            )
+            .await;
+    }
+
+    let panel = Panel::from_frame(&dataset.returns)?;
+    info!(
+        sessions = panel.sessions(),
+        tickers = panel.tickers(),
+        "Laid the window out session by session"
+    );
+
+    // RandomRanking last, so the control sits at the foot of the table it makes readable.
+    let baselines: Vec<Box<dyn Predictor>> = vec![
+        Box::new(Persistence),
+        Box::new(Momentum {
+            sessions: parameters.momentum_sessions,
+        }),
+        Box::new(CrossSectionalMean),
+        Box::new(RandomRanking { seed: RANDOM_SEED }),
+    ];
+
+    let mut measured = Vec::with_capacity(baselines.len());
+    for baseline in &baselines {
+        let evaluation = evaluate(baseline.as_ref(), &panel);
+        let readings: Vec<Option<f64>> = evaluation
+            .sessions
+            .iter()
+            .map(|session| session.information_coefficient)
+            .collect();
+
+        let record = laboratory::StabilityMeasured {
+            predictor: evaluation.predictor.clone(),
+            statistic: STATISTIC.to_string(),
+            sessions: readings.iter().flatten().count(),
+            autocorrelations: (1..=DEFAULT_LAGS)
+                .filter_map(|lag| stability::autocorrelation(&readings, lag))
+                .collect(),
+            sign_agreements: (1..=DEFAULT_LAGS)
+                .filter_map(|lag| stability::sign_agreement(&readings, lag))
+                .collect(),
+        };
+        info!(
+            predictor = record.predictor,
+            sessions = record.sessions,
+            first_lag = record
+                .autocorrelations
+                .first()
+                .map(|measured| measured.correlation),
+            first_lag_agreement = record.sign_agreements.first().map(|measured| measured.rate),
+            "Followed a forecast through time"
+        );
+
+        if let Some(journal) = journal.as_ref() {
+            journal
+                .record(
+                    run_id,
+                    Utc::now(),
+                    laboratory::Observation::StabilityMeasured(record.clone()),
+                )
+                .await;
+        }
+        measured.push(record);
+    }
+
+    Ok(measured)
+}
+
+/// One block per forecast, one row per lag.
+fn render(measured: &[laboratory::StabilityMeasured]) -> String {
+    let mut rendered = String::new();
+    for record in measured {
+        rendered.push_str(&format!(
+            "\n{} ({}, {} sessions measured)\n{:>5}{:>28}{:>28}\n",
+            record.predictor,
+            record.statistic,
+            record.sessions,
+            "lag",
+            "autocorrelation",
+            "sign_agreement"
+        ));
+        for lag in 1..=DEFAULT_LAGS {
+            let correlation = record
+                .autocorrelations
+                .iter()
+                .find(|measured| measured.lag == lag);
+            let agreement = record
+                .sign_agreements
+                .iter()
+                .find(|measured| measured.lag == lag);
+            if correlation.is_none() && agreement.is_none() {
+                continue;
+            }
+            rendered.push_str(&format!(
+                "{lag:>5}{:>28}{:>28}\n",
+                correlation.map_or_else(
+                    || "unmeasurable".to_string(),
+                    |measured| format!(
+                        "{:+.4} ± {:.4} ({})",
+                        measured.correlation, measured.standard_error, measured.pairs
+                    )
+                ),
+                agreement.map_or_else(
+                    || "unmeasurable".to_string(),
+                    |measured| format!(
+                        "{:.4} ± {:.4} ({})",
+                        measured.rate, measured.standard_error, measured.pairs
+                    )
+                ),
+            ));
+        }
+    }
+    rendered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fund::laboratory::stability::{Autocorrelation, SignAgreement};
+
+    fn arguments(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn test_arguments_default_from_the_right() {
+        let parameters = Parameters::parse(&[]).unwrap();
+        assert_eq!(parameters.lookback_days, 730);
+        assert_eq!(parameters.momentum_sessions, 20);
+
+        let parameters = Parameters::parse(&arguments(&["365"])).unwrap();
+        assert_eq!(parameters.lookback_days, 365);
+        assert_eq!(parameters.momentum_sessions, 20);
+
+        let parameters = Parameters::parse(&arguments(&["365", "5"])).unwrap();
+        assert_eq!(parameters.lookback_days, 365);
+        assert_eq!(parameters.momentum_sessions, 5);
+    }
+
+    #[test]
+    fn test_an_unusable_argument_is_refused() {
+        for value in ["3o5", "0", "-5", ""] {
+            assert!(
+                Parameters::parse(&arguments(&[value])).is_err(),
+                "{value:?} must be refused"
+            );
+        }
+        assert!(Parameters::parse(&arguments(&["365", "0"])).is_err());
+        assert!(Parameters::parse(&arguments(&["365", "20", "7"])).is_err());
+    }
+
+    /// The sign is the whole finding, and a negative autocorrelation is a different and tradeable
+    /// answer from no autocorrelation — so it must not render bare in a column of positives.
+    #[test]
+    fn test_a_rendered_row_carries_its_sign_and_its_error() {
+        let rendered = render(&[laboratory::StabilityMeasured {
+            predictor: "persistence".to_string(),
+            statistic: STATISTIC.to_string(),
+            sessions: 498,
+            autocorrelations: vec![Autocorrelation {
+                lag: 1,
+                correlation: -0.0731,
+                standard_error: 0.0448,
+                pairs: 498,
+            }],
+            sign_agreements: vec![SignAgreement {
+                lag: 1,
+                rate: 0.5341,
+                standard_error: 0.0224,
+                pairs: 498,
+            }],
+        }]);
+
+        assert!(rendered.contains("-0.0731 ± 0.0448 (498)"), "{rendered}");
+        assert!(rendered.contains("0.5341 ± 0.0224 (498)"), "{rendered}");
+        assert!(rendered.contains("persistence"), "{rendered}");
+    }
+
+    /// A forecast that never ranked has no series to follow. Rendering that as zero would read as a
+    /// measured absence of memory rather than an absence of measurement.
+    #[test]
+    fn test_a_forecast_with_no_series_is_not_rendered_as_zero() {
+        let rendered = render(&[laboratory::StabilityMeasured {
+            predictor: "cross_sectional_mean".to_string(),
+            statistic: STATISTIC.to_string(),
+            sessions: 0,
+            autocorrelations: Vec::new(),
+            sign_agreements: Vec::new(),
+        }]);
+
+        assert!(rendered.contains("cross_sectional_mean"), "{rendered}");
+        assert!(!rendered.contains("0.0000"), "{rendered}");
+    }
+}

--- a/src/laboratory.rs
+++ b/src/laboratory.rs
@@ -9,3 +9,4 @@ pub mod information;
 pub mod journal;
 pub mod metrics;
 pub mod predictor;
+pub mod stability;

--- a/src/laboratory/journal.rs
+++ b/src/laboratory/journal.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 use crate::laboratory::dataset::DatasetFingerprint;
 use crate::laboratory::metrics::Distribution;
 use crate::laboratory::predictor::Evaluation;
+use crate::laboratory::stability::{Autocorrelation, SignAgreement};
 
 /// The shape of a laboratory record, versioned independently of the application journal.
 pub const SCHEMA_VERSION: u32 = 1;
@@ -47,6 +48,7 @@ pub enum Observation {
     DatasetBuilt(DatasetBuilt),
     ForecastScored(ForecastScored),
     FeatureTriaged(FeatureTriaged),
+    StabilityMeasured(StabilityMeasured),
 }
 
 impl Observation {
@@ -56,8 +58,23 @@ impl Observation {
             Observation::DatasetBuilt(_) => "dataset_built",
             Observation::ForecastScored(_) => "forecast_scored",
             Observation::FeatureTriaged(_) => "feature_triaged",
+            Observation::StabilityMeasured(_) => "stability_measured",
         }
     }
+}
+
+/// Whether one forecast's per-session readings carry into the sessions after them.
+///
+/// Both statistics are recorded because they answer the same question at different bluntness: a
+/// series can co-move in magnitude while its sign is a coin, and only the sign is tradeable.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct StabilityMeasured {
+    pub predictor: String,
+    /// Which per-session statistic was followed through time.
+    pub statistic: String,
+    pub sessions: usize,
+    pub autocorrelations: Vec<Autocorrelation>,
+    pub sign_agreements: Vec<SignAgreement>,
 }
 
 /// How much one feature says about the session it precedes.
@@ -309,6 +326,24 @@ mod tests {
         assert_eq!(triaged.experiment_type(), "feature_triaged");
         assert_ne!(triaged.experiment_type(), forecast.experiment_type());
         assert_ne!(triaged.experiment_type(), observation().experiment_type());
+
+        let stability = Observation::StabilityMeasured(StabilityMeasured {
+            predictor: "persistence".to_string(),
+            statistic: "information_coefficient".to_string(),
+            sessions: 498,
+            autocorrelations: Vec::new(),
+            sign_agreements: Vec::new(),
+        });
+        let value: serde_json::Value = serde_json::to_value(&stability).unwrap();
+
+        assert_eq!(
+            value["experiment_type"],
+            serde_json::json!("stability_measured")
+        );
+        assert_eq!(stability.experiment_type(), "stability_measured");
+        for other in [&forecast, &triaged, &observation()] {
+            assert_ne!(stability.experiment_type(), other.experiment_type());
+        }
     }
 
     /// Two different counts, and conflating them would read a forecast that ranked twice out of

--- a/src/laboratory/metrics.rs
+++ b/src/laboratory/metrics.rs
@@ -165,7 +165,7 @@ fn average_ranks(values: &[f64]) -> Option<Vec<f64>> {
 }
 
 /// Correlation of two equal-length series, or `None` where either cannot vary.
-fn pearson_correlation(left: &[f64], right: &[f64]) -> Option<f64> {
+pub(crate) fn pearson_correlation(left: &[f64], right: &[f64]) -> Option<f64> {
     if left.len() != right.len() || left.len() < 2 {
         return None;
     }

--- a/src/laboratory/stability.rs
+++ b/src/laboratory/stability.rs
@@ -1,0 +1,191 @@
+//! Whether a per-session reading carries into the sessions after it.
+//!
+//! The cross-sectional statistics say nothing about time; this asks whether their sign holds.
+
+use serde::Serialize;
+
+use crate::laboratory::metrics::pearson_correlation;
+
+/// Lags reported by default. Ten sessions is two trading weeks, far enough for a decay to show.
+pub const DEFAULT_LAGS: usize = 10;
+
+/// How a session's reading relates to the reading `lag` sessions later.
+///
+/// The error is taken under the null that the series has no memory, which is the hypothesis being
+/// tested — so a correlation inside twice its error is a series that forgets.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct Autocorrelation {
+    pub lag: usize,
+    pub correlation: f64,
+    pub standard_error: f64,
+    pub pairs: usize,
+}
+
+/// How often a session's reading shares a sign with the reading `lag` sessions later.
+///
+/// The error is that of a coin rather than of the observed rate, for the same reason: one half is
+/// the claim being tested.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct SignAgreement {
+    pub lag: usize,
+    pub rate: f64,
+    pub standard_error: f64,
+    pub pairs: usize,
+}
+
+/// Pairs each session's reading with the one `lag` sessions later, where both exist.
+///
+/// A session the statistic could not measure breaks the run rather than closing it: pairing across
+/// the gap would call a longer step a shorter one, which is what session contiguity already forbids
+/// on the other side of the measurement.
+fn paired_by_lag(values: &[Option<f64>], lag: usize) -> (Vec<f64>, Vec<f64>) {
+    if lag == 0 || lag >= values.len() {
+        return (Vec::new(), Vec::new());
+    }
+    values
+        .iter()
+        .zip(&values[lag..])
+        .filter_map(|(current, later)| current.zip(*later))
+        .filter(|(current, later)| current.is_finite() && later.is_finite())
+        .unzip()
+}
+
+/// Correlation between each session's reading and the reading `lag` sessions later.
+pub fn autocorrelation(values: &[Option<f64>], lag: usize) -> Option<Autocorrelation> {
+    let (current, later) = paired_by_lag(values, lag);
+    let correlation = pearson_correlation(&current, &later)?;
+    Some(Autocorrelation {
+        lag,
+        correlation,
+        standard_error: 1.0 / (current.len() as f64).sqrt(),
+        pairs: current.len(),
+    })
+}
+
+/// Share of pairs whose two readings share a sign.
+///
+/// The blunt form of the same question and the one a book acts on: above a half is a relationship
+/// that held, below is one that flipped. A reading of exactly zero points nowhere and takes its
+/// pair with it.
+pub fn sign_agreement(values: &[Option<f64>], lag: usize) -> Option<SignAgreement> {
+    let (current, later) = paired_by_lag(values, lag);
+    let agreed: Vec<bool> = current
+        .iter()
+        .zip(&later)
+        .filter(|(first, second)| **first != 0.0 && **second != 0.0)
+        .map(|(first, second)| first.is_sign_positive() == second.is_sign_positive())
+        .collect();
+    if agreed.len() < 2 {
+        return None;
+    }
+    Some(SignAgreement {
+        lag,
+        rate: agreed.iter().filter(|agreement| **agreement).count() as f64 / agreed.len() as f64,
+        standard_error: 0.5 / (agreed.len() as f64).sqrt(),
+        pairs: agreed.len(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn readings(values: impl IntoIterator<Item = f64>) -> Vec<Option<f64>> {
+        values.into_iter().map(Some).collect()
+    }
+
+    /// A series that flips every session is as far from memoryless as one that repeats — and the
+    /// difference is the sign. Reading only "is it positive" would call this nothing, when it is a
+    /// relationship a book could act on by flipping with it.
+    #[test]
+    fn test_an_alternating_series_is_measured_as_strongly_negative() {
+        let series = readings((0..200).map(|index| if index % 2 == 0 { 0.1 } else { -0.1 }));
+
+        let first = autocorrelation(&series, 1).unwrap();
+        assert!((first.correlation + 1.0).abs() < 1e-9, "{first:?}");
+        assert_eq!(sign_agreement(&series, 1).unwrap().rate, 0.0);
+
+        // And two sessions on it is back where it started.
+        let second = autocorrelation(&series, 2).unwrap();
+        assert!((second.correlation - 1.0).abs() < 1e-9, "{second:?}");
+        assert_eq!(sign_agreement(&series, 2).unwrap().rate, 1.0);
+    }
+
+    /// A relationship that holds its sign reads as a whole agreement, whatever its magnitudes do.
+    #[test]
+    fn test_a_series_that_keeps_its_sign_agrees_throughout() {
+        let series = readings((0..200).map(|index| 0.01 * ((index % 7) + 1) as f64));
+        assert_eq!(sign_agreement(&series, 1).unwrap().rate, 1.0);
+    }
+
+    /// The control the whole measurement is read against: a series with no memory must land inside
+    /// its own error, or the error is wrong and every other row is unreadable.
+    #[test]
+    fn test_a_memoryless_series_lands_inside_its_error() {
+        use rand::{rngs::StdRng, RngExt, SeedableRng};
+        let mut generator = StdRng::seed_from_u64(0x5EED);
+        let series = readings((0..2000).map(|_| generator.random::<f64>() - 0.5));
+
+        let measured = autocorrelation(&series, 1).unwrap();
+        assert!(
+            measured.correlation.abs() < 2.0 * measured.standard_error,
+            "{measured:?}"
+        );
+        let agreement = sign_agreement(&series, 1).unwrap();
+        assert!(
+            (agreement.rate - 0.5).abs() < 2.0 * agreement.standard_error,
+            "{agreement:?}"
+        );
+    }
+
+    /// A session that could not be measured is a hole, not a join. Closing it would pair readings
+    /// two sessions apart and report the answer as a one-session step.
+    #[test]
+    fn test_a_gap_is_not_paired_across() {
+        let series = vec![Some(1.0), None, Some(2.0), None, Some(3.0), None, Some(4.0)];
+        assert_eq!(autocorrelation(&series, 1), None, "no adjacent pair exists");
+
+        // Two sessions apart every pair straddles a hole, and those are real.
+        let measured = autocorrelation(&series, 2).unwrap();
+        assert_eq!(measured.pairs, 3);
+    }
+
+    /// Only the pairs that survive the holes count toward the error, or a series measured on a
+    /// third of its sessions would claim the precision of one measured throughout.
+    #[test]
+    fn test_the_error_counts_the_pairs_and_not_the_sessions() {
+        let mut series = readings((0..101).map(|index| index as f64));
+        for index in (1..101).step_by(2) {
+            series[index] = None;
+        }
+
+        let measured = autocorrelation(&series, 2).unwrap();
+        assert_eq!(measured.pairs, 50);
+        assert!(
+            (measured.standard_error - 1.0 / 50.0_f64.sqrt()).abs() < 1e-12,
+            "{measured:?}"
+        );
+    }
+
+    /// A reading of exactly zero agrees with nothing. Counting it as positive would put a thumb on
+    /// the scale in whichever direction `is_sign_positive` happens to answer.
+    #[test]
+    fn test_a_zero_reading_carries_no_sign() {
+        let series = readings([0.1, 0.0, 0.1, 0.1, 0.1]);
+        let agreement = sign_agreement(&series, 1).unwrap();
+        assert_eq!(agreement.pairs, 2, "the two pairs the zero is not in");
+        assert_eq!(agreement.rate, 1.0);
+    }
+
+    #[test]
+    fn test_an_unusable_lag_or_series_is_refused() {
+        let series = readings([0.1, 0.2, 0.3]);
+        assert_eq!(autocorrelation(&series, 0), None);
+        assert_eq!(autocorrelation(&series, 3), None);
+        assert_eq!(autocorrelation(&series, 9), None);
+        assert_eq!(sign_agreement(&series, 0), None);
+        assert_eq!(sign_agreement(&series, 3), None);
+        assert_eq!(autocorrelation(&[], 1), None);
+        assert_eq!(autocorrelation(&[Some(f64::NAN); 20], 1), None);
+    }
+}


### PR DESCRIPTION
# Overview

Task 4 showed the model's inputs carry real information about the session they precede. It could not say whether that information points the same way twice, because mutual information has no sign. This asks that question directly.

**The answer is no.** A session's directional reading says nothing about the next session's. That closes the diagnostic arc and takes task 16 off the table.

## Changes

- `laboratory::stability` — `autocorrelation` and `sign_agreement` over a per-session series at any lag. Its own module rather than `metrics`, whose documentation commits it to being cross-sectional on the grounds that pooling sessions measures time variation a neutral book cannot trade; that is precisely what this measures.
- `src/bin/laboratory_stability.rs` — scores the four baselines session by session, then follows each one's information-coefficient series through lags one to ten. `RandomRanking` runs last, as the control.
- `laboratory::journal` — a new `stability_measured` record, and `metrics::pearson_correlation` widened to `pub(crate)` so the correlation is written once rather than twice.

## Context

730 days, 499 sessions, `RandomRanking` as a row that cannot have structure:

```
predictor         lag 1 autocorrelation      lag 1 sign agreement
persistence        -0.0487 ± 0.0448 (498)    0.4980 ± 0.0224 (498)
momentum           -0.0241 ± 0.0457 (479)    0.4864 ± 0.0228 (479)
random_ranking     +0.0375 ± 0.0448 (498)    0.5040 ± 0.0224 (498)
```

Persistence's lag-1 autocorrelation is **1.1 standard errors** from zero and its sign agreement is **0.09** from a coin.

**The control is what stops the larger lags from being read as findings.** Momentum at lag 4 reads −0.1768, which is 3.9 standard errors and looks like something. But `random_ranking` at lag 8 reads −0.1349, 3.0 standard errors, and `random_ranking` draws a fresh ordering every session with no memory by construction. Across thirty correlations and thirty agreements, roughly three excursions past two standard errors are expected from nothing, and roughly three appear — one of them in the control. Never read a lag table without a memoryless row in it.

**Sign agreement is quieter than autocorrelation at every lag.** No agreement rate reaches two standard errors from a half while four correlations do. Whatever weak co-movement of magnitude those excursions reflect, it is not the sign — and only the sign is tradeable.

**Two decisions in the measurement worth stating.**

Both error bars are taken under the null rather than from the observation: `1/√pairs` for the correlation and `0.5/√pairs` for the rate. "No memory" and "a coin" are the hypotheses being tested, and an error derived from the observed value is the wrong yardstick for rejecting them.

A session the cross-section could not rank is a hole, not a join. Compacting the gaps away would pair readings two sessions apart and report the answer as a one-session step — the same error session contiguity forbids on the other side of the measurement — so `paired_by_lag` indexes the series in place and drops any pair missing either end.

**What this rules out, precisely.** Unconditional memory: the reading is not predictable from *its own past* at one to ten sessions. It does **not** rule out prediction from an observable state — volatility, dispersion, breadth. That is task 7, whose original trigger died with 3c and which now has a better one: a per-session coefficient with standard deviation near 0.16 around a mean of zero and no time memory at all is exactly the shape a state-dependent signal makes.

**Where the arc now points.** Unlearnable target refuted by #1088, contaminated data by #1081, wrong objective by #1087, and capacity ruled out here — architecture cannot rescue a target whose sign does not persist, so task 16 is not worth buying. What remains is task 7, the cheapest test of whether the reading is predictable at all, and task 17, which changes what is being forecast and is blocked on the consolidated quote feed regardless.

## Verification

- `devenv tasks run checks:rust` green, exit 0, clippy clean
- The statistic pinned against known answers: a series that flips every session returns exactly −1 at lag 1 and +1 at lag 2, one that holds its sign agrees throughout, and a seeded memoryless series lands inside its own error on both measures
- Three mutations run, each failing exactly its own test and nothing else — compacting the gaps away, computing the error off sessions rather than pairs, and counting a zero reading as a direction
- One real run against the development archive over 730 days, not fixtures; `cross_sectional_mean` correctly reports no series at all rather than a zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stability analysis for forecast session metrics, including autocorrelation and sign-agreement measurements across multiple time lags.
  * Added command-line options for configurable lookback periods and session momentum.
  * Added support for recording stability measurements in laboratory journals.
  * Added results displaying correlations, agreement rates, standard errors, and sample counts.

* **Bug Fixes**
  * Improved handling of missing, invalid, or insufficient data by reporting measurements as unavailable instead of zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->