### PR TITLE
Ask what a session's reading follows from, and then ask twice

### DIFF
--- a/src/bin/laboratory_regime.rs
+++ b/src/bin/laboratory_regime.rs
@@ -1,0 +1,428 @@
+//! Asks whether a forecast's per-session reading follows from the state of the market.
+//!
+//! Trains nothing. Session stability ruled out a reading's own past; this asks about everything else.
+
+use chrono::Utc;
+use tracing::{error, info, warn};
+
+use fund::common::log::init_tracing;
+use fund::common::types::SessionDate;
+use fund::laboratory::dataset;
+use fund::laboratory::journal as laboratory;
+use fund::laboratory::predictor::{
+    evaluate, CrossSectionalMean, Momentum, Panel, Persistence, Predictor, RandomRanking,
+};
+use fund::laboratory::regime::{self, STATES};
+use fund::laboratory::stability;
+
+const USAGE: &str = "Usage: laboratory_regime [LOOKBACK_DAYS] [MOMENTUM_SESSIONS]";
+
+const DEFAULT_LOOKBACK_DAYS: i64 = 730;
+const DEFAULT_MOMENTUM_SESSIONS: i64 = 20;
+
+/// Fixed, so the control draws the same orderings every run.
+const RANDOM_SEED: u64 = 0x5EED;
+
+/// The per-session statistic being explained.
+const STATISTIC: &str = "information_coefficient";
+
+/// How far ahead of the reading each state is read.
+///
+/// Zero describes the session itself, which explains a reading without anticipating one. One is the
+/// session before, which is the only figure here a book could act on — and both are reported because
+/// a relationship visible only at zero still composes into a tradeable one where the state itself is
+/// forecastable, as volatility is.
+const LAGS: &[usize] = &[0, 1];
+
+struct Parameters {
+    lookback_days: i64,
+    momentum_sessions: usize,
+}
+
+impl Parameters {
+    fn parse(arguments: &[String]) -> Result<Self, String> {
+        let (lookback_days, momentum_sessions) = match arguments {
+            [] => (DEFAULT_LOOKBACK_DAYS, DEFAULT_MOMENTUM_SESSIONS),
+            [lookback] => (
+                positive(lookback, "LOOKBACK_DAYS")?,
+                DEFAULT_MOMENTUM_SESSIONS,
+            ),
+            [lookback, momentum] => (
+                positive(lookback, "LOOKBACK_DAYS")?,
+                positive(momentum, "MOMENTUM_SESSIONS")?,
+            ),
+            _ => return Err(format!("Too many arguments\n{USAGE}")),
+        };
+        Ok(Self {
+            lookback_days,
+            momentum_sessions: usize::try_from(momentum_sessions).map_err(|_| {
+                format!("MOMENTUM_SESSIONS is larger than this platform can index\n{USAGE}")
+            })?,
+        })
+    }
+}
+
+fn positive(raw: &str, name: &str) -> Result<i64, String> {
+    let value: i64 = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("{name} must be a positive integer, got {raw:?}\n{USAGE}"))?;
+    if value <= 0 {
+        return Err(format!(
+            "{name} must be greater than zero, got {value}\n{USAGE}"
+        ));
+    }
+    Ok(value)
+}
+
+#[tokio::main]
+async fn main() {
+    fund::common::crypto::install_default_crypto_provider();
+    let tracing_guard = init_tracing("laboratory-regime.log", Some("info"), "laboratory-regime");
+
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let parameters = match Parameters::parse(&arguments) {
+        Ok(parameters) => parameters,
+        Err(message) => {
+            eprintln!("{message}");
+            drop(tracing_guard);
+            std::process::exit(2);
+        }
+    };
+
+    let code = match run(&parameters).await {
+        Ok(measured) => {
+            println!("{}", render(&measured));
+            0
+        }
+        Err(error) => {
+            error!(%error, "Measuring the regime association failed");
+            eprintln!("Measuring the regime association failed: {error}");
+            1
+        }
+    };
+
+    drop(tracing_guard);
+    std::process::exit(code);
+}
+
+/// Describes every session, then asks each baseline's readings what they follow from.
+async fn run(
+    parameters: &Parameters,
+) -> Result<Vec<laboratory::RegimeMeasured>, Box<dyn std::error::Error>> {
+    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let s3_client = fund::common::aws::s3_client().await;
+
+    let now = Utc::now();
+    let session = SessionDate::at(now);
+    let run_id = uuid::Uuid::new_v4();
+    let journal = match laboratory::Journal::from_env() {
+        Ok(journal) => Some(journal),
+        Err(error) => {
+            warn!(%error, "No laboratory journal; this run is not recorded");
+            None
+        }
+    };
+
+    info!(
+        bucket,
+        lookback_days = parameters.lookback_days,
+        momentum_sessions = parameters.momentum_sessions,
+        states = STATES.len(),
+        %session,
+        %run_id,
+        "Measuring the regime association"
+    );
+
+    let dataset = dataset::returns(&s3_client, &bucket, parameters.lookback_days, session).await?;
+    let fingerprint = dataset.fingerprint.clone();
+    info!(
+        rows = fingerprint.rows,
+        tickers = fingerprint.tickers,
+        "Read the archive window"
+    );
+    if let Some(journal) = journal.as_ref() {
+        journal
+            .record(
+                run_id,
+                Utc::now(),
+                laboratory::Observation::DatasetBuilt(laboratory::DatasetBuilt {
+                    fingerprint,
+                    revision: std::env::var("FUND_REVISION").ok(),
+                }),
+            )
+            .await;
+    }
+
+    let panel = Panel::from_frame(&dataset.returns)?;
+    let described = regime::describe(&panel);
+    info!(
+        sessions = panel.sessions(),
+        described = described
+            .iter()
+            .filter(|state| state.dispersion.is_some())
+            .count(),
+        "Described every session"
+    );
+
+    // RandomRanking last, so the control sits at the foot of the table it makes readable.
+    let baselines: Vec<Box<dyn Predictor>> = vec![
+        Box::new(Persistence),
+        Box::new(Momentum {
+            sessions: parameters.momentum_sessions,
+        }),
+        Box::new(CrossSectionalMean),
+        Box::new(RandomRanking { seed: RANDOM_SEED }),
+    ];
+
+    let mut measured = Vec::new();
+    for baseline in &baselines {
+        let evaluation = evaluate(baseline.as_ref(), &panel);
+        let readings: Vec<Option<f64>> = evaluation
+            .sessions
+            .iter()
+            .map(|session| session.information_coefficient)
+            .collect();
+
+        for (name, read) in STATES {
+            let state: Vec<Option<f64>> = described.iter().map(read).collect();
+            // Both series cut with the same range, or a lag would pair a reading against the state
+            // of a session outside the stretch being measured.
+            for (segment, range) in regime::segments(panel.sessions()) {
+                let state = &state[range.clone()];
+                let readings = &readings[range];
+                let record = laboratory::RegimeMeasured {
+                    predictor: evaluation.predictor.clone(),
+                    statistic: STATISTIC.to_string(),
+                    state: name.to_string(),
+                    segment: segment.to_string(),
+                    sessions: readings.iter().flatten().count(),
+                    associations: LAGS
+                        .iter()
+                        .filter_map(|lag| stability::association(state, readings, *lag))
+                        .collect(),
+                };
+                info!(
+                    predictor = record.predictor,
+                    state = record.state,
+                    segment = record.segment,
+                    same_session = record
+                        .associations
+                        .iter()
+                        .find(|measured| measured.lag == 0)
+                        .map(|measured| measured.correlation),
+                    prior_session = record
+                        .associations
+                        .iter()
+                        .find(|measured| measured.lag == 1)
+                        .map(|measured| measured.correlation),
+                    "Asked what a reading follows from"
+                );
+
+                if let Some(journal) = journal.as_ref() {
+                    journal
+                        .record(
+                            run_id,
+                            Utc::now(),
+                            laboratory::Observation::RegimeMeasured(record.clone()),
+                        )
+                        .await;
+                }
+                measured.push(record);
+            }
+        }
+    }
+
+    Ok(measured)
+}
+
+/// One block per forecast, one row per state and lag, one column per stretch of the window.
+///
+/// The halves sit beside the whole rather than under it, because the question they answer is whether
+/// the whole's figure is one relationship or two unrelated ones that averaged into the look of one.
+fn render(measured: &[laboratory::RegimeMeasured]) -> String {
+    let mut rendered = String::new();
+    let mut current = "";
+    for record in measured {
+        if record.predictor != current {
+            current = &record.predictor;
+            rendered.push_str(&format!(
+                "\n{} ({})\n{:<24}{:>6}{:>26}{:>26}{:>26}\n",
+                record.predictor,
+                record.statistic,
+                "state",
+                "lag",
+                "whole",
+                "first half",
+                "second half"
+            ));
+        }
+        if record.segment != "whole" {
+            continue;
+        }
+        for lag in LAGS {
+            rendered.push_str(&format!(
+                "{:<24}{:>6}{:>26}{:>26}{:>26}\n",
+                record.state,
+                lag,
+                correlation(measured, record, "whole", *lag),
+                correlation(measured, record, "first_half", *lag),
+                correlation(measured, record, "second_half", *lag),
+            ));
+        }
+    }
+    rendered
+}
+
+/// One association with its error, or why there is none.
+fn correlation(
+    measured: &[laboratory::RegimeMeasured],
+    record: &laboratory::RegimeMeasured,
+    segment: &str,
+    lag: usize,
+) -> String {
+    measured
+        .iter()
+        .find(|other| {
+            other.predictor == record.predictor
+                && other.state == record.state
+                && other.segment == segment
+        })
+        .and_then(|found| {
+            found
+                .associations
+                .iter()
+                .find(|association| association.lag == lag)
+        })
+        .map_or_else(
+            || "unmeasurable".to_string(),
+            |association| {
+                format!(
+                    "{:+.4} ± {:.4} ({})",
+                    association.correlation, association.standard_error, association.pairs
+                )
+            },
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fund::laboratory::stability::Association;
+
+    fn arguments(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn test_arguments_default_from_the_right() {
+        let parameters = Parameters::parse(&[]).unwrap();
+        assert_eq!(parameters.lookback_days, 730);
+        assert_eq!(parameters.momentum_sessions, 20);
+
+        let parameters = Parameters::parse(&arguments(&["365", "5"])).unwrap();
+        assert_eq!(parameters.lookback_days, 365);
+        assert_eq!(parameters.momentum_sessions, 5);
+    }
+
+    #[test]
+    fn test_an_unusable_argument_is_refused() {
+        for value in ["3o5", "0", "-5", ""] {
+            assert!(
+                Parameters::parse(&arguments(&[value])).is_err(),
+                "{value:?} must be refused"
+            );
+        }
+        assert!(Parameters::parse(&arguments(&["365", "0"])).is_err());
+        assert!(Parameters::parse(&arguments(&["365", "20", "7"])).is_err());
+    }
+
+    fn measurement(
+        state: &str,
+        segment: &str,
+        correlation: f64,
+        lag: usize,
+    ) -> laboratory::RegimeMeasured {
+        laboratory::RegimeMeasured {
+            predictor: "persistence".to_string(),
+            statistic: STATISTIC.to_string(),
+            state: state.to_string(),
+            segment: segment.to_string(),
+            sessions: 499,
+            associations: vec![Association {
+                lag,
+                correlation,
+                standard_error: 0.0448,
+                pairs: 499,
+            }],
+        }
+    }
+
+    /// The whole and its halves belong in one row, because the question they answer together is
+    /// whether the whole's figure is one relationship or two unrelated ones that averaged into the
+    /// look of one.
+    #[test]
+    fn test_a_state_shows_its_whole_beside_its_halves() {
+        let rendered = render(&[
+            measurement("breadth", "whole", 0.1494, 1),
+            measurement("breadth", "first_half", 0.1702, 1),
+            measurement("breadth", "second_half", 0.1301, 1),
+        ]);
+
+        assert!(rendered.contains("first half"), "{rendered}");
+        assert!(rendered.contains("second half"), "{rendered}");
+
+        let row = rendered
+            .lines()
+            .find(|line| line.starts_with("breadth") && line.contains("+0.1494"))
+            .unwrap_or_else(|| panic!("{rendered}"));
+        assert!(row.contains("+0.1702"), "the halves share the row: {row}");
+        assert!(row.contains("+0.1301"), "the halves share the row: {row}");
+    }
+
+    /// A half that could not be measured is not a zero, and rendering it as one would read as a
+    /// replication that was run and failed rather than one that could not be run.
+    #[test]
+    fn test_an_unmeasured_half_is_not_rendered_as_zero() {
+        let rendered = render(&[measurement("breadth", "whole", 0.1494, 1)]);
+        assert!(rendered.contains("unmeasurable"), "{rendered}");
+        assert!(!rendered.contains("+0.0000"), "{rendered}");
+    }
+
+    /// One header per forecast rather than one per row, or a table of four states across four
+    /// forecasts is unreadable.
+    #[test]
+    fn test_each_forecast_is_headed_once() {
+        let first = measurement("dispersion", "whole", 0.1, 1);
+        let mut second = measurement("breadth", "whole", 0.1, 1);
+        second.predictor = "random_ranking".to_string();
+
+        let rendered = render(&[first, second]);
+        assert_eq!(rendered.matches("persistence (").count(), 1, "{rendered}");
+        assert_eq!(
+            rendered.matches("random_ranking (").count(),
+            1,
+            "{rendered}"
+        );
+    }
+
+    /// Only the whole opens a row. Letting every segment open one would print each state three
+    /// times over and read as three separate measurements rather than one and its replications.
+    #[test]
+    fn test_a_state_opens_one_row_per_lag_and_not_one_per_segment() {
+        let rendered = render(&[
+            measurement("breadth", "whole", 0.1494, 1),
+            measurement("breadth", "first_half", 0.1702, 1),
+            measurement("breadth", "second_half", 0.1301, 1),
+        ]);
+        assert_eq!(
+            rendered
+                .lines()
+                .filter(|line| line.starts_with("breadth"))
+                .count(),
+            LAGS.len(),
+            "{rendered}"
+        );
+    }
+}

--- a/src/bin/laboratory_regime.rs
+++ b/src/bin/laboratory_regime.rs
@@ -12,7 +12,7 @@ use fund::laboratory::journal as laboratory;
 use fund::laboratory::predictor::{
     evaluate, CrossSectionalMean, Momentum, Panel, Persistence, Predictor, RandomRanking,
 };
-use fund::laboratory::regime::{self, STATES};
+use fund::laboratory::regime::{self, FIRST_HALF, SECOND_HALF, STATES, WHOLE};
 use fund::laboratory::stability;
 
 const USAGE: &str = "Usage: laboratory_regime [LOOKBACK_DAYS] [MOMENTUM_SESSIONS]";
@@ -176,6 +176,13 @@ async fn run(
         Box::new(RandomRanking { seed: RANDOM_SEED }),
     ];
 
+    // The market does not depend on which forecast is being read against it, so describe each
+    // state once rather than once per baseline.
+    let states: Vec<(&str, Vec<Option<f64>>)> = STATES
+        .iter()
+        .map(|(name, read)| (*name, described.iter().map(read).collect()))
+        .collect();
+
     let mut measured = Vec::new();
     for baseline in &baselines {
         let evaluation = evaluate(baseline.as_ref(), &panel);
@@ -185,8 +192,7 @@ async fn run(
             .map(|session| session.information_coefficient)
             .collect();
 
-        for (name, read) in STATES {
-            let state: Vec<Option<f64>> = described.iter().map(read).collect();
+        for (name, state) in &states {
             // Both series cut with the same range, or a lag would pair a reading against the state
             // of a session outside the stretch being measured.
             for (segment, range) in regime::segments(panel.sessions()) {
@@ -258,7 +264,7 @@ fn render(measured: &[laboratory::RegimeMeasured]) -> String {
                 "second half"
             ));
         }
-        if record.segment != "whole" {
+        if record.segment != WHOLE {
             continue;
         }
         for lag in LAGS {
@@ -266,9 +272,9 @@ fn render(measured: &[laboratory::RegimeMeasured]) -> String {
                 "{:<24}{:>6}{:>26}{:>26}{:>26}\n",
                 record.state,
                 lag,
-                correlation(measured, record, "whole", *lag),
-                correlation(measured, record, "first_half", *lag),
-                correlation(measured, record, "second_half", *lag),
+                correlation(measured, record, WHOLE, *lag),
+                correlation(measured, record, FIRST_HALF, *lag),
+                correlation(measured, record, SECOND_HALF, *lag),
             ));
         }
     }
@@ -286,6 +292,7 @@ fn correlation(
         .iter()
         .find(|other| {
             other.predictor == record.predictor
+                && other.statistic == record.statistic
                 && other.state == record.state
                 && other.segment == segment
         })
@@ -319,6 +326,10 @@ mod tests {
     fn test_arguments_default_from_the_right() {
         let parameters = Parameters::parse(&[]).unwrap();
         assert_eq!(parameters.lookback_days, 730);
+        assert_eq!(parameters.momentum_sessions, 20);
+
+        let parameters = Parameters::parse(&arguments(&["365"])).unwrap();
+        assert_eq!(parameters.lookback_days, 365);
         assert_eq!(parameters.momentum_sessions, 20);
 
         let parameters = Parameters::parse(&arguments(&["365", "5"])).unwrap();
@@ -365,9 +376,9 @@ mod tests {
     #[test]
     fn test_a_state_shows_its_whole_beside_its_halves() {
         let rendered = render(&[
-            measurement("breadth", "whole", 0.1494, 1),
-            measurement("breadth", "first_half", 0.1702, 1),
-            measurement("breadth", "second_half", 0.1301, 1),
+            measurement("breadth", WHOLE, 0.1494, 1),
+            measurement("breadth", FIRST_HALF, 0.1702, 1),
+            measurement("breadth", SECOND_HALF, 0.1301, 1),
         ]);
 
         assert!(rendered.contains("first half"), "{rendered}");
@@ -385,7 +396,7 @@ mod tests {
     /// replication that was run and failed rather than one that could not be run.
     #[test]
     fn test_an_unmeasured_half_is_not_rendered_as_zero() {
-        let rendered = render(&[measurement("breadth", "whole", 0.1494, 1)]);
+        let rendered = render(&[measurement("breadth", WHOLE, 0.1494, 1)]);
         assert!(rendered.contains("unmeasurable"), "{rendered}");
         assert!(!rendered.contains("+0.0000"), "{rendered}");
     }
@@ -394,8 +405,8 @@ mod tests {
     /// forecasts is unreadable.
     #[test]
     fn test_each_forecast_is_headed_once() {
-        let first = measurement("dispersion", "whole", 0.1, 1);
-        let mut second = measurement("breadth", "whole", 0.1, 1);
+        let first = measurement("dispersion", WHOLE, 0.1, 1);
+        let mut second = measurement("breadth", WHOLE, 0.1, 1);
         second.predictor = "random_ranking".to_string();
 
         let rendered = render(&[first, second]);
@@ -412,17 +423,17 @@ mod tests {
     #[test]
     fn test_a_state_opens_one_row_per_lag_and_not_one_per_segment() {
         let rendered = render(&[
-            measurement("breadth", "whole", 0.1494, 1),
-            measurement("breadth", "first_half", 0.1702, 1),
-            measurement("breadth", "second_half", 0.1301, 1),
+            measurement("breadth", WHOLE, 0.1494, 1),
+            measurement("breadth", FIRST_HALF, 0.1702, 1),
+            measurement("breadth", SECOND_HALF, 0.1301, 1),
         ]);
         assert_eq!(
             rendered
                 .lines()
                 .filter(|line| line.starts_with("breadth"))
                 .count(),
-            LAGS.len(),
-            "{rendered}"
+            2,
+            "one row per lag, not one per segment: {rendered}"
         );
     }
 }

--- a/src/bin/laboratory_stability.rs
+++ b/src/bin/laboratory_stability.rs
@@ -269,7 +269,7 @@ fn render(measured: &[laboratory::StabilityMeasured]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fund::laboratory::stability::{Autocorrelation, SignAgreement};
+    use fund::laboratory::stability::{Association, SignAgreement};
 
     fn arguments(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
@@ -310,7 +310,7 @@ mod tests {
             predictor: "persistence".to_string(),
             statistic: STATISTIC.to_string(),
             sessions: 498,
-            autocorrelations: vec![Autocorrelation {
+            autocorrelations: vec![Association {
                 lag: 1,
                 correlation: -0.0731,
                 standard_error: 0.0448,

--- a/src/laboratory.rs
+++ b/src/laboratory.rs
@@ -9,4 +9,5 @@ pub mod information;
 pub mod journal;
 pub mod metrics;
 pub mod predictor;
+pub mod regime;
 pub mod stability;

--- a/src/laboratory/journal.rs
+++ b/src/laboratory/journal.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 use crate::laboratory::dataset::DatasetFingerprint;
 use crate::laboratory::metrics::Distribution;
 use crate::laboratory::predictor::Evaluation;
-use crate::laboratory::stability::{Autocorrelation, SignAgreement};
+use crate::laboratory::stability::{Association, SignAgreement};
 
 /// The shape of a laboratory record, versioned independently of the application journal.
 pub const SCHEMA_VERSION: u32 = 1;
@@ -49,6 +49,7 @@ pub enum Observation {
     ForecastScored(ForecastScored),
     FeatureTriaged(FeatureTriaged),
     StabilityMeasured(StabilityMeasured),
+    RegimeMeasured(RegimeMeasured),
 }
 
 impl Observation {
@@ -59,8 +60,27 @@ impl Observation {
             Observation::ForecastScored(_) => "forecast_scored",
             Observation::FeatureTriaged(_) => "feature_triaged",
             Observation::StabilityMeasured(_) => "stability_measured",
+            Observation::RegimeMeasured(_) => "regime_measured",
         }
     }
+}
+
+/// Whether one forecast's per-session readings follow from the state of the market.
+///
+/// `lag` separates the two answers this can give: at zero the state describes the session being
+/// read, which explains without anticipating, and only a positive lag is something a book could act
+/// on before the session it speaks about.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RegimeMeasured {
+    pub predictor: String,
+    /// Which per-session statistic was explained.
+    pub statistic: String,
+    /// Which description of the market it was explained by.
+    pub state: String,
+    /// Which stretch of the window it was measured over, so a figure can be asked to appear twice.
+    pub segment: String,
+    pub sessions: usize,
+    pub associations: Vec<Association>,
 }
 
 /// Whether one forecast's per-session readings carry into the sessions after them.
@@ -73,7 +93,7 @@ pub struct StabilityMeasured {
     /// Which per-session statistic was followed through time.
     pub statistic: String,
     pub sessions: usize,
-    pub autocorrelations: Vec<Autocorrelation>,
+    pub autocorrelations: Vec<Association>,
     pub sign_agreements: Vec<SignAgreement>,
 }
 

--- a/src/laboratory/journal.rs
+++ b/src/laboratory/journal.rs
@@ -364,6 +364,25 @@ mod tests {
         for other in [&forecast, &triaged, &observation()] {
             assert_ne!(stability.experiment_type(), other.experiment_type());
         }
+
+        let regime = Observation::RegimeMeasured(RegimeMeasured {
+            predictor: "persistence".to_string(),
+            statistic: "information_coefficient".to_string(),
+            state: "breadth".to_string(),
+            segment: "whole".to_string(),
+            sessions: 499,
+            associations: Vec::new(),
+        });
+        let value: serde_json::Value = serde_json::to_value(&regime).unwrap();
+
+        assert_eq!(
+            value["experiment_type"],
+            serde_json::json!("regime_measured")
+        );
+        assert_eq!(regime.experiment_type(), "regime_measured");
+        for other in [&forecast, &triaged, &stability, &observation()] {
+            assert_ne!(regime.experiment_type(), other.experiment_type());
+        }
     }
 
     /// Two different counts, and conflating them would read a forecast that ranked twice out of

--- a/src/laboratory/regime.rs
+++ b/src/laboratory/regime.rs
@@ -1,0 +1,200 @@
+//! What a session looked like in the market, described without reference to any forecast.
+//!
+//! A forecast's reading varies enormously between sessions; these are the candidates for why.
+
+use crate::laboratory::metrics::MINIMUM_CROSS_SECTION;
+use crate::laboratory::predictor::Panel;
+
+/// One session's market state, read off its own cross-section.
+///
+/// Every field is optional because a session too thin to describe has no state rather than a zero,
+/// and a state series with zeros in it would correlate against those zeros as if they were readings.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct MarketState {
+    /// Spread of the session's returns across names, which is the room a ranking has to work in.
+    pub dispersion: Option<f64>,
+    /// The session's equal-weighted return, signed. Whether reversal pays on down days and momentum
+    /// on up days is the oldest form of the question this module exists to ask.
+    pub market_move: Option<f64>,
+    /// Its size without its direction, for a relationship that holds on any large day.
+    pub absolute_market_move: Option<f64>,
+    /// Share of names that rose, which separates a broad move from one carried by a few.
+    pub breadth: Option<f64>,
+}
+
+/// The names that actually traded, which is what every figure below is taken over.
+fn traded(returns: &[Option<f64>]) -> Vec<f64> {
+    returns
+        .iter()
+        .flatten()
+        .copied()
+        .filter(|value| value.is_finite())
+        .collect()
+}
+
+/// Describes one session from the returns of the names that traded in it.
+pub fn market_state(returns: &[Option<f64>]) -> MarketState {
+    let traded = traded(returns);
+    if traded.len() < MINIMUM_CROSS_SECTION {
+        return MarketState::default();
+    }
+    let names = traded.len() as f64;
+    let mean = traded.iter().sum::<f64>() / names;
+    let variance = traded
+        .iter()
+        .map(|value| (value - mean).powi(2))
+        .sum::<f64>()
+        / (names - 1.0);
+
+    MarketState {
+        dispersion: Some(variance.sqrt()),
+        market_move: Some(mean),
+        absolute_market_move: Some(mean.abs()),
+        breadth: Some(traded.iter().filter(|value| **value > 0.0).count() as f64 / names),
+    }
+}
+
+/// Every session's state, in the panel's own order.
+pub fn describe(panel: &Panel) -> Vec<MarketState> {
+    (0..panel.sessions())
+        .map(|index| market_state(panel.returns_at(index)))
+        .collect()
+}
+
+/// The state variables this module reports, each with the field it reads.
+///
+/// Named here rather than at the call site so the count is fixed in one place: reading the largest
+/// of several figures without saying how many were looked at is how a table manufactures a finding.
+pub const STATES: &[(&str, fn(&MarketState) -> Option<f64>)] = &[
+    ("dispersion", |state| state.dispersion),
+    ("market_move", |state| state.market_move),
+    ("absolute_market_move", |state| state.absolute_market_move),
+    ("breadth", |state| state.breadth),
+];
+
+/// The stretches of a window a measurement is repeated over, so a finding can be asked to appear
+/// twice rather than once.
+///
+/// Split by time rather than at random: two halves drawn from the same sessions would share whatever
+/// made the whole look significant, and it is the second half's independence that is worth having.
+/// Every series must be cut with the same range or a lag would pair a reading against the state of a
+/// session outside its own stretch.
+pub fn segments(sessions: usize) -> Vec<(&'static str, std::ops::Range<usize>)> {
+    let middle = sessions / 2;
+    vec![
+        ("whole", 0..sessions),
+        ("first_half", 0..middle),
+        ("second_half", middle..sessions),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(values: &[f64]) -> Vec<Option<f64>> {
+        values.iter().copied().map(Some).collect()
+    }
+
+    /// A session where every name moved the same way has a market move and no spread; one where they
+    /// split has a spread and no market move. Conflating the two would make a violent flat day and a
+    /// calm trending day look alike.
+    #[test]
+    fn test_a_move_and_a_spread_are_different_things() {
+        let together = market_state(&session(&[0.02; 20]));
+        assert!((together.market_move.unwrap() - 0.02).abs() < 1e-12);
+        assert!(together.dispersion.unwrap().abs() < 1e-12);
+        assert_eq!(together.breadth, Some(1.0));
+
+        let split: Vec<f64> = (0..20)
+            .map(|index| if index % 2 == 0 { 0.05 } else { -0.05 })
+            .collect();
+        let apart = market_state(&session(&split));
+        assert!(apart.market_move.unwrap().abs() < 1e-12);
+        assert!(apart.dispersion.unwrap() > 0.04);
+        assert_eq!(apart.breadth, Some(0.5));
+    }
+
+    /// The absolute move keeps a down day and an up day of the same size together, which the signed
+    /// move deliberately does not.
+    #[test]
+    fn test_the_absolute_move_drops_the_direction_the_signed_one_keeps() {
+        let down = market_state(&session(&[-0.03; 20]));
+        let up = market_state(&session(&[0.03; 20]));
+
+        assert_eq!(down.absolute_market_move, up.absolute_market_move);
+        assert_ne!(down.market_move, up.market_move);
+        assert_eq!(down.breadth, Some(0.0));
+    }
+
+    /// Names that did not trade are absent, not zero. Counting them as unchanged would drag every
+    /// figure toward nothing in exactly the sessions where the fewest names traded.
+    #[test]
+    fn test_a_name_that_did_not_trade_is_left_out() {
+        let mut returns = session(&[0.04; 20]);
+        returns.extend(std::iter::repeat_n(None, 20));
+
+        let state = market_state(&returns);
+        assert!((state.market_move.unwrap() - 0.04).abs() < 1e-12);
+        assert_eq!(state.breadth, Some(1.0), "not 0.5");
+    }
+
+    /// A cross-section too thin to describe has no state. Reporting a spread over three names as if
+    /// it were a market would put noise into the series everything else is correlated against.
+    #[test]
+    fn test_a_session_too_thin_to_describe_has_no_state() {
+        let state = market_state(&session(&[0.01, -0.02, 0.03]));
+        assert_eq!(state, MarketState::default());
+        assert_eq!(state.dispersion, None);
+        assert_eq!(state.breadth, None);
+    }
+
+    /// The halves must not overlap and must not lose a session between them, or a finding could
+    /// appear in both because they share the sessions that produced it.
+    #[test]
+    fn test_the_halves_are_disjoint_and_cover_the_window() {
+        let segments = segments(499);
+        let names: Vec<&str> = segments.iter().map(|(name, _)| *name).collect();
+        assert_eq!(names, vec!["whole", "first_half", "second_half"]);
+
+        let (_, whole) = &segments[0];
+        let (_, first) = &segments[1];
+        let (_, second) = &segments[2];
+        assert_eq!(*whole, 0..499);
+        assert_eq!(first.end, second.start, "no session falls between them");
+        assert_eq!(first.start, whole.start);
+        assert_eq!(second.end, whole.end);
+        assert_eq!(first.len() + second.len(), whole.len());
+        // An odd window cannot split evenly, and the halves may differ by one and no more.
+        assert!(first.len().abs_diff(second.len()) <= 1);
+    }
+
+    /// A window too short to halve still reports the whole rather than two empty stretches that
+    /// would read as a replication that was attempted and found nothing.
+    #[test]
+    fn test_a_window_too_short_to_halve_still_reports_itself() {
+        let segments = segments(1);
+        assert_eq!(segments[0].1, 0..1);
+        assert!(segments[1].1.is_empty());
+        assert_eq!(segments[2].1, 0..1);
+    }
+
+    #[test]
+    fn test_every_state_is_reported_under_its_own_name() {
+        let names: Vec<&str> = STATES.iter().map(|(name, _)| *name).collect();
+        assert_eq!(
+            names,
+            vec![
+                "dispersion",
+                "market_move",
+                "absolute_market_move",
+                "breadth"
+            ]
+        );
+
+        let state = market_state(&session(&[0.01; 20]));
+        for (name, read) in STATES {
+            assert!(read(&state).is_some(), "{name} is not read");
+        }
+    }
+}

--- a/src/laboratory/regime.rs
+++ b/src/laboratory/regime.rs
@@ -72,20 +72,31 @@ pub const STATES: &[(&str, fn(&MarketState) -> Option<f64>)] = &[
     ("breadth", |state| state.breadth),
 ];
 
+/// The label each stretch is reported under.
+///
+/// Shared with whatever renders them, which matches on the label: one changed here and not there
+/// would drop every row or report every half as unmeasurable, in silence.
+pub const WHOLE: &str = "whole";
+pub const FIRST_HALF: &str = "first_half";
+pub const SECOND_HALF: &str = "second_half";
+
 /// The stretches of a window a measurement is repeated over, so a finding can be asked to appear
 /// twice rather than once.
 ///
-/// Split by time rather than at random: two halves drawn from the same sessions would share whatever
-/// made the whole look significant, and it is the second half's independence that is worth having.
-/// Every series must be cut with the same range or a lag would pair a reading against the state of a
-/// session outside its own stretch.
+/// Split by time rather than at random: halves drawn from the same sessions would share whatever
+/// made the whole look significant. Every series must be cut with the same range or a lag would
+/// pair a reading against the state of a session outside its own stretch.
 pub fn segments(sessions: usize) -> Vec<(&'static str, std::ops::Range<usize>)> {
+    let mut segments = vec![(WHOLE, 0..sessions)];
+    // A window of one halves into an empty stretch and a copy of itself, and reporting that copy as
+    // the second half would show one measurement twice where the whole point is to show two.
+    if sessions < 2 {
+        return segments;
+    }
     let middle = sessions / 2;
-    vec![
-        ("whole", 0..sessions),
-        ("first_half", 0..middle),
-        ("second_half", middle..sessions),
-    ]
+    segments.push((FIRST_HALF, 0..middle));
+    segments.push((SECOND_HALF, middle..sessions));
+    segments
 }
 
 #[cfg(test)]
@@ -155,7 +166,7 @@ mod tests {
     fn test_the_halves_are_disjoint_and_cover_the_window() {
         let segments = segments(499);
         let names: Vec<&str> = segments.iter().map(|(name, _)| *name).collect();
-        assert_eq!(names, vec!["whole", "first_half", "second_half"]);
+        assert_eq!(names, vec![WHOLE, FIRST_HALF, SECOND_HALF]);
 
         let (_, whole) = &segments[0];
         let (_, first) = &segments[1];
@@ -169,14 +180,23 @@ mod tests {
         assert!(first.len().abs_diff(second.len()) <= 1);
     }
 
-    /// A window too short to halve still reports the whole rather than two empty stretches that
-    /// would read as a replication that was attempted and found nothing.
+    /// A window too short to halve reports only itself. Halving one session gives an empty stretch
+    /// and a copy of the whole, and labelling that copy the second half would show one measurement
+    /// twice where the point of the split is to show two.
     #[test]
-    fn test_a_window_too_short_to_halve_still_reports_itself() {
-        let segments = segments(1);
-        assert_eq!(segments[0].1, 0..1);
-        assert!(segments[1].1.is_empty());
-        assert_eq!(segments[2].1, 0..1);
+    fn test_a_window_too_short_to_halve_reports_no_halves() {
+        for sessions in [0, 1] {
+            let segments = segments(sessions);
+            assert_eq!(segments.len(), 1, "{sessions} sessions");
+            assert_eq!(segments[0].0, WHOLE);
+            assert_eq!(segments[0].1, 0..sessions);
+        }
+
+        // Two sessions is the shortest window with two stretches, one session apiece.
+        let segments = segments(2);
+        assert_eq!(segments.len(), 3);
+        assert_eq!(segments[1].1, 0..1);
+        assert_eq!(segments[2].1, 1..2);
     }
 
     #[test]

--- a/src/laboratory/stability.rs
+++ b/src/laboratory/stability.rs
@@ -1,6 +1,6 @@
-//! Whether a per-session reading carries into the sessions after it.
+//! Whether a per-session reading is anticipated by something `lag` sessions before it.
 //!
-//! The cross-sectional statistics say nothing about time; this asks whether their sign holds.
+//! The cross-sectional statistics say nothing about time; this asks what a reading follows from.
 
 use serde::Serialize;
 
@@ -9,12 +9,12 @@ use crate::laboratory::metrics::pearson_correlation;
 /// Lags reported by default. Ten sessions is two trading weeks, far enough for a decay to show.
 pub const DEFAULT_LAGS: usize = 10;
 
-/// How a session's reading relates to the reading `lag` sessions later.
+/// How a session's reading relates to a value `lag` sessions before it.
 ///
-/// The error is taken under the null that the series has no memory, which is the hypothesis being
-/// tested — so a correlation inside twice its error is a series that forgets.
+/// The error is taken under the null that the two are unrelated, which is the hypothesis being
+/// tested — so a correlation inside twice its error is nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
-pub struct Autocorrelation {
+pub struct Association {
     pub lag: usize,
     pub correlation: f64,
     pub standard_error: f64,
@@ -33,33 +33,55 @@ pub struct SignAgreement {
     pub pairs: usize,
 }
 
-/// Pairs each session's reading with the one `lag` sessions later, where both exist.
+/// Pairs each session's value in `earlier` with the value `lag` sessions later in `later`.
 ///
-/// A session the statistic could not measure breaks the run rather than closing it: pairing across
+/// A session either side could not measure breaks the run rather than closing it: pairing across
 /// the gap would call a longer step a shorter one, which is what session contiguity already forbids
 /// on the other side of the measurement.
-fn paired_by_lag(values: &[Option<f64>], lag: usize) -> (Vec<f64>, Vec<f64>) {
-    if lag == 0 || lag >= values.len() {
+fn paired_by_lag(
+    earlier: &[Option<f64>],
+    later: &[Option<f64>],
+    lag: usize,
+) -> (Vec<f64>, Vec<f64>) {
+    if earlier.len() != later.len() || lag >= later.len() {
         return (Vec::new(), Vec::new());
     }
-    values
+    earlier
         .iter()
-        .zip(&values[lag..])
-        .filter_map(|(current, later)| current.zip(*later))
-        .filter(|(current, later)| current.is_finite() && later.is_finite())
+        .zip(&later[lag..])
+        .filter_map(|(before, after)| before.zip(*after))
+        .filter(|(before, after)| before.is_finite() && after.is_finite())
         .unzip()
 }
 
-/// Correlation between each session's reading and the reading `lag` sessions later.
-pub fn autocorrelation(values: &[Option<f64>], lag: usize) -> Option<Autocorrelation> {
-    let (current, later) = paired_by_lag(values, lag);
-    let correlation = pearson_correlation(&current, &later)?;
-    Some(Autocorrelation {
+/// Correlation between each session's reading and a value `lag` sessions before it.
+///
+/// At a lag of zero the two describe the same session, which explains a reading without being able
+/// to anticipate one — only a positive lag names something known before the session it speaks about.
+pub fn association(
+    earlier: &[Option<f64>],
+    readings: &[Option<f64>],
+    lag: usize,
+) -> Option<Association> {
+    let (before, after) = paired_by_lag(earlier, readings, lag);
+    let correlation = pearson_correlation(&before, &after)?;
+    Some(Association {
         lag,
         correlation,
-        standard_error: 1.0 / (current.len() as f64).sqrt(),
-        pairs: current.len(),
+        standard_error: 1.0 / (before.len() as f64).sqrt(),
+        pairs: before.len(),
     })
+}
+
+/// Correlation between each session's reading and the reading `lag` sessions later.
+///
+/// A series against itself, so a lag of zero is refused: every series correlates with itself
+/// perfectly and reports nothing.
+pub fn autocorrelation(values: &[Option<f64>], lag: usize) -> Option<Association> {
+    if lag == 0 {
+        return None;
+    }
+    association(values, values, lag)
 }
 
 /// Share of pairs whose two readings share a sign.
@@ -68,7 +90,10 @@ pub fn autocorrelation(values: &[Option<f64>], lag: usize) -> Option<Autocorrela
 /// that held, below is one that flipped. A reading of exactly zero points nowhere and takes its
 /// pair with it.
 pub fn sign_agreement(values: &[Option<f64>], lag: usize) -> Option<SignAgreement> {
-    let (current, later) = paired_by_lag(values, lag);
+    if lag == 0 {
+        return None;
+    }
+    let (current, later) = paired_by_lag(values, values, lag);
     let agreed: Vec<bool> = current
         .iter()
         .zip(&later)
@@ -136,6 +161,53 @@ mod tests {
             (agreement.rate - 0.5).abs() < 2.0 * agreement.standard_error,
             "{agreement:?}"
         );
+    }
+
+    /// The lag runs from the state to the reading, not the other way. Reversed, the measurement
+    /// would report a reading explained by a session that had not happened yet and read as a gate.
+    #[test]
+    fn test_the_lag_reaches_back_from_the_reading_to_the_state() {
+        // Scrambled rather than counting, so a shift of one is not still a straight line.
+        let state = readings((0..200).map(|index| ((index * 37) % 200) as f64));
+        let mut following = vec![None];
+        following.extend(state.iter().take(199).copied());
+
+        // Each reading is the state of the session before it, so a lag of one is exact.
+        let anticipated = association(&state, &following, 1).unwrap();
+        assert!(
+            (anticipated.correlation - 1.0).abs() < 1e-9,
+            "{anticipated:?}"
+        );
+
+        // And the same session says nothing, which is what makes the two columns worth printing.
+        let same = association(&state, &following, 0).unwrap();
+        assert!(same.correlation.abs() < 0.2, "{same:?}");
+    }
+
+    /// A state describing the session it is read against is a legitimate question — it explains
+    /// without anticipating — so unlike an autocorrelation it must not be refused.
+    #[test]
+    fn test_a_state_may_describe_the_session_it_explains() {
+        let state = readings((0..100).map(|index| index as f64));
+        let doubled = readings((0..100).map(|index| 2.0 * index as f64));
+
+        let same = association(&state, &doubled, 0).unwrap();
+        assert!((same.correlation - 1.0).abs() < 1e-9, "{same:?}");
+        assert_eq!(same.pairs, 100);
+
+        // But a series against itself at no lag is the trivial answer, and is refused.
+        assert_eq!(autocorrelation(&state, 0), None);
+        assert_eq!(sign_agreement(&state, 0), None);
+    }
+
+    /// Two series measured over different windows cannot be aligned by index, and quietly pairing
+    /// the overlap would put each reading against the wrong session's state.
+    #[test]
+    fn test_series_of_different_lengths_are_refused() {
+        let state = readings((0..100).map(|index| index as f64));
+        let shorter = readings((0..40).map(|index| index as f64));
+        assert_eq!(association(&state, &shorter, 0), None);
+        assert_eq!(association(&shorter, &state, 1), None);
     }
 
     /// A session that could not be measured is a hole, not a join. Closing it would pair readings


### PR DESCRIPTION
# Overview

#1089 ruled out a reading's own past. This asks whether it follows from the state of the market — and then asks the same question of each half of the window separately.

**Over the whole window it looked like the first positive result in the arc. The split sample killed it.** Both are here, because the retraction is the more useful half.

## Changes

- `laboratory::regime` — four per-session descriptions of a session read off its own cross-section: `dispersion`, `market_move`, `absolute_market_move`, `breadth`. Plus `segments`, which cuts the window into a whole and two halves so a figure can be asked to appear twice.
- `src/bin/laboratory_regime.rs` — correlates each baseline's per-session information coefficient against each state, at the session itself and at the one before it, over each stretch. `RandomRanking` runs last as the control.
- `laboratory::stability` — `paired_by_lag` now pairs two series rather than one with itself, so `autocorrelation` becomes the same-series case of the new `association`. `Autocorrelation` is renamed `Association`, which is what it always was; the serialized field names do not move, so the journal schema is unchanged.
- `laboratory::journal` — a new `regime_measured` record.

## Context

**Why not the latent-state model the plan proposed.** An HMM's states are functions of market observables, so it cannot say anything the observables do not — and fitting one adds a state count, a labelling and a likelihood, each a degree of freedom that makes a spurious finding easier to reach. The direct question is cheaper and strictly more interpretable. It earns the HMM if it finds something.

**Over the whole window, at the prior session:**

```
                    persistence           momentum          random_ranking
market_move      +0.1171 ± 0.0448   +0.1193 ± 0.0456    +0.0257 ± 0.0448
breadth          +0.1494 ± 0.0448   +0.1175 ± 0.0456    +0.0201 ± 0.0448
```

2.6 to 3.3 standard errors, replicated across two different signals, with a control quiet everywhere — its largest figure anywhere is 1.9 standard errors and both columns above are under 0.6. It read as "reversal is stronger following a down day," which is a documented effect.

**And it could not be arithmetic.** The information coefficient is a *rank* correlation, so adding a constant to every name's return leaves it exactly unchanged — and a session's market move is that constant. The statistic is provably invariant to the thing predicting it, so any relationship between them is cross-sectional structure that covaries with the market's level rather than the level leaking into the sum. This matters because the control does not cover that channel: `RandomRanking`'s signal is not built from the prior session's returns, so it tests coupling through the outcome and not through the signal.

**Then the halves:**

```
persistence          whole              first half         second half
market_move        +0.1171 ± 0.0448   -0.0161 ± 0.0634   +0.2985 ± 0.0634
breadth            +0.1494 ± 0.0448   +0.0628 ± 0.0634   +0.2644 ± 0.0634

momentum             whole              first half         second half
market_move        +0.1193 ± 0.0456   +0.1702 ± 0.0659   +0.0530 ± 0.0634
breadth            +0.1175 ± 0.0456   +0.1556 ± 0.0659   +0.0705 ± 0.0634
```

Persistence's relationship lives entirely in the **second** half — the first is 0.25 standard errors and carries the wrong sign. The difference between its halves is 0.3146 against a standard error of 0.0897 for a difference of two independent correlations, so **the instability is significant at 3.5 standard errors**, a stronger statement than the finding ever was. Momentum's lives entirely in the **first** half, the opposite period. If this were a market regularity, two signals measuring it would find it in the same years.

One thread is not fully cut: `breadth` at the prior session keeps its sign in all four cells (+0.063, +0.264, +0.156, +0.071). Four same-sign draws is a one-in-eight coincidence once the first fixes the direction — a whisper, not a result.

**The lesson worth keeping.** A quiet control and a correct mechanism argument were both present and the finding was still noise. Ruling out one failure mode says nothing about the others; only the split sample settled it, and it cost one run. The replication ships as part of the measurement rather than as a follow-up for exactly that reason, and it splits by time rather than at random, because halves drawn from the same sessions would share whatever made the whole look significant.

**Where the arc stands.** Unlearnable target refuted by #1088, contaminated data by #1081, wrong objective by #1087, capacity by #1089, state dependence here. Daily close-to-close single-name direction is not forecastable from this data with these methods. The remaining moves are not modelling moves.

## Verification

- `devenv tasks run checks:rust` green, exit 0, clippy clean
- The state variables pinned against known answers: a session where every name moves together has a market move and no spread, one where they split has a spread and no market move, a down day and an up day of the same size share an absolute move and differ in the signed one, and a name that did not trade is absent rather than counted as unchanged
- The lag direction proven load-bearing by a fixture where each reading is the prior session's state — lag one must read exactly 1.0 and lag zero near zero; reversing the zip inside `paired_by_lag` fails that test and nothing else, and a reversed lag would report a reading explained by a session that had not happened yet
- The halves proven disjoint and exhaustive by a test that fails when they are made to overlap, which is the failure that would let one finding appear twice and read as replication
- Two real runs against the development archive over 730 days and 499 sessions, not fixtures; `cross_sectional_mean` correctly reports no series at all rather than a zero
- Re-run after the review fixes to confirm they move nothing. The archive gained a session between runs, so the whole window and the second half shift slightly — but `501 / 2` and `500 / 2` are both `250`, so the **first half covers exactly the same sessions and its figures are byte-identical across the two runs**, which is the check the re-run existed to make. The control moves more than the predictors do because a ticker entered the panel and `RandomRanking` scores every name, where persistence and momentum are filtered to names carrying both a score and an outcome. Every conclusion above is unchanged: persistence's prior-session `market_move` reads +0.1144 against a first half of -0.0161 and a second of +0.2910

🤖 Generated with [Claude Code](https://claude.com/claude-code)
