### PR TITLE
Ask whether a dislocated spread actually closes

### DIFF
--- a/src/bin/laboratory_convergence.rs
+++ b/src/bin/laboratory_convergence.rs
@@ -1,0 +1,406 @@
+//! Asks whether a dislocated spread closes, which is the premise the pair book rests on.
+//!
+//! Trains nothing and consults no model: convergence is a fact about prices, not a forecast.
+
+use chrono::Utc;
+use tracing::{error, info, warn};
+
+use fund::common::log::init_tracing;
+use fund::common::types::SessionDate;
+use fund::laboratory::convergence::{self, Closes, Entry, Selection, HORIZONS};
+use fund::laboratory::dataset;
+use fund::laboratory::journal as laboratory;
+use fund::laboratory::regime::segments;
+
+const USAGE: &str = "Usage: laboratory_convergence [LOOKBACK_DAYS] [UNIVERSE_SIZE]";
+
+const DEFAULT_LOOKBACK_DAYS: i64 = 730;
+
+/// Names drawn from the archive's universe.
+///
+/// Pair enumeration is quadratic per session, so this is the knob that decides whether the run
+/// takes minutes or hours. Two hundred names is ~19,900 pairs against the full universe's 660,000.
+const DEFAULT_UNIVERSE_SIZE: i64 = 200;
+
+/// Fixed, so the sample is the same universe every run and two runs are comparable.
+const RANDOM_SEED: u64 = 0x5EED;
+
+/// The control runs second, so it sits under the arm it is there to make readable.
+const SELECTIONS: &[Selection] = &[Selection::Screened, Selection::Unscreened];
+
+struct Parameters {
+    lookback_days: i64,
+    universe_size: usize,
+}
+
+impl Parameters {
+    fn parse(arguments: &[String]) -> Result<Self, String> {
+        let (lookback_days, universe_size) = match arguments {
+            [] => (DEFAULT_LOOKBACK_DAYS, DEFAULT_UNIVERSE_SIZE),
+            [lookback] => (positive(lookback, "LOOKBACK_DAYS")?, DEFAULT_UNIVERSE_SIZE),
+            [lookback, universe] => (
+                positive(lookback, "LOOKBACK_DAYS")?,
+                positive(universe, "UNIVERSE_SIZE")?,
+            ),
+            _ => return Err(format!("Too many arguments\n{USAGE}")),
+        };
+        Ok(Self {
+            lookback_days,
+            universe_size: usize::try_from(universe_size).map_err(|_| {
+                format!("UNIVERSE_SIZE is larger than this platform can index\n{USAGE}")
+            })?,
+        })
+    }
+}
+
+fn positive(raw: &str, name: &str) -> Result<i64, String> {
+    let value: i64 = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("{name} must be a positive integer, got {raw:?}\n{USAGE}"))?;
+    if value <= 0 {
+        return Err(format!(
+            "{name} must be greater than zero, got {value}\n{USAGE}"
+        ));
+    }
+    Ok(value)
+}
+
+#[tokio::main]
+async fn main() {
+    fund::common::crypto::install_default_crypto_provider();
+    let tracing_guard = init_tracing(
+        "laboratory-convergence.log",
+        Some("info"),
+        "laboratory-convergence",
+    );
+
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let parameters = match Parameters::parse(&arguments) {
+        Ok(parameters) => parameters,
+        Err(message) => {
+            eprintln!("{message}");
+            drop(tracing_guard);
+            std::process::exit(2);
+        }
+    };
+
+    let code = match run(&parameters).await {
+        Ok(measured) => {
+            println!("{}", render(&measured));
+            0
+        }
+        Err(error) => {
+            error!(%error, "Measuring spread convergence failed");
+            eprintln!("Measuring spread convergence failed: {error}");
+            1
+        }
+    };
+
+    drop(tracing_guard);
+    std::process::exit(code);
+}
+
+/// Opens every entry the screen's price tests admit, follows each forward, and splits the result.
+async fn run(
+    parameters: &Parameters,
+) -> Result<Vec<laboratory::ConvergenceMeasured>, Box<dyn std::error::Error>> {
+    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let s3_client = fund::common::aws::s3_client().await;
+
+    let session = SessionDate::at(Utc::now());
+    let run_id = uuid::Uuid::new_v4();
+    let journal = match laboratory::Journal::from_env() {
+        Ok(journal) => Some(journal),
+        Err(error) => {
+            warn!(%error, "No laboratory journal; this run is not recorded");
+            None
+        }
+    };
+
+    info!(
+        bucket,
+        lookback_days = parameters.lookback_days,
+        universe_size = parameters.universe_size,
+        horizons = HORIZONS,
+        %session,
+        %run_id,
+        "Measuring spread convergence"
+    );
+
+    let dataset = dataset::returns(&s3_client, &bucket, parameters.lookback_days, session).await?;
+    let fingerprint = dataset.fingerprint.clone();
+    info!(
+        rows = fingerprint.rows,
+        tickers = fingerprint.tickers,
+        "Read the archive window"
+    );
+    if let Some(journal) = journal.as_ref() {
+        journal
+            .record(
+                run_id,
+                Utc::now(),
+                laboratory::Observation::DatasetBuilt(laboratory::DatasetBuilt {
+                    fingerprint,
+                    revision: std::env::var("FUND_REVISION").ok(),
+                }),
+            )
+            .await;
+    }
+
+    let closes = Closes::from_frame(&dataset.returns)?;
+    let universe = convergence::sample_universe(&closes, parameters.universe_size, RANDOM_SEED);
+    info!(
+        sessions = closes.sessions(),
+        universe = universe.len(),
+        pairs = universe.len() * universe.len().saturating_sub(1) / 2,
+        "Sampled the universe"
+    );
+
+    let mut measured = Vec::new();
+    for selection in SELECTIONS {
+        // Every session once, then split by where each entry opened. Splitting first would enumerate
+        // the same pairs twice over, and enumeration is the whole cost of the run.
+        let mut entries: Vec<Entry> = Vec::new();
+        for index in 0..closes.sessions() {
+            entries.extend(convergence::entries_at(
+                &closes, &universe, index, *selection,
+            ));
+        }
+        let admitted = entries.len();
+        let entries = convergence::without_reentry(entries);
+        info!(
+            selection = selection.as_str(),
+            admitted,
+            entries = entries.len(),
+            "Opened every entry the price tests admit, once per episode"
+        );
+
+        for (segment, range) in segments(closes.sessions()) {
+            let within: Vec<Entry> = entries
+                .iter()
+                .filter(|entry| range.contains(&entry.session))
+                .cloned()
+                .collect();
+            let record = laboratory::ConvergenceMeasured {
+                selection: selection.as_str().to_string(),
+                segment: segment.to_string(),
+                sessions: range.len(),
+                universe: universe.len(),
+                entries: within.len(),
+                median_sessions_to_convergence: convergence::median_sessions_to_convergence(
+                    &within,
+                ),
+                mean_entry_z_score: convergence::mean_entry_z_score(&within),
+                curves: convergence::curves(&within),
+            };
+            info!(
+                selection = record.selection,
+                segment = record.segment,
+                entries = record.entries,
+                median = record.median_sessions_to_convergence,
+                converged_at_five = record.curves.get(4).map(|curve| curve.converged),
+                converged_at_twenty = record.curves.last().map(|curve| curve.converged),
+                "Followed a cohort forward"
+            );
+
+            if let Some(journal) = journal.as_ref() {
+                journal
+                    .record(
+                        run_id,
+                        Utc::now(),
+                        laboratory::Observation::ConvergenceMeasured(record.clone()),
+                    )
+                    .await;
+            }
+            measured.push(record);
+        }
+    }
+
+    Ok(measured)
+}
+
+/// One block per stretch of the window, with the control beside the screened arm rather than under it.
+///
+/// Side by side because the only readable quantity is the difference: regression to the mean lands
+/// on both arms, so a screened share means nothing until the control's share sits next to it.
+fn render(measured: &[laboratory::ConvergenceMeasured]) -> String {
+    let mut rendered = String::new();
+    // In the order the run produced them, so the block order is the measurement's rather than a
+    // second list here that can drift from it.
+    let mut seen: Vec<&str> = Vec::new();
+    for record in measured {
+        if !seen.contains(&record.segment.as_str()) {
+            seen.push(&record.segment);
+        }
+    }
+
+    for segment in seen {
+        let arms: Vec<&laboratory::ConvergenceMeasured> = measured
+            .iter()
+            .filter(|record| record.segment == segment)
+            .collect();
+
+        rendered.push_str(&format!("\n{segment}\n"));
+        for arm in &arms {
+            rendered.push_str(&format!(
+                "  {:<12} {} entries, entered at z {}, median {} sessions to convergence\n",
+                arm.selection,
+                arm.entries,
+                arm.mean_entry_z_score
+                    .map_or_else(|| "unmeasured".to_string(), |mean| format!("{mean:.3}")),
+                arm.median_sessions_to_convergence
+                    .map_or_else(|| "no".to_string(), |median| format!("{median:.1}"))
+            ));
+        }
+
+        rendered.push_str(&format!("{:>8}", "horizon"));
+        for arm in &arms {
+            rendered.push_str(&format!("{:>34}", arm.selection));
+        }
+        rendered.push('\n');
+        rendered.push_str(&format!("{:>8}", ""));
+        for _ in &arms {
+            rendered.push_str(&format!(
+                "{:>9}{:>9}{:>9}{:>7}",
+                "converged", "stopped", "open", "n"
+            ));
+        }
+        rendered.push('\n');
+
+        for horizon in 1..=HORIZONS {
+            rendered.push_str(&format!("{horizon:>8}"));
+            for arm in &arms {
+                match arm.curves.iter().find(|curve| curve.horizon == horizon) {
+                    Some(curve) => rendered.push_str(&format!(
+                        "{:>9.4}{:>9.4}{:>9.4}{:>7}",
+                        curve.converged, curve.stopped, curve.open, curve.entries
+                    )),
+                    // A horizon nothing reached is absent, not a row of zeros: zeros read as a
+                    // cohort that was followed and did nothing.
+                    None => rendered.push_str(&format!("{:>34}", "unmeasured")),
+                }
+            }
+            rendered.push('\n');
+        }
+    }
+    rendered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fund::laboratory::convergence::Curve;
+
+    fn arguments(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn test_arguments_default_from_the_right() {
+        let parameters = Parameters::parse(&[]).unwrap();
+        assert_eq!(parameters.lookback_days, 730);
+        assert_eq!(parameters.universe_size, 200);
+
+        let parameters = Parameters::parse(&arguments(&["365"])).unwrap();
+        assert_eq!(parameters.lookback_days, 365);
+        assert_eq!(parameters.universe_size, 200);
+
+        let parameters = Parameters::parse(&arguments(&["365", "50"])).unwrap();
+        assert_eq!(parameters.lookback_days, 365);
+        assert_eq!(parameters.universe_size, 50);
+    }
+
+    #[test]
+    fn test_an_unusable_argument_is_refused() {
+        for value in ["3o5", "0", "-5", ""] {
+            assert!(
+                Parameters::parse(&arguments(&[value])).is_err(),
+                "{value:?} must be refused"
+            );
+        }
+        assert!(Parameters::parse(&arguments(&["365", "0"])).is_err());
+        assert!(Parameters::parse(&arguments(&["365", "200", "7"])).is_err());
+    }
+
+    fn measurement(
+        selection: &str,
+        segment: &str,
+        converged: f64,
+    ) -> laboratory::ConvergenceMeasured {
+        laboratory::ConvergenceMeasured {
+            selection: selection.to_string(),
+            segment: segment.to_string(),
+            sessions: 499,
+            universe: 200,
+            entries: 1_284,
+            median_sessions_to_convergence: Some(4.0),
+            mean_entry_z_score: Some(2.61),
+            curves: (1..=HORIZONS)
+                .map(|horizon| Curve {
+                    horizon,
+                    converged,
+                    stopped: 0.1,
+                    open: 0.9 - converged,
+                    entries: 1_284,
+                })
+                .collect(),
+        }
+    }
+
+    /// The control belongs on the same row as the arm it controls. Regression to the mean lands on
+    /// both, so a screened share printed alone reads as a result when it may be arithmetic.
+    #[test]
+    fn test_an_arm_and_its_control_share_a_row() {
+        let rendered = render(&[
+            measurement("screened", "whole", 0.42),
+            measurement("unscreened", "whole", 0.37),
+        ]);
+
+        let row = rendered
+            .lines()
+            .find(|line| line.trim_start().starts_with("5 "))
+            .unwrap_or_else(|| panic!("{rendered}"));
+        assert!(row.contains("0.4200"), "{row}");
+        assert!(row.contains("0.3700"), "the control shares the row: {row}");
+    }
+
+    /// Each stretch of the window is its own block, or the replication reads as more of the same
+    /// measurement rather than as a check on it.
+    #[test]
+    fn test_each_stretch_is_its_own_block() {
+        let rendered = render(&[
+            measurement("screened", "whole", 0.42),
+            measurement("screened", "first_half", 0.11),
+            measurement("screened", "second_half", 0.73),
+        ]);
+
+        for segment in ["whole", "first_half", "second_half"] {
+            assert_eq!(
+                rendered.matches(segment).count(),
+                1,
+                "{segment} heads exactly one block: {rendered}"
+            );
+        }
+        assert!(
+            rendered.contains("0.1100") && rendered.contains("0.7300"),
+            "{rendered}"
+        );
+    }
+
+    /// A cohort that never converged reports no median rather than a zero, which would read as
+    /// convergence on the entry session itself.
+    #[test]
+    fn test_a_cohort_that_never_converged_has_no_median() {
+        let mut record = measurement("screened", "whole", 0.0);
+        record.median_sessions_to_convergence = None;
+
+        let rendered = render(&[record]);
+        assert!(
+            rendered.contains("no sessions to convergence"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("0.0 sessions"), "{rendered}");
+    }
+}

--- a/src/bin/laboratory_convergence.rs
+++ b/src/bin/laboratory_convergence.rs
@@ -272,14 +272,14 @@ fn render(measured: &[laboratory::ConvergenceMeasured]) -> String {
         for horizon in 1..=HORIZONS {
             rendered.push_str(&format!("{horizon:>8}"));
             for arm in &arms {
+                // A horizon no entry was priced at prints as absent rather than as three zeros,
+                // which would read as a cohort that was followed and did nothing.
                 match arm.curves.iter().find(|curve| curve.horizon == horizon) {
-                    Some(curve) => rendered.push_str(&format!(
+                    Some(curve) if curve.entries > 0 => rendered.push_str(&format!(
                         "{:>9.4}{:>9.4}{:>9.4}{:>7}",
                         curve.converged, curve.stopped, curve.open, curve.entries
                     )),
-                    // A horizon nothing reached is absent, not a row of zeros: zeros read as a
-                    // cohort that was followed and did nothing.
-                    None => rendered.push_str(&format!("{:>34}", "unmeasured")),
+                    Some(_) | None => rendered.push_str(&format!("{:>34}", "unmeasured")),
                 }
             }
             rendered.push('\n');
@@ -387,6 +387,22 @@ mod tests {
             rendered.contains("0.1100") && rendered.contains("0.7300"),
             "{rendered}"
         );
+    }
+
+    /// A horizon no entry was priced at prints as absent, not as three zeros — which would read as
+    /// a cohort that was followed and stayed open rather than one that could not be read.
+    #[test]
+    fn test_a_horizon_with_no_entries_is_not_rendered_as_zero() {
+        let mut record = measurement("screened", "whole", 0.42);
+        record.curves[4].entries = 0;
+
+        let rendered = render(&[record]);
+        let row = rendered
+            .lines()
+            .find(|line| line.trim_start().starts_with("5 "))
+            .unwrap_or_else(|| panic!("{rendered}"));
+        assert!(row.contains("unmeasured"), "{row}");
+        assert!(!row.contains("0.0000"), "{row}");
     }
 
     /// A cohort that never converged reports no median rather than a zero, which would read as

--- a/src/laboratory.rs
+++ b/src/laboratory.rs
@@ -2,6 +2,7 @@
 //!
 //! Everything here reads the archive and writes its own journal. Nothing here decides a trade.
 
+pub mod convergence;
 pub mod dataset;
 pub mod export;
 pub mod forecast;

--- a/src/laboratory/convergence.rs
+++ b/src/laboratory/convergence.rs
@@ -160,11 +160,8 @@ pub const HORIZONS: usize = 20;
 
 /// How a pair is admitted, which is the whole of the control.
 ///
-/// The two differ in one test and share everything else — the same fit window, the same entry
-/// threshold, the same fixed model, the same forward walk. An extreme z is extreme partly because
-/// the mean and dispersion it is measured against were *estimated* on sixty sessions, so it is less
-/// extreme next session under a pure random walk. That regression to the mean is arithmetic rather
-/// than economics and it lands on both arms equally, which is what makes the difference readable.
+/// The two differ in one test and share everything else, so the regression to the mean that an
+/// estimated dispersion produces lands on both equally. That is what makes the difference readable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Selection {
     /// The screen's band on log-return correlation, which is what makes two names a pair.
@@ -196,11 +193,42 @@ pub enum Resolution {
     Unresolved,
 }
 
+/// Which forward horizons an entry could be priced at, one bit per horizon.
+///
+/// A horizon neither leg traded in is *unobserved* rather than open: the position existed, but a
+/// session with no price cannot say whether it had already terminated. A single count of horizons
+/// reached would carry across such a gap and report it as an entry seen still open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Observed(u32);
+
+impl Observed {
+    const _FITS: () = assert!(HORIZONS <= u32::BITS as usize);
+
+    fn mark(&mut self, horizon: usize) {
+        if (1..=HORIZONS).contains(&horizon) {
+            self.0 |= 1 << (horizon - 1);
+        }
+    }
+
+    /// Whether this entry was priced at `horizon`.
+    pub fn contains(self, horizon: usize) -> bool {
+        (1..=HORIZONS).contains(&horizon) && self.0 & (1 << (horizon - 1)) != 0
+    }
+
+    /// The furthest horizon priced, which is how long the pair was occupied.
+    pub fn last(self) -> usize {
+        u32::BITS.saturating_sub(self.0.leading_zeros()) as usize
+    }
+
+    pub fn count(self) -> usize {
+        self.0.count_ones() as usize
+    }
+}
+
 /// One pair opened at one session, and what became of it.
 ///
-/// `observed` is the last horizon both legs could be priced at, and it is what separates an entry
-/// that survived twenty sessions without resolving from one the archive ran out under. Folding the
-/// second into the first would report a truncated entry as a pair that failed to converge.
+/// `observed` separates an entry that survived twenty sessions without resolving from one the
+/// archive ran out under, and from one whose legs stopped printing partway.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Entry {
     pub session: usize,
@@ -208,17 +236,17 @@ pub struct Entry {
     pub short: String,
     pub entry_z_score: f64,
     pub resolution: Resolution,
-    pub observed: usize,
+    pub observed: Observed,
 }
 
 impl Entry {
-    /// Where this entry stands at `horizon`, or `None` if it was never followed that far.
+    /// Where this entry stands at `horizon`, or `None` if it could not be read there.
     fn at(&self, horizon: usize) -> Option<Resolution> {
         match self.resolution {
             Resolution::Converged(step) | Resolution::Stopped(step) if step <= horizon => {
                 Some(self.resolution)
             }
-            _ if self.observed >= horizon => Some(Resolution::Unresolved),
+            _ if self.observed.contains(horizon) => Some(Resolution::Unresolved),
             _ => None,
         }
     }
@@ -240,9 +268,8 @@ pub struct Curve {
 /// Every entry `session` admits under `selection`, each followed forward until it resolves.
 ///
 /// The fit window ends at the session *before* the one entry is judged at, mirroring production,
-/// where the window is closed daily bars and the observation is a live price. Scoring an
-/// observation against a distribution it belongs to bounds the z-score by the sample size, and a
-/// bounded z cannot reach the threshold it is compared against.
+/// where the window is closed daily bars and the observation is a live price. A window containing
+/// the observation inflates its own dispersion by the very move being scored.
 pub fn entries_at(
     closes: &Closes,
     universe: &[&str],
@@ -338,7 +365,7 @@ fn follow(
     session: usize,
     entry_z_score: f64,
 ) -> Entry {
-    let mut observed = 0;
+    let mut observed = Observed::default();
     let mut resolution = Resolution::Unresolved;
 
     for step in 1..=HORIZONS {
@@ -346,8 +373,9 @@ fn follow(
         if index >= closes.sessions() {
             break;
         }
-        // A leg that did not trade leaves this horizon unobserved and the walk continues: the
-        // horizon counts sessions elapsed, which a missing bar does not change.
+        // A leg that did not trade leaves this horizon unmarked and the walk continues: the horizon
+        // counts sessions elapsed, which a missing bar does not change, but nothing can be read off
+        // a session with no price.
         let (Some(long_price), Some(short_price)) =
             (closes.close_at(long, index), closes.close_at(short, index))
         else {
@@ -356,7 +384,7 @@ fn follow(
         let Some(z_score) = model.z_score(long_price, short_price) else {
             continue;
         };
-        observed = step;
+        observed.mark(step);
 
         match exit_reason(z_score, entry_z_score) {
             Some(CloseReason::Convergence) => {
@@ -391,13 +419,9 @@ fn breaks(window: &[f64]) -> bool {
 
 /// Drops every entry taken on a pair that was already open, which production cannot take.
 ///
-/// A spread stays dislocated for days, so the same episode is admitted on each of them and ten
-/// correlated outcomes read as ten independent ones. [`crate::portfolio::screen::select_disjoint`]
-/// excludes every held ticker, so the book opens an episode once.
-///
-/// Per pair rather than per ticker, which is the weaker of the two guarantees production gives.
-/// Matching the stronger one means simulating the book's ranking and its position limit, which is a
-/// replay and not a measurement of prices.
+/// A spread stays dislocated for days, so without this one episode is admitted on each of them and
+/// ten correlated outcomes read as ten independent ones. Keyed per pair rather than per ticker,
+/// which is the weaker of the two guarantees [`crate::portfolio::screen::select_disjoint`] gives.
 pub fn without_reentry(mut entries: Vec<Entry>) -> Vec<Entry> {
     entries.sort_by(|left, right| {
         left.session
@@ -427,7 +451,7 @@ pub fn without_reentry(mut entries: Vec<Entry>) -> Vec<Entry> {
         let until = entry.session
             + match entry.resolution {
                 Resolution::Converged(step) | Resolution::Stopped(step) => step,
-                Resolution::Unresolved => entry.observed,
+                Resolution::Unresolved => entry.observed.last(),
             };
         held_through.insert(pair, until);
         kept.push(entry);
@@ -466,10 +490,9 @@ pub fn curves(entries: &[Entry]) -> Vec<Curve> {
 
 /// The average z-score entries were opened at, which is what a convergence is worth.
 ///
-/// The curves count outcomes and the two outcomes are not the same size: converging travels the
-/// whole way back to the mean, and stopping travels
-/// [`crate::portfolio::screen::STOP_LOSS_WIDENING`]. Without this the shares cannot be turned into
-/// a statement about money in either direction.
+/// Converging travels the whole way back to the mean and stopping travels
+/// [`crate::portfolio::screen::STOP_LOSS_WIDENING`], so without this the shares cannot be turned
+/// into a statement about money in either direction.
 pub fn mean_entry_z_score(entries: &[Entry]) -> Option<f64> {
     if entries.is_empty() {
         return None;
@@ -630,10 +653,9 @@ mod tests {
 
     /// A pair whose spread path is written directly rather than inferred from two price series.
     ///
-    /// `AAA` is a common factor and `BBB` is that factor plus `spread`, so the fitted spread *is*
-    /// `spread` up to a constant and a dislocation can be placed at a chosen number of standard
-    /// deviations. `direction` flips `BBB`'s exposure to the factor, which is how an anti-correlated
-    /// pair is built without disturbing the spread.
+    /// `AAA` is a common factor and `BBB` is that factor plus `spread`, so a dislocation can be
+    /// placed at a chosen number of standard deviations. `direction` flips `BBB`'s exposure to the
+    /// factor, which builds an anti-correlated pair without disturbing the spread.
     fn pair(direction: f64, spread: impl Fn(usize) -> f64) -> DataFrame {
         let mut rows: Vec<(&str, i64, f64)> = Vec::new();
         let mut factor = 0.0;
@@ -776,7 +798,17 @@ mod tests {
         assert!(entries_at(&closes, &["AAA", "BBB"], 0, Selection::Screened).is_empty());
     }
 
+    /// An entry priced at every horizon up to `observed`, which is the gapless case.
     fn entry(resolution: Resolution, observed: usize) -> Entry {
+        priced(resolution, &(1..=observed).collect::<Vec<_>>())
+    }
+
+    /// An entry priced at exactly `horizons`, so a gap can be placed where a test needs one.
+    fn priced(resolution: Resolution, horizons: &[usize]) -> Entry {
+        let mut observed = Observed::default();
+        for horizon in horizons {
+            observed.mark(*horizon);
+        }
         Entry {
             session: 10,
             long: "AAA".to_string(),
@@ -866,9 +898,16 @@ mod tests {
             short: short.to_string(),
             entry_z_score: 2.5,
             resolution,
-            observed: match resolution {
-                Resolution::Converged(step) | Resolution::Stopped(step) => step,
-                Resolution::Unresolved => HORIZONS,
+            observed: {
+                let mut observed = Observed::default();
+                let reached = match resolution {
+                    Resolution::Converged(step) | Resolution::Stopped(step) => step,
+                    Resolution::Unresolved => HORIZONS,
+                };
+                for horizon in 1..=reached {
+                    observed.mark(horizon);
+                }
+                observed
             },
         }
     }
@@ -909,6 +948,62 @@ mod tests {
             opened("CCC", "DDD", 11, Resolution::Unresolved),
         ]);
         assert_eq!(kept.len(), 2, "{kept:?}");
+    }
+
+    /// A horizon neither leg printed in is unobserved, not open. Carrying across the gap would
+    /// report a session that could not be read as one where the pair was seen still open, and it
+    /// biases every curve toward "open" by exactly the entries with holes in them.
+    #[test]
+    fn test_a_horizon_that_could_not_be_priced_is_not_counted_as_open() {
+        // Priced at one, two and four; three is a session one leg did not trade.
+        let entries = vec![priced(Resolution::Unresolved, &[1, 2, 4])];
+        let curves = curves(&entries);
+
+        assert_eq!(curves[1].entries, 1, "horizon two was priced");
+        assert_eq!(curves[2].entries, 0, "horizon three was not");
+        assert_eq!(curves[3].entries, 1, "and horizon four was priced again");
+    }
+
+    /// A resolution still carries to every later horizon across a gap: once the spread has been
+    /// seen to converge, no later missing price makes that unknown again.
+    #[test]
+    fn test_a_resolution_carries_across_a_gap() {
+        let entries = vec![priced(Resolution::Converged(2), &[1, 2])];
+        let curves = curves(&entries);
+
+        assert_eq!(
+            curves[9].entries, 1,
+            "horizon ten, long after the last price"
+        );
+        assert!((curves[9].converged - 1.0).abs() < 1e-12);
+    }
+
+    /// The pair is occupied until the furthest horizon it was priced at, so a gap does not free it
+    /// early and admit a second entry from the same unresolved episode.
+    #[test]
+    fn test_a_gap_does_not_free_the_pair_early() {
+        let mut first = priced(Resolution::Unresolved, &[1, 2, 8]);
+        first.session = 10;
+        let mut second = priced(Resolution::Converged(1), &[1]);
+        second.session = 15;
+
+        assert_eq!(
+            without_reentry(vec![first, second]).len(),
+            1,
+            "session 15 falls inside the first entry's occupancy, which runs to 18"
+        );
+    }
+
+    /// The average is over every entry, and no entry is an absent average rather than zero.
+    #[test]
+    fn test_the_mean_entry_z_score_is_absent_without_entries() {
+        let mut low = entry(Resolution::Converged(2), 2);
+        low.entry_z_score = 2.0;
+        let mut high = entry(Resolution::Stopped(3), 3);
+        high.entry_z_score = 4.5;
+
+        assert_eq!(mean_entry_z_score(&[low, high]), Some(3.25));
+        assert_eq!(mean_entry_z_score(&[]), None);
     }
 
     /// The sample is reproducible from its seed, drawn without replacement, and a different seed

--- a/src/laboratory/convergence.rs
+++ b/src/laboratory/convergence.rs
@@ -1,0 +1,955 @@
+//! Whether a dislocated spread closes, which is the premise the pair book rests on.
+//!
+//! Measured without the model, because whether it converges is a fact about prices and not a forecast.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use polars::prelude::*;
+use rand::{rngs::StdRng, RngExt, SeedableRng};
+use serde::Serialize;
+
+use crate::common::types::CloseReason;
+use crate::models::tide::TideError;
+use crate::portfolio::evaluate::exit_reason;
+use crate::portfolio::screen::{
+    logarithmic_returns, pearson_correlation, worst_session_move, SpreadModel, CORRELATION_MAXIMUM,
+    CORRELATION_MINIMUM, CORRELATION_WINDOW_SESSIONS, ENTRY_Z_SCORE, ENTRY_Z_SCORE_CAP,
+    MAXIMUM_SESSION_LOGARITHMIC_RETURN,
+};
+
+/// Closing prices for every name, along one session axis.
+///
+/// Keyed by ticker rather than laid out as a grid because pair work reaches for two whole series at
+/// a time, never for one session across every name — which is the shape [`crate::laboratory::predictor::Panel`]
+/// exists to serve.
+pub struct Closes {
+    sessions: Vec<i64>,
+    by_ticker: BTreeMap<String, Vec<Option<f64>>>,
+}
+
+impl Closes {
+    /// Reads `ticker`, `timestamp` and `close_price` into one series per name.
+    pub fn from_frame(frame: &DataFrame) -> Result<Self, TideError> {
+        let tickers = frame.column("ticker")?.str()?;
+        let timestamps = frame.column("timestamp")?.i64()?;
+        let closes = frame.column("close_price")?.cast(&DataType::Float64)?;
+        let closes = closes.f64()?;
+        if tickers.null_count() > 0 || timestamps.null_count() > 0 {
+            return Err(TideError::Data(
+                "closes need every row to name its ticker and its session".to_string(),
+            ));
+        }
+
+        let sessions: Vec<i64> = timestamps
+            .into_no_null_iter()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let session_of: BTreeMap<i64, usize> = sessions
+            .iter()
+            .enumerate()
+            .map(|(index, session)| (*session, index))
+            .collect();
+
+        let mut by_ticker: BTreeMap<String, Vec<Option<f64>>> = BTreeMap::new();
+        for ((ticker, timestamp), close) in tickers
+            .into_no_null_iter()
+            .zip(timestamps.into_no_null_iter())
+            .zip(closes)
+        {
+            let Some(index) = session_of.get(&timestamp) else {
+                continue;
+            };
+            let series = by_ticker
+                .entry(ticker.to_string())
+                .or_insert_with(|| vec![None; sessions.len()]);
+            // A price of zero or below cannot be logged and a spread is built from logs, so it is
+            // absent rather than carried forward as a number the fit would reject later.
+            series[*index] = close.filter(|price| price.is_finite() && *price > 0.0);
+        }
+
+        Ok(Self {
+            sessions,
+            by_ticker,
+        })
+    }
+
+    pub fn sessions(&self) -> usize {
+        self.sessions.len()
+    }
+
+    pub fn session_at(&self, index: usize) -> Option<i64> {
+        self.sessions.get(index).copied()
+    }
+
+    /// Every name, in a fixed order so a sampled universe is reproducible.
+    pub fn tickers(&self) -> Vec<&str> {
+        self.by_ticker.keys().map(String::as_str).collect()
+    }
+
+    pub fn close_at(&self, ticker: &str, session: usize) -> Option<f64> {
+        self.by_ticker.get(ticker)?.get(session).copied().flatten()
+    }
+
+    /// The last `length` sessions at or before `session` where both names traded.
+    ///
+    /// Aligned on sessions both legs were present for, rather than on each leg's own last `length`
+    /// prices: a hedge ratio fitted across a session one leg missed regresses prices from different
+    /// days on each other.
+    pub fn aligned_window(
+        &self,
+        first: &str,
+        second: &str,
+        session: usize,
+        length: usize,
+    ) -> Option<(Vec<f64>, Vec<f64>)> {
+        let first = self.by_ticker.get(first)?;
+        let second = self.by_ticker.get(second)?;
+        if session >= self.sessions.len() || length == 0 {
+            return None;
+        }
+
+        let mut left = Vec::with_capacity(length);
+        let mut right = Vec::with_capacity(length);
+        for index in (0..=session).rev() {
+            if let (Some(one), Some(other)) = (first[index], second[index]) {
+                left.push(one);
+                right.push(other);
+                if left.len() == length {
+                    break;
+                }
+            }
+        }
+        if left.len() < length {
+            return None;
+        }
+        // Collected newest first, and a fit reads them oldest first.
+        left.reverse();
+        right.reverse();
+        Some((left, right))
+    }
+}
+
+/// A reproducible sample of at most `size` names, drawn without replacement.
+///
+/// The *universe* is sampled and not the pairs, so the selection logic stays production's rather
+/// than an approximation of it — just over a smaller universe. Pair enumeration is quadratic per
+/// session, and the archive's ~1,150 names are 660,000 pairs against a sample of 200's 19,900.
+pub fn sample_universe(closes: &Closes, size: usize, seed: u64) -> Vec<&str> {
+    let mut universe = closes.tickers();
+    if universe.len() <= size {
+        return universe;
+    }
+    let mut generator = StdRng::seed_from_u64(seed);
+    // Partial Fisher-Yates: the first `size` slots become the sample, so no name is drawn twice.
+    for slot in 0..size {
+        let swap = slot + generator.random_range(0..universe.len() - slot);
+        universe.swap(slot, swap);
+    }
+    universe.truncate(size);
+    // Sorted, so a pair is enumerated in the same order whatever the draw put where.
+    universe.sort_unstable();
+    universe
+}
+
+/// Sessions an entry is followed for before it is reported as unresolved.
+///
+/// A ceiling on the measurement, not a holding period: the terminal event and the horizon it
+/// happened at are both recorded, so the curves say where to hold rather than assuming it.
+pub const HORIZONS: usize = 20;
+
+/// How a pair is admitted, which is the whole of the control.
+///
+/// The two differ in one test and share everything else — the same fit window, the same entry
+/// threshold, the same fixed model, the same forward walk. An extreme z is extreme partly because
+/// the mean and dispersion it is measured against were *estimated* on sixty sessions, so it is less
+/// extreme next session under a pure random walk. That regression to the mean is arithmetic rather
+/// than economics and it lands on both arms equally, which is what makes the difference readable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Selection {
+    /// The screen's band on log-return correlation, which is what makes two names a pair.
+    Screened,
+    /// The band dropped, so a pair is any two names whose spread happens to be dislocated.
+    ///
+    /// Exhaustive rather than a random sample of pairs: the population minus one filter is the
+    /// same null with no seed to report and no sampling error of its own.
+    Unscreened,
+}
+
+impl Selection {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Selection::Screened => "screened",
+            Selection::Unscreened => "unscreened",
+        }
+    }
+}
+
+/// What first happened to an entry, and how many sessions after it opened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Resolution {
+    /// The spread fell back through its fitted mean.
+    Converged(usize),
+    /// The spread widened past the stop, measured from this entry's own z-score.
+    Stopped(usize),
+    /// Neither, through every forward session the pair could be priced at.
+    Unresolved,
+}
+
+/// One pair opened at one session, and what became of it.
+///
+/// `observed` is the last horizon both legs could be priced at, and it is what separates an entry
+/// that survived twenty sessions without resolving from one the archive ran out under. Folding the
+/// second into the first would report a truncated entry as a pair that failed to converge.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Entry {
+    pub session: usize,
+    pub long: String,
+    pub short: String,
+    pub entry_z_score: f64,
+    pub resolution: Resolution,
+    pub observed: usize,
+}
+
+impl Entry {
+    /// Where this entry stands at `horizon`, or `None` if it was never followed that far.
+    fn at(&self, horizon: usize) -> Option<Resolution> {
+        match self.resolution {
+            Resolution::Converged(step) | Resolution::Stopped(step) if step <= horizon => {
+                Some(self.resolution)
+            }
+            _ if self.observed >= horizon => Some(Resolution::Unresolved),
+            _ => None,
+        }
+    }
+}
+
+/// Where a cohort of entries stands at one horizon.
+///
+/// The three shares are of `entries`, which counts only the entries followed this far — an entry
+/// the archive ran out under leaves the denominator rather than counting as still open.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Curve {
+    pub horizon: usize,
+    pub converged: f64,
+    pub stopped: f64,
+    pub open: f64,
+    pub entries: usize,
+}
+
+/// Every entry `session` admits under `selection`, each followed forward until it resolves.
+///
+/// The fit window ends at the session *before* the one entry is judged at, mirroring production,
+/// where the window is closed daily bars and the observation is a live price. Scoring an
+/// observation against a distribution it belongs to bounds the z-score by the sample size, and a
+/// bounded z cannot reach the threshold it is compared against.
+pub fn entries_at(
+    closes: &Closes,
+    universe: &[&str],
+    session: usize,
+    selection: Selection,
+) -> Vec<Entry> {
+    let Some(fitted_through) = session.checked_sub(1) else {
+        return Vec::new();
+    };
+
+    let mut entries = Vec::new();
+    for (offset, first) in universe.iter().enumerate() {
+        for second in &universe[offset + 1..] {
+            let Some((first_window, second_window)) =
+                closes.aligned_window(first, second, fitted_through, CORRELATION_WINDOW_SESSIONS)
+            else {
+                continue;
+            };
+            if breaks(&first_window) || breaks(&second_window) {
+                continue;
+            }
+            match selection {
+                Selection::Screened => {
+                    let correlation = pearson_correlation(
+                        &logarithmic_returns(&first_window),
+                        &logarithmic_returns(&second_window),
+                    );
+                    match correlation {
+                        Some(correlation)
+                            if (CORRELATION_MINIMUM..=CORRELATION_MAXIMUM)
+                                .contains(&correlation) => {}
+                        Some(_) | None => continue,
+                    }
+                }
+                Selection::Unscreened => {}
+            }
+
+            let (Some(first_price), Some(second_price)) = (
+                closes.close_at(first, session),
+                closes.close_at(second, session),
+            ) else {
+                continue;
+            };
+
+            // Both orientations, because ordinary least squares is not symmetric and the spread has
+            // to be fitted the way round it would be held. At most one clears a positive threshold.
+            let orientations = [
+                (
+                    second,
+                    &second_window,
+                    second_price,
+                    first,
+                    &first_window,
+                    first_price,
+                ),
+                (
+                    first,
+                    &first_window,
+                    first_price,
+                    second,
+                    &second_window,
+                    second_price,
+                ),
+            ];
+            for (long, long_window, long_price, short, short_window, short_price) in orientations {
+                let Some(model) = SpreadModel::fit(long_window, short_window) else {
+                    continue;
+                };
+                let Some(entry_z_score) = model.z_score(long_price, short_price) else {
+                    continue;
+                };
+                if !(ENTRY_Z_SCORE..=ENTRY_Z_SCORE_CAP).contains(&entry_z_score) {
+                    continue;
+                }
+                entries.push(follow(closes, &model, long, short, session, entry_z_score));
+                break;
+            }
+        }
+    }
+    entries
+}
+
+/// Walks an entry forward against the model it was opened on, never refitting.
+///
+/// Refitting would drag the fitted mean toward the current spread as the window absorbed the
+/// dislocation, manufacturing convergence out of bookkeeping. Production's rolling behaviour is a
+/// separate comparison, not this measurement.
+fn follow(
+    closes: &Closes,
+    model: &SpreadModel,
+    long: &str,
+    short: &str,
+    session: usize,
+    entry_z_score: f64,
+) -> Entry {
+    let mut observed = 0;
+    let mut resolution = Resolution::Unresolved;
+
+    for step in 1..=HORIZONS {
+        let index = session + step;
+        if index >= closes.sessions() {
+            break;
+        }
+        // A leg that did not trade leaves this horizon unobserved and the walk continues: the
+        // horizon counts sessions elapsed, which a missing bar does not change.
+        let (Some(long_price), Some(short_price)) =
+            (closes.close_at(long, index), closes.close_at(short, index))
+        else {
+            continue;
+        };
+        let Some(z_score) = model.z_score(long_price, short_price) else {
+            continue;
+        };
+        observed = step;
+
+        match exit_reason(z_score, entry_z_score) {
+            Some(CloseReason::Convergence) => {
+                resolution = Resolution::Converged(step);
+                break;
+            }
+            Some(CloseReason::StopLoss) => {
+                resolution = Resolution::Stopped(step);
+                break;
+            }
+            // Neither arises from a spread reading; both are the book flattening for its own reasons.
+            Some(CloseReason::EndOfDay) | Some(CloseReason::PositionMissing) | None => {}
+        }
+    }
+
+    Entry {
+        session,
+        long: long.to_string(),
+        short: short.to_string(),
+        entry_z_score,
+        resolution,
+        observed,
+    }
+}
+
+/// A fit window holding a move too large to be one distribution, which the screen also refuses.
+fn breaks(window: &[f64]) -> bool {
+    worst_session_move(window).is_some_and(|logarithmic_return| {
+        logarithmic_return.abs() > MAXIMUM_SESSION_LOGARITHMIC_RETURN
+    })
+}
+
+/// Drops every entry taken on a pair that was already open, which production cannot take.
+///
+/// A spread stays dislocated for days, so the same episode is admitted on each of them and ten
+/// correlated outcomes read as ten independent ones. [`crate::portfolio::screen::select_disjoint`]
+/// excludes every held ticker, so the book opens an episode once.
+///
+/// Per pair rather than per ticker, which is the weaker of the two guarantees production gives.
+/// Matching the stronger one means simulating the book's ranking and its position limit, which is a
+/// replay and not a measurement of prices.
+pub fn without_reentry(mut entries: Vec<Entry>) -> Vec<Entry> {
+    entries.sort_by(|left, right| {
+        left.session
+            .cmp(&right.session)
+            .then_with(|| left.long.cmp(&right.long))
+            .then_with(|| left.short.cmp(&right.short))
+    });
+
+    let mut held_through: BTreeMap<(String, String), usize> = BTreeMap::new();
+    let mut kept = Vec::with_capacity(entries.len());
+    for entry in entries {
+        // Keyed unordered, because the book holds the two tickers and not an orientation: a pair
+        // that flips which leg is expensive is the same two positions being re-entered.
+        let pair = if entry.long <= entry.short {
+            (entry.long.clone(), entry.short.clone())
+        } else {
+            (entry.short.clone(), entry.long.clone())
+        };
+        if held_through
+            .get(&pair)
+            .is_some_and(|until| entry.session <= *until)
+        {
+            continue;
+        }
+        // An unresolved entry occupies the pair for as long as it could be priced, not for the full
+        // horizon: past that the archive says nothing, so neither does the guard.
+        let until = entry.session
+            + match entry.resolution {
+                Resolution::Converged(step) | Resolution::Stopped(step) => step,
+                Resolution::Unresolved => entry.observed,
+            };
+        held_through.insert(pair, until);
+        kept.push(entry);
+    }
+    kept
+}
+
+/// Where a cohort stands at each horizon from one to [`HORIZONS`].
+pub fn curves(entries: &[Entry]) -> Vec<Curve> {
+    (1..=HORIZONS)
+        .map(|horizon| {
+            let standing: Vec<Resolution> = entries
+                .iter()
+                .filter_map(|entry| entry.at(horizon))
+                .collect();
+            let share = |count: usize| {
+                if standing.is_empty() {
+                    0.0
+                } else {
+                    count as f64 / standing.len() as f64
+                }
+            };
+            let count = |matching: fn(&Resolution) -> bool| {
+                standing.iter().filter(|state| matching(state)).count()
+            };
+            Curve {
+                horizon,
+                converged: share(count(|state| matches!(state, Resolution::Converged(_)))),
+                stopped: share(count(|state| matches!(state, Resolution::Stopped(_)))),
+                open: share(count(|state| matches!(state, Resolution::Unresolved))),
+                entries: standing.len(),
+            }
+        })
+        .collect()
+}
+
+/// The average z-score entries were opened at, which is what a convergence is worth.
+///
+/// The curves count outcomes and the two outcomes are not the same size: converging travels the
+/// whole way back to the mean, and stopping travels
+/// [`crate::portfolio::screen::STOP_LOSS_WIDENING`]. Without this the shares cannot be turned into
+/// a statement about money in either direction.
+pub fn mean_entry_z_score(entries: &[Entry]) -> Option<f64> {
+    if entries.is_empty() {
+        return None;
+    }
+    let total: f64 = entries.iter().map(|entry| entry.entry_z_score).sum();
+    Some(total / entries.len() as f64)
+}
+
+/// The median sessions a converging entry took, over the entries that converged.
+///
+/// Deliberately not over every entry: an unresolved entry has no convergence horizon, and giving it
+/// one — [`HORIZONS`], say — would report a number no entry produced.
+pub fn median_sessions_to_convergence(entries: &[Entry]) -> Option<f64> {
+    let mut horizons: Vec<usize> = entries
+        .iter()
+        .filter_map(|entry| match entry.resolution {
+            Resolution::Converged(step) => Some(step),
+            Resolution::Stopped(_) | Resolution::Unresolved => None,
+        })
+        .collect();
+    if horizons.is_empty() {
+        return None;
+    }
+    horizons.sort_unstable();
+
+    let middle = horizons.len() / 2;
+    if horizons.len().is_multiple_of(2) {
+        Some((horizons[middle - 1] + horizons[middle]) as f64 / 2.0)
+    } else {
+        Some(horizons[middle] as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DAY: i64 = 86_400_000;
+
+    /// Two names over five sessions, with the third missing for BBB.
+    fn frame() -> DataFrame {
+        let rows: Vec<(&str, i64, Option<f64>)> = vec![
+            ("AAA", 0, Some(10.0)),
+            ("AAA", DAY, Some(11.0)),
+            ("AAA", 2 * DAY, Some(12.0)),
+            ("AAA", 3 * DAY, Some(13.0)),
+            ("AAA", 4 * DAY, Some(14.0)),
+            ("BBB", 0, Some(50.0)),
+            ("BBB", DAY, Some(51.0)),
+            ("BBB", 2 * DAY, None),
+            ("BBB", 3 * DAY, Some(53.0)),
+            ("BBB", 4 * DAY, Some(54.0)),
+        ];
+        DataFrame::new(vec![
+            Column::new(
+                "ticker".into(),
+                rows.iter().map(|row| row.0).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "timestamp".into(),
+                rows.iter().map(|row| row.1).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "close_price".into(),
+                rows.iter().map(|row| row.2).collect::<Vec<_>>(),
+            ),
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn test_a_series_is_read_per_name_along_one_session_axis() {
+        let closes = Closes::from_frame(&frame()).unwrap();
+        assert_eq!(closes.sessions(), 5);
+        assert_eq!(closes.tickers(), vec!["AAA", "BBB"]);
+        assert_eq!(closes.close_at("AAA", 0), Some(10.0));
+        assert_eq!(closes.close_at("BBB", 2), None, "BBB did not trade");
+        assert_eq!(closes.close_at("CCC", 0), None);
+        assert_eq!(closes.session_at(4), Some(4 * DAY));
+    }
+
+    /// The window skips the session one leg missed rather than pairing prices from different days,
+    /// which is what a hedge ratio fitted across the hole would regress against each other.
+    #[test]
+    fn test_a_window_aligns_on_the_sessions_both_legs_traded() {
+        let closes = Closes::from_frame(&frame()).unwrap();
+
+        let (first, second) = closes.aligned_window("AAA", "BBB", 4, 4).unwrap();
+        assert_eq!(
+            first,
+            vec![10.0, 11.0, 13.0, 14.0],
+            "session two is skipped"
+        );
+        assert_eq!(second, vec![50.0, 51.0, 53.0, 54.0]);
+    }
+
+    /// A window shorter than asked for is refused rather than returned short: the spread's mean and
+    /// dispersion come from a fixed number of sessions, and a shorter sample moves both.
+    #[test]
+    fn test_a_window_that_cannot_be_filled_is_refused() {
+        let closes = Closes::from_frame(&frame()).unwrap();
+
+        assert_eq!(closes.aligned_window("AAA", "BBB", 4, 5), None, "only four");
+        assert_eq!(closes.aligned_window("AAA", "BBB", 1, 3), None);
+        assert_eq!(closes.aligned_window("AAA", "CCC", 4, 2), None);
+        assert_eq!(closes.aligned_window("AAA", "BBB", 9, 2), None);
+        assert_eq!(closes.aligned_window("AAA", "BBB", 4, 0), None);
+    }
+
+    /// The window ends at the session asked for and reaches backward, never forward. Reaching
+    /// forward would fit a spread on prices the session it is judged at had not seen.
+    #[test]
+    fn test_a_window_ends_where_it_is_asked_to() {
+        let closes = Closes::from_frame(&frame()).unwrap();
+
+        let (first, _) = closes.aligned_window("AAA", "BBB", 1, 2).unwrap();
+        assert_eq!(first, vec![10.0, 11.0]);
+        let (first, _) = closes.aligned_window("AAA", "BBB", 3, 2).unwrap();
+        assert_eq!(first, vec![11.0, 13.0], "session two is still skipped");
+    }
+
+    /// A price at or below zero has no logarithm, and a spread is built from logs.
+    #[test]
+    fn test_a_price_that_cannot_be_logged_is_absent() {
+        let mut rows = frame();
+        rows.with_column(Column::new(
+            "close_price".into(),
+            vec![
+                Some(10.0),
+                Some(0.0),
+                Some(12.0),
+                Some(-1.0),
+                Some(14.0),
+                Some(50.0),
+                Some(51.0),
+                None,
+                Some(53.0),
+                Some(54.0),
+            ],
+        ))
+        .unwrap();
+
+        let closes = Closes::from_frame(&rows).unwrap();
+        assert_eq!(closes.close_at("AAA", 1), None, "zero has no logarithm");
+        assert_eq!(closes.close_at("AAA", 3), None, "nor does a negative price");
+        assert_eq!(closes.close_at("AAA", 0), Some(10.0));
+    }
+
+    /// The session both fixtures dislocate at, chosen so a full fit window precedes it.
+    const DISLOCATION: usize = 65;
+    const SESSIONS: usize = 80;
+
+    /// Ordinary spread dispersion, as a log-price difference.
+    ///
+    /// The entry threshold is in units of the fitted standard deviation, which for a sine of this
+    /// amplitude is `AMPLITUDE / sqrt(2)`, so a dislocation is written as a multiple of that.
+    const AMPLITUDE: f64 = 0.01;
+
+    /// A pair whose spread path is written directly rather than inferred from two price series.
+    ///
+    /// `AAA` is a common factor and `BBB` is that factor plus `spread`, so the fitted spread *is*
+    /// `spread` up to a constant and a dislocation can be placed at a chosen number of standard
+    /// deviations. `direction` flips `BBB`'s exposure to the factor, which is how an anti-correlated
+    /// pair is built without disturbing the spread.
+    fn pair(direction: f64, spread: impl Fn(usize) -> f64) -> DataFrame {
+        let mut rows: Vec<(&str, i64, f64)> = Vec::new();
+        let mut factor = 0.0;
+        for session in 0..SESSIONS {
+            // Increments roughly twice the spread's, which puts the log-return correlation inside
+            // the screened band rather than at either edge of it.
+            factor += 0.014 * (session as f64 * 1.7).sin();
+            rows.push(("AAA", session as i64 * DAY, 100.0 * factor.exp()));
+            rows.push((
+                "BBB",
+                session as i64 * DAY,
+                50.0 * (direction * factor + spread(session)).exp(),
+            ));
+        }
+        DataFrame::new(vec![
+            Column::new(
+                "ticker".into(),
+                rows.iter().map(|row| row.0).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "timestamp".into(),
+                rows.iter().map(|row| row.1).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "close_price".into(),
+                rows.iter().map(|row| row.2).collect::<Vec<_>>(),
+            ),
+        ])
+        .unwrap()
+    }
+
+    /// The spread oscillates, steps out for two sessions, then crosses back through its own mean.
+    fn dislocated(session: usize) -> f64 {
+        match session {
+            _ if session < DISLOCATION => AMPLITUDE * (session as f64 * 0.9).sin(),
+            _ if session < DISLOCATION + 2 => 3.0 * AMPLITUDE / std::f64::consts::SQRT_2,
+            _ => -AMPLITUDE,
+        }
+    }
+
+    /// The fixture has to produce an entry at all, or every test built on it passes vacuously —
+    /// which is how a screened arm reporting nothing reads as a strategy that never fires.
+    #[test]
+    fn test_the_fixture_opens_a_pair_at_the_dislocation() {
+        let closes = Closes::from_frame(&pair(1.0, dislocated)).unwrap();
+        let entries = entries_at(&closes, &["AAA", "BBB"], DISLOCATION, Selection::Screened);
+
+        assert_eq!(entries.len(), 1, "{entries:?}");
+        let entry = &entries[0];
+        assert_eq!(entry.short, "BBB", "the expensive leg is the short one");
+        assert_eq!(entry.long, "AAA");
+        assert!(entry.entry_z_score >= 2.0, "{}", entry.entry_z_score);
+        assert!(entry.entry_z_score <= 5.0, "{}", entry.entry_z_score);
+    }
+
+    /// The window the spread is measured against must end before the session being judged, or it
+    /// contains the observation and inflates its own dispersion by exactly the move being scored.
+    ///
+    /// Read at the cap rather than at the entry threshold, because that is where the difference
+    /// bites. A window of sixty admitting one point `d` deviations out reports it at roughly
+    /// `d / sqrt(1 + d² / 61)`, which stays above two for every `d` above two — so an entry fires
+    /// either way and only the *upper* bound separates them. At five and a half deviations the
+    /// honest reading is past [`ENTRY_Z_SCORE_CAP`] and refused, and the contaminated one is 4.4
+    /// and admitted: the guard against unadjusted corporate actions stops working silently.
+    #[test]
+    fn test_the_fit_window_ends_before_the_session_it_judges() {
+        let beyond_the_cap = |session: usize| match session {
+            _ if session < DISLOCATION => AMPLITUDE * (session as f64 * 0.9).sin(),
+            _ => 5.5 * AMPLITUDE / std::f64::consts::SQRT_2,
+        };
+        let closes = Closes::from_frame(&pair(1.0, beyond_the_cap)).unwrap();
+
+        assert!(
+            entries_at(&closes, &["AAA", "BBB"], DISLOCATION, Selection::Screened).is_empty(),
+            "a spread this far out is refused, not traded"
+        );
+    }
+
+    /// Convergence is the spread falling back through the mean it was fitted against, and the
+    /// fixture returns to its own level two sessions after it left.
+    #[test]
+    fn test_a_returning_spread_resolves_as_converged() {
+        let closes = Closes::from_frame(&pair(1.0, dislocated)).unwrap();
+        let entries = entries_at(&closes, &["AAA", "BBB"], DISLOCATION, Selection::Screened);
+
+        assert_eq!(
+            entries[0].resolution,
+            Resolution::Converged(2),
+            "{:?}",
+            entries[0]
+        );
+    }
+
+    /// A spread that keeps widening stops out rather than converging, and the stop is measured from
+    /// this entry's own z-score rather than from a fixed line.
+    #[test]
+    fn test_a_widening_spread_resolves_as_stopped() {
+        // Entry is three standard deviations out and the stop sits 1.5 further, so a spread that
+        // steps to six and stays there is unambiguously past it.
+        let widening = |session: usize| match session {
+            _ if session < DISLOCATION => AMPLITUDE * (session as f64 * 0.9).sin(),
+            _ if session < DISLOCATION + 1 => 3.0 * AMPLITUDE / std::f64::consts::SQRT_2,
+            _ => 6.0 * AMPLITUDE / std::f64::consts::SQRT_2,
+        };
+
+        let closes = Closes::from_frame(&pair(1.0, widening)).unwrap();
+        let entries = entries_at(&closes, &["AAA", "BBB"], DISLOCATION, Selection::Screened);
+        assert_eq!(entries.len(), 1, "{entries:?}");
+        assert_eq!(
+            entries[0].resolution,
+            Resolution::Stopped(1),
+            "{:?}",
+            entries[0]
+        );
+    }
+
+    /// The correlation band is the only test the control drops, and dropping it has to admit pairs
+    /// the screen refuses — otherwise the two arms measure the same population and the control
+    /// cannot say anything.
+    #[test]
+    fn test_the_control_admits_what_the_band_refuses() {
+        // The same spread path, with BBB's exposure to the common factor flipped. Their log returns
+        // now anti-correlate, which the band refuses and the control does not.
+        let closes = Closes::from_frame(&pair(-1.0, dislocated)).unwrap();
+
+        assert!(
+            entries_at(&closes, &["AAA", "BBB"], DISLOCATION, Selection::Screened).is_empty(),
+            "an anti-correlated pair is outside the band"
+        );
+        assert!(
+            !entries_at(&closes, &["AAA", "BBB"], DISLOCATION, Selection::Unscreened).is_empty(),
+            "and the control has to see it, or it is not a control"
+        );
+    }
+
+    /// The window ends one session before entry, so nothing can be screened at session zero.
+    #[test]
+    fn test_nothing_is_entered_at_the_first_session() {
+        let closes = Closes::from_frame(&pair(1.0, dislocated)).unwrap();
+        assert!(entries_at(&closes, &["AAA", "BBB"], 0, Selection::Screened).is_empty());
+    }
+
+    fn entry(resolution: Resolution, observed: usize) -> Entry {
+        Entry {
+            session: 10,
+            long: "AAA".to_string(),
+            short: "BBB".to_string(),
+            entry_z_score: 2.5,
+            resolution,
+            observed,
+        }
+    }
+
+    /// An entry the archive ran out under leaves the denominator rather than counting as still
+    /// open. Counting it would report a truncated entry as a pair that failed to converge.
+    #[test]
+    fn test_an_entry_not_followed_to_a_horizon_is_not_counted_there() {
+        let entries = vec![
+            entry(Resolution::Converged(3), 3),
+            entry(Resolution::Unresolved, 5),
+        ];
+        let curves = curves(&entries);
+
+        assert_eq!(curves[4].horizon, 5);
+        assert_eq!(curves[4].entries, 2, "both were followed five sessions");
+        assert_eq!(curves[5].horizon, 6);
+        assert_eq!(
+            curves[5].entries, 1,
+            "only the resolved one is still countable"
+        );
+        assert!((curves[5].converged - 1.0).abs() < 1e-12);
+    }
+
+    /// A resolution is carried forward to every later horizon: a pair that converged at three has
+    /// converged at ten, and reporting it as open there would flatten the curve it is drawn on.
+    #[test]
+    fn test_a_resolution_carries_forward_and_does_not_carry_back() {
+        let entries = vec![entry(Resolution::Stopped(4), 4)];
+        let curves = curves(&entries);
+
+        assert_eq!(curves[2].entries, 1, "horizon three, followed that far");
+        assert!((curves[2].open - 1.0).abs() < 1e-12, "not yet stopped");
+        assert!((curves[3].stopped - 1.0).abs() < 1e-12, "stopped at four");
+        assert!((curves[19].stopped - 1.0).abs() < 1e-12, "still stopped");
+    }
+
+    /// The three shares partition the entries followed to a horizon, so they sum to one wherever
+    /// there is anything to count. A gap between them would be an outcome nothing reports.
+    #[test]
+    fn test_the_shares_at_a_horizon_sum_to_one() {
+        let entries = vec![
+            entry(Resolution::Converged(2), 2),
+            entry(Resolution::Stopped(6), 6),
+            entry(Resolution::Unresolved, 20),
+        ];
+        for curve in curves(&entries) {
+            if curve.entries == 0 {
+                continue;
+            }
+            let total = curve.converged + curve.stopped + curve.open;
+            assert!((total - 1.0).abs() < 1e-12, "{curve:?}");
+        }
+    }
+
+    /// The median is over the entries that converged and not over every entry: an unresolved entry
+    /// has no convergence horizon, and lending it one reports a number no entry produced.
+    #[test]
+    fn test_the_median_counts_only_the_entries_that_converged() {
+        let entries = vec![
+            entry(Resolution::Converged(2), 2),
+            entry(Resolution::Converged(8), 8),
+            entry(Resolution::Stopped(1), 1),
+            entry(Resolution::Unresolved, 20),
+        ];
+        assert_eq!(median_sessions_to_convergence(&entries), Some(5.0));
+
+        let entries = vec![entry(Resolution::Converged(3), 3)];
+        assert_eq!(median_sessions_to_convergence(&entries), Some(3.0));
+        assert_eq!(
+            median_sessions_to_convergence(&[entry(Resolution::Unresolved, 20)]),
+            None,
+            "no convergence is absent, not zero"
+        );
+    }
+
+    fn opened(long: &str, short: &str, session: usize, resolution: Resolution) -> Entry {
+        Entry {
+            session,
+            long: long.to_string(),
+            short: short.to_string(),
+            entry_z_score: 2.5,
+            resolution,
+            observed: match resolution {
+                Resolution::Converged(step) | Resolution::Stopped(step) => step,
+                Resolution::Unresolved => HORIZONS,
+            },
+        }
+    }
+
+    /// A spread stays dislocated for days, so the same episode is admitted on each of them. Keeping
+    /// them all reports one outcome several times over as several independent ones.
+    #[test]
+    fn test_a_pair_is_not_reentered_while_it_is_still_open() {
+        let kept = without_reentry(vec![
+            opened("AAA", "BBB", 10, Resolution::Converged(4)),
+            opened("AAA", "BBB", 11, Resolution::Converged(3)),
+            opened("AAA", "BBB", 13, Resolution::Converged(1)),
+            opened("AAA", "BBB", 15, Resolution::Stopped(2)),
+        ]);
+
+        assert_eq!(kept.len(), 2, "{kept:?}");
+        assert_eq!(kept[0].session, 10, "the first entry of the episode");
+        assert_eq!(kept[1].session, 15, "and the next one after it closed");
+    }
+
+    /// The guard is on the two tickers and not on the orientation, because the book holds positions.
+    /// A pair that flips which leg is expensive is the same two names being re-entered.
+    #[test]
+    fn test_a_flipped_orientation_is_the_same_pair() {
+        let kept = without_reentry(vec![
+            opened("AAA", "BBB", 10, Resolution::Converged(5)),
+            opened("BBB", "AAA", 12, Resolution::Converged(1)),
+        ]);
+        assert_eq!(kept.len(), 1, "{kept:?}");
+    }
+
+    /// One pair being open says nothing about another, or the guard would silently thin the
+    /// universe down to whichever pair happened to enter first.
+    #[test]
+    fn test_the_guard_is_per_pair_and_not_across_the_book() {
+        let kept = without_reentry(vec![
+            opened("AAA", "BBB", 10, Resolution::Unresolved),
+            opened("CCC", "DDD", 11, Resolution::Unresolved),
+        ]);
+        assert_eq!(kept.len(), 2, "{kept:?}");
+    }
+
+    /// The sample is reproducible from its seed, drawn without replacement, and a different seed
+    /// draws a different set — a sampler that ignored its seed would silently measure one universe.
+    #[test]
+    fn test_the_universe_sample_is_seeded_and_without_replacement() {
+        let mut rows: Vec<(String, i64, f64)> = Vec::new();
+        for name in 0..50 {
+            rows.push((format!("T{name:03}"), 0, 10.0));
+        }
+        let frame = DataFrame::new(vec![
+            Column::new(
+                "ticker".into(),
+                rows.iter().map(|row| row.0.as_str()).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "timestamp".into(),
+                rows.iter().map(|row| row.1).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "close_price".into(),
+                rows.iter().map(|row| row.2).collect::<Vec<_>>(),
+            ),
+        ])
+        .unwrap();
+        let closes = Closes::from_frame(&frame).unwrap();
+
+        let sample = sample_universe(&closes, 10, 19_985);
+        assert_eq!(sample.len(), 10);
+        assert_eq!(sample, sample_universe(&closes, 10, 19_985), "reproducible");
+        assert_ne!(sample, sample_universe(&closes, 10, 7), "and seeded");
+
+        let mut distinct = sample.clone();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert_eq!(distinct.len(), 10, "no name is drawn twice");
+
+        assert_eq!(
+            sample_universe(&closes, 500, 19_985).len(),
+            50,
+            "a sample larger than the universe is the universe"
+        );
+    }
+}

--- a/src/laboratory/journal.rs
+++ b/src/laboratory/journal.rs
@@ -10,6 +10,7 @@ use tokio::io::AsyncWriteExt;
 use tracing::{debug, error};
 use uuid::Uuid;
 
+use crate::laboratory::convergence::Curve;
 use crate::laboratory::dataset::DatasetFingerprint;
 use crate::laboratory::metrics::Distribution;
 use crate::laboratory::predictor::Evaluation;
@@ -50,6 +51,7 @@ pub enum Observation {
     FeatureTriaged(FeatureTriaged),
     StabilityMeasured(StabilityMeasured),
     RegimeMeasured(RegimeMeasured),
+    ConvergenceMeasured(ConvergenceMeasured),
 }
 
 impl Observation {
@@ -61,8 +63,30 @@ impl Observation {
             Observation::FeatureTriaged(_) => "feature_triaged",
             Observation::StabilityMeasured(_) => "stability_measured",
             Observation::RegimeMeasured(_) => "regime_measured",
+            Observation::ConvergenceMeasured(_) => "convergence_measured",
         }
     }
+}
+
+/// Whether a dislocated spread closes, which is the premise the pair book rests on.
+///
+/// `selection` carries the control and `segment` the replication, so an arm that only converges over
+/// one half of the window says so in the record rather than in a follow-up nobody runs.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ConvergenceMeasured {
+    /// How the pair was admitted: the screen's correlation band, or the population without it.
+    pub selection: String,
+    /// Which stretch of the window the entries were opened in.
+    pub segment: String,
+    pub sessions: usize,
+    pub universe: usize,
+    pub entries: usize,
+    /// Over the entries that converged, so no convergence is absent rather than zero.
+    pub median_sessions_to_convergence: Option<f64>,
+    /// What the shares are worth: a convergence earns roughly this many deviations and a stop loses
+    /// [`crate::portfolio::screen::STOP_LOSS_WIDENING`], so the curves alone cannot say which wins.
+    pub mean_entry_z_score: Option<f64>,
+    pub curves: Vec<Curve>,
 }
 
 /// Whether one forecast's per-session readings follow from the state of the market.
@@ -382,6 +406,27 @@ mod tests {
         assert_eq!(regime.experiment_type(), "regime_measured");
         for other in [&forecast, &triaged, &stability, &observation()] {
             assert_ne!(regime.experiment_type(), other.experiment_type());
+        }
+
+        let convergence = Observation::ConvergenceMeasured(ConvergenceMeasured {
+            selection: "screened".to_string(),
+            segment: "whole".to_string(),
+            sessions: 499,
+            universe: 200,
+            entries: 1_284,
+            median_sessions_to_convergence: None,
+            mean_entry_z_score: None,
+            curves: Vec::new(),
+        });
+        let value: serde_json::Value = serde_json::to_value(&convergence).unwrap();
+
+        assert_eq!(
+            value["experiment_type"],
+            serde_json::json!("convergence_measured")
+        );
+        assert_eq!(convergence.experiment_type(), "convergence_measured");
+        for other in [&forecast, &triaged, &stability, &regime, &observation()] {
+            assert_ne!(convergence.experiment_type(), other.experiment_type());
         }
     }
 

--- a/src/laboratory/regime.rs
+++ b/src/laboratory/regime.rs
@@ -61,14 +61,14 @@ pub fn describe(panel: &Panel) -> Vec<MarketState> {
         .collect()
 }
 
-/// Reads one field of a session's state, so [`STATES`] can name the field beside its label.
-pub type StateReader = fn(&MarketState) -> Option<f64>;
-
 /// The state variables this module reports, each with the field it reads.
 ///
 /// Named here rather than at the call site so the count is fixed in one place: reading the largest
 /// of several figures without saying how many were looked at is how a table manufactures a finding.
-pub const STATES: &[(&str, StateReader)] = &[
+// A label paired with the field it reads is the whole table; naming the function pointer would add
+// public API for one use, which the repository guidelines refuse.
+#[allow(clippy::type_complexity)]
+pub const STATES: &[(&str, fn(&MarketState) -> Option<f64>)] = &[
     ("dispersion", |state| state.dispersion),
     ("market_move", |state| state.market_move),
     ("absolute_market_move", |state| state.absolute_market_move),

--- a/src/laboratory/regime.rs
+++ b/src/laboratory/regime.rs
@@ -61,11 +61,14 @@ pub fn describe(panel: &Panel) -> Vec<MarketState> {
         .collect()
 }
 
+/// Reads one field of a session's state, so [`STATES`] can name the field beside its label.
+pub type StateReader = fn(&MarketState) -> Option<f64>;
+
 /// The state variables this module reports, each with the field it reads.
 ///
 /// Named here rather than at the call site so the count is fixed in one place: reading the largest
 /// of several figures without saying how many were looked at is how a table manufactures a finding.
-pub const STATES: &[(&str, fn(&MarketState) -> Option<f64>)] = &[
+pub const STATES: &[(&str, StateReader)] = &[
     ("dispersion", |state| state.dispersion),
     ("market_move", |state| state.market_move),
     ("absolute_market_move", |state| state.absolute_market_move),

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -23,8 +23,8 @@ pub const CORRELATION_WINDOW_SESSIONS: usize = 60;
 /// hedge ratio, turning `ln(short) - hedge_ratio * ln(long)` into a sum that hedges nothing, and
 /// sizing is dollar-neutral regardless — so admitting one is a directional bet wearing a
 /// market-neutral name.
-const CORRELATION_MINIMUM: f64 = 0.5;
-const CORRELATION_MAXIMUM: f64 = 0.95;
+pub const CORRELATION_MINIMUM: f64 = 0.5;
+pub const CORRELATION_MAXIMUM: f64 = 0.95;
 
 /// Spread z-score at which a pair is worth opening.
 pub const ENTRY_Z_SCORE: f64 = 2.0;
@@ -684,7 +684,7 @@ fn aligned_logs(long_closes: &[f64], short_closes: &[f64]) -> Option<(Vec<f64>, 
 /// Signed so the recorded detail says which way the series jumped, and largest rather than first so
 /// the number a bound gets calibrated against is the worst one present. Iterates rather than reusing
 /// [`logarithmic_returns`], which would collect a vector per ticker on a pass that screens over a thousand.
-fn worst_session_move(window: &[f64]) -> Option<f64> {
+pub(crate) fn worst_session_move(window: &[f64]) -> Option<f64> {
     window
         .windows(2)
         .filter(|pair| pair[0] > 0.0 && pair[1] > 0.0)
@@ -693,7 +693,7 @@ fn worst_session_move(window: &[f64]) -> Option<f64> {
 }
 
 /// Period-over-period log returns. One shorter than its input.
-fn logarithmic_returns(prices: &[f64]) -> Vec<f64> {
+pub(crate) fn logarithmic_returns(prices: &[f64]) -> Vec<f64> {
     prices
         .windows(2)
         .filter(|window| window[0] > 0.0 && window[1] > 0.0)
@@ -720,7 +720,7 @@ fn standard_deviation(values: &[f64], mean: f64) -> Option<f64> {
 }
 
 /// Pearson correlation. `None` when either series has no dispersion to correlate.
-fn pearson_correlation(left: &[f64], right: &[f64]) -> Option<f64> {
+pub(crate) fn pearson_correlation(left: &[f64], right: &[f64]) -> Option<f64> {
     let count = left.len().min(right.len());
     if count < 2 {
         return None;


### PR DESCRIPTION
# Overview

The pair book rests on a premise nobody had measured: that a spread two standard deviations from its fitted mean comes back. TiDE was only the *fourth* of four screen tests, so the first three carry the strategy on their own — and the model diagnostic arc never touched them.

**It does not come back, and the correlation band makes it worse than no filter at all.**

## Changes

- `laboratory::convergence` — `Closes` (one close series per name along a shared session axis), `sample_universe`, `entries_at`, `without_reentry`, `curves`, `median_sessions_to_convergence`, `mean_entry_z_score`. Reuses production's arithmetic rather than restating it: `SpreadModel::fit`, `exit_reason`, `pearson_correlation`, `worst_session_move`, and the correlation band itself.
- `src/bin/laboratory_convergence.rs` — opens every entry the screen's price tests admit over each session, follows each forward to twenty horizons, and reports the screened arm beside its control over the whole window and both halves.
- `laboratory::journal` — a new `convergence_measured` record.
- `portfolio::screen` — `CORRELATION_MINIMUM`/`CORRELATION_MAXIMUM` to `pub`, `pearson_correlation`/`worst_session_move`/`logarithmic_returns` to `pub(crate)`. A copy of the spread formula in the laboratory would measure a spread the book does not trade, and would drift the first time either side changed.
- `laboratory::regime` — a narrow `#[allow(clippy::type_complexity)]` on `STATES` for a warning it has carried since #1090, where the branch was described as clippy clean and was not. (A type alias first, reverted on review: a public alias for one table is the single-use abstraction the guidelines refuse.)

## Context

**Deliberately without the model.** Whether a spread converges is a fact about prices. Gating it on TiDE would have measured the model again — the thing #1088 through #1090 already established has no signal. Tests one to three only.

**At horizon 20, whole window:**

```
                entries   entry z   converged   stopped   still open
screened          3,464     2.611      0.1818    0.4634       0.3549
control          29,738     2.633      0.2216    0.4496       0.3288
```

**A dislocated spread stops out two and a half times as often as it converges.** The two outcomes are different sizes — a convergence travels the whole 2.6 deviations back to the mean, a stop travels `STOP_LOSS_WIDENING` = 1.5 — so the frequencies alone give `0.1818 × 2.611 − 0.4634 × 1.5` = **−0.22σ per entry before costs**.

**The correlation band is anti-selective.** The control converges more at *every one of the twenty horizons*, in the whole window and in both halves. Both arms enter at the same distance out, 2.611 against 2.633, which is what rules out the confound that would otherwise explain the gap. And the control is negative too, at −0.09σ — so this is not a screen that picks badly and could pick better. Entering a dislocated daily spread at all is the losing part, and the filter adds to the loss.

**Three decisions do the work.**

*The entry model is held fixed going forward.* Production refits mean and σ on a rolling window with the hedge ratio pinned. For measurement that manufactures the answer: a rolling window absorbs the dislocation, drags its own mean toward the current spread, and produces convergence out of bookkeeping.

*The control is the population minus the correlation filter*, not a random sample of pairs. The two arms then differ in exactly one test, there is no seed to report, and it carries no sampling error of its own. It is load-bearing because an extreme z is extreme partly from *estimation* error on sixty sessions, so z at t+1 is less extreme even under a pure random walk — Galton regression, not economics, landing on both arms equally.

*Entries are deduplicated to one per episode.* A spread stays dislocated for days and `select_disjoint` will not re-enter a held pair, so without the guard one outcome is counted ten times as ten independent ones. It cut the screened arm from 14,475 admissions to 3,464 episodes. Per pair rather than per ticker, which is the weaker of the two guarantees production gives — matching the stronger one means simulating the book's ranking and position limit, which is a replay and not a measurement of prices.

**Split sample from the start**, per the #1090 lesson, and split by time rather than at random.

**The caveat, stated rather than buried.** Entries share legs and cluster in time, so a binomial standard error on 3,464 would overstate the confidence. The direction is what carries the result — consistent across twenty horizons and two disjoint halves, which no single-sample error bar claims.

**What this does not say.** It measures the z-event the strategy's own exit rule is written in, not realized profit and loss; spreads and costs would only move both numbers the same way. And it is daily close-to-close, which is the horizon mismatch again — the book flattens same-session, so the intraday version of this premise is untested and is now the only version left open.

## Verification

- `devenv tasks run checks:rust` green, exit 0, clippy clean apart from a pre-existing `redundant_closure` in `tests/test_handlers.rs`
- **Two real runs against the development archive** over 730 days, 501 sessions and 200 sampled names — not fixtures. The second added `mean_entry_z_score` and changed no measured figure: every row of both tables is byte-identical across the two runs
- A 40-name probe first, which found the same direction on a different universe
- The lookahead guard proven load-bearing **after a first attempt that was not**. The obvious test — that a window ending at the entry session scores it lower — passed with the offset deliberately broken. At n=60 the contamination inflates σ by about 6% and shifts the mean by 0.05σ, which is not enough to push a 3σ reading below the entry threshold, so an entry fires either way and only the *upper* bound separates them. The test now reads at 5.5 deviations, where the honest figure is past `ENTRY_Z_SCORE_CAP` and refused while the contaminated one is 4.4 and admitted: the guard against unadjusted corporate actions stops working silently. Breaking the offset now fails that test and nothing else
- The fixture writes the spread path directly rather than inferring it from two price series, so a dislocation can be placed at a chosen number of deviations; a first attempt at 20% was 21σ and past the cap, and every test built on it passed vacuously
- Censoring proven load-bearing: an entry the archive ran out under leaves the denominator at horizons it was never followed to, and a test fails if it is counted as still open — which would report a truncated entry as a pair that failed to converge
- The re-entry guard proven load-bearing on both axes: repeated entries within one episode collapse to the first, and a flipped orientation counts as the same pair
- **Re-measured after the review fixes**, third real run. The unpriced-horizon fix moves the middle of the curve and not its ends: about 11% of entries have a hole somewhere in the first ten horizons, so the horizon-ten denominator falls from 3,360 to 2,978 and the screened converged share rises from 0.0845 to 0.0954. Horizon twenty is byte-identical, which it must be — the old rule counted an entry at the last horizon exactly when the furthest bit was set, so the two treatments agree there by construction. **Every figure quoted above is at horizon twenty and none of them moved**, and the control still converges more at every horizon in every segment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
