### PR TITLE
Stop counting an unwritten intraday session twice

### DIFF
--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -351,6 +351,23 @@ fn count_sessions_without_data(
         .count()
 }
 
+/// Chunk sessions that will leave no partition behind, counted once each.
+///
+/// A session goes unwritten either because the daily archive could not describe it or because the
+/// vendor returned no bars for it, and the two overlap: an undescribed session is skipped before a
+/// fetch, so it is also unanswered. Counting the reasons separately counted those sessions twice.
+/// Taken with the written and failed counts, this partitions the chunk.
+fn count_intraday_sessions_without_data(
+    chunk: &[SessionDate],
+    described: &BTreeSet<SessionDate>,
+    answered: &BTreeSet<SessionDate>,
+) -> usize {
+    chunk
+        .iter()
+        .filter(|session| !described.contains(session) || !answered.contains(session))
+        .count()
+}
+
 /// Fetches one chunk of sessions and writes their partitions, accumulating into `summary`.
 async fn archive_chunk(
     s3_client: &S3Client,
@@ -548,9 +565,10 @@ async fn archive_intraday_chunk(
             %first, %last,
             "Some sessions have no daily partition to screen against; leaving them unwritten"
         );
-        summary.sessions_without_data += undescribed;
     }
     if universe.symbols.is_empty() {
+        // Nothing to fetch, so nothing in the chunk gets written.
+        summary.sessions_without_data += chunk.len();
         return Ok(());
     }
     info!(
@@ -628,7 +646,8 @@ async fn archive_intraday_chunk(
     }
 
     let answered: BTreeSet<SessionDate> = by_session.keys().copied().collect();
-    summary.sessions_without_data += chunk.iter().filter(|s| !answered.contains(s)).count();
+    summary.sessions_without_data +=
+        count_intraday_sessions_without_data(chunk, &universe.described, &answered);
     if symbols_failed > 0 {
         summary.symbols_failed += symbols_failed;
         // Loud, because the partitions below are about to be written *without* these names and
@@ -1337,6 +1356,30 @@ mod tests {
             answered.len() + failed.len() + without_data,
             requested.len()
         );
+    }
+
+    /// A session with no daily universe to screen against is skipped before any fetch, so it is
+    /// also unanswered. Counting both reasons inflated the five-year backfill's figure to exactly
+    /// twice the sessions it left unwritten.
+    #[test]
+    fn test_a_session_missing_its_universe_is_counted_once_not_twice() {
+        let chunk = vec![
+            session(2026, 6, 1),
+            session(2026, 6, 2),
+            session(2026, 6, 3),
+        ];
+        // 06-01 has no daily partition, so it is never fetched and never answers.
+        let described: BTreeSet<SessionDate> = [session(2026, 6, 2), session(2026, 6, 3)].into();
+        let answered: BTreeSet<SessionDate> = [session(2026, 6, 2)].into();
+
+        let without_data = count_intraday_sessions_without_data(&chunk, &described, &answered);
+
+        assert_eq!(
+            without_data, 2,
+            "06-01 lacks a universe and 06-03 lacks bars; neither may be counted twice"
+        );
+        // One written session (06-02) plus the two above accounts for the whole chunk.
+        assert_eq!(without_data + 1, 3);
     }
 
     /// A response can be grouped under a session that was never requested — the bar's own timestamp

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -353,10 +353,9 @@ fn count_sessions_without_data(
 
 /// Chunk sessions that will leave no partition behind, counted once each.
 ///
-/// A session goes unwritten either because the daily archive could not describe it or because the
-/// vendor returned no bars for it, and the two overlap: an undescribed session is skipped before a
-/// fetch, so it is also unanswered. Counting the reasons separately counted those sessions twice.
-/// Taken with the written and failed counts, this partitions the chunk.
+/// A session is unwritten when the daily archive cannot describe it or the vendor returns no bars,
+/// and an undescribed session is skipped before any fetch, so the two conditions overlap rather
+/// than partition. Taken with the written and failed counts, this partitions the chunk.
 fn count_intraday_sessions_without_data(
     chunk: &[SessionDate],
     described: &BTreeSet<SessionDate>,


### PR DESCRIPTION
# Overview

## Changes

- Collapse the two `sessions_without_data` accumulation sites in `archive_intraday_chunk` into `count_intraday_sessions_without_data`, mirroring the `count_sessions_without_data` helper the daily path already uses
- Count the chunk being abandoned at the empty-universe early return, which the removed first site had been covering for
- Add `test_a_session_missing_its_universe_is_counted_once_not_twice`

## Context

The five-year intraday backfill finished cleanly but reported an impossible summary:

```
requested 1281 sessions, wrote 1231, 100 without data, 0 failed, 257493119 bars, 0 symbols missing
```

`1231 + 100` exceeds `1281` by exactly 50, and the run's forty warnings name exactly 50 undescribed sessions.

The two accumulation sites counted overlapping sets. The first added every session the daily archive could not describe; the second added every session missing from `answered`. The overlap is structural rather than incidental — an undescribed session is skipped before any fetch is issued, so it can never answer, and it fell into both.

**No archived data is affected.** Undescribed sessions were already skipped at the write, so the defect was confined to the reported figure. Verified against the development bucket: 1,254 five-minute partitions against 1,254 daily ones, with an empty set difference in *both* directions rather than merely matching counts.

The test was proven load-bearing by restoring the old two-site arithmetic inside the new helper and watching it fail with `left: 3, right: 2` — the double-count reproduced exactly.

Rebased onto master after #1096 merged; the two touch different files (`archive.rs` here, `dataset.rs` there) and the rebase was clean. Local verification after the rebase: `checks:rust` exit 0, 724 tests passing.