### PR TITLE
Give the laboratory an intraday reader

### DIFF
--- a/.claude/skills/update-pull-request/SKILL.md
+++ b/.claude/skills/update-pull-request/SKILL.md
@@ -195,7 +195,7 @@ Follow these steps:
   - `check_failures.json`: Check name, conclusion, details URL
   - `pr_review_comments_raw.json`: Full flat array of all review comments including replies (use for full context if needed)
 
-- Note that check-runs and workflow runs are distinct; to fetch logs, obtain the workflow run ID from `check_runs_raw.json` and use `gh api repos/${OWNER}/${REPO}/actions/runs/{run_id}/logs`. If logs are inaccessible via API, run `devenv tasks run checks:python` or `devenv tasks run checks:rust` locally to replicate the errors.
+- Note that check-runs and workflow runs are distinct; to fetch logs, obtain the workflow run ID from `check_runs_raw.json` and use `gh api repos/${OWNER}/${REPO}/actions/runs/{run_id}/logs`. If logs are inaccessible via API, run `devenv tasks run checks:rust` or `devenv tasks run checks:base` locally to replicate the errors.
 - Group all feedback (check failures, review threads, outdated threads, PR-level comments) using judgement: by file, by theme, by type of change, or whatever makes most sense for the specific pull request; ensure each group maintains the full metadata for all items it contains.
 - Analyze dependencies between feedback groups to determine which are independent (can be worked in parallel) and which are interdependent (must be handled sequentially).
 - For each piece of feedback, evaluate whether to address it (make code changes) or reject it (explain why the feedback doesn't apply); provide clear reasoning for each decision.
@@ -229,13 +229,13 @@ Follow these steps:
 ### 6. Verify Changes
 
 - After implementing each group's fixes, run verification checks locally:
-  - Run `devenv tasks run checks:python` if any Python files, `pyproject.toml`, or `uv.lock` were modified.
   - Run `devenv tasks run checks:rust` if any Rust files were modified.
+  - Run `devenv tasks run checks:base` if any nix, markdown, yaml, toml, or sql files were modified.
   - **Note**: Local verification confirms fixes work in the development environment. Remote continuous integration will re-run after changes are pushed in the "Commit and Push Changes" step.
 - If checks fail, resolve issues and re-run until passing before moving to the next group.
 - Do not proceed to the next feedback group until current group's changes pass verification.
 - Repeat steps 4-6 for each feedback group until all have been addressed.
-- Always run final comprehensive verification using `devenv tasks run checks:python` and `devenv tasks run checks:rust` before proceeding.
+- Always run final comprehensive verification using `devenv tasks run checks:all` before proceeding, which is `checks:base` and every `checks:rust` subtask.
 
 ### 7. Commit and Push Changes
 

--- a/src/laboratory/dataset.rs
+++ b/src/laboratory/dataset.rs
@@ -122,6 +122,86 @@ pub async fn build(
     Ok(PreparedDataset { fit, fingerprint })
 }
 
+/// One intraday window, folded for splits and otherwise raw.
+pub struct IntradayDataset {
+    /// Every bar in the window at the requested cadence, split-folded and bounded.
+    pub bars: DataFrame,
+    pub fingerprint: DatasetFingerprint,
+}
+
+/// Reads the intraday partitions in the window and folds splits into them.
+///
+/// **Deliberately stops short of the daily path's universe screen.** The intraday universe was
+/// already decided at ingestion from each session's *daily* bar, and re-applying a daily volume
+/// floor to a five-minute bar — whose volume is a fraction of the session's — would empty the
+/// window rather than screen it.
+pub async fn intraday(
+    s3_client: &S3Client,
+    bucket: &str,
+    interval: BarInterval,
+    lookback_days: i64,
+    session: SessionDate,
+) -> Result<IntradayDataset, DatasetError> {
+    match interval {
+        BarInterval::OneMinute | BarInterval::FiveMinute => {}
+        // The daily partitions are a different shape and a different screen; `returns` reads those.
+        BarInterval::OneDay => {
+            return Err(DatasetError::Window(
+                "intraday reads an intraday cadence; use returns for daily bars".to_string(),
+            ))
+        }
+    }
+
+    let splits_frame = archive::read_partition(s3_client, bucket, archive::SPLITS_ARCHIVE_KEY)
+        .await?
+        .ok_or_else(|| {
+            DatasetError::Window(format!(
+                "no splits table at {}; refusing to build on unadjusted prices",
+                archive::SPLITS_ARCHIVE_KEY
+            ))
+        })?;
+    let splits_digest = digest_of(&splits_frame)?;
+    let splits = adjust::SplitTable::from_dataframe(&splits_frame)?;
+
+    let boundaries_frame =
+        archive::read_partition(s3_client, bucket, archive::BOUNDARIES_ARCHIVE_KEY).await?;
+    let boundaries_digest = boundaries_frame
+        .as_ref()
+        .map(digest_of)
+        .transpose()?
+        .unwrap_or(0);
+    let boundaries = match boundaries_frame {
+        Some(frame) => truncate::BoundaryTable::from_dataframe(&frame)?,
+        None => {
+            warn!(
+                key = archive::BOUNDARIES_ARCHIVE_KEY,
+                "No boundary table in the archive; building on unbounded series"
+            );
+            truncate::BoundaryTable::default()
+        }
+    };
+
+    let bars = load_archived_bars(
+        s3_client,
+        bucket,
+        interval,
+        lookback_days,
+        session,
+        &splits,
+        &boundaries,
+    )
+    .await?;
+    let fingerprint = fingerprint_of(
+        &bars,
+        session,
+        lookback_days,
+        splits_digest,
+        boundaries_digest,
+    )?;
+
+    Ok(IntradayDataset { bars, fingerprint })
+}
+
 /// Reads the same window as [`build`] and engineers returns from it, fitting nothing.
 ///
 /// The rows are the rows the model would train on, because a baseline measured over a wider
@@ -187,6 +267,7 @@ async fn read_window(
     let equity_bars = load_archived_bars(
         s3_client,
         bucket,
+        BarInterval::OneDay,
         lookback_days,
         session,
         &splits,
@@ -242,12 +323,13 @@ fn fingerprint_of(
 async fn load_archived_bars(
     s3_client: &S3Client,
     bucket: &str,
+    interval: BarInterval,
     lookback_days: i64,
     session: SessionDate,
     splits: &adjust::SplitTable,
     boundaries: &truncate::BoundaryTable,
 ) -> Result<DataFrame, DatasetError> {
-    let daily_prefix = archive::bar_archive_prefix(BarInterval::OneDay);
+    let daily_prefix = archive::bar_archive_prefix(interval);
     let mut frames: Vec<LazyFrame> = Vec::new();
     let mut unreadable = 0usize;
     let mut date = session.plus_calendar_days(-lookback_days);
@@ -393,6 +475,34 @@ mod tests {
             Column::new("timestamp".into(), timestamps),
         ])
         .unwrap()
+    }
+
+    #[test]
+    fn test_the_intraday_reader_refuses_a_daily_cadence() {
+        // No network: the guard runs before anything is read, which is the point of it being a
+        // guard. `returns` is the daily path and applies a screen this one deliberately does not.
+        let refused = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("a test runtime")
+            .block_on(async {
+                let client = crate::common::aws::s3_client().await;
+                intraday(
+                    &client,
+                    "bucket-that-is-never-read",
+                    BarInterval::OneDay,
+                    730,
+                    SessionDate::from_date(
+                        chrono::NaiveDate::from_ymd_opt(2026, 8, 20).expect("a valid test date"),
+                    ),
+                )
+                .await
+            });
+
+        assert!(
+            matches!(refused, Err(DatasetError::Window(ref message)) if message.contains("returns")),
+            "a daily cadence must be refused, naming the path that serves it"
+        );
     }
 
     #[test]

--- a/src/laboratory/dataset.rs
+++ b/src/laboratory/dataset.rs
@@ -152,34 +152,7 @@ pub async fn intraday(
         }
     }
 
-    let splits_frame = archive::read_partition(s3_client, bucket, archive::SPLITS_ARCHIVE_KEY)
-        .await?
-        .ok_or_else(|| {
-            DatasetError::Window(format!(
-                "no splits table at {}; refusing to build on unadjusted prices",
-                archive::SPLITS_ARCHIVE_KEY
-            ))
-        })?;
-    let splits_digest = digest_of(&splits_frame)?;
-    let splits = adjust::SplitTable::from_dataframe(&splits_frame)?;
-
-    let boundaries_frame =
-        archive::read_partition(s3_client, bucket, archive::BOUNDARIES_ARCHIVE_KEY).await?;
-    let boundaries_digest = boundaries_frame
-        .as_ref()
-        .map(digest_of)
-        .transpose()?
-        .unwrap_or(0);
-    let boundaries = match boundaries_frame {
-        Some(frame) => truncate::BoundaryTable::from_dataframe(&frame)?,
-        None => {
-            warn!(
-                key = archive::BOUNDARIES_ARCHIVE_KEY,
-                "No boundary table in the archive; building on unbounded series"
-            );
-            truncate::BoundaryTable::default()
-        }
-    };
+    let adjustments = read_adjustments(s3_client, bucket).await?;
 
     let bars = load_archived_bars(
         s3_client,
@@ -187,16 +160,16 @@ pub async fn intraday(
         interval,
         lookback_days,
         session,
-        &splits,
-        &boundaries,
+        &adjustments.splits,
+        &adjustments.boundaries,
     )
     .await?;
     let fingerprint = fingerprint_of(
         &bars,
         session,
         lookback_days,
-        splits_digest,
-        boundaries_digest,
+        adjustments.splits_digest,
+        adjustments.boundaries_digest,
     )?;
 
     Ok(IntradayDataset { bars, fingerprint })
@@ -235,6 +208,50 @@ async fn read_window(
     lookback_days: i64,
     session: SessionDate,
 ) -> Result<(DataFrame, DatasetFingerprint), DatasetError> {
+    let adjustments = read_adjustments(s3_client, bucket).await?;
+
+    let equity_bars = load_archived_bars(
+        s3_client,
+        bucket,
+        BarInterval::OneDay,
+        lookback_days,
+        session,
+        &adjustments.splits,
+        &adjustments.boundaries,
+    )
+    .await?;
+
+    let equity_details = details::details_to_dataframe(&details::parse_embedded_details()?)?;
+    let consolidated = consolidate_data(equity_bars, equity_details)?;
+    let filtered = filter_training_bars(consolidated, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME)?;
+
+    let fingerprint = fingerprint_of(
+        &filtered,
+        session,
+        lookback_days,
+        adjustments.splits_digest,
+        adjustments.boundaries_digest,
+    )?;
+
+    Ok((filtered, fingerprint))
+}
+
+/// The tables every archive window is folded through, and the digests that identify them.
+///
+/// The two digests are carried in named fields rather than returned as a pair because both are
+/// `u64`: swapping them would compile, and would silently join two runs' journal records wrongly.
+struct Adjustments {
+    splits: adjust::SplitTable,
+    boundaries: truncate::BoundaryTable,
+    splits_digest: u64,
+    boundaries_digest: u64,
+}
+
+/// Reads the split and boundary tables that both the daily and the intraday path fold through.
+///
+/// A missing boundary table warns and leaves the series unbounded, but a missing splits table is
+/// refused: unadjusted prices carry a false return across every split in the window.
+async fn read_adjustments(s3_client: &S3Client, bucket: &str) -> Result<Adjustments, DatasetError> {
     let splits_frame = archive::read_partition(s3_client, bucket, archive::SPLITS_ARCHIVE_KEY)
         .await?
         .ok_or_else(|| {
@@ -264,30 +281,12 @@ async fn read_window(
         }
     };
 
-    let equity_bars = load_archived_bars(
-        s3_client,
-        bucket,
-        BarInterval::OneDay,
-        lookback_days,
-        session,
-        &splits,
-        &boundaries,
-    )
-    .await?;
-
-    let equity_details = details::details_to_dataframe(&details::parse_embedded_details()?)?;
-    let consolidated = consolidate_data(equity_bars, equity_details)?;
-    let filtered = filter_training_bars(consolidated, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME)?;
-
-    let fingerprint = fingerprint_of(
-        &filtered,
-        session,
-        lookback_days,
+    Ok(Adjustments {
+        splits,
+        boundaries,
         splits_digest,
         boundaries_digest,
-    )?;
-
-    Ok((filtered, fingerprint))
+    })
 }
 
 /// Describes the frame the model will be fitted on, before fitting consumes it.
@@ -477,6 +476,19 @@ mod tests {
         .unwrap()
     }
 
+    /// A client that resolves nothing: no profile, no environment, no instance metadata.
+    ///
+    /// The default chain would run all of those before the first request, which is discovery a test
+    /// that never sends a request has no reason to pay for.
+    fn unused_s3_client() -> S3Client {
+        S3Client::new(
+            &aws_config::SdkConfig::builder()
+                .region(aws_config::Region::new("us-east-1"))
+                .behavior_version(aws_config::BehaviorVersion::latest())
+                .build(),
+        )
+    }
+
     #[test]
     fn test_the_intraday_reader_refuses_a_daily_cadence() {
         // No network: the guard runs before anything is read, which is the point of it being a
@@ -486,7 +498,7 @@ mod tests {
             .build()
             .expect("a test runtime")
             .block_on(async {
-                let client = crate::common::aws::s3_client().await;
+                let client = unused_s3_client();
                 intraday(
                     &client,
                     "bucket-that-is-never-read",


### PR DESCRIPTION
# Overview

`dataset::returns` is the daily path and hardcoded the daily cadence, so nothing could read the five-minute partitions #1095 started writing. This is the reader, and a stale-reference cleanup that rode along.

## Changes

- `dataset::intraday` — reads intraday partitions in a window, folds splits, and stops there.
- `load_archived_bars` takes the cadence rather than assuming it.
- `.claude/skills/update-pull-request` — pointed at tasks that exist.

## Context

**It deliberately stops short of the daily path's tail, and that is the whole design decision.** `consolidate_data` inner-joins the details table and `filter_training_bars` applies a **one-million-share floor**. A five-minute bar's volume is a fraction of its session's, so that floor would empty the window rather than screen it. The intraday universe was already decided at ingestion, from each session's own *daily* bar, which is where a daily screen belongs.

**It refuses `OneDay`**, for the same reason `fetch_intraday` does: the daily partitions are a different shape under a different screen, and `returns` is the path that serves them. The guard runs before anything is read, which is what makes it testable without a network.

**Everything below `load_archived_bars` was already cadence-agnostic** — the stitch, the boundary truncation, the split fold — because a split factor keys on a date and not on a bar width. Only the prefix needed the parameter.

**The skill cleanup** is unrelated and in its own commit: it told the reader to run `devenv tasks run checks:python` in three places. There is no Python in this repository and no such task, so anyone following it got a task-not-found error at the step that verifies the work. Now `checks:base` for the non-Rust types, and `checks:all` for the final verification rather than two tasks listed by hand.

## Verification

- `devenv tasks run checks:rust` and `checks:base` both green
- The cadence guard proven to run before any read, so it needs no bucket

## Archive state, done alongside this

- **Daily archive extended to five years**: 1,254 partitions, 2021-08-23 to 2026-08-20. 744 written on the first pass, 29 holidays, and one session — 2021-08-20 — that **aged out of Massive's rolling five-year window between the morning probe and the afternoon run**, on the same calendar day. That is the now-or-never argument for taking five years, observed live rather than assumed.
- **Orphaned daily tree deleted**: the 505 objects under `data/equity/bars/year=…` superseded by `interval=one_day/` in #1092. Verified first that every old key was present in the new tree (0 missing) and that the deletion plan touched no `interval=` key.
- **The five-year intraday backfill is running**, ~3.3 hours, development bucket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading intraday datasets with one- and five-minute bars.
  - Intraday data can optionally be constrained by specified boundaries and includes dataset fingerprint information.
  - Intraday loading uses split-adjusted data and bypasses daily universe filtering.
- **Bug Fixes**
  - Daily dataset loading now selects archive partitions according to the requested interval.
  - Daily cadence is correctly rejected when using the intraday loader.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->