### PR TITLE
Fill the intraday archive

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -18,7 +18,7 @@ CREATE EXTENSION IF NOT EXISTS pg_cron;
 --
 -- One retention policy covers every interval, which is the accepted cost of a single table.
 --
--- The post-close sync writes only 'one_day'. 'one_minute' is equally legal and the constraint is
+-- The post-close sync writes only 'one_day'. 'one_minute' and 'five_minute' are equally legal and
 -- what is enforced: it is the tag fetch_snapshots applies to Alpaca's minuteBar in memory, and the
 -- second value the primary-key tests need. These are the snake_case of the BarInterval variants in
 -- common::types, which is what lets the enum derive the same strings for serde, and they must match
@@ -26,7 +26,7 @@ CREATE EXTENSION IF NOT EXISTS pg_cron;
 CREATE TABLE IF NOT EXISTS equity_bars (
     ticker                        TEXT             NOT NULL,
     bar_interval                  TEXT             NOT NULL
-        CHECK (bar_interval IN ('one_minute', 'one_day')),
+        CHECK (bar_interval IN ('one_minute', 'five_minute', 'one_day')),
     timestamp                     TIMESTAMPTZ      NOT NULL,
     open_price                    DOUBLE PRECISION NOT NULL,
     high_price                    DOUBLE PRECISION NOT NULL,

--- a/src/bin/seed_intraday_bars_s3.rs
+++ b/src/bin/seed_intraday_bars_s3.rs
@@ -1,0 +1,198 @@
+//! Backfills the intraday bar archive from Massive, one cadence at a time.
+//!
+//! Reads and repairs `data/equity/bars/interval=<cadence>/`. No database is touched.
+
+use chrono::NaiveDate;
+use tracing::{error, info};
+
+use fund::common::log::init_tracing;
+use fund::common::massive::MassiveClient;
+use fund::common::types::{BarInterval, SessionDate};
+use fund::data::archive;
+
+const USAGE: &str = "Usage: seed_intraday_bars_s3 START_DATE END_DATE [CADENCE]\n\
+                     Dates are Eastern calendar dates, inclusive: YYYY-MM-DD.\n\
+                     CADENCE is five_minute (default) or one_minute.";
+
+/// What the archive is filled with unless told otherwise.
+///
+/// Five minutes, because coverage across the whole universe puts the cliff between one minute and
+/// five: 95.8% of names clear 99% of regular-session buckets at five, against 33.2% at one.
+const DEFAULT_CADENCE: BarInterval = BarInterval::FiveMinute;
+
+struct Parameters {
+    start: SessionDate,
+    end: SessionDate,
+    interval: BarInterval,
+}
+
+impl Parameters {
+    fn parse(arguments: &[String]) -> Result<Self, String> {
+        let (start, end, cadence) = match arguments {
+            [start, end] => (start, end, None),
+            [start, end, cadence] => (start, end, Some(cadence)),
+            _ => {
+                return Err(format!(
+                    "Expected two dates and an optional cadence\n{USAGE}"
+                ))
+            }
+        };
+
+        let start = session(start, "START_DATE")?;
+        let end = session(end, "END_DATE")?;
+        if start > end {
+            return Err(format!("START_DATE must not be after END_DATE\n{USAGE}"));
+        }
+
+        // Refused rather than silently redirected: the aggregates route stamps a daily bar sixteen
+        // hours from where the grouped route stamps it, so a daily backfill taken here would not
+        // line up with the archive it landed beside.
+        let interval = match cadence.map(String::as_str) {
+            None => DEFAULT_CADENCE,
+            Some("five_minute") => BarInterval::FiveMinute,
+            Some("one_minute") => BarInterval::OneMinute,
+            Some(other) => {
+                return Err(format!(
+                    "CADENCE must be five_minute or one_minute, got {other:?}\n{USAGE}"
+                ))
+            }
+        };
+
+        Ok(Self {
+            start,
+            end,
+            interval,
+        })
+    }
+}
+
+/// Parses an Eastern calendar date, which is what a session is.
+fn session(raw: &str, name: &str) -> Result<SessionDate, String> {
+    NaiveDate::parse_from_str(raw.trim(), "%Y-%m-%d")
+        .map(SessionDate::from_date)
+        .map_err(|_| format!("{name} must be YYYY-MM-DD, got {raw:?}\n{USAGE}"))
+}
+
+#[tokio::main]
+async fn main() {
+    fund::common::crypto::install_default_crypto_provider();
+    let tracing_guard = init_tracing(
+        "seed-intraday-bars-s3.log",
+        Some("info"),
+        "seed-intraday-bars-s3",
+    );
+
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let parameters = match Parameters::parse(&arguments) {
+        Ok(parameters) => parameters,
+        Err(message) => {
+            eprintln!("{message}");
+            drop(tracing_guard);
+            std::process::exit(2);
+        }
+    };
+
+    let code = match run(&parameters).await {
+        Ok(summary) => {
+            println!(
+                "requested {} sessions, wrote {}, {} without data, {} failed, {} bars, {} symbols missing",
+                summary.sessions_requested,
+                summary.sessions_written,
+                summary.sessions_without_data,
+                summary.sessions_failed.len(),
+                summary.bars_written,
+                summary.symbols_failed
+            );
+            0
+        }
+        Err(error) => {
+            error!(%error, "Seeding the intraday bar archive failed");
+            eprintln!("Seeding the intraday bar archive failed: {error}");
+            1
+        }
+    };
+
+    drop(tracing_guard);
+    std::process::exit(code);
+}
+
+/// Repairs the intraday archive over the requested window.
+///
+/// Only the sessions the bucket is missing are fetched, so re-running over a repaired range costs
+/// one listing and nothing else.
+async fn run(
+    parameters: &Parameters,
+) -> Result<archive::ArchiveSummary, Box<dyn std::error::Error>> {
+    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let massive = MassiveClient::from_env()?;
+    let s3_client = fund::common::aws::s3_client().await;
+
+    info!(
+        bucket,
+        start = %parameters.start,
+        end = %parameters.end,
+        interval = %parameters.interval,
+        "Seeding the intraday bar archive from Massive"
+    );
+
+    Ok(archive::archive_intraday_sessions(
+        &s3_client,
+        &massive,
+        &bucket,
+        parameters.interval,
+        parameters.start,
+        parameters.end,
+    )
+    .await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arguments(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn test_the_cadence_defaults_to_five_minutes() {
+        let parameters = Parameters::parse(&arguments(&["2026-08-01", "2026-08-20"])).unwrap();
+        assert_eq!(parameters.interval, BarInterval::FiveMinute);
+        assert_eq!(parameters.start, SessionDate::from_date(date(2026, 8, 1)));
+        assert_eq!(parameters.end, SessionDate::from_date(date(2026, 8, 20)));
+
+        let parameters =
+            Parameters::parse(&arguments(&["2026-08-01", "2026-08-20", "one_minute"])).unwrap();
+        assert_eq!(parameters.interval, BarInterval::OneMinute);
+    }
+
+    fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(year, month, day).expect("a valid test date")
+    }
+
+    /// A daily cadence would come from the aggregates route, which stamps a daily bar sixteen hours
+    /// from where the grouped route stamps it — so a backfill taken here would not line up with the
+    /// archive it landed beside.
+    #[test]
+    fn test_a_daily_cadence_is_refused() {
+        assert!(Parameters::parse(&arguments(&["2026-08-01", "2026-08-20", "one_day"])).is_err());
+        assert!(Parameters::parse(&arguments(&["2026-08-01", "2026-08-20", "1Day"])).is_err());
+    }
+
+    #[test]
+    fn test_an_unusable_window_is_refused() {
+        assert!(Parameters::parse(&arguments(&["2026-08-20", "2026-08-01"])).is_err());
+        assert!(Parameters::parse(&arguments(&["2026-13-01", "2026-08-20"])).is_err());
+        assert!(Parameters::parse(&arguments(&["not-a-date", "2026-08-20"])).is_err());
+        assert!(Parameters::parse(&arguments(&["2026-08-01"])).is_err());
+        assert!(Parameters::parse(&[]).is_err());
+    }
+
+    /// A one-day window is a window, not an error: it is how a single missing session is repaired.
+    #[test]
+    fn test_a_single_session_window_is_allowed() {
+        let parameters = Parameters::parse(&arguments(&["2026-08-20", "2026-08-20"])).unwrap();
+        assert_eq!(parameters.start, parameters.end);
+    }
+}

--- a/src/bin/seed_intraday_bars_s3.rs
+++ b/src/bin/seed_intraday_bars_s3.rs
@@ -44,9 +44,8 @@ impl Parameters {
             return Err(format!("START_DATE must not be after END_DATE\n{USAGE}"));
         }
 
-        // Refused rather than silently redirected: the aggregates route stamps a daily bar sixteen
-        // hours from where the grouped route stamps it, so a daily backfill taken here would not
-        // line up with the archive it landed beside.
+        // Refused rather than redirected: the aggregates route stamps a daily bar sixteen hours
+        // from where the grouped route does, so it would not line up with the archive beside it.
         let interval = match cadence.map(String::as_str) {
             None => DEFAULT_CADENCE,
             Some("five_minute") => BarInterval::FiveMinute,
@@ -165,6 +164,12 @@ mod tests {
         let parameters =
             Parameters::parse(&arguments(&["2026-08-01", "2026-08-20", "one_minute"])).unwrap();
         assert_eq!(parameters.interval, BarInterval::OneMinute);
+
+        // The documented spelling, passed explicitly. Without this a typo in that arm sends a user
+        // who followed the usage text to the "CADENCE must be" error and the default test still passes.
+        let parameters =
+            Parameters::parse(&arguments(&["2026-08-01", "2026-08-20", "five_minute"])).unwrap();
+        assert_eq!(parameters.interval, BarInterval::FiveMinute);
     }
 
     fn date(year: i32, month: u32, day: u32) -> NaiveDate {

--- a/src/common/massive.rs
+++ b/src/common/massive.rs
@@ -282,6 +282,9 @@ fn parse_bar(raw_ticker: &str, interval: BarInterval, row: &AggregateBarRow) -> 
 }
 
 /// Fetches whole-market daily bars from Massive.
+/// Cloneable so a fan-out can hand one to each task. `reqwest::Client` is a handle over a shared
+/// pool, so a clone shares the connections rather than opening its own.
+#[derive(Clone)]
 pub struct MassiveClient {
     http_client: reqwest::Client,
     credentials: MassiveCredentials,

--- a/src/common/massive.rs
+++ b/src/common/massive.rs
@@ -2,7 +2,7 @@
 
 use chrono::{DateTime, NaiveDate};
 use serde::Deserialize;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::common::types::{BarInterval, EquityBar, EquitySplit, SessionDate, Ticker};
 
@@ -76,6 +76,29 @@ fn grouped_bars_url(base: &str, date: NaiveDate) -> String {
     )
 }
 
+/// Builds the aggregates URL for one symbol over an inclusive date range.
+///
+/// `adjusted=false` because the archive stores raw prices and folds splits at read time; the route
+/// adjusts by default, and an adjusted bar written into a raw archive is a silent restatement.
+fn aggregates_url(
+    base: &str,
+    ticker: &str,
+    interval: BarInterval,
+    from: NaiveDate,
+    to: NaiveDate,
+) -> String {
+    let (multiplier, timespan) = interval.massive_timespan();
+    format!(
+        "{}/v2/aggs/ticker/{}/range/{}/{}/{}/{}?adjusted=false&limit={AGGREGATES_PAGE_SIZE}",
+        base.trim_end_matches('/'),
+        ticker,
+        multiplier,
+        timespan,
+        from.format("%Y-%m-%d"),
+        to.format("%Y-%m-%d")
+    )
+}
+
 /// Builds the first splits URL, on the same normalization as [`grouped_bars_url`].
 ///
 /// Unfiltered by date, because the whole table is 29 pages and three seconds.
@@ -100,6 +123,15 @@ fn same_origin(base: &str, cursor: &str) -> bool {
         _ => false,
     }
 }
+
+/// Rows per aggregates page.
+///
+/// The documented and measured maximum. A five-minute cadence is a few hundred rows per session
+/// including extended hours, so this covers years of one symbol in a single response.
+const AGGREGATES_PAGE_SIZE: usize = 50_000;
+
+/// Pages followed before an aggregates fetch gives up, bounding a cursor that never terminates.
+const AGGREGATES_PAGE_LIMIT: usize = 200;
 
 /// Rows per splits page.
 ///
@@ -160,6 +192,16 @@ fn parse_split(row: &SplitRow) -> Option<EquitySplit> {
 struct GroupedBarRow {
     #[serde(rename = "T")]
     ticker: String,
+    #[serde(flatten)]
+    bar: AggregateBarRow,
+}
+
+/// One bar, without the symbol it belongs to.
+///
+/// The per-ticker aggregates route names the symbol in the URL rather than repeating it on every
+/// row, so the ticker arrives from the caller there and from the `T` field on the grouped route.
+#[derive(Deserialize, Debug)]
+struct AggregateBarRow {
     c: Option<f64>,
     h: Option<f64>,
     l: Option<f64>,
@@ -168,6 +210,13 @@ struct GroupedBarRow {
     t: u64,
     v: Option<f64>,
     vw: Option<f64>,
+}
+
+/// The aggregates envelope. `next_url` is absent on the last page, as on the splits route.
+#[derive(Deserialize)]
+struct AggregatesResponse {
+    results: Option<Vec<AggregateBarRow>>,
+    next_url: Option<String>,
 }
 
 /// The grouped-daily envelope. Unknown fields (`adjusted`, `queryCount`, `request_id`, `status`)
@@ -202,11 +251,11 @@ fn is_common_stock_symbol(raw: &str) -> bool {
 }
 
 /// Converts an untrusted row into a validated [`EquityBar`], or `None`.
-fn parse_bar(row: &GroupedBarRow) -> Option<EquityBar> {
-    if !is_common_stock_symbol(&row.ticker) {
+fn parse_bar(raw_ticker: &str, interval: BarInterval, row: &AggregateBarRow) -> Option<EquityBar> {
+    if !is_common_stock_symbol(raw_ticker) {
         return None;
     }
-    let ticker = Ticker::new(&row.ticker)?;
+    let ticker = Ticker::new(raw_ticker)?;
     let timestamp = DateTime::from_timestamp_millis(i64::try_from(row.t).ok()?)?;
 
     let volume = row
@@ -219,7 +268,7 @@ fn parse_bar(row: &GroupedBarRow) -> Option<EquityBar> {
 
     EquityBar::new(
         ticker,
-        BarInterval::OneDay,
+        interval,
         timestamp,
         row.o?,
         row.h?,
@@ -317,7 +366,10 @@ impl MassiveClient {
         };
 
         let received = rows.len();
-        let bars: Vec<EquityBar> = rows.iter().filter_map(parse_bar).collect();
+        let bars: Vec<EquityBar> = rows
+            .iter()
+            .filter_map(|row| parse_bar(&row.ticker, BarInterval::OneDay, &row.bar))
+            .collect();
 
         let dropped = received.saturating_sub(bars.len());
         if dropped > 0 {
@@ -340,6 +392,80 @@ impl MassiveClient {
     /// The response covers announced-but-unexecuted splits as well as historical ones, so a caller
     /// holding the result has the feed's whole current opinion rather than a window of it — which is
     /// what makes replacing the stored table safe when a split is cancelled and disappears.
+    /// Fetches one symbol's bars at an intraday cadence over an inclusive date range.
+    ///
+    /// **Refuses [`BarInterval::OneDay`].** This route stamps a daily bar at midnight Eastern where
+    /// the grouped route stamps it at the session close — sixteen hours apart for the same bar — so
+    /// a daily series taken from here and joined to the archive yields every session twice.
+    pub async fn fetch_intraday(
+        &self,
+        ticker: &str,
+        interval: BarInterval,
+        from: NaiveDate,
+        to: NaiveDate,
+    ) -> Result<Vec<EquityBar>, MassiveError> {
+        match interval {
+            BarInterval::OneMinute | BarInterval::FiveMinute => {}
+            BarInterval::OneDay => {
+                return Err(MassiveError::Parse(
+                    "the aggregates route stamps a daily bar at midnight where the grouped route \
+                     stamps it at the close; use fetch_grouped_daily"
+                        .to_string(),
+                ))
+            }
+        }
+
+        let mut url = aggregates_url(&self.credentials.base_url, ticker, interval, from, to);
+        let mut bars: Vec<EquityBar> = Vec::new();
+        let mut received = 0usize;
+
+        for _ in 1..=AGGREGATES_PAGE_LIMIT {
+            let response = self.authorized(&url).send().await?;
+            if !response.status().is_success() {
+                let status = response.status().as_u16();
+                let body = response.text().await.unwrap_or_default();
+                return Err(MassiveError::Api { status, body });
+            }
+
+            let payload: AggregatesResponse = response.json().await.map_err(|error| {
+                MassiveError::Parse(format!("Failed to parse {ticker} aggregates: {error}"))
+            })?;
+
+            let rows = payload.results.unwrap_or_default();
+            received += rows.len();
+            bars.extend(
+                rows.iter()
+                    .filter_map(|row| parse_bar(ticker, interval, row)),
+            );
+
+            let Some(next_url) = payload.next_url else {
+                let dropped = received.saturating_sub(bars.len());
+                if dropped > 0 {
+                    debug!(
+                        ticker,
+                        dropped, received, "Dropped aggregate rows that failed validation"
+                    );
+                }
+                return Ok(bars);
+            };
+            // Checked before it is followed, for the reason `fetch_splits` gives: the request that
+            // follows re-attaches the bearer token and this URL came out of the response body.
+            if !same_origin(&self.credentials.base_url, &next_url) {
+                return Err(MassiveError::Cursor {
+                    host: reqwest::Url::parse(&next_url)
+                        .ok()
+                        .and_then(|cursor| cursor.host_str().map(str::to_string))
+                        .unwrap_or_else(|| "an unparseable URL".to_string()),
+                });
+            }
+            url = next_url;
+        }
+
+        Err(MassiveError::Parse(format!(
+            "{ticker} aggregates pagination did not end within {AGGREGATES_PAGE_LIMIT} pages"
+        )))
+    }
+
     pub async fn fetch_splits(&self) -> Result<Vec<EquitySplit>, MassiveError> {
         let mut url = splits_url(&self.credentials.base_url);
         let mut splits: Vec<EquitySplit> = Vec::new();
@@ -426,6 +552,164 @@ mod tests {
                 "{base}"
             );
         }
+    }
+
+    /// The two minute cadences differ only in the multiplier, so a copied arm would silently fetch
+    /// one-minute bars for a five-minute request. `adjusted=false` is pinned here too: the route
+    /// adjusts by default, and an adjusted bar in a raw archive is a silent restatement.
+    #[test]
+    fn test_the_aggregates_url_carries_the_cadence_and_refuses_adjustment() {
+        let url = aggregates_url(
+            "https://api.massive.com/",
+            "AAPL",
+            BarInterval::FiveMinute,
+            date("2026-08-18"),
+            date("2026-08-20"),
+        );
+        assert!(
+            url.starts_with(
+                "https://api.massive.com/v2/aggs/ticker/AAPL/range/5/minute/2026-08-18/2026-08-20"
+            ),
+            "{url}"
+        );
+        assert!(url.contains("adjusted=false"), "{url}");
+
+        let minute = aggregates_url(
+            "https://api.massive.com",
+            "AAPL",
+            BarInterval::OneMinute,
+            date("2026-08-18"),
+            date("2026-08-20"),
+        );
+        assert!(minute.contains("/range/1/minute/"), "{minute}");
+    }
+
+    /// The route stamps a daily bar at midnight Eastern where the grouped route stamps it at the
+    /// close. A daily series taken from here and joined to the archive yields every session twice,
+    /// sixteen hours apart, with neither copy obviously wrong.
+    #[tokio::test]
+    async fn test_a_daily_interval_is_refused_by_the_intraday_route() {
+        let server = mockito::Server::new_async().await;
+        let result = MassiveClient::for_tests(&server.url())
+            .fetch_intraday(
+                "AAPL",
+                BarInterval::OneDay,
+                date("2026-08-18"),
+                date("2026-08-20"),
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(MassiveError::Parse(ref message)) if message.contains("grouped")),
+            "a daily interval must be refused with a message naming the right route"
+        );
+    }
+
+    /// The per-ticker route names the symbol in the URL and not on each row, so the ticker has to
+    /// come from the caller. Reading it off the row would leave every bar unattributed.
+    #[tokio::test]
+    async fn test_the_ticker_and_interval_come_from_the_caller() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(
+                r#"{"status":"OK","results":[
+                    {"v":2153,"vw":316.9,"o":316.96,"c":317.0,"h":317.0,"l":316.83,"t":1787183940000,"n":42}
+                ]}"#,
+            )
+            .create_async()
+            .await;
+
+        let bars = MassiveClient::for_tests(&server.url())
+            .fetch_intraday(
+                "MSFT",
+                BarInterval::FiveMinute,
+                date("2026-08-18"),
+                date("2026-08-20"),
+            )
+            .await
+            .expect("the fetch must succeed");
+
+        assert_eq!(bars.len(), 1);
+        assert_eq!(bars[0].ticker().as_str(), "MSFT");
+        assert_eq!(bars[0].bar_interval(), BarInterval::FiveMinute);
+        mock.assert_async().await;
+    }
+
+    /// A cursor is followed to the end and the pages accumulate, which is what makes a multi-year
+    /// range of one symbol a single call rather than the caller's problem.
+    #[tokio::test]
+    async fn test_an_aggregates_cursor_is_followed_to_the_end() {
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let first = server
+            .mock(
+                "GET",
+                "/v2/aggs/ticker/AAPL/range/5/minute/2026-08-18/2026-08-20",
+            )
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"status":"OK","results":[
+                    {{"v":10,"vw":1.0,"o":1.0,"c":1.0,"h":1.0,"l":1.0,"t":1787183940000,"n":1}}
+                ],"next_url":"{base}/page-two"}}"#
+            ))
+            .create_async()
+            .await;
+        let second = server
+            .mock("GET", "/page-two")
+            .with_status(200)
+            .with_body(
+                r#"{"status":"OK","results":[
+                    {"v":20,"vw":2.0,"o":2.0,"c":2.0,"h":2.0,"l":2.0,"t":1787184240000,"n":2}
+                ]}"#,
+            )
+            .create_async()
+            .await;
+
+        let bars = MassiveClient::for_tests(&base)
+            .fetch_intraday(
+                "AAPL",
+                BarInterval::FiveMinute,
+                date("2026-08-18"),
+                date("2026-08-20"),
+            )
+            .await
+            .expect("the fetch must succeed");
+
+        assert_eq!(bars.len(), 2, "both pages, not just the first");
+        first.assert_async().await;
+        second.assert_async().await;
+    }
+
+    /// A cursor pointing somewhere else must not receive the bearer token. The URL arrives in a
+    /// response body, so following it blindly lets the response choose where the credential goes.
+    #[tokio::test]
+    async fn test_an_aggregates_cursor_off_origin_is_refused() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(
+                r#"{"status":"OK","results":[],"next_url":"https://elsewhere.example/page-two"}"#,
+            )
+            .create_async()
+            .await;
+
+        let result = MassiveClient::for_tests(&server.url())
+            .fetch_intraday(
+                "AAPL",
+                BarInterval::FiveMinute,
+                date("2026-08-18"),
+                date("2026-08-20"),
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(MassiveError::Cursor { .. })),
+            "{result:?}"
+        );
     }
 
     /// `matches!` rather than `assert_eq!`, because `MassiveCredentials` deliberately has no

--- a/src/common/massive.rs
+++ b/src/common/massive.rs
@@ -82,7 +82,7 @@ fn grouped_bars_url(base: &str, date: NaiveDate) -> String {
 /// adjusts by default, and an adjusted bar written into a raw archive is a silent restatement.
 fn aggregates_url(
     base: &str,
-    ticker: &str,
+    ticker: &Ticker,
     interval: BarInterval,
     from: NaiveDate,
     to: NaiveDate,
@@ -399,10 +399,11 @@ impl MassiveClient {
     ///
     /// **Refuses [`BarInterval::OneDay`].** This route stamps a daily bar at midnight Eastern where
     /// the grouped route stamps it at the session close — sixteen hours apart for the same bar — so
-    /// a daily series taken from here and joined to the archive yields every session twice.
+    /// a daily series taken from here and joined to the archive yields every session twice. The
+    /// symbol is a [`Ticker`] because it lands in a URL path on a request carrying the bearer token.
     pub async fn fetch_intraday(
         &self,
-        ticker: &str,
+        ticker: &Ticker,
         interval: BarInterval,
         from: NaiveDate,
         to: NaiveDate,
@@ -438,14 +439,14 @@ impl MassiveClient {
             received += rows.len();
             bars.extend(
                 rows.iter()
-                    .filter_map(|row| parse_bar(ticker, interval, row)),
+                    .filter_map(|row| parse_bar(ticker.as_str(), interval, row)),
             );
 
             let Some(next_url) = payload.next_url else {
                 let dropped = received.saturating_sub(bars.len());
                 if dropped > 0 {
                     debug!(
-                        ticker,
+                        %ticker,
                         dropped, received, "Dropped aggregate rows that failed validation"
                     );
                 }
@@ -527,6 +528,11 @@ impl MassiveClient {
 mod tests {
     use super::*;
 
+    /// A validated symbol, which is what the aggregates route now takes.
+    fn symbol(raw: &str) -> Ticker {
+        Ticker::new(raw).expect("a valid test symbol")
+    }
+
     fn date(value: &str) -> NaiveDate {
         NaiveDate::parse_from_str(value, "%Y-%m-%d").expect("a valid test date")
     }
@@ -564,7 +570,7 @@ mod tests {
     fn test_the_aggregates_url_carries_the_cadence_and_refuses_adjustment() {
         let url = aggregates_url(
             "https://api.massive.com/",
-            "AAPL",
+            &symbol("AAPL"),
             BarInterval::FiveMinute,
             date("2026-08-18"),
             date("2026-08-20"),
@@ -579,7 +585,7 @@ mod tests {
 
         let minute = aggregates_url(
             "https://api.massive.com",
-            "AAPL",
+            &symbol("AAPL"),
             BarInterval::OneMinute,
             date("2026-08-18"),
             date("2026-08-20"),
@@ -595,7 +601,7 @@ mod tests {
         let server = mockito::Server::new_async().await;
         let result = MassiveClient::for_tests(&server.url())
             .fetch_intraday(
-                "AAPL",
+                &symbol("AAPL"),
                 BarInterval::OneDay,
                 date("2026-08-18"),
                 date("2026-08-20"),
@@ -626,7 +632,7 @@ mod tests {
 
         let bars = MassiveClient::for_tests(&server.url())
             .fetch_intraday(
-                "MSFT",
+                &symbol("MSFT"),
                 BarInterval::FiveMinute,
                 date("2026-08-18"),
                 date("2026-08-20"),
@@ -673,7 +679,7 @@ mod tests {
 
         let bars = MassiveClient::for_tests(&base)
             .fetch_intraday(
-                "AAPL",
+                &symbol("AAPL"),
                 BarInterval::FiveMinute,
                 date("2026-08-18"),
                 date("2026-08-20"),
@@ -702,7 +708,7 @@ mod tests {
 
         let result = MassiveClient::for_tests(&server.url())
             .fetch_intraday(
-                "AAPL",
+                &symbol("AAPL"),
                 BarInterval::FiveMinute,
                 date("2026-08-18"),
                 date("2026-08-20"),

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -583,12 +583,17 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for PairID {
 #[serde(rename_all = "snake_case")]
 pub enum BarInterval {
     OneMinute,
+    FiveMinute,
     OneDay,
 }
 
 impl BarInterval {
     /// Every variant, for exhaustive iteration in tests and validation.
-    pub const ALL: [BarInterval; 2] = [BarInterval::OneMinute, BarInterval::OneDay];
+    pub const ALL: [BarInterval; 3] = [
+        BarInterval::OneMinute,
+        BarInterval::FiveMinute,
+        BarInterval::OneDay,
+    ];
 
     /// The canonical stored form, matching the `bar_interval` CHECK constraint.
     ///
@@ -597,7 +602,20 @@ impl BarInterval {
     pub fn as_str(self) -> &'static str {
         match self {
             BarInterval::OneMinute => "one_minute",
+            BarInterval::FiveMinute => "five_minute",
             BarInterval::OneDay => "one_day",
+        }
+    }
+
+    /// The multiplier and timespan Massive's aggregates route spells this interval with.
+    ///
+    /// Separate from [`BarInterval::as_str`] because the two vocabularies answer to different
+    /// owners: one is the stored form a CHECK constraint pins, the other is a vendor's URL.
+    pub fn massive_timespan(self) -> (u32, &'static str) {
+        match self {
+            BarInterval::OneMinute => (1, "minute"),
+            BarInterval::FiveMinute => (5, "minute"),
+            BarInterval::OneDay => (1, "day"),
         }
     }
 
@@ -1596,6 +1614,23 @@ mod tests {
     fn test_bar_interval_stored_form_matches_the_check_constraint() {
         assert_eq!(BarInterval::OneDay.as_str(), "one_day");
         assert_eq!(BarInterval::OneMinute.as_str(), "one_minute");
+        assert_eq!(BarInterval::FiveMinute.as_str(), "five_minute");
+    }
+
+    /// Massive's aggregates route spells an interval as a multiplier and a timespan, and the two
+    /// minute cadences differ only in the multiplier — so a copied arm is invisible until every
+    /// five-minute request silently returns one-minute bars.
+    #[test]
+    fn test_each_interval_maps_to_a_distinct_massive_timespan() {
+        assert_eq!(BarInterval::OneMinute.massive_timespan(), (1, "minute"));
+        assert_eq!(BarInterval::FiveMinute.massive_timespan(), (5, "minute"));
+        assert_eq!(BarInterval::OneDay.massive_timespan(), (1, "day"));
+
+        let spellings: std::collections::BTreeSet<(u32, &str)> = BarInterval::ALL
+            .iter()
+            .map(|i| i.massive_timespan())
+            .collect();
+        assert_eq!(spellings.len(), 3);
     }
 
     /// The serde derive and the stored form must produce the same string. They did not before the

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -15,7 +15,7 @@ use tracing::{info, warn};
 use crate::common::alpaca::MarketDataClient;
 use crate::common::aws::{date_from_partitioned_key, date_partitioned_key};
 use crate::common::massive::MassiveClient;
-use crate::common::types::{BarInterval, SessionDate};
+use crate::common::types::{BarInterval, SessionDate, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
 use crate::data::{bars, boundaries, splits};
 
 /// Root of the bar archive, never a partition prefix on its own — [`bar_archive_prefix`] adds the
@@ -170,6 +170,12 @@ pub struct ArchiveSummary {
     pub sessions_failed: Vec<SessionDate>,
     /// Bars written across every partition this pass touched.
     pub bars_written: usize,
+    /// Symbols an intraday pass could not fetch after every attempt.
+    ///
+    /// Reported because nothing downstream can detect one. A session-level gap scan sees the
+    /// partition and moves on, so a symbol missing from it stays missing until someone re-runs the
+    /// window deliberately. Always zero on the daily path, which fetches the market in one call.
+    pub symbols_failed: usize,
 }
 
 /// Every weekday in `[start, end]` that the archive should be able to answer for.
@@ -214,12 +220,13 @@ fn sessions_to_request(
 async fn present_sessions(
     s3_client: &S3Client,
     bucket: &str,
+    interval: BarInterval,
     start: SessionDate,
     end: SessionDate,
 ) -> Result<BTreeSet<SessionDate>, ArchiveError> {
     // Scoped to the cadence being repaired. Listing the whole bar tree would count an intraday
     // partition as a daily session already present, and the gap scan would stop fetching it.
-    let prefix = bar_archive_prefix(BarInterval::OneDay);
+    let prefix = bar_archive_prefix(interval);
     let mut present = BTreeSet::new();
     let mut pages = s3_client
         .list_objects_v2()
@@ -271,7 +278,14 @@ pub async fn archive_missing_sessions(
     window_end: SessionDate,
 ) -> Result<ArchiveSummary, ArchiveError> {
     let expected = expected_sessions(window_start, window_end);
-    let present = present_sessions(s3_client, bucket, window_start, window_end).await?;
+    let present = present_sessions(
+        s3_client,
+        bucket,
+        BarInterval::OneDay,
+        window_start,
+        window_end,
+    )
+    .await?;
     let requested = sessions_to_request(&expected, &present);
 
     info!(
@@ -366,7 +380,15 @@ async fn archive_chunk(
         let fetched_frame = bars::bars_to_dataframe(&bars_for_session)?;
         let fetched_rows = fetched_frame.height();
 
-        match write_partition(s3_client, bucket, session, fetched_frame).await {
+        match write_partition(
+            s3_client,
+            bucket,
+            BarInterval::OneDay,
+            session,
+            fetched_frame,
+        )
+        .await
+        {
             Ok(()) => {
                 // The rows this pass contributed, not the partition's height. Counting the merged
                 // total reported the archive's size as though every pass had just written it.
@@ -386,6 +408,230 @@ async fn archive_chunk(
     Ok(())
 }
 
+/// Sessions held in memory before an intraday pass writes its partitions and releases the buffer.
+///
+/// A month. Requests are ticker-major and partitions are session-major, so a chunk has to hold every
+/// name before any one session can be written — a quarter of five-minute bars over this universe is
+/// several hundred megabytes, where a month is a fifth of that. Smaller chunks cost requests rather
+/// than memory: the request count is the universe times the number of chunks.
+const INTRADAY_CHUNK_SESSIONS: usize = 21;
+
+/// Attempts per symbol before a chunk gives up on it.
+///
+/// Load-bearing rather than defensive. A session-level gap scan cannot see a *symbol*-level hole:
+/// the partition exists, so the next pass never re-requests it, and one dropped response becomes a
+/// name permanently missing from that month. A single transient failure was observed in the first
+/// twenty-two sessions and the same request succeeded immediately afterward.
+const INTRADAY_SYMBOL_ATTEMPTS: usize = 3;
+
+/// Symbols fetched at once.
+///
+/// The vendor imposes no rate limit worth pacing against — 25 sequential requests measured at
+/// roughly twelve a second with no throttling — so this bounds our own concurrency rather than
+/// respecting theirs, and keeps a failure to a handful of symbols rather than the whole chunk.
+const INTRADAY_CONCURRENCY: usize = 8;
+
+/// Fetches and writes every intraday partition in `[window_start, window_end]` the archive lacks.
+///
+/// A set difference like [`archive_missing_sessions`], and scoped to `interval` throughout, so a
+/// five-minute pass neither sees nor writes the daily partitions beside it.
+pub async fn archive_intraday_sessions(
+    s3_client: &S3Client,
+    massive: &MassiveClient,
+    bucket: &str,
+    interval: BarInterval,
+    window_start: SessionDate,
+    window_end: SessionDate,
+) -> Result<ArchiveSummary, ArchiveError> {
+    let expected = expected_sessions(window_start, window_end);
+    let present = present_sessions(s3_client, bucket, interval, window_start, window_end).await?;
+    // No correction window: an intraday bar is not restated after the close the way a daily one is,
+    // and re-fetching a month to find that out would cost the universe in requests.
+    let requested: Vec<SessionDate> = expected
+        .iter()
+        .copied()
+        .filter(|session| !present.contains(session))
+        .collect();
+
+    info!(
+        %window_start,
+        %window_end,
+        interval = %interval,
+        expected = expected.len(),
+        present = present.len(),
+        requested = requested.len(),
+        "Scanned the intraday archive for gaps"
+    );
+
+    let mut summary = ArchiveSummary {
+        sessions_requested: requested.len(),
+        ..Default::default()
+    };
+    for chunk in requested.chunks(INTRADAY_CHUNK_SESSIONS) {
+        archive_intraday_chunk(s3_client, massive, bucket, interval, chunk, &mut summary).await?;
+    }
+
+    info!(
+        sessions_requested = summary.sessions_requested,
+        sessions_written = summary.sessions_written,
+        sessions_without_data = summary.sessions_without_data,
+        sessions_failed = summary.sessions_failed.len(),
+        bars_written = summary.bars_written,
+        "Intraday archive updated"
+    );
+    Ok(summary)
+}
+
+/// One chunk: derive the universe, fan out over it, then write a partition per session.
+async fn archive_intraday_chunk(
+    s3_client: &S3Client,
+    massive: &MassiveClient,
+    bucket: &str,
+    interval: BarInterval,
+    chunk: &[SessionDate],
+    summary: &mut ArchiveSummary,
+) -> Result<(), ArchiveError> {
+    let (Some(first), Some(last)) = (chunk.first(), chunk.last()) else {
+        return Ok(());
+    };
+    let universe = universe_over(s3_client, bucket, chunk).await?;
+    if universe.is_empty() {
+        // The daily archive has nothing to say about these sessions, so there is no universe to
+        // fetch. Counted as answered-with-nothing rather than failed, which is what it is.
+        summary.sessions_without_data += chunk.len();
+        return Ok(());
+    }
+    info!(
+        %first,
+        %last,
+        universe = universe.len(),
+        "Fetching an intraday chunk"
+    );
+
+    let mut pending: Vec<String> = universe.into_iter().collect();
+    let mut tasks = tokio::task::JoinSet::new();
+    let mut bars: Vec<crate::common::types::EquityBar> = Vec::new();
+    let mut symbols_failed = 0usize;
+
+    loop {
+        while tasks.len() < INTRADAY_CONCURRENCY {
+            let Some(ticker) = pending.pop() else { break };
+            let client = massive.clone();
+            let (from, to) = (first.date(), last.date());
+            tasks.spawn(async move {
+                let mut last_error = None;
+                for _ in 0..INTRADAY_SYMBOL_ATTEMPTS {
+                    match client.fetch_intraday(&ticker, interval, from, to).await {
+                        Ok(bars) => return Ok(bars),
+                        Err(error) => last_error = Some(error),
+                    }
+                }
+                Err(last_error.expect("a failed attempt records its error"))
+            });
+        }
+        let Some(finished) = tasks.join_next().await else {
+            break;
+        };
+        match finished {
+            Ok(Ok(fetched)) => bars.extend(fetched),
+            // One symbol's failure costs that symbol, not the chunk. The session stays absent from
+            // the archive only if every symbol in it failed, and the next pass requests it again.
+            Ok(Err(error)) => {
+                symbols_failed += 1;
+                warn!(%error, "A symbol's intraday fetch failed; continuing the chunk");
+            }
+            Err(error) => {
+                symbols_failed += 1;
+                warn!(%error, "An intraday fetch task did not complete");
+            }
+        }
+    }
+
+    // Keyed by the bar's own timestamp rather than by the session requested, on the same reasoning
+    // as the daily path: a response that answers for a neighbouring session must not land under the
+    // wrong key. An extended-hours bar is still its own Eastern date, which is what makes this safe.
+    let mut by_session: std::collections::BTreeMap<SessionDate, Vec<_>> =
+        std::collections::BTreeMap::new();
+    for bar in bars {
+        by_session
+            .entry(SessionDate::at(bar.timestamp()))
+            .or_default()
+            .push(bar);
+    }
+
+    let answered: BTreeSet<SessionDate> = by_session.keys().copied().collect();
+    summary.sessions_without_data += chunk.iter().filter(|s| !answered.contains(s)).count();
+    if symbols_failed > 0 {
+        summary.symbols_failed += symbols_failed;
+        // Loud, because the partitions below are about to be written *without* these names and
+        // nothing downstream can tell that from a complete one.
+        warn!(
+            symbols_failed,
+            attempts = INTRADAY_SYMBOL_ATTEMPTS,
+            %first,
+            %last,
+            "Some symbols could not be fetched; their bars are absent from this chunk's partitions"
+        );
+    }
+
+    for (session, bars_for_session) in by_session {
+        // A bar dated outside the chunk is a vendor answering beyond the range asked for. Writing it
+        // would put rows in a partition this pass never claimed and never verified.
+        if !chunk.contains(&session) {
+            continue;
+        }
+        let frame = bars::bars_to_dataframe(&bars_for_session)?;
+        let rows = frame.height();
+        match write_partition(s3_client, bucket, interval, session, frame).await {
+            Ok(()) => {
+                summary.sessions_written += 1;
+                summary.bars_written += rows;
+            }
+            Err(ArchiveError::Contended { key, attempts }) => {
+                warn!(key, attempts, %session, "Partition contended; the next pass will retry it");
+                summary.sessions_failed.push(session);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+/// The names that traded across `sessions`, read from the daily archive and screened as the model
+/// screens them.
+///
+/// **Survivorship-free by construction.** The daily partitions are whole-market and were written on
+/// the day, so a name that has since delisted is still present in the sessions it traded. Taking the
+/// list from today's market instead would sample only the survivors — and a pair that blew up is
+/// exactly the one a convergence study must not drop.
+async fn universe_over(
+    s3_client: &S3Client,
+    bucket: &str,
+    sessions: &[SessionDate],
+) -> Result<BTreeSet<String>, ArchiveError> {
+    let daily = bar_archive_prefix(BarInterval::OneDay);
+    let mut universe = BTreeSet::new();
+
+    for session in sessions {
+        let key = date_partitioned_key(&daily, session.date());
+        let Some(frame) = read_partition(s3_client, bucket, &key).await? else {
+            continue;
+        };
+        let screened = frame
+            .lazy()
+            .filter(
+                col("close_price")
+                    .gt_eq(lit(MINIMUM_CLOSE_PRICE))
+                    .and(col("volume").gt_eq(lit(MINIMUM_VOLUME))),
+            )
+            .select([col("ticker")])
+            .collect()?;
+        let tickers = screened.column("ticker")?.str()?;
+        universe.extend(tickers.into_iter().flatten().map(str::to_string));
+    }
+    Ok(universe)
+}
+
 /// Merges `fetched` into the partition for `session` and writes it back, conditional on what it read.
 ///
 /// The read-merge-write is a compare-and-swap. S3 returns the object's `ETag` on read, and the write
@@ -399,10 +645,11 @@ async fn archive_chunk(
 async fn write_partition(
     s3_client: &S3Client,
     bucket: &str,
+    interval: BarInterval,
     session: SessionDate,
     fetched: DataFrame,
 ) -> Result<(), ArchiveError> {
-    let key = date_partitioned_key(&bar_archive_prefix(BarInterval::OneDay), session.date());
+    let key = date_partitioned_key(&bar_archive_prefix(interval), session.date());
     write_merged(s3_client, bucket, key, fetched, |existing, fetched, key| {
         merge_or_replace(existing, fetched, key)
     })
@@ -823,6 +1070,38 @@ mod tests {
             let key = date_partitioned_key(&bar_archive_prefix(interval), date);
             assert_eq!(date_from_partitioned_key(&key), Some(date), "key: {key}");
         }
+    }
+
+    /// The intraday pass deliberately has no correction window, unlike the daily one. A daily bar
+    /// gets restated after the close; an intraday bar does not, and re-requesting a month to learn
+    /// that would cost the whole universe in requests rather than one grouped call.
+    #[test]
+    fn test_the_intraday_scan_requests_only_what_is_absent() {
+        let expected = expected_sessions(session(2026, 6, 1), session(2026, 6, 5));
+        // The two most recent sessions are held, which is where the daily correction window bites.
+        let present: BTreeSet<SessionDate> = [session(2026, 6, 4), session(2026, 6, 5)]
+            .into_iter()
+            .collect();
+
+        let requested: Vec<SessionDate> = expected
+            .iter()
+            .copied()
+            .filter(|s| !present.contains(s))
+            .collect();
+        assert_eq!(
+            requested,
+            vec![
+                session(2026, 6, 1),
+                session(2026, 6, 2),
+                session(2026, 6, 3)
+            ],
+            "nothing already held is re-requested"
+        );
+
+        // The daily path re-requests the two held sessions on top, to pick up restatements.
+        let daily = sessions_to_request(&expected, &present);
+        assert_eq!(daily.len(), 5, "{daily:?}");
+        assert!(daily.contains(&session(2026, 6, 5)), "{daily:?}");
     }
 
     /// 2026-06-01 is a Monday, so the week runs Mon-Fri 1..=5 and the weekend is 6-7.

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -792,6 +792,10 @@ mod tests {
             date_partitioned_key(&bar_archive_prefix(BarInterval::OneMinute), date),
             "data/equity/bars/interval=one_minute/year=2026/month=08/day=19/data.parquet"
         );
+        assert_eq!(
+            date_partitioned_key(&bar_archive_prefix(BarInterval::FiveMinute), date),
+            "data/equity/bars/interval=five_minute/year=2026/month=08/day=19/data.parquet"
+        );
     }
 
     /// Two cadences of one session must not collide, which is the whole reason the segment exists.
@@ -804,9 +808,10 @@ mod tests {
             .map(|interval| date_partitioned_key(&bar_archive_prefix(*interval), date))
             .collect();
 
-        // Two, the cadences that exist today. Pinned rather than taken from `BarInterval::ALL`, so
-        // adding a variant has to come here and say what its key is rather than passing silently.
-        assert_eq!(keys.len(), 2);
+        // Three, the cadences that exist today. Pinned rather than taken from `BarInterval::ALL`,
+        // so adding a variant has to come here and say what its key is rather than passing
+        // silently — which is what caught `five_minute` arriving.
+        assert_eq!(keys.len(), 3);
     }
 
     /// The cadence segment sits before the date partition, so the date inverse still reads the tail

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -15,7 +15,9 @@ use tracing::{info, warn};
 use crate::common::alpaca::MarketDataClient;
 use crate::common::aws::{date_from_partitioned_key, date_partitioned_key};
 use crate::common::massive::MassiveClient;
-use crate::common::types::{BarInterval, SessionDate, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
+use crate::common::types::{
+    BarInterval, EquityBar, SessionDate, Ticker, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME,
+};
 use crate::data::{bars, boundaries, splits};
 
 /// Root of the bar archive, never a partition prefix on its own — [`bar_archive_prefix`] adds the
@@ -172,9 +174,9 @@ pub struct ArchiveSummary {
     pub bars_written: usize,
     /// Symbols an intraday pass could not fetch after every attempt.
     ///
-    /// Reported because nothing downstream can detect one. A session-level gap scan sees the
+    /// Reported because nothing downstream can detect one: a session-level gap scan sees the
     /// partition and moves on, so a symbol missing from it stays missing until someone re-runs the
-    /// window deliberately. Always zero on the daily path, which fetches the market in one call.
+    /// window. Always zero on the daily path, which fetches the market in one call.
     pub symbols_failed: usize,
 }
 
@@ -410,19 +412,58 @@ async fn archive_chunk(
 
 /// Sessions held in memory before an intraday pass writes its partitions and releases the buffer.
 ///
-/// A month. Requests are ticker-major and partitions are session-major, so a chunk has to hold every
-/// name before any one session can be written — a quarter of five-minute bars over this universe is
-/// several hundred megabytes, where a month is a fifth of that. Smaller chunks cost requests rather
-/// than memory: the request count is the universe times the number of chunks.
+/// A month, because requests are ticker-major and partitions session-major: a chunk holds every name
+/// before any one session can be written, and a quarter of five-minute bars is several hundred
+/// megabytes where a month is a fifth of that. Smaller chunks trade requests for memory.
 const INTRADAY_CHUNK_SESSIONS: usize = 21;
 
 /// Attempts per symbol before a chunk gives up on it.
 ///
-/// Load-bearing rather than defensive. A session-level gap scan cannot see a *symbol*-level hole:
-/// the partition exists, so the next pass never re-requests it, and one dropped response becomes a
-/// name permanently missing from that month. A single transient failure was observed in the first
-/// twenty-two sessions and the same request succeeded immediately afterward.
+/// Load-bearing rather than defensive: a session-level gap scan cannot see a *symbol*-level hole, so
+/// one dropped response becomes a name permanently missing from that month. A single transient
+/// failure appeared in the first twenty-two sessions and succeeded immediately on retry.
 const INTRADAY_SYMBOL_ATTEMPTS: usize = 3;
+
+/// Pause before a symbol's next attempt, growing with the attempt number.
+///
+/// Eight tasks retrying without one turns a vendor throttle into twenty-four immediate requests at
+/// an endpoint that is already refusing.
+fn retry_delay(attempt: usize) -> std::time::Duration {
+    std::time::Duration::from_millis(250 << attempt.min(4))
+}
+
+/// Whether a failure is worth another attempt.
+///
+/// A 404 for a delisted symbol can never succeed, and a survivorship-free universe is full of them,
+/// so retrying every refusal scales the wasted requests with the delisted tail. Throttling and
+/// server faults are the transient statuses; a transport error carries no status and is transient by
+/// nature.
+fn is_transient(error: &crate::common::massive::MassiveError) -> bool {
+    match error {
+        crate::common::massive::MassiveError::Api { status, .. } => {
+            *status == 429 || (500..600).contains(status)
+        }
+        crate::common::massive::MassiveError::Request(_)
+        | crate::common::massive::MassiveError::Parse(_) => true,
+        crate::common::massive::MassiveError::Cursor { .. } => false,
+    }
+}
+
+/// The sessions an intraday pass must request: those the archive does not already hold.
+///
+/// No correction window, unlike [`sessions_to_request`]. An intraday bar is not restated after the
+/// close the way a daily one is, and re-fetching a month to learn that costs the whole universe in
+/// requests rather than one grouped call.
+fn intraday_sessions_to_request(
+    expected: &[SessionDate],
+    present: &BTreeSet<SessionDate>,
+) -> Vec<SessionDate> {
+    expected
+        .iter()
+        .copied()
+        .filter(|session| !present.contains(session))
+        .collect()
+}
 
 /// Symbols fetched at once.
 ///
@@ -445,13 +486,7 @@ pub async fn archive_intraday_sessions(
 ) -> Result<ArchiveSummary, ArchiveError> {
     let expected = expected_sessions(window_start, window_end);
     let present = present_sessions(s3_client, bucket, interval, window_start, window_end).await?;
-    // No correction window: an intraday bar is not restated after the close the way a daily one is,
-    // and re-fetching a month to find that out would cost the universe in requests.
-    let requested: Vec<SessionDate> = expected
-        .iter()
-        .copied()
-        .filter(|session| !present.contains(session))
-        .collect();
+    let requested = intraday_sessions_to_request(&expected, &present);
 
     info!(
         %window_start,
@@ -471,11 +506,20 @@ pub async fn archive_intraday_sessions(
         archive_intraday_chunk(s3_client, massive, bucket, interval, chunk, &mut summary).await?;
     }
 
+    if summary.symbols_failed > 0 {
+        // Warned separately from the summary below, because this is the only outcome here that
+        // needs a person: nothing re-requests a session that was written without one of its names.
+        warn!(
+            symbols_failed = summary.symbols_failed,
+            "Some symbols are absent from the partitions this pass wrote; re-run the window to repair them"
+        );
+    }
     info!(
         sessions_requested = summary.sessions_requested,
         sessions_written = summary.sessions_written,
         sessions_without_data = summary.sessions_without_data,
         sessions_failed = summary.sessions_failed.len(),
+        symbols_failed = summary.symbols_failed,
         bars_written = summary.bars_written,
         "Intraday archive updated"
     );
@@ -495,22 +539,31 @@ async fn archive_intraday_chunk(
         return Ok(());
     };
     let universe = universe_over(s3_client, bucket, chunk).await?;
-    if universe.is_empty() {
-        // The daily archive has nothing to say about these sessions, so there is no universe to
-        // fetch. Counted as answered-with-nothing rather than failed, which is what it is.
-        summary.sessions_without_data += chunk.len();
+    let undescribed = chunk.len() - universe.described.len();
+    if undescribed > 0 {
+        // Left absent so the next pass retries, rather than written from a universe that never
+        // included whatever traded only in the sessions the daily archive is missing.
+        warn!(
+            undescribed,
+            %first, %last,
+            "Some sessions have no daily partition to screen against; leaving them unwritten"
+        );
+        summary.sessions_without_data += undescribed;
+    }
+    if universe.symbols.is_empty() {
         return Ok(());
     }
     info!(
         %first,
         %last,
-        universe = universe.len(),
+        universe = universe.symbols.len(),
+        described = universe.described.len(),
         "Fetching an intraday chunk"
     );
 
-    let mut pending: Vec<String> = universe.into_iter().collect();
+    let mut pending: Vec<Ticker> = universe.symbols.iter().cloned().collect();
     let mut tasks = tokio::task::JoinSet::new();
-    let mut bars: Vec<crate::common::types::EquityBar> = Vec::new();
+    let mut bars: Vec<EquityBar> = Vec::new();
     let mut symbols_failed = 0usize;
 
     loop {
@@ -520,13 +573,27 @@ async fn archive_intraday_chunk(
             let (from, to) = (first.date(), last.date());
             tasks.spawn(async move {
                 let mut last_error = None;
-                for _ in 0..INTRADAY_SYMBOL_ATTEMPTS {
+                for attempt in 0..INTRADAY_SYMBOL_ATTEMPTS {
                     match client.fetch_intraday(&ticker, interval, from, to).await {
                         Ok(bars) => return Ok(bars),
-                        Err(error) => last_error = Some(error),
+                        Err(error) => {
+                            // A refusal the vendor will repeat is not worth repeating at it. A
+                            // survivorship-free universe is full of delisted names, so retrying
+                            // every 404 three times scales the waste with the delisted tail.
+                            if !is_transient(&error) {
+                                return Err((ticker, error));
+                            }
+                            last_error = Some(error);
+                        }
                     }
+                    // Backed off, because eight tasks retrying without one turns a vendor throttle
+                    // into twenty-four immediate requests at an endpoint already refusing.
+                    tokio::time::sleep(retry_delay(attempt)).await;
                 }
-                Err(last_error.expect("a failed attempt records its error"))
+                Err((
+                    ticker,
+                    last_error.expect("a failed attempt records its error"),
+                ))
             });
         }
         let Some(finished) = tasks.join_next().await else {
@@ -536,9 +603,11 @@ async fn archive_intraday_chunk(
             Ok(Ok(fetched)) => bars.extend(fetched),
             // One symbol's failure costs that symbol, not the chunk. The session stays absent from
             // the archive only if every symbol in it failed, and the next pass requests it again.
-            Ok(Err(error)) => {
+            Ok(Err((ticker, error))) => {
                 symbols_failed += 1;
-                warn!(%error, "A symbol's intraday fetch failed; continuing the chunk");
+                // Named, because this is the one outcome nothing downstream can detect and an
+                // operator cannot repair a symbol they have not been told about.
+                warn!(%ticker, %error, "A symbol's intraday fetch failed; continuing the chunk");
             }
             Err(error) => {
                 symbols_failed += 1;
@@ -547,9 +616,8 @@ async fn archive_intraday_chunk(
         }
     }
 
-    // Keyed by the bar's own timestamp rather than by the session requested, on the same reasoning
-    // as the daily path: a response that answers for a neighbouring session must not land under the
-    // wrong key. An extended-hours bar is still its own Eastern date, which is what makes this safe.
+    // Keyed by the bar's own timestamp, not the session requested, so a response answering for a
+    // neighbour cannot land under the wrong key. Extended hours are still their own Eastern date.
     let mut by_session: std::collections::BTreeMap<SessionDate, Vec<_>> =
         std::collections::BTreeMap::new();
     for bar in bars {
@@ -577,7 +645,9 @@ async fn archive_intraday_chunk(
     for (session, bars_for_session) in by_session {
         // A bar dated outside the chunk is a vendor answering beyond the range asked for. Writing it
         // would put rows in a partition this pass never claimed and never verified.
-        if !chunk.contains(&session) {
+        // Skipped when the daily archive could not describe the session: a partition written from a
+        // universe that never covered it would look complete and never be revisited.
+        if !universe.described.contains(&session) {
             continue;
         }
         let frame = bars::bars_to_dataframe(&bars_for_session)?;
@@ -608,15 +678,18 @@ async fn universe_over(
     s3_client: &S3Client,
     bucket: &str,
     sessions: &[SessionDate],
-) -> Result<BTreeSet<String>, ArchiveError> {
+) -> Result<Universe, ArchiveError> {
     let daily = bar_archive_prefix(BarInterval::OneDay);
-    let mut universe = BTreeSet::new();
+    let mut universe = Universe::default();
 
     for session in sessions {
         let key = date_partitioned_key(&daily, session.date());
         let Some(frame) = read_partition(s3_client, bucket, &key).await? else {
+            // The session this chunk would be screened against is absent, so there is no universe
+            // for it and no way to call an intraday partition for it complete.
             continue;
         };
+        universe.described.insert(*session);
         let screened = frame
             .lazy()
             .filter(
@@ -627,9 +700,21 @@ async fn universe_over(
             .select([col("ticker")])
             .collect()?;
         let tickers = screened.column("ticker")?.str()?;
-        universe.extend(tickers.into_iter().flatten().map(str::to_string));
+        universe
+            .symbols
+            .extend(tickers.into_iter().flatten().filter_map(Ticker::new));
     }
     Ok(universe)
+}
+
+/// The names to fetch, and the sessions the daily archive could actually describe.
+///
+/// The two travel together because a session the daily archive lacks contributes no names, so an
+/// intraday partition written for it would look complete while missing whatever traded only then.
+#[derive(Default)]
+struct Universe {
+    symbols: BTreeSet<Ticker>,
+    described: BTreeSet<SessionDate>,
 }
 
 /// Merges `fetched` into the partition for `session` and writes it back, conditional on what it read.
@@ -1083,11 +1168,7 @@ mod tests {
             .into_iter()
             .collect();
 
-        let requested: Vec<SessionDate> = expected
-            .iter()
-            .copied()
-            .filter(|s| !present.contains(s))
-            .collect();
+        let requested = intraday_sessions_to_request(&expected, &present);
         assert_eq!(
             requested,
             vec![


### PR DESCRIPTION
# Overview

Task 3b of the statistical arbitrage plan, and the whole critical path back to re-running the convergence measurement at a horizon the book can actually hold.

**#1091 killed daily statistical arbitrage.** Every measurement in it was close-to-close, and the book flattens intraday — so the version of the premise that matters has never been tested. This is the data to test it with, and it costs nothing: Massive Stocks Starter already serves five years of consolidated intraday on the plan we pay for.

## Changes

- `BarInterval::FiveMinute`, plus `massive_timespan()` mapping each cadence to Massive's URL spelling.
- `MassiveClient::fetch_intraday` — per-symbol aggregates with `next_url` pagination, reusing `fetch_splits`' `same_origin` credential guard. **Refuses `OneDay`.**
- `archive::archive_intraday_sessions` — gap scan, monthly chunks, bounded fan-out, one partition per session.
- `src/bin/seed_intraday_bars_s3.rs` — the runner.
- `present_sessions` and `write_partition` are now cadence-aware; `ArchiveSummary` carries `symbols_failed`.
- `schema.sql` CHECK extended to `five_minute`.

## Context

**Five minutes, not one or fifteen.** Coverage measured across the whole universe — 1,678 names over 5 sessions — puts the cliff between one and five:

| grid | median | ≥99% | <90% |
|---|---|---|---|
| 1-minute | 96.8% | 33.2% | 410 names |
| **5-minute** | **100%** | **95.8%** | **22 names** |
| 15-minute | 100% | 98.7% | 15 names |

Fifteen buys 50 more names out of 1,678 and costs two thirds of the observations.

**The universe comes from the daily archive, and this is the part that decides whether the measurement means anything.** There is no grouped intraday route, so names must be enumerated. Taking them from *today's* market and pulling five years back samples only the survivors — and a pair that blew up is exactly the one a convergence study must not drop. The daily partitions are whole-market and were written on the day, so they are survivorship-free by construction. The union over one month is **2,923 names against a single session's ~1,800**, which is the size of the effect.

**A vendor trap, refused at the boundary.** The aggregates route stamps a daily bar at **midnight Eastern**; the grouped route stamps the same bar at **16:00**. Sixteen hours apart, same provider. A daily series taken from here and joined to the archive yields every session twice with neither copy obviously wrong — and the archive is correct today only because it happens to use the grouped route. `fetch_intraday` refuses `OneDay` rather than documenting it.

**`adjusted=false`** is pinned in the URL and in a test. The route adjusts by default; an adjusted bar in a raw archive is a silent restatement.

**No correction window**, unlike the daily pass. An intraday bar is not restated after the close, and re-fetching a month to learn that costs the whole universe in requests rather than one grouped call.

**Per-symbol retry is load-bearing, not defensive.** A session-level gap scan cannot see a *symbol*-level hole: the partition exists, so the next pass never re-requests it, and one dropped response becomes a name permanently missing from that month. Exactly one transient failure appeared in the first 22 sessions — Citigroup, whose same request succeeded immediately after — which is how the gap was found rather than shipped.

**Chunking.** Requests are ticker-major and partitions session-major, so a chunk holds every name before any session is written. A quarter is several hundred megabytes; a month is a fifth of that. Smaller chunks trade requests for memory.

## Verification

- `devenv tasks run checks:rust` green, clippy clean apart from a pre-existing `redundant_closure` in `tests/test_handlers.rs`
- **Real run against the development bucket**, 2026-07-21 to 2026-08-19: 22 sessions, **5,855,542 bars, 3m29s**
- The written 2026-08-19 partition inspected in DuckDB: **186,995 rows, 1,804 tickers, `bar_interval = five_minute`, 04:00 to 19:55 Eastern** — extended hours stored and left to read-time filtering, because discarding at ingestion is the irreversible choice
- The URL test fails if the five-minute multiplier is copied from one-minute; the ticker/interval test fails if either is read off the row instead of the caller. Both proven by breaking them
- All 15 pre-existing Massive tests still pass after `GroupedBarRow` was refactored to flatten a shared `AggregateBarRow`
- The pinned cadence count from #1092 caught this change: it moved from two to three and stopped to make the `five_minute` key explicit

## Follow-ups, deliberately not here

- **The full five-year backfill.** Extrapolating the measured rate, ~3.3 hours as a background job. Worth running once this merges; `INTRADAY_CONCURRENCY` is the knob if that is too slow.
- **A symbol-level gap scan.** `symbols_failed` surfaces the residue but nothing repairs it automatically — a session written without a name is indistinguishable from a complete one. Retry covers the transient case, which is the one observed.
- **Nightly ingestion and the production backfill** stay in task 3c, gated on the intraday measurement working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for five-minute market bars alongside one-minute and daily intervals.
  - Added intraday data retrieval across date ranges with pagination and validation.
  - Added tools to repair missing intraday archive sessions using one-minute or five-minute data.
  - Intraday archives now organize, process, and report data by cadence.
- **Bug Fixes**
  - Improved handling of missing sessions, unavailable symbols, failed requests, and invalid date or interval selections.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->