### PR TITLE
EXPERIMENT: measure the llvm-cov cache (do not merge)

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -48,14 +48,7 @@ jobs:
           shared-key: rust-continuous-integration
           save-if: true
           add-rust-environment-hash-key: false
-      - name: Cache llvm-cov artifacts
-        if: steps.changes.outputs.rust == 'true'
-        uses: actions/cache@v4
-        with:
-          path: target/llvm-cov-target
-          key: llvm-cov-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            llvm-cov-${{ runner.os }}-
+      # EXPERIMENT -- llvm-cov cache disabled to measure whether it pays. Do not merge.
       - name: Run base checks
         run: devenv --secretspec-provider env --secretspec-profile development tasks run checks:base
       # The integration test targets need a database and an S3-compatible

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -1,4 +1,5 @@
 //! The S3 bar archive: the trainer's data, repaired to a window rather than topped up by a night.
+//! EXPERIMENT: this line exists only to make the paths filter run the Rust checks.
 //!
 //! One partition per session under `data/equity/bars/year=/month=/day=/data.parquet`.
 


### PR DESCRIPTION
Throwaway, do not merge. Disables the llvm-cov cache so its restore cost can be compared against the build it accelerates. Branched from master so #1093's gate is not a confound, and it touches a Rust file so the paths filter actually runs the Rust checks.

**Baseline** (run 31024457316): `Cache llvm-cov artifacts` 117s + `Run Rust checks` 226s = **343s**.

If this run's `Run Rust checks` comes in under 343s the cache is a net loss and should be deleted. Closing either way.