### PR TITLE
Partition the bar archive on its cadence

### DIFF
--- a/.claude/skills/generate-fund-report/SKILL.md
+++ b/.claude/skills/generate-fund-report/SKILL.md
@@ -255,7 +255,7 @@ aws s3 ls s3://<ARTIFACTS_BUCKET>/models/tide/ --profile <PROFILE> --region us-e
 List recent equity bar exports:
 
 ```bash
-aws s3 ls s3://<DATA_BUCKET>/data/equity/bars/ --profile <PROFILE> --region us-east-1 | sort | tail -5
+aws s3 ls s3://<DATA_BUCKET>/data/equity/bars/interval=one_day/ --profile <PROFILE> --region us-east-1 | sort | tail -5
 ```
 
 Compare timestamps with model run and equity bar data from Group A. Flag discrepancies.

--- a/devenv.nix
+++ b/devenv.nix
@@ -1050,7 +1050,7 @@ in {
       export AWS_S3_MODEL_ARTIFACT_PATH="models/tide-smoke/"
       export FUND_EPOCHS="''${FUND_EPOCHS:-1}"
       echo "Rehearsing against PRODUCTION ($FUND_EPOCHS epoch(s), lookback ''${FUND_LOOKBACK_DAYS:-trainer default})"
-      echo "  Reading and repairing s3://$AWS_S3_BUCKET_NAME/data/equity/bars/"
+      echo "  Reading and repairing s3://$AWS_S3_BUCKET_NAME/data/equity/bars/interval=one_day/"
       echo "  Publishing to s3://$AWS_S3_BUCKET_NAME/$AWS_S3_MODEL_ARTIFACT_PATH, which nothing serves from."
       secretspec run -- cargo run --release --bin tide_model_trainer
     '';

--- a/src/bin/seed_equity_bars_s3.rs
+++ b/src/bin/seed_equity_bars_s3.rs
@@ -125,7 +125,7 @@ async fn main() {
 /// Repairs the archive over `range` and returns what the pass accomplished.
 ///
 /// Reads `AWS_S3_BUCKET_NAME` and the Massive credentials from the environment, and writes bar
-/// partitions under `data/equity/bars/`. No database is touched. Only the sessions the bucket is
+/// partitions under `data/equity/bars/interval=one_day/`. No database is touched. Only the sessions the bucket is
 /// missing are fetched, so the cost of a run is the size of the gap rather than the size of the
 /// range, and re-running over a repaired range is close to free.
 async fn run(range: &ArchiveRange) -> Result<archive::ArchiveSummary, Box<dyn std::error::Error>> {

--- a/src/common/aws.rs
+++ b/src/common/aws.rs
@@ -11,7 +11,7 @@ pub async fn s3_client() -> aws_sdk_s3::Client {
 }
 
 /// Build the Hive-partitioned S3 key for one day of parquet data, e.g.
-/// `data/equity/bars/year=2026/month=06/day=10/data.parquet`. The single
+/// `data/equity/bars/interval=one_day/year=2026/month=06/day=10/data.parquet`. The single
 /// source of truth for the date-partition layout: the data manager's daily
 /// writers and exports, the historical backfill, and the tide trainer's
 /// reader all derive their keys here so they can never diverge.

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -18,14 +18,12 @@ use crate::common::massive::MassiveClient;
 use crate::common::types::{BarInterval, SessionDate};
 use crate::data::{bars, boundaries, splits};
 
-/// S3 prefix for the bar archive.
+/// Root of the bar archive, never a partition prefix on its own — [`bar_archive_prefix`] adds the
+/// cadence, and a key built without one collides with every other cadence of the same session.
 ///
 /// Deliberately not under `exports/`, which is where the application's nightly database export
 /// lands. The two datasets live in one bucket and describe overlapping facts, and giving them one
 /// prefix would make whichever job ran second the one that mattered.
-///
-/// Never used directly as a partition prefix — [`bar_archive_prefix`] adds the cadence, and a key
-/// built without it would collide with every other cadence of the same session.
 pub const BAR_ARCHIVE_PREFIX: &str = "data/equity/bars";
 
 /// The archive prefix for one bar cadence.

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -1,6 +1,6 @@
 //! The S3 bar archive: the trainer's data, repaired to a window rather than topped up by a night.
 //!
-//! One partition per session under `data/equity/bars/year=/month=/day=/data.parquet`.
+//! One partition per session and cadence under `data/equity/bars/interval=/year=/month=/day=/`.
 
 use std::collections::BTreeSet;
 use std::io::Cursor;
@@ -15,7 +15,7 @@ use tracing::{info, warn};
 use crate::common::alpaca::MarketDataClient;
 use crate::common::aws::{date_from_partitioned_key, date_partitioned_key};
 use crate::common::massive::MassiveClient;
-use crate::common::types::SessionDate;
+use crate::common::types::{BarInterval, SessionDate};
 use crate::data::{bars, boundaries, splits};
 
 /// S3 prefix for the bar archive.
@@ -23,7 +23,20 @@ use crate::data::{bars, boundaries, splits};
 /// Deliberately not under `exports/`, which is where the application's nightly database export
 /// lands. The two datasets live in one bucket and describe overlapping facts, and giving them one
 /// prefix would make whichever job ran second the one that mattered.
+///
+/// Never used directly as a partition prefix — [`bar_archive_prefix`] adds the cadence, and a key
+/// built without it would collide with every other cadence of the same session.
 pub const BAR_ARCHIVE_PREFIX: &str = "data/equity/bars";
+
+/// The archive prefix for one bar cadence.
+///
+/// Hive-partitioned on the interval, so a reader that scans the tree gets the cadence as a column
+/// and a second cadence costs one more value rather than a parallel tree. Daily and intraday bars
+/// describe overlapping facts — a daily bar is the aggregate of its own intraday bars — and one
+/// partition holding both would make whichever job wrote last the one that mattered.
+pub fn bar_archive_prefix(interval: BarInterval) -> String {
+    format!("{BAR_ARCHIVE_PREFIX}/interval={interval}")
+}
 
 /// S3 key for the ticker metadata that accompanies the archive.
 ///
@@ -206,18 +219,21 @@ async fn present_sessions(
     start: SessionDate,
     end: SessionDate,
 ) -> Result<BTreeSet<SessionDate>, ArchiveError> {
+    // Scoped to the cadence being repaired. Listing the whole bar tree would count an intraday
+    // partition as a daily session already present, and the gap scan would stop fetching it.
+    let prefix = bar_archive_prefix(BarInterval::OneDay);
     let mut present = BTreeSet::new();
     let mut pages = s3_client
         .list_objects_v2()
         .bucket(bucket)
-        .prefix(format!("{BAR_ARCHIVE_PREFIX}/"))
+        .prefix(format!("{prefix}/"))
         .into_paginator()
         .send();
 
     while let Some(page) = pages.next().await {
         let page = page.map_err(|error| ArchiveError::List {
             bucket: bucket.to_string(),
-            prefix: BAR_ARCHIVE_PREFIX.to_string(),
+            prefix: prefix.clone(),
             message: error.to_string(),
         })?;
         for object in page.contents() {
@@ -388,7 +404,7 @@ async fn write_partition(
     session: SessionDate,
     fetched: DataFrame,
 ) -> Result<(), ArchiveError> {
-    let key = date_partitioned_key(BAR_ARCHIVE_PREFIX, session.date());
+    let key = date_partitioned_key(&bar_archive_prefix(BarInterval::OneDay), session.date());
     write_merged(s3_client, bucket, key, fetched, |existing, fetched, key| {
         merge_or_replace(existing, fetched, key)
     })
@@ -761,6 +777,47 @@ mod tests {
         SessionDate::from_date(
             NaiveDate::from_ymd_opt(year, month, day).expect("test date must be valid"),
         )
+    }
+
+    /// The stored layout, pinned to literals. Everything already written lives at these keys, and a
+    /// silent change to either the segment name or its position orphans the whole archive — the gap
+    /// scan would report every session missing and refetch five years over an intact bucket.
+    #[test]
+    fn test_the_partition_key_carries_its_cadence() {
+        let date = NaiveDate::from_ymd_opt(2026, 8, 19).expect("test date must be valid");
+
+        assert_eq!(
+            date_partitioned_key(&bar_archive_prefix(BarInterval::OneDay), date),
+            "data/equity/bars/interval=one_day/year=2026/month=08/day=19/data.parquet"
+        );
+        assert_eq!(
+            date_partitioned_key(&bar_archive_prefix(BarInterval::OneMinute), date),
+            "data/equity/bars/interval=one_minute/year=2026/month=08/day=19/data.parquet"
+        );
+    }
+
+    /// Two cadences of one session must not collide, which is the whole reason the segment exists.
+    /// A shared key would make whichever job wrote last the one that mattered.
+    #[test]
+    fn test_two_cadences_of_one_session_do_not_share_a_key() {
+        let date = NaiveDate::from_ymd_opt(2026, 8, 19).expect("test date must be valid");
+        let keys: std::collections::BTreeSet<String> = BarInterval::ALL
+            .iter()
+            .map(|interval| date_partitioned_key(&bar_archive_prefix(*interval), date))
+            .collect();
+
+        assert_eq!(keys.len(), BarInterval::ALL.len());
+    }
+
+    /// The cadence segment sits before the date partition, so the date inverse still reads the tail
+    /// of the key. Without this the gap scan cannot recover a session from a listing.
+    #[test]
+    fn test_the_cadence_segment_does_not_break_the_date_inverse() {
+        let date = NaiveDate::from_ymd_opt(2026, 8, 19).expect("test date must be valid");
+        for interval in BarInterval::ALL {
+            let key = date_partitioned_key(&bar_archive_prefix(interval), date);
+            assert_eq!(date_from_partitioned_key(&key), Some(date), "key: {key}");
+        }
     }
 
     /// 2026-06-01 is a Monday, so the week runs Mon-Fri 1..=5 and the weekend is 6-7.

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -804,7 +804,9 @@ mod tests {
             .map(|interval| date_partitioned_key(&bar_archive_prefix(*interval), date))
             .collect();
 
-        assert_eq!(keys.len(), BarInterval::ALL.len());
+        // Two, the cadences that exist today. Pinned rather than taken from `BarInterval::ALL`, so
+        // adding a variant has to come here and say what its key is rather than passing silently.
+        assert_eq!(keys.len(), 2);
     }
 
     /// The cadence segment sits before the date partition, so the date inverse still reads the tail

--- a/src/laboratory/dataset.rs
+++ b/src/laboratory/dataset.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use tracing::warn;
 
 use crate::common::aws::date_partitioned_key;
-use crate::common::types::{SessionDate, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
+use crate::common::types::{BarInterval, SessionDate, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
 use crate::data::{adjust, archive, bars, details, truncate};
 use crate::models::tide::data::{clean_data, engineer_features, Target, TrainingFraction};
 use crate::models::tide::fit::{filter_training_bars, fit, FitResult};
@@ -247,6 +247,7 @@ async fn load_archived_bars(
     splits: &adjust::SplitTable,
     boundaries: &truncate::BoundaryTable,
 ) -> Result<DataFrame, DatasetError> {
+    let daily_prefix = archive::bar_archive_prefix(BarInterval::OneDay);
     let mut frames: Vec<LazyFrame> = Vec::new();
     let mut unreadable = 0usize;
     let mut date = session.plus_calendar_days(-lookback_days);
@@ -255,7 +256,7 @@ async fn load_archived_bars(
             date = date.plus_calendar_days(1);
             continue;
         }
-        let key = date_partitioned_key(archive::BAR_ARCHIVE_PREFIX, date.date());
+        let key = date_partitioned_key(&daily_prefix, date.date());
         if let Some(frame) = archive::read_partition(s3_client, bucket, &key).await? {
             match bars::project_bar_frame(frame) {
                 Ok(projected) => frames.push(projected.lazy()),

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -37,12 +37,16 @@ SET VARIABLE bucket = getenv('AWS_S3_BUCKET_NAME');
 -- Trainer archive (data/) -- the model's training input
 -- ---------------------------------------------------------------------------
 
+-- Scoped to one cadence rather than globbing the whole bar tree. The archive is partitioned on
+-- interval, so an unscoped glob would union daily and intraday bars into one view and every query
+-- against it would silently double-count. hive_partitioning still surfaces interval as a column,
+-- which is what makes the scoping visible in a result rather than only here.
 .print 'Loading training_bars...'
 DROP VIEW IF EXISTS training_bars;
 CREATE OR REPLACE VIEW training_bars AS
 SELECT *
 FROM read_parquet(
-    's3://' || getvariable('bucket') || '/data/equity/bars/**/*.parquet',
+    's3://' || getvariable('bucket') || '/data/equity/bars/interval=one_day/**/*.parquet',
     hive_partitioning = true
 );
 


### PR DESCRIPTION
# Overview

The archive has one partition per session and no way to say what cadence that session's bars are. Daily bars are the only thing in it today so nothing has broken, but intraday bars are the next thing to land — and a daily and a five-minute partition for one session would collide at the same key, making whichever job wrote last the one that mattered.

That is the exact failure `BAR_ARCHIVE_PREFIX`'s own comment already warns about for `exports/`. This applies the same reasoning one level down.

**First of two.** This is the layout change alone, deliberately separate from the intraday ingestion that follows, so a change to a path the trainer depends on can be verified and rolled back on its own.

## Changes

- `data::archive` — `bar_archive_prefix(BarInterval)` puts a hive segment before the date partition: `data/equity/bars/interval=one_day/year=2026/month=08/day=19/data.parquet`. `BAR_ARCHIVE_PREFIX` stays, documented as never usable directly.
- `present_sessions` now lists under one cadence rather than the whole bar tree.
- `laboratory::dataset` reads the daily prefix.
- `tools/duckdb_initialization.sql` — `training_bars` scoped to `interval=one_day`.
- `devenv.nix`, `seed_equity_bars_s3`, the fund-report skill, and the `date_partitioned_key` doc example updated to the new path.

## Context

**Why hive-partitioned rather than a parallel tree.** A reader scanning the archive gets the cadence as a column, and a second cadence costs one more value rather than a second tree with its own copy of the layout logic. `hive_partitioning` is already enabled on the DuckDB view, so `interval` arrives as a real column for free.

**No sub-partition below the day.** One session of five-minute bars is ~200k rows and ~5 MB, which is one healthy parquet file. Splitting by time of day would produce 78 files of ~2,500 rows: small-file overhead on every read, worse columnar compression, and 78× the requests to scan a day. The threshold where sub-partitioning pays is around 100 MB per file, which even one-minute bars over the whole universe (~840k rows, ~20 MB) do not reach. It stays additive if that ever changes.

**`date_from_partitioned_key` needed no change.** It already parsed the tail of the key rather than the whole of it, explicitly so it would be "indifferent to the prefix and cannot be broken by one being renamed." That foresight paid for itself here — there is a test pinning that the cadence segment does not break it.

**Two collisions this prevents, both silent:**

- `present_sessions` left unscoped would count an intraday partition as a daily session already present, and the gap scan would stop fetching that day.
- `training_bars` globbed `data/equity/bars/**/*.parquet`, which would have unioned both cadences into one view and double-counted every query against it.

**Blast radius.** The trading application does not read the bar archive. Only `tide_model_trainer`, `seed_equity_bars_s3`, and the laboratory binaries do.

## Verification

- `devenv tasks run checks:rust` green, exit 0, clippy clean apart from a pre-existing `redundant_closure` in `tests/test_handlers.rs`
- **Development bucket migrated:** 505 objects copied server-side, dry-run first. ETags identical on a three-partition sample spanning 2024, 2025 and 2026
- **Both trees compared in DuckDB: 5,575,323 rows each, and the same count of distinct `(ticker, timestamp)`.** The migration is exact
- **Read end to end through the new path** — `laboratory_convergence` against the migrated bucket reads 575,728 rows over 500 sessions. Yesterday's run read 576,506 over 501; the delta is the 730-day window rolling forward one day and dropping its oldest session, which the DuckDB comparison above rules out as data loss
- Three new tests pin the layout to literals: the exact stored key per cadence, that no two cadences share a key, and that the date inverse still recovers the session

## Deployment

**Nothing to do. Checked rather than assumed: the production bucket has no bar archive at all.**

`s3://oscm-fund-production/` holds 52 objects and 6.6 MB — `data/equity/details/details.csv`, plus `exports/` and `models/`. There are zero objects under `data/equity/bars/`. The trainer has only ever run against a development bucket, so there is no production data to migrate and no ordering constraint on this merge.

When production does first build a bar archive, `present_sessions` finds the prefix empty and the gap scan treats it as an empty archive — the case it is explicitly designed for — and writes the new layout from the start. Production skips the old layout entirely rather than needing to be moved off it.

**The old development tree is deliberately left in place.** Nothing reads or writes it now. Deleting it belongs in a separate commit so a rollback between merge and verification has somewhere to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
