### PR TITLE
Cut continuous integration from fourteen minutes to about eight

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -44,7 +44,7 @@ jobs:
               - '.sqlfluff'
               - '.sqlfluffignore'
               - 'devenv.lock'
-      # Deliberately no disk-freeing step either. Removing dotnet, ghc and boost
+      # Deliberately no disk-freeing step. Removing dotnet, ghc and boost
       # cost 35-70s of every run; measured on run 32382969223 the runner starts
       # with 87G free and the removal recovers 11G nothing asks for.
       #
@@ -71,6 +71,7 @@ jobs:
       # across runs 32381409920 and 32383074109, the Rust checks took 370s with
       # it and 369s without. Swatinem/rust-cache above already covers ~/.cargo
       # and target/, which is why the second cache was redundant.
+
       # Gated because it lints nix, markdown, yaml, toml and sql and none of those
       # are in most pull requests here: nineteen of the last twenty-five merged
       # were Rust-only, and each paid two and a half minutes to lint files they

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -22,14 +22,37 @@ jobs:
         uses: dorny/paths-filter@v3
         id: changes
         with:
+          # `.sqlx/` is Rust's: the build runs with SQLX_OFFLINE, so a wrong cache
+          # fails compilation and nothing else would catch it. devenv defines the
+          # toolchain both halves run under, so it triggers both rather than
+          # picking one.
           filters: |
             rust:
               - '**/*.rs'
               - '**/Cargo.toml'
               - '**/Cargo.lock'
+              - '.sqlx/**'
+              - 'devenv.nix'
+              - 'devenv.lock'
+            base:
+              - '**/*.nix'
+              - '**/*.md'
+              - '**/*.yaml'
+              - '**/*.yml'
+              - '**/*.toml'
+              - '**/*.sql'
+              - '.sqlfluff'
+              - '.sqlfluffignore'
+              - 'devenv.lock'
+      # Reports the headroom either side, because nothing here records whether the
+      # removal is still load-bearing. It costs 35-70s of every run, and if the
+      # runner turns out to have room to spare the step can go rather than be
+      # optimized.
       - name: Free disk space
         run: |
+          echo "before: $(df -h --output=avail / | tail -1 | tr -d ' ') available on /"
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+          echo "after:  $(df -h --output=avail / | tail -1 | tr -d ' ') available on /"
       # Deliberately no Nix binary cache action here. devenv pins nixpkgs to
       # `cachix/devenv-nixpkgs/rolling` and configures `devenv.cachix.org` as a
       # substituter, so that cache and `cache.nixos.org` already serve the whole
@@ -56,7 +79,13 @@ jobs:
           key: llvm-cov-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             llvm-cov-${{ runner.os }}-
+      # Gated because it lints nix, markdown, yaml, toml and sql and none of those
+      # are in most pull requests here: nineteen of the last twenty-five merged
+      # were Rust-only, and each paid two and a half minutes to lint files they
+      # did not touch. `Cargo.toml` matches both filters, so a dependency bump
+      # still gets its toml linted.
       - name: Run base checks
+        if: steps.changes.outputs.base == 'true'
         run: devenv --secretspec-provider env --secretspec-profile development tasks run checks:base
       # The integration test targets need a database and an S3-compatible
       # object store. Only those two are started, not the fund services: those

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -66,14 +66,11 @@ jobs:
           shared-key: rust-continuous-integration
           save-if: true
           add-rust-environment-hash-key: false
-      - name: Cache llvm-cov artifacts
-        if: steps.changes.outputs.rust == 'true'
-        uses: actions/cache@v4
-        with:
-          path: target/llvm-cov-target
-          key: llvm-cov-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            llvm-cov-${{ runner.os }}-
+      # Deliberately no llvm-cov cache. It restored target/llvm-cov-target at a
+      # cost of 117-180s on every Rust pull request and bought nothing: measured
+      # across runs 32381409920 and 32383074109, the Rust checks took 370s with
+      # it and 369s without. Swatinem/rust-cache above already covers ~/.cargo
+      # and target/, which is why the second cache was redundant.
       # Gated because it lints nix, markdown, yaml, toml and sql and none of those
       # are in most pull requests here: nineteen of the last twenty-five merged
       # were Rust-only, and each paid two and a half minutes to lint files they

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -44,15 +44,10 @@ jobs:
               - '.sqlfluff'
               - '.sqlfluffignore'
               - 'devenv.lock'
-      # Reports the headroom either side, because nothing here records whether the
-      # removal is still load-bearing. It costs 35-70s of every run, and if the
-      # runner turns out to have room to spare the step can go rather than be
-      # optimized.
-      - name: Free disk space
-        run: |
-          echo "before: $(df -h --output=avail / | tail -1 | tr -d ' ') available on /"
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
-          echo "after:  $(df -h --output=avail / | tail -1 | tr -d ' ') available on /"
+      # Deliberately no disk-freeing step either. Removing dotnet, ghc and boost
+      # cost 35-70s of every run; measured on run 32382969223 the runner starts
+      # with 87G free and the removal recovers 11G nothing asks for.
+      #
       # Deliberately no Nix binary cache action here. devenv pins nixpkgs to
       # `cachix/devenv-nixpkgs/rolling` and configures `devenv.cachix.org` as a
       # substituter, so that cache and `cache.nixos.org` already serve the whole


### PR DESCRIPTION
# Overview

A ten-minute run was the optimistic case; the real ones are twelve to sixteen. Measured across three runs, **only 43% of the time was the Rust checks**. This removes three things that were not paying for themselves, each settled by measurement rather than argument.

## Changes

- A `base` paths-filter output, and `Run base checks` gated on it. **Nineteen of the last twenty-five merged pull requests were Rust-only** and each spent over two minutes linting file types it had not touched.
- `Free disk space` deleted.
- The llvm-cov cache deleted.
- Filter gaps closed: `.sqlx/**`, `devenv.nix`, `devenv.lock` added to `rust`; `.sqlfluff`, `.sqlfluffignore`, `devenv.lock` added to `base`.

## Context

**Where the time went**, on run 32381409920 (14m12s):

```
  secs   share  step
   370   43.4%  Run Rust checks
   180   21.1%  Cache llvm-cov artifacts
   129   15.1%  Run base checks
    67    7.9%  Free disk space
    57    6.7%  Cache Rust dependencies
    20    2.3%  Install devenv
    10    1.2%  Install Nix
```

**The llvm-cov cache bought nothing, and this is the headline.** It was the only line hitting *every* Rust pull request. A throwaway branch off master with the cache removed ran the same checks: 180s restore + 370s of checks became 0s + **369s**. One second apart. `Swatinem/rust-cache` immediately above already caches `~/.cargo` and `target/`, so the second cache was re-fetching what the first had provided.

**Freeing disk space freed disk nobody wanted.** Instrumenting it reported **87G available before the removal and 98G after** — 51 seconds spent recovering 11G against a Rust target directory that is a tenth of what was already free. Deleted rather than backgrounded: overlapping the deletion with the Nix install would have introduced the one race that could genuinely exhaust a disk, to solve a problem that does not exist.

**Three holes the filter turned up.** `.sqlx/` belongs to Rust — the build runs under `SQLX_OFFLINE`, so a stale cache fails compilation and nothing else reads those files; without this a pull request regenerating only the cache would have run *no* checks and reported success. The sqlfluff configuration belongs to base for the same reason its `.sql` files do. And devenv defines the toolchain both halves run under, so it triggers both.

**Deliberately not splitting base and Rust into parallel jobs.** With the gate in place it buys about forty seconds in expectation, because the case where the two could overlap is precisely the quarter of pull requests that touch both — and it costs a second runner and a duplicated Nix install.

## Expected

| | Rust-only (76%) | Mixed (24%) |
|---|---|---|
| Before | ~14m | ~14m |
| After | **~8m** | **~10m** |

## Verification

- `devenv tasks run checks:base` green, which includes the yaml lint over this workflow
- The llvm-cov removal measured on a branch off master so this branch's gate could not confound it: #1094, closed
- The disk figures measured on this branch's own run, 32382969223
- This pull request touches `.yaml`, so it exercises `base == true`; its first run also exercised `rust == false` and skipped every Rust step, finishing in 3m35s