### PR TITLE
Measure whether a dislocated pair converges inside the session

### DIFF
--- a/src/bin/laboratory_intraday_convergence.rs
+++ b/src/bin/laboratory_intraday_convergence.rs
@@ -57,7 +57,9 @@ impl Parameters {
             [session, lookback, universe] => (
                 session,
                 positive(lookback, "LOOKBACK_DAYS")?,
-                positive(universe, "UNIVERSE")? as usize,
+                usize::try_from(positive(universe, "UNIVERSE")?).map_err(|_| {
+                    format!("UNIVERSE is larger than this platform can index\n{USAGE}")
+                })?,
             ),
             _ => return Err(format!("Expected an end session\n{USAGE}")),
         };
@@ -233,7 +235,7 @@ fn report(selection: Selection, entries: &[IntradayEntry]) {
                 0.0
             };
             println!(
-                "\n  drift from entry to last bar: {:+.5} sigma  se {:.5}  {ratio:+.2} standard \
+                "\n  drift from entry to the session end: {:+.5} sigma  se {:.5}  {ratio:+.2} standard \
                  errors  over {} sessions ({} entries)",
                 reading.mean, reading.standard_error, reading.sessions, reading.entries
             );

--- a/src/bin/laboratory_intraday_convergence.rs
+++ b/src/bin/laboratory_intraday_convergence.rs
@@ -1,0 +1,290 @@
+//! Does a dislocated pair converge inside the session, and does it beat the spread it pays?
+//!
+//! Screened pairs against an unscreened control, both measured on intraday volume-weighted prices.
+
+use chrono::NaiveDate;
+use tracing::{error, info};
+
+use fund::common::alpaca::{AlpacaCredentials, TradingClient};
+use fund::common::log::init_tracing;
+use fund::common::types::{BarInterval, SessionDate};
+use fund::laboratory::convergence::{curves_of, sample_universe, Closes, Curve, Selection};
+use fund::laboratory::intraday::{self, SessionHours};
+use fund::laboratory::intraday_convergence::{self, IntradayEntry};
+use fund::laboratory::{dataset, intraday_convergence as measure};
+
+use std::collections::BTreeMap;
+
+use chrono::Timelike;
+
+const USAGE: &str =
+    "Usage: laboratory_intraday_convergence END_SESSION [LOOKBACK_DAYS] [UNIVERSE]\n\
+                     END_SESSION is an Eastern calendar date: YYYY-MM-DD.";
+
+/// Calendar days of archive to measure over by default.
+const DEFAULT_LOOKBACK_DAYS: i64 = 90;
+
+/// Names sampled from the universe by default.
+///
+/// Pairs grow with the square, so the whole intraday universe is millions of pairs per session.
+/// Two hundred names is ~19,900 pairs, which is what #1091 measured the daily version over.
+const DEFAULT_UNIVERSE: usize = 200;
+
+/// Fixed, so two runs over one archive draw the same sample and differ only where the data does.
+const SAMPLE_SEED: u64 = 0x5EED;
+
+/// Round-trip cost in z-score units is not knowable without the fitted sigma, so the cost is
+/// reported in basis points beside the result rather than folded into it.
+///
+/// Measured by Roll's estimator over the same archive: 9 to 13 basis points.
+const EFFECTIVE_SPREAD_BASIS_POINTS: f64 = 10.0;
+
+struct Parameters {
+    session: SessionDate,
+    lookback_days: i64,
+    universe: usize,
+}
+
+impl Parameters {
+    fn parse(arguments: &[String]) -> Result<Self, String> {
+        let (session, lookback, universe) = match arguments {
+            [session] => (session, DEFAULT_LOOKBACK_DAYS, DEFAULT_UNIVERSE),
+            [session, lookback] => (
+                session,
+                positive(lookback, "LOOKBACK_DAYS")?,
+                DEFAULT_UNIVERSE,
+            ),
+            [session, lookback, universe] => (
+                session,
+                positive(lookback, "LOOKBACK_DAYS")?,
+                positive(universe, "UNIVERSE")? as usize,
+            ),
+            _ => return Err(format!("Expected an end session\n{USAGE}")),
+        };
+        let session = NaiveDate::parse_from_str(session.trim(), "%Y-%m-%d")
+            .map(SessionDate::from_date)
+            .map_err(|_| format!("END_SESSION must be YYYY-MM-DD\n{USAGE}"))?;
+        if universe < 2 {
+            return Err(format!("UNIVERSE must name at least two tickers\n{USAGE}"));
+        }
+        Ok(Self {
+            session,
+            lookback_days: lookback,
+            universe,
+        })
+    }
+}
+
+fn positive(raw: &str, name: &str) -> Result<i64, String> {
+    match raw.trim().parse::<i64>() {
+        Ok(value) if value > 0 => Ok(value),
+        _ => Err(format!("{name} must be a positive number\n{USAGE}")),
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    fund::common::crypto::install_default_crypto_provider();
+    let tracing_guard = init_tracing(
+        "laboratory-intraday-convergence.log",
+        Some("info"),
+        "laboratory-intraday-convergence",
+    );
+
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let parameters = match Parameters::parse(&arguments) {
+        Ok(parameters) => parameters,
+        Err(message) => {
+            eprintln!("{message}");
+            drop(tracing_guard);
+            std::process::exit(2);
+        }
+    };
+
+    let code = match run(&parameters).await {
+        Ok(()) => 0,
+        Err(error) => {
+            error!(%error, "The intraday convergence measurement failed");
+            eprintln!("The intraday convergence measurement failed: {error}");
+            1
+        }
+    };
+    drop(tracing_guard);
+    std::process::exit(code);
+}
+
+async fn run(parameters: &Parameters) -> Result<(), Box<dyn std::error::Error>> {
+    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let s3_client = fund::common::aws::s3_client().await;
+
+    // The models are fitted on daily closes, as production fits them, so the daily window must
+    // cover the correlation window ahead of the first session judged as well as the window itself.
+    let daily = dataset::returns(
+        &s3_client,
+        &bucket,
+        parameters.lookback_days + 150,
+        parameters.session,
+    )
+    .await?;
+    let closes = Closes::from_frame(&daily.returns)?;
+    let universe: Vec<&str> = sample_universe(&closes, parameters.universe, SAMPLE_SEED);
+    info!(
+        sessions = closes.sessions(),
+        universe = universe.len(),
+        "Read the daily closes the models are fitted on"
+    );
+
+    let intraday_bars = dataset::intraday(
+        &s3_client,
+        &bucket,
+        BarInterval::FiveMinute,
+        parameters.lookback_days,
+        parameters.session,
+    )
+    .await?;
+    let hours = session_hours(parameters).await?;
+    let vwaps = intraday::session_vwaps(&intraday_bars.bars, BarInterval::FiveMinute, &hours)?;
+    info!(sessions = vwaps.len(), "Read the intraday prices");
+
+    // Sessions are joined by their own date rather than by position: the intraday window and the
+    // daily window cover different spans, so an index into one means nothing in the other.
+    let daily_index: BTreeMap<SessionDate, usize> = (0..closes.sessions())
+        .filter_map(|index| {
+            let stamp = closes.session_at(index)?;
+            let instant = chrono::DateTime::from_timestamp_millis(stamp)?;
+            Some((SessionDate::at(instant), index))
+        })
+        .collect();
+
+    for selection in [Selection::Screened, Selection::Unscreened] {
+        let mut entries: Vec<IntradayEntry> = Vec::new();
+        for (session, prices) in &vwaps {
+            let Some(daily_session) = daily_index.get(session).copied() else {
+                continue;
+            };
+            entries.extend(measure::entries_in_session(
+                &closes,
+                prices,
+                &universe,
+                *session,
+                daily_session,
+                selection,
+            ));
+        }
+        report(selection, &entries);
+    }
+    Ok(())
+}
+
+/// The exchange's published hours for every session in the window.
+async fn session_hours(
+    parameters: &Parameters,
+) -> Result<BTreeMap<SessionDate, SessionHours>, Box<dyn std::error::Error>> {
+    let client = TradingClient::from_env(AlpacaCredentials::from_env()?);
+    let start = parameters.session.date() - chrono::Duration::days(parameters.lookback_days);
+    let days = client
+        .fetch_calendar(start, parameters.session.date())
+        .await?;
+
+    let mut hours = BTreeMap::new();
+    for day in days {
+        let open = day.session_open().hour() * 60 + day.session_open().minute();
+        let close = day.session_close().hour() * 60 + day.session_close().minute();
+        if let Some(published) = SessionHours::new(open, close) {
+            hours.insert(SessionDate::from_date(day.session_date()), published);
+        }
+    }
+    Ok(hours)
+}
+
+/// Prints one cohort's curve and what it is worth.
+fn report(selection: Selection, entries: &[IntradayEntry]) {
+    println!("\n=== {} ===", selection.as_str());
+    if entries.is_empty() {
+        println!("no entries");
+        return;
+    }
+    let states: Vec<_> = entries.iter().map(IntradayEntry::state).collect();
+    let curves = curves_of(&states);
+    let mean_z = intraday_convergence::mean_entry_z_score(entries).unwrap_or(0.0);
+
+    println!("entries {}, mean entry z {mean_z:.3}", entries.len());
+    println!("  horizon  entries  converged  stopped  open");
+    for Curve {
+        horizon,
+        converged,
+        stopped,
+        open,
+        entries: standing,
+    } in &curves
+    {
+        println!("  {horizon:>7}  {standing:>7}  {converged:>9.4}  {stopped:>7.4}  {open:>5.4}");
+    }
+
+    // The statistic the horizon can answer. Full convergence asks a daily-sigma dislocation to
+    // close inside a hundred minutes, so the binary resolution above reads zero whatever the pairs
+    // do; drift measures how far the spread actually travelled.
+    match measure::drift(entries) {
+        Some(reading) => {
+            let ratio = if reading.standard_error > 0.0 {
+                reading.mean / reading.standard_error
+            } else {
+                0.0
+            };
+            println!(
+                "\n  drift from entry to last bar: {:+.5} sigma  se {:.5}  {ratio:+.2} standard \
+                 errors  over {} sessions ({} entries)",
+                reading.mean, reading.standard_error, reading.sessions, reading.entries
+            );
+            println!(
+                "  share moving toward the mean: {:.4}  (a coin is 0.5000)",
+                reading.share_converging
+            );
+        }
+        None => println!("\n  drift not measurable"),
+    }
+
+    if let Some(final_curve) = curves.last() {
+        let expected = final_curve.converged * mean_z
+            - final_curve.stopped * fund::portfolio::screen::STOP_LOSS_WIDENING;
+        println!(
+            "\n  expected value at horizon {}: {expected:+.4} sigma per entry",
+            final_curve.horizon
+        );
+        println!(
+            "  round-trip cost is about {EFFECTIVE_SPREAD_BASIS_POINTS:.0} basis points; a sigma \
+             is worth that only if the fitted spread is wider than it"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arguments(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn test_the_defaults_and_overrides_parse() {
+        let parameters = Parameters::parse(&arguments(&["2026-08-20"])).unwrap();
+        assert_eq!(parameters.lookback_days, 90);
+        assert_eq!(parameters.universe, 200);
+
+        let parameters = Parameters::parse(&arguments(&["2026-08-20", "30", "50"])).unwrap();
+        assert_eq!(parameters.lookback_days, 30);
+        assert_eq!(parameters.universe, 50);
+    }
+
+    /// One ticker makes no pairs, so a universe of one would measure nothing and report it as a
+    /// clean null rather than as a refusal.
+    #[test]
+    fn test_an_unusable_window_is_refused() {
+        assert!(Parameters::parse(&arguments(&["2026-08-20", "30", "1"])).is_err());
+        assert!(Parameters::parse(&arguments(&["2026-08-20", "0"])).is_err());
+        assert!(Parameters::parse(&arguments(&["not-a-date"])).is_err());
+        assert!(Parameters::parse(&[]).is_err());
+    }
+}

--- a/src/laboratory.rs
+++ b/src/laboratory.rs
@@ -8,6 +8,7 @@ pub mod export;
 pub mod forecast;
 pub mod information;
 pub mod intraday;
+pub mod intraday_convergence;
 pub mod journal;
 pub mod metrics;
 pub mod predictor;

--- a/src/laboratory/convergence.rs
+++ b/src/laboratory/convergence.rs
@@ -241,10 +241,6 @@ pub struct Entry {
 
 impl Entry {
     /// Where this entry stands at `horizon`, or `None` if it could not be read there.
-    fn at(&self, horizon: usize) -> Option<Resolution> {
-        state_at(self.resolution, self.observed, horizon)
-    }
-
     /// The pair this entry contributes to a curve, without its identity.
     fn state(&self) -> (Resolution, Observed) {
         (self.resolution, self.observed)
@@ -424,7 +420,7 @@ fn follow(
 }
 
 /// A fit window holding a move too large to be one distribution, which the screen also refuses.
-fn breaks(window: &[f64]) -> bool {
+pub(crate) fn breaks(window: &[f64]) -> bool {
     worst_session_move(window).is_some_and(|logarithmic_return| {
         logarithmic_return.abs() > MAXIMUM_SESSION_LOGARITHMIC_RETURN
     })

--- a/src/laboratory/convergence.rs
+++ b/src/laboratory/convergence.rs
@@ -204,7 +204,7 @@ pub struct Observed(u32);
 impl Observed {
     const _FITS: () = assert!(HORIZONS <= u32::BITS as usize);
 
-    fn mark(&mut self, horizon: usize) {
+    pub(crate) fn mark(&mut self, horizon: usize) {
         if (1..=HORIZONS).contains(&horizon) {
             self.0 |= 1 << (horizon - 1);
         }
@@ -242,13 +242,26 @@ pub struct Entry {
 impl Entry {
     /// Where this entry stands at `horizon`, or `None` if it could not be read there.
     fn at(&self, horizon: usize) -> Option<Resolution> {
-        match self.resolution {
-            Resolution::Converged(step) | Resolution::Stopped(step) if step <= horizon => {
-                Some(self.resolution)
-            }
-            _ if self.observed.contains(horizon) => Some(Resolution::Unresolved),
-            _ => None,
+        state_at(self.resolution, self.observed, horizon)
+    }
+
+    /// The pair this entry contributes to a curve, without its identity.
+    fn state(&self) -> (Resolution, Observed) {
+        (self.resolution, self.observed)
+    }
+}
+
+/// Where one entry stands at `horizon`, or `None` where it was never priced there.
+///
+/// An entry that resolved before `horizon` keeps its resolution: the question each horizon asks is
+/// what has become of the cohort by then, not what is happening at that instant.
+fn state_at(resolution: Resolution, observed: Observed, horizon: usize) -> Option<Resolution> {
+    match resolution {
+        Resolution::Converged(step) | Resolution::Stopped(step) if step <= horizon => {
+            Some(resolution)
         }
+        _ if observed.contains(horizon) => Some(Resolution::Unresolved),
+        _ => None,
     }
 }
 
@@ -461,11 +474,19 @@ pub fn without_reentry(mut entries: Vec<Entry>) -> Vec<Entry> {
 
 /// Where a cohort stands at each horizon from one to [`HORIZONS`].
 pub fn curves(entries: &[Entry]) -> Vec<Curve> {
+    curves_of(&entries.iter().map(Entry::state).collect::<Vec<_>>())
+}
+
+/// The same curve over any entries carrying a resolution and what they were priced at.
+///
+/// Shared with the intraday measurement, whose horizons are bars rather than sessions: the shape of
+/// the question is identical and only the unit of the horizon differs.
+pub fn curves_of(states: &[(Resolution, Observed)]) -> Vec<Curve> {
     (1..=HORIZONS)
         .map(|horizon| {
-            let standing: Vec<Resolution> = entries
+            let standing: Vec<Resolution> = states
                 .iter()
-                .filter_map(|entry| entry.at(horizon))
+                .filter_map(|(resolution, observed)| state_at(*resolution, *observed, horizon))
                 .collect();
             let share = |count: usize| {
                 if standing.is_empty() {

--- a/src/laboratory/intraday.rs
+++ b/src/laboratory/intraday.rs
@@ -529,6 +529,84 @@ mod tests {
             .collect()
     }
 
+    /// Rows carrying a volume-weighted price as well as a close, which is what the archive holds
+    /// and what the convergence measurement reads.
+    fn priced_frame(rows: &[(&str, i64, f64, f64)]) -> DataFrame {
+        DataFrame::new(vec![
+            Column::new(
+                "ticker".into(),
+                rows.iter().map(|row| row.0).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "timestamp".into(),
+                rows.iter().map(|row| row.1).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "close_price".into(),
+                rows.iter().map(|row| row.2).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "volume_weighted_average_price".into(),
+                rows.iter().map(|row| row.3).collect::<Vec<_>>(),
+            ),
+        ])
+        .unwrap()
+    }
+
+    /// VWAP is placed at each bar's own index, and a bar that did not print leaves a hole rather
+    /// than letting its neighbours close over it.
+    #[test]
+    fn test_vwaps_are_placed_by_bar_and_keep_their_gaps() {
+        let bars = priced_frame(&[
+            ("AAA", eastern_bar(2026, 6, 1, 9, 30), 100.0, 100.5),
+            // 09:35 never printed.
+            ("AAA", eastern_bar(2026, 6, 1, 9, 40), 102.0, 101.5),
+        ]);
+
+        let vwaps = session_vwaps(&bars, BarInterval::FiveMinute, &regular_hours()).unwrap();
+        let placed = &vwaps[&session_of(2026, 6, 1)]["AAA"];
+
+        assert_eq!(placed[0], Some(100.5));
+        assert_eq!(placed[1], None, "09:35 did not print");
+        assert_eq!(placed[2], Some(101.5));
+        assert_eq!(placed.len(), 78);
+    }
+
+    /// The VWAP column is read, not the close. Reading closes would price half the effective spread
+    /// into every reading taken from this frame.
+    #[test]
+    fn test_vwaps_read_the_volume_weighted_column_not_the_close() {
+        let bars = priced_frame(&[("AAA", eastern_bar(2026, 6, 1, 9, 30), 100.0, 200.0)]);
+
+        let vwaps = session_vwaps(&bars, BarInterval::FiveMinute, &regular_hours()).unwrap();
+
+        assert_eq!(vwaps[&session_of(2026, 6, 1)]["AAA"][0], Some(200.0));
+    }
+
+    /// A daily cadence has no intraday grid to index bars against.
+    #[test]
+    fn test_vwaps_refuse_a_daily_cadence() {
+        let bars = priced_frame(&[("AAA", eastern_bar(2026, 6, 1, 9, 30), 100.0, 100.5)]);
+        assert!(session_vwaps(&bars, BarInterval::OneDay, &regular_hours()).is_err());
+    }
+
+    /// A half-day closes at 13:00, and post-market prints must not enter the price grid either.
+    #[test]
+    fn test_vwaps_respect_an_early_close() {
+        let session = session_of(2026, 11, 27);
+        let bars = priced_frame(&[
+            ("AAA", eastern_bar(2026, 11, 27, 12, 55), 100.0, 100.5),
+            ("AAA", eastern_bar(2026, 11, 27, 14, 0), 120.0, 120.5),
+        ]);
+        let mut hours = BTreeMap::new();
+        hours.insert(session, SessionHours::new(9 * 60 + 30, 13 * 60).unwrap());
+
+        let vwaps = session_vwaps(&bars, BarInterval::FiveMinute, &hours).unwrap();
+        let placed = &vwaps[&session]["AAA"];
+
+        assert_eq!(placed.iter().flatten().count(), 1, "only the 12:55 print");
+    }
+
     /// The whole reason this module exists: a five-minute return must never be an overnight one.
     #[test]
     fn test_a_return_never_spans_two_sessions() {

--- a/src/laboratory/intraday.rs
+++ b/src/laboratory/intraday.rs
@@ -137,47 +137,7 @@ pub fn session_returns(
         )));
     }
 
-    let tickers = bars.column("ticker")?.str()?;
-    let timestamps = bars.column("timestamp")?.i64()?;
-    let closes = bars.column("close_price")?.cast(&DataType::Float64)?;
-    let closes = closes.f64()?;
-    if tickers.null_count() > 0 || timestamps.null_count() > 0 {
-        return Err(IntradayError::Shape(
-            "every bar must name its ticker and its instant".to_string(),
-        ));
-    }
-
-    // Closes are placed at their own bar index rather than pushed in arrival order, so a gap stays
-    // a gap. Keyed by session as well as ticker: a return must never cross the overnight boundary.
-    let mut closes_by_key: BTreeMap<(SessionDate, String), Vec<Option<f64>>> = BTreeMap::new();
-    for ((ticker, timestamp), close) in tickers
-        .into_no_null_iter()
-        .zip(timestamps.into_no_null_iter())
-        .zip(closes)
-    {
-        let Some(close) = close.filter(|price| price.is_finite() && *price > 0.0) else {
-            continue;
-        };
-        let Some(instant) = chrono::DateTime::from_timestamp_millis(timestamp) else {
-            continue;
-        };
-        let session = SessionDate::at(instant);
-        let session_hours = hours
-            .get(&session)
-            .copied()
-            .unwrap_or_else(SessionHours::regular);
-        let eastern = eastern_datetime(instant);
-        let minute = eastern.time().hour() * 60 + eastern.time().minute();
-        let Some(index) = session_hours.bar_index(minute, interval_minutes) else {
-            continue;
-        };
-        let slots = closes_by_key
-            .entry((session, ticker.to_string()))
-            .or_insert_with(|| vec![None; session_hours.bars(interval_minutes)]);
-        if let Some(slot) = slots.get_mut(index) {
-            *slot = Some(close);
-        }
-    }
+    let closes_by_key = place_by_bar(bars, "close_price", interval_minutes, hours)?;
 
     let mut by_session: BTreeMap<SessionDate, BTreeMap<String, Vec<Option<f64>>>> = BTreeMap::new();
     for ((session, ticker), prices) in closes_by_key {
@@ -205,6 +165,92 @@ pub fn session_returns(
         .into_iter()
         .map(|(session, by_ticker)| SessionReturns { session, by_ticker })
         .collect())
+}
+
+/// Places one price column at each bar's own index within its session.
+///
+/// Indexing by bar rather than by arrival order is what keeps a gap a gap: a name that did not
+/// print leaves an empty slot instead of letting its neighbours close over the hole.
+fn place_by_bar(
+    bars: &DataFrame,
+    column: &str,
+    interval_minutes: u32,
+    hours: &BTreeMap<SessionDate, SessionHours>,
+) -> Result<BTreeMap<(SessionDate, String), Vec<Option<f64>>>, IntradayError> {
+    let tickers = bars.column("ticker")?.str()?;
+    let timestamps = bars.column("timestamp")?.i64()?;
+    let prices = bars.column(column)?.cast(&DataType::Float64)?;
+    let prices = prices.f64()?;
+    if tickers.null_count() > 0 || timestamps.null_count() > 0 {
+        return Err(IntradayError::Shape(
+            "every bar must name its ticker and its instant".to_string(),
+        ));
+    }
+
+    let mut placed: BTreeMap<(SessionDate, String), Vec<Option<f64>>> = BTreeMap::new();
+    for ((ticker, timestamp), price) in tickers
+        .into_no_null_iter()
+        .zip(timestamps.into_no_null_iter())
+        .zip(prices)
+    {
+        let Some(price) = price.filter(|value| value.is_finite() && *value > 0.0) else {
+            continue;
+        };
+        let Some(instant) = chrono::DateTime::from_timestamp_millis(timestamp) else {
+            continue;
+        };
+        let session = SessionDate::at(instant);
+        let session_hours = hours
+            .get(&session)
+            .copied()
+            .unwrap_or_else(SessionHours::regular);
+        let eastern = eastern_datetime(instant);
+        let minute = eastern.time().hour() * 60 + eastern.time().minute();
+        let Some(index) = session_hours.bar_index(minute, interval_minutes) else {
+            continue;
+        };
+        let slots = placed
+            .entry((session, ticker.to_string()))
+            .or_insert_with(|| vec![None; session_hours.bars(interval_minutes)]);
+        if let Some(slot) = slots.get_mut(index) {
+            *slot = Some(price);
+        }
+    }
+    Ok(placed)
+}
+
+/// Volume-weighted average price at each bar, by session and name.
+///
+/// **VWAP rather than the close, deliberately.** A bar's close is whichever side of the spread the
+/// last trade hit; its volume-weighted average is drawn from every trade in the bar and does not sit
+/// on one side. Measured over the whole universe the two differ by about nine basis points, which is
+/// the effective spread [`bounce`] recovers — so reading a spread off closes prices half of it in.
+pub fn session_vwaps(
+    bars: &DataFrame,
+    interval: BarInterval,
+    hours: &BTreeMap<SessionDate, SessionHours>,
+) -> Result<BTreeMap<SessionDate, BTreeMap<String, Vec<Option<f64>>>>, IntradayError> {
+    let (interval_minutes, unit) = interval.massive_timespan();
+    if unit != "minute" {
+        return Err(IntradayError::Shape(format!(
+            "intraday prices need a minute cadence, got {interval}"
+        )));
+    }
+    let placed = place_by_bar(
+        bars,
+        "volume_weighted_average_price",
+        interval_minutes,
+        hours,
+    )?;
+
+    let mut by_session: BTreeMap<SessionDate, BTreeMap<String, Vec<Option<f64>>>> = BTreeMap::new();
+    for ((session, ticker), prices) in placed {
+        by_session
+            .entry(session)
+            .or_default()
+            .insert(ticker, prices);
+    }
+    Ok(by_session)
 }
 
 /// Sample autocorrelation of a series at `lag`, or `None` when it is not estimable.

--- a/src/laboratory/intraday_convergence.rs
+++ b/src/laboratory/intraday_convergence.rs
@@ -5,8 +5,7 @@
 use std::collections::BTreeMap;
 
 use crate::common::types::SessionDate;
-use crate::laboratory::convergence::{Closes, Observed, Resolution, Selection, HORIZONS};
-use crate::models::tide::TideError;
+use crate::laboratory::convergence::{breaks, Closes, Observed, Resolution, Selection, HORIZONS};
 use crate::portfolio::screen::{
     logarithmic_returns, pearson_correlation, SpreadModel, CONVERGENCE_Z_SCORE,
     CORRELATION_MAXIMUM, CORRELATION_MINIMUM, CORRELATION_WINDOW_SESSIONS, ENTRY_Z_SCORE,
@@ -15,10 +14,8 @@ use crate::portfolio::screen::{
 
 /// Bars between the reading an entry fires on and the first bar it is judged at.
 ///
-/// **One, not zero, and this is the load-bearing choice.** A dislocation measured at bar `k` that
-/// "converges" at bar `k + 1` is the spread oscillating, not the pair closing: the same artefact
-/// that made five-minute persistence read eighteen standard errors from zero and vanish when a
-/// single bar was skipped. Resolution therefore starts one bar after the entry.
+/// One, not zero: a dislocation that "converges" at the very next bar is the spread oscillating
+/// rather than the pair closing.
 pub const RESOLUTION_SKIP: usize = 1;
 
 /// One pair opened at one bar of one session, and what became of it before the close.
@@ -30,9 +27,11 @@ pub struct IntradayEntry {
     pub long: String,
     pub short: String,
     pub entry_z_score: f64,
-    /// The spread's z-score at the last bar it could be priced at, which is where the book would
-    /// have flattened it.
-    pub exit_z_score: Option<f64>,
+    /// The spread's z-score at the last bar of the session it could be priced at.
+    ///
+    /// Read to the session's end rather than to the horizon cap, because that is where the book
+    /// flattens; stopping at the cap would measure a hundred minutes and call it a session.
+    pub final_z_score: Option<f64>,
     pub resolution: Resolution,
     pub observed: Observed,
 }
@@ -71,6 +70,12 @@ pub fn entries_in_session(
             else {
                 continue;
             };
+            // The same guard the daily measurement applies. A corporate-action-sized move inside
+            // the window corrupts the fit it is the whole basis of, in both cohorts, so it is
+            // checked before the correlation screen rather than as part of it.
+            if breaks(&first_window) || breaks(&second_window) {
+                continue;
+            }
             if let Selection::Screened = selection {
                 let correlation = pearson_correlation(
                     &logarithmic_returns(&first_window),
@@ -160,9 +165,12 @@ fn follow(
     let entry_bar = entry_bar?;
     let stop_at = entry_z_score + STOP_LOSS_WIDENING;
 
+    // Walked to the end of the session, independently of the resolution walk below: the book holds
+    // to the close whatever the rules did in between, so the drift statistic must see that bar.
+    let final_z_score = (entry_bar + RESOLUTION_SKIP + 1..bars).rev().find_map(z_at);
+
     let mut observed = Observed::default();
     let mut resolution = Resolution::Unresolved;
-    let mut exit_z_score = None;
     for horizon in 1..=HORIZONS {
         // `+ horizon` after the skip, so horizon one is the first bar the skip has not hidden.
         // Writing `+ horizon - 1` here judged the adjacent bar and defeated the constant entirely.
@@ -172,7 +180,6 @@ fn follow(
         }
         let Some(z_score) = z_at(bar) else { continue };
         observed.mark(horizon);
-        exit_z_score = Some(z_score);
         if z_score <= CONVERGENCE_Z_SCORE {
             resolution = Resolution::Converged(horizon);
             break;
@@ -189,7 +196,7 @@ fn follow(
         long: long.to_string(),
         short: short.to_string(),
         entry_z_score,
-        exit_z_score,
+        final_z_score,
         resolution,
         observed,
     })
@@ -202,12 +209,10 @@ pub fn mean_entry_z_score(entries: &[IntradayEntry]) -> Option<f64> {
     })
 }
 
-/// How far the spread travelled, in fitted standard deviations, between entry and the last bar.
+/// How far the spread travelled, in fitted standard deviations, between entry and the session's end.
 ///
-/// **The statistic the intraday horizon can actually answer.** Full convergence asks a spread
-/// dislocated by daily sigma to close entirely within a hundred minutes, which is many times a
-/// typical intraday move, so the binary resolution reads zero whatever the pairs do. Negative drift
-/// is movement toward the fitted mean.
+/// Negative is movement toward the fitted mean. Reported instead of a convergence rate because a
+/// threshold set in daily sigma is not reachable inside one session.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Drift {
     /// Mean over sessions of each session's own mean drift.
@@ -222,16 +227,14 @@ pub struct Drift {
 
 /// Measures drift with one reading per session.
 ///
-/// **Aggregated by session deliberately.** A session contributes thousands of entries drawn from
-/// one universe over one set of hours, so they move together; treating them as independent divides
-/// by the square root of a number far larger than the information present and reports a regime as a
-/// discovery. The same correction the five-minute baselines needed.
+/// Aggregated by session because a session's entries are drawn from one universe over one set of
+/// hours and move together; per-entry errors would divide by far more than the information present.
 pub fn drift(entries: &[IntradayEntry]) -> Option<Drift> {
     let mut by_session: BTreeMap<SessionDate, Vec<f64>> = BTreeMap::new();
     let mut toward = 0_usize;
     let mut counted = 0_usize;
     for entry in entries {
-        let Some(exit) = entry.exit_z_score else {
+        let Some(exit) = entry.final_z_score else {
             continue;
         };
         let travelled = exit - entry.entry_z_score;
@@ -488,8 +491,10 @@ mod tests {
 
         assert!(!entries.is_empty());
         for entry in &entries {
-            assert!(entry.entry_z_score >= ENTRY_Z_SCORE);
-            assert!(entry.entry_z_score <= ENTRY_Z_SCORE_CAP);
+            // Literals, not the constants the entry logic reads: an expectation derived from the
+            // value under test moves with it and can never fail.
+            assert!(entry.entry_z_score >= 2.0);
+            assert!(entry.entry_z_score <= 5.0);
         }
     }
 
@@ -509,10 +514,119 @@ mod tests {
             Selection::Unscreened,
         );
 
+        // Exactly one, not at most one: `<= 1` also passes a fixture that stopped opening at all.
+        assert_eq!(entries.len(), 1, "one pair yields one entry per session");
+    }
+
+    fn entry_with(session: SessionDate, entry: f64, final_z: Option<f64>) -> IntradayEntry {
+        IntradayEntry {
+            session,
+            entry_bar: 0,
+            long: "LONG".to_string(),
+            short: "SHORT".to_string(),
+            entry_z_score: entry,
+            final_z_score: final_z,
+            resolution: Resolution::Unresolved,
+            observed: Observed::default(),
+        }
+    }
+
+    /// An entry the session ran out under carries no travel, and counting it as zero drift would
+    /// pull the mean toward a null nothing measured.
+    #[test]
+    fn test_drift_ignores_entries_that_were_never_priced_again() {
+        let session = session_of(2026, 6, 1);
+        assert_eq!(drift(&[entry_with(session, 2.5, None)]), None);
+        assert_eq!(drift(&[]), None);
+    }
+
+    /// One session gives no spread between sessions to take a standard error from, and reporting
+    /// zero there would make a single day read as infinitely significant.
+    #[test]
+    fn test_drift_needs_more_than_one_session() {
+        let session = session_of(2026, 6, 1);
+        let entries = vec![
+            entry_with(session, 2.5, Some(2.0)),
+            entry_with(session, 2.5, Some(2.2)),
+        ];
+        assert_eq!(drift(&entries), None);
+    }
+
+    /// The mean is over sessions, not over entries: a session with a thousand entries must not
+    /// outvote one with ten, which is what treating entries as independent would do.
+    #[test]
+    fn test_drift_weights_sessions_not_entries() {
+        let busy = session_of(2026, 6, 1);
+        let quiet = session_of(2026, 6, 2);
+        let mut entries = vec![entry_with(quiet, 2.5, Some(3.5))];
+        // Ten entries in one session, all travelling -1.0.
+        entries.extend((0..10).map(|_| entry_with(busy, 2.5, Some(1.5))));
+
+        let reading = drift(&entries).expect("two sessions");
+
+        // Session means are -1.0 and +1.0, so the mean over sessions is zero. Weighted by entries
+        // it would have been about -0.82.
         assert!(
-            entries.len() <= 1,
-            "got {} entries for one pair",
-            entries.len()
+            reading.mean.abs() < 1e-12,
+            "expected the two sessions to cancel, got {}",
+            reading.mean
+        );
+        assert_eq!(reading.sessions, 2);
+        assert_eq!(reading.entries, 11);
+    }
+
+    /// The share counts entries whose spread moved toward the mean, which is the population check
+    /// on a mean one large move could otherwise carry.
+    #[test]
+    fn test_share_converging_counts_entries_moving_toward_the_mean() {
+        let first = session_of(2026, 6, 1);
+        let second = session_of(2026, 6, 2);
+        let entries = vec![
+            entry_with(first, 2.5, Some(2.0)),
+            entry_with(first, 2.5, Some(3.0)),
+            entry_with(second, 2.5, Some(2.0)),
+            entry_with(second, 2.5, Some(2.5)),
+        ];
+
+        let reading = drift(&entries).expect("two sessions");
+
+        // Two of four fell, one rose, one was unchanged — unchanged is not toward the mean.
+        assert!((reading.share_converging - 0.5).abs() < 1e-12);
+    }
+
+    /// A window carrying a corporate-action-sized move corrupts the fit it is the whole basis of,
+    /// so the pair must be dropped before anything is fitted on it.
+    #[test]
+    fn test_a_window_with_a_structural_break_is_refused() {
+        let mut frame_rows = daily_frame(0.01);
+        // A ten-for-one split leaves a -230% log return in the window.
+        let closes = frame_rows
+            .column("close_price")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .into_no_null_iter()
+            .enumerate()
+            .map(|(index, price)| if index > 60 { price / 10.0 } else { price })
+            .collect::<Vec<f64>>();
+        frame_rows
+            .with_column(Column::new("close_price".into(), closes))
+            .unwrap();
+        let closes = Closes::from_frame(&frame_rows).unwrap();
+        let prices = pair_prices(3.0, 10, Some(8));
+
+        let entries = entries_in_session(
+            &closes,
+            &prices,
+            &universe(),
+            session_of(2026, 6, 1),
+            closes.sessions() - 1,
+            Selection::Unscreened,
+        );
+
+        assert!(
+            entries.is_empty(),
+            "a window containing a split must not be fitted on"
         );
     }
 

--- a/src/laboratory/intraday_convergence.rs
+++ b/src/laboratory/intraday_convergence.rs
@@ -1,0 +1,537 @@
+//! Does a dislocated pair converge inside the session, which is the horizon the book can hold?
+//!
+//! The model is fitted on daily closes, as production fits it; only the observation is intraday.
+
+use std::collections::BTreeMap;
+
+use crate::common::types::SessionDate;
+use crate::laboratory::convergence::{Closes, Observed, Resolution, Selection, HORIZONS};
+use crate::models::tide::TideError;
+use crate::portfolio::screen::{
+    logarithmic_returns, pearson_correlation, SpreadModel, CONVERGENCE_Z_SCORE,
+    CORRELATION_MAXIMUM, CORRELATION_MINIMUM, CORRELATION_WINDOW_SESSIONS, ENTRY_Z_SCORE,
+    ENTRY_Z_SCORE_CAP, STOP_LOSS_WIDENING,
+};
+
+/// Bars between the reading an entry fires on and the first bar it is judged at.
+///
+/// **One, not zero, and this is the load-bearing choice.** A dislocation measured at bar `k` that
+/// "converges" at bar `k + 1` is the spread oscillating, not the pair closing: the same artefact
+/// that made five-minute persistence read eighteen standard errors from zero and vanish when a
+/// single bar was skipped. Resolution therefore starts one bar after the entry.
+pub const RESOLUTION_SKIP: usize = 1;
+
+/// One pair opened at one bar of one session, and what became of it before the close.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IntradayEntry {
+    pub session: SessionDate,
+    /// Bars from the session open at which the dislocation was read.
+    pub entry_bar: usize,
+    pub long: String,
+    pub short: String,
+    pub entry_z_score: f64,
+    /// The spread's z-score at the last bar it could be priced at, which is where the book would
+    /// have flattened it.
+    pub exit_z_score: Option<f64>,
+    pub resolution: Resolution,
+    pub observed: Observed,
+}
+
+impl IntradayEntry {
+    /// The pair this entry contributes to a curve, without its identity.
+    pub fn state(&self) -> (Resolution, Observed) {
+        (self.resolution, self.observed)
+    }
+}
+
+/// Every name's volume-weighted price at every bar of one session.
+pub type SessionPrices = BTreeMap<String, Vec<Option<f64>>>;
+
+/// Reads one session's intraday prices against models fitted on the daily closes before it.
+///
+/// `daily_session` indexes the session inside `daily`; the fit window ends at the session *before*
+/// it, so the dislocation being judged never enters the distribution it is judged against.
+pub fn entries_in_session(
+    daily: &Closes,
+    prices: &SessionPrices,
+    universe: &[&str],
+    session: SessionDate,
+    daily_session: usize,
+    selection: Selection,
+) -> Vec<IntradayEntry> {
+    let Some(fitted_through) = daily_session.checked_sub(1) else {
+        return Vec::new();
+    };
+
+    let mut entries = Vec::new();
+    for (offset, first) in universe.iter().enumerate() {
+        for second in &universe[offset + 1..] {
+            let Some((first_window, second_window)) =
+                daily.aligned_window(first, second, fitted_through, CORRELATION_WINDOW_SESSIONS)
+            else {
+                continue;
+            };
+            if let Selection::Screened = selection {
+                let correlation = pearson_correlation(
+                    &logarithmic_returns(&first_window),
+                    &logarithmic_returns(&second_window),
+                );
+                let Some(correlation) = correlation else {
+                    continue;
+                };
+                if !(CORRELATION_MINIMUM..=CORRELATION_MAXIMUM).contains(&correlation) {
+                    continue;
+                }
+            }
+            let (Some(first_prices), Some(second_prices)) =
+                (prices.get(*first), prices.get(*second))
+            else {
+                continue;
+            };
+
+            // Both orientations, because the pair opens with whichever leg is the expensive one
+            // short. Only the first that clears the entry band is taken, so one pair yields at most
+            // one entry per session and cannot be counted twice in the same cohort.
+            let orientations = [
+                (
+                    *first,
+                    &first_window,
+                    first_prices,
+                    *second,
+                    &second_window,
+                    second_prices,
+                ),
+                (
+                    *second,
+                    &second_window,
+                    second_prices,
+                    *first,
+                    &first_window,
+                    first_prices,
+                ),
+            ];
+            for (long, long_window, long_prices, short, short_window, short_prices) in orientations
+            {
+                let Some(model) = SpreadModel::fit(long_window, short_window) else {
+                    continue;
+                };
+                let Some(entry) = follow(&model, session, long, long_prices, short, short_prices)
+                else {
+                    continue;
+                };
+                entries.push(entry);
+                break;
+            }
+        }
+    }
+    entries
+}
+
+/// Walks the session's bars, opening at the first dislocation and following it to the close.
+///
+/// The model is never refitted. Refitting intraday would drag the fitted mean toward the current
+/// spread as the window absorbed the dislocation, manufacturing convergence out of bookkeeping.
+fn follow(
+    model: &SpreadModel,
+    session: SessionDate,
+    long: &str,
+    long_prices: &[Option<f64>],
+    short: &str,
+    short_prices: &[Option<f64>],
+) -> Option<IntradayEntry> {
+    let bars = long_prices.len().min(short_prices.len());
+    let z_at = |bar: usize| -> Option<f64> {
+        let (Some(long_price), Some(short_price)) = (long_prices[bar], short_prices[bar]) else {
+            return None;
+        };
+        model.z_score(long_price, short_price)
+    };
+
+    let mut entry_bar = None;
+    let mut entry_z_score = 0.0;
+    for bar in 0..bars {
+        let Some(z_score) = z_at(bar) else { continue };
+        if (ENTRY_Z_SCORE..=ENTRY_Z_SCORE_CAP).contains(&z_score) {
+            entry_bar = Some(bar);
+            entry_z_score = z_score;
+            break;
+        }
+    }
+    let entry_bar = entry_bar?;
+    let stop_at = entry_z_score + STOP_LOSS_WIDENING;
+
+    let mut observed = Observed::default();
+    let mut resolution = Resolution::Unresolved;
+    let mut exit_z_score = None;
+    for horizon in 1..=HORIZONS {
+        // `+ horizon` after the skip, so horizon one is the first bar the skip has not hidden.
+        // Writing `+ horizon - 1` here judged the adjacent bar and defeated the constant entirely.
+        let bar = entry_bar + RESOLUTION_SKIP + horizon;
+        if bar >= bars {
+            break;
+        }
+        let Some(z_score) = z_at(bar) else { continue };
+        observed.mark(horizon);
+        exit_z_score = Some(z_score);
+        if z_score <= CONVERGENCE_Z_SCORE {
+            resolution = Resolution::Converged(horizon);
+            break;
+        }
+        if z_score >= stop_at {
+            resolution = Resolution::Stopped(horizon);
+            break;
+        }
+    }
+
+    Some(IntradayEntry {
+        session,
+        entry_bar,
+        long: long.to_string(),
+        short: short.to_string(),
+        entry_z_score,
+        exit_z_score,
+        resolution,
+        observed,
+    })
+}
+
+/// The average z-score entries were opened at, which is what a convergence would be worth.
+pub fn mean_entry_z_score(entries: &[IntradayEntry]) -> Option<f64> {
+    (!entries.is_empty()).then(|| {
+        entries.iter().map(|entry| entry.entry_z_score).sum::<f64>() / entries.len() as f64
+    })
+}
+
+/// How far the spread travelled, in fitted standard deviations, between entry and the last bar.
+///
+/// **The statistic the intraday horizon can actually answer.** Full convergence asks a spread
+/// dislocated by daily sigma to close entirely within a hundred minutes, which is many times a
+/// typical intraday move, so the binary resolution reads zero whatever the pairs do. Negative drift
+/// is movement toward the fitted mean.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Drift {
+    /// Mean over sessions of each session's own mean drift.
+    pub mean: f64,
+    /// Standard error over sessions, not over entries.
+    pub standard_error: f64,
+    /// Share of entries whose spread moved toward the fitted mean. A coin lands at one half.
+    pub share_converging: f64,
+    pub sessions: usize,
+    pub entries: usize,
+}
+
+/// Measures drift with one reading per session.
+///
+/// **Aggregated by session deliberately.** A session contributes thousands of entries drawn from
+/// one universe over one set of hours, so they move together; treating them as independent divides
+/// by the square root of a number far larger than the information present and reports a regime as a
+/// discovery. The same correction the five-minute baselines needed.
+pub fn drift(entries: &[IntradayEntry]) -> Option<Drift> {
+    let mut by_session: BTreeMap<SessionDate, Vec<f64>> = BTreeMap::new();
+    let mut toward = 0_usize;
+    let mut counted = 0_usize;
+    for entry in entries {
+        let Some(exit) = entry.exit_z_score else {
+            continue;
+        };
+        let travelled = exit - entry.entry_z_score;
+        by_session.entry(entry.session).or_default().push(travelled);
+        if travelled < 0.0 {
+            toward += 1;
+        }
+        counted += 1;
+    }
+    if counted == 0 {
+        return None;
+    }
+
+    let session_means: Vec<f64> = by_session
+        .values()
+        .map(|values| values.iter().sum::<f64>() / values.len() as f64)
+        .collect();
+    if session_means.len() < 2 {
+        return None;
+    }
+    let sessions = session_means.len() as f64;
+    let mean = session_means.iter().sum::<f64>() / sessions;
+    let variance = session_means
+        .iter()
+        .map(|value| (value - mean).powi(2))
+        .sum::<f64>()
+        / (sessions - 1.0);
+
+    Some(Drift {
+        mean,
+        standard_error: (variance / sessions).sqrt(),
+        share_converging: toward as f64 / counted as f64,
+        sessions: session_means.len(),
+        entries: counted,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use polars::prelude::*;
+
+    fn session_of(year: i32, month: u32, day: u32) -> SessionDate {
+        SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(year, month, day).unwrap())
+    }
+
+    /// A pair whose spread sits at `dislocation` standard deviations at `at_bar`, and returns to
+    /// zero afterwards. Written as a spread path so the dislocation is exact rather than hoped for.
+    fn pair_prices(
+        dislocation: f64,
+        at_bar: usize,
+        converge_after: Option<usize>,
+    ) -> SessionPrices {
+        let sigma = 0.01;
+        let mut long = Vec::new();
+        let mut short = Vec::new();
+        for bar in 0..40 {
+            // Convergence overshoots slightly rather than returning to exactly zero: the fitted
+            // mean of the daily window is near zero but not identically so, and a fixture that
+            // stops on the boundary would test the tie rather than the crossing.
+            let spread = if bar < at_bar {
+                0.0
+            } else {
+                match converge_after {
+                    Some(after) if bar >= at_bar + after => -sigma,
+                    _ => dislocation * sigma,
+                }
+            };
+            long.push(Some(100.0_f64));
+            short.push(Some(100.0 * spread.exp()));
+        }
+        let mut prices = SessionPrices::new();
+        prices.insert("LONG".to_string(), long);
+        prices.insert("SHORT".to_string(), short);
+        prices
+    }
+
+    /// Sixty daily sessions of two names whose log spread has standard deviation `sigma`.
+    fn daily_frame(sigma: f64) -> DataFrame {
+        let mut tickers = Vec::new();
+        let mut timestamps = Vec::new();
+        let mut closes = Vec::new();
+        for index in 0..CORRELATION_WINDOW_SESSIONS + 2 {
+            let wobble = if index % 2 == 0 { sigma } else { -sigma };
+            let drift = index as f64 * 0.001;
+            for (ticker, price) in [
+                ("LONG", 100.0 * drift.exp()),
+                ("SHORT", 100.0 * (drift + wobble).exp()),
+            ] {
+                tickers.push(ticker);
+                timestamps.push(index as i64 * 86_400_000);
+                closes.push(price);
+            }
+        }
+        DataFrame::new(vec![
+            Column::new("ticker".into(), tickers),
+            Column::new("timestamp".into(), timestamps),
+            Column::new("close_price".into(), closes),
+        ])
+        .unwrap()
+    }
+
+    fn universe() -> Vec<&'static str> {
+        vec!["LONG", "SHORT"]
+    }
+
+    /// A spread that is dislocated throughout except for a single bar immediately after entry.
+    /// That one bar is the shape bid-ask bounce makes: a price that lands on the other side of the
+    /// spread once and comes straight back, with nothing having actually converged.
+    fn pair_with_a_single_bar_dip(dislocation: f64, at_bar: usize) -> SessionPrices {
+        let sigma = 0.01;
+        let mut long = Vec::new();
+        let mut short = Vec::new();
+        for bar in 0..40 {
+            let spread = match bar {
+                bar if bar < at_bar => 0.0,
+                bar if bar == at_bar + 1 => -sigma,
+                _ => dislocation * sigma,
+            };
+            long.push(Some(100.0_f64));
+            short.push(Some(100.0 * spread.exp()));
+        }
+        let mut prices = SessionPrices::new();
+        prices.insert("LONG".to_string(), long);
+        prices.insert("SHORT".to_string(), short);
+        prices
+    }
+
+    /// The bar immediately after entry must be invisible to the resolution walk. Judged there, the
+    /// single-bar dip above reads as an instant convergence — which is the spread oscillating, the
+    /// same artefact that made five-minute persistence read eighteen standard errors from zero and
+    /// vanish when one bar was skipped.
+    #[test]
+    fn test_the_bar_immediately_after_entry_is_not_judged() {
+        assert_eq!(RESOLUTION_SKIP, 1);
+        let closes = Closes::from_frame(&daily_frame(0.01)).unwrap();
+        let prices = pair_with_a_single_bar_dip(3.0, 10);
+
+        let entries = entries_in_session(
+            &closes,
+            &prices,
+            &universe(),
+            session_of(2026, 6, 1),
+            closes.sessions() - 1,
+            Selection::Unscreened,
+        );
+
+        assert!(!entries.is_empty(), "a three sigma dislocation must open");
+        for entry in &entries {
+            assert!(
+                !matches!(entry.resolution, Resolution::Converged(_)),
+                "the dip sits on the skipped bar and must not resolve the entry, got {:?}",
+                entry.resolution
+            );
+        }
+    }
+
+    /// A dislocation that persists and then closes is a real convergence and must be counted.
+    #[test]
+    fn test_a_lasting_dislocation_that_closes_is_counted() {
+        let closes = Closes::from_frame(&daily_frame(0.01)).unwrap();
+        let session = session_of(2026, 6, 1);
+        let prices = pair_prices(3.0, 10, Some(8));
+
+        let entries = entries_in_session(
+            &closes,
+            &prices,
+            &universe(),
+            session,
+            closes.sessions() - 1,
+            Selection::Unscreened,
+        );
+
+        assert!(!entries.is_empty(), "a three sigma dislocation must open");
+        assert!(
+            entries
+                .iter()
+                .any(|entry| matches!(entry.resolution, Resolution::Converged(_))),
+            "a spread that returns to its mean inside the session converges"
+        );
+    }
+
+    /// A dislocation that never closes must run to the session's end unresolved, not be counted as
+    /// either outcome — the book flattens at the close whatever the spread is doing.
+    #[test]
+    fn test_a_dislocation_that_never_closes_is_unresolved() {
+        let closes = Closes::from_frame(&daily_frame(0.01)).unwrap();
+        let session = session_of(2026, 6, 1);
+        let prices = pair_prices(3.0, 10, None);
+
+        let entries = entries_in_session(
+            &closes,
+            &prices,
+            &universe(),
+            session,
+            closes.sessions() - 1,
+            Selection::Unscreened,
+        );
+
+        assert!(!entries.is_empty());
+        for entry in &entries {
+            assert_eq!(entry.resolution, Resolution::Unresolved);
+        }
+    }
+
+    /// The fit window must end before the session being judged. A window containing the dislocation
+    /// inflates its own dispersion by the move being scored and quietly refuses the entry.
+    #[test]
+    fn test_the_fit_window_ends_before_the_session_it_judges() {
+        let closes = Closes::from_frame(&daily_frame(0.01)).unwrap();
+        let session = session_of(2026, 6, 1);
+        let prices = pair_prices(3.0, 10, Some(8));
+
+        let honest = entries_in_session(
+            &closes,
+            &prices,
+            &universe(),
+            session,
+            closes.sessions() - 1,
+            Selection::Unscreened,
+        );
+
+        assert!(
+            !honest.is_empty(),
+            "the fit must not contain the move it scores"
+        );
+        // Session zero has nothing before it, so there is no window and no entry.
+        let none = entries_in_session(
+            &closes,
+            &prices,
+            &universe(),
+            session,
+            0,
+            Selection::Unscreened,
+        );
+        assert!(none.is_empty());
+    }
+
+    /// A pair opens with whichever leg is expensive short, so entry z is positive by construction
+    /// and convergence is unambiguously a fall toward zero.
+    #[test]
+    fn test_entry_z_scores_are_positive_by_orientation() {
+        let closes = Closes::from_frame(&daily_frame(0.01)).unwrap();
+        let prices = pair_prices(3.0, 10, Some(8));
+
+        let entries = entries_in_session(
+            &closes,
+            &prices,
+            &universe(),
+            session_of(2026, 6, 1),
+            closes.sessions() - 1,
+            Selection::Unscreened,
+        );
+
+        assert!(!entries.is_empty());
+        for entry in &entries {
+            assert!(entry.entry_z_score >= ENTRY_Z_SCORE);
+            assert!(entry.entry_z_score <= ENTRY_Z_SCORE_CAP);
+        }
+    }
+
+    /// One pair yields at most one entry per session, or a cohort would double-count the pair that
+    /// happened to clear the band in both orientations.
+    #[test]
+    fn test_a_pair_opens_at_most_once_in_a_session() {
+        let closes = Closes::from_frame(&daily_frame(0.01)).unwrap();
+        let prices = pair_prices(3.0, 10, Some(8));
+
+        let entries = entries_in_session(
+            &closes,
+            &prices,
+            &universe(),
+            session_of(2026, 6, 1),
+            closes.sessions() - 1,
+            Selection::Unscreened,
+        );
+
+        assert!(
+            entries.len() <= 1,
+            "got {} entries for one pair",
+            entries.len()
+        );
+    }
+
+    /// A name absent from the session's prices cannot be entered, and must not panic the walk.
+    #[test]
+    fn test_a_name_without_intraday_prices_is_skipped() {
+        let closes = Closes::from_frame(&daily_frame(0.01)).unwrap();
+        let mut prices = pair_prices(3.0, 10, Some(8));
+        prices.remove("SHORT");
+
+        let entries = entries_in_session(
+            &closes,
+            &prices,
+            &universe(),
+            session_of(2026, 6, 1),
+            closes.sessions() - 1,
+            Selection::Unscreened,
+        );
+
+        assert!(entries.is_empty());
+    }
+}


### PR DESCRIPTION
# Overview

## Changes

- Add `src/laboratory/intraday_convergence.rs`: entries opened from models fitted on daily closes and followed across a session's five-minute bars, with `Drift` as the statistic
- Add `src/bin/laboratory_intraday_convergence.rs`
- Add `intraday::session_vwaps` and extract `place_by_bar`, shared with `session_returns`
- Share `convergence::curves_of` between the daily and intraday measurements; remove `Entry::at`, which it orphaned

## Context

Task 5, the main event. #1091 measured convergence over twenty **sessions**; the book flattens every position the same session, so that answered a question about a horizon it cannot hold. This asks it at the horizon that matters.

| window ends | cohort | entries | entry z | drift | share toward mean |
|---|---|---|---|---|---|
| 2026-08-20 | screened | 4,161 | 2.376 | -0.0220 (-1.24) | 0.5082 |
| 2026-08-20 | control | 80,638 | 2.365 | -0.0192 (-1.16) | 0.5187 |
| 2024-03-15 | screened | 3,332 | 2.406 | -0.0341 (-1.69) | 0.5365 |
| 2024-03-15 | control | 35,871 | 2.371 | -0.0231 (-1.56) | 0.5180 |
| 2022-06-30 | screened | 8,377 | 2.385 | -0.0215 (-1.08) | 0.5222 |
| 2022-06-30 | control | 32,251 | 2.362 | -0.0354 (-1.59) | 0.5182 |

Drift is the z-score's travel from entry to the session's last priced bar, in fitted standard deviations; negative is movement toward the mean. Standard errors are over sessions.

**All six cohorts drift toward the mean and all six shares exceed one half.** Nothing clears 1.69 standard errors, so the sign consistency is suggestive rather than evidence — three windows all negative is about one-in-eight by chance.

**It cannot pay for itself.** The largest drift is 0.035 sigma on a 2.4 sigma entry, about 1.5% of the dislocation, against a ~10 basis point round trip. Weak reversion exists; it is roughly an order of magnitude too small to trade.

**The correlation band earns nothing.** Screened beats the control in two windows and loses in the third. Whatever reversion exists belongs to dislocated pairs generally, not the cointegrated ones the screen selects — the same conclusion #1091 reached daily, where the band was outright anti-selective.

### Three framing errors corrected

1. **The binary converge/stop framing was mis-scaled.** `CONVERGENCE_Z_SCORE = 0.0` asks a spread dislocated by *daily* sigma to close entirely inside the horizon. It reported 0.0000 converged and 99.85% open — a statement about units, not pairs. `Drift` replaced it.
2. **Standard errors first treated every entry as independent.** ~80,000 entries from 62 sessions read **+6.12 and -5.54 standard errors in different windows** — significant and opposite in sign, which is the only reason it was caught. The defect #1098 had just corrected in the baselines, repeated one pull request later.
3. **Drift stopped at the horizon cap, not the session close** (review, Greptile P1). Twenty bars is a hundred minutes. Correcting it turned sign-inconsistent readings into six uniformly negative ones — **the "clean null" first reported here was an artefact of truncation**, and the body has been rewritten accordingly.

### Design

**VWAP rather than closes for every intraday spread reading.** Close and VWAP differ by **9.2 basis points** across the universe, which is the effective spread; reading a spread off closes prices half of it in.

**`RESOLUTION_SKIP = 1`** leaves the bar immediately after entry unjudged. Writing the arithmetic as `entry_bar + SKIP + horizon - 1` judged the adjacent bar anyway and silently defeated the constant; a test caught it, then was proven load-bearing by setting the constant to zero and watching it fail.

**The structural-break guard** `breaks` is applied in both cohorts before the correlation screen, matching the daily path — a corporate-action-sized move in the window corrupts the fit the z-score rests on.

Sessions are joined between the daily and intraday windows **by date, not by index**.

### Verification

`checks:rust` exit 0; 761 tests passing. Run against the development bucket's five-minute archive, not fixtures.

One test failed once during development, in a run overlapping a background `checks:rust` job holding the test postgres and object store; runs since are clean and the failing test name was not captured. Flagged rather than omitted.