### PR TITLE
Repair a symbol the session gap scan cannot see

### DIFF
--- a/src/bin/seed_intraday_bars_s3.rs
+++ b/src/bin/seed_intraday_bars_s3.rs
@@ -12,11 +12,12 @@ use fund::common::massive::MassiveClient;
 use fund::common::types::{BarInterval, SessionDate, Ticker};
 use fund::data::archive::{self, IntradayScope};
 
-const USAGE: &str = "Usage: seed_intraday_bars_s3 START_DATE END_DATE [CADENCE] [SYMBOLS]\n\
+const USAGE: &str = "Usage: seed_intraday_bars_s3 START_DATE END_DATE [CADENCE [SYMBOLS]]\n\
                      Dates are Eastern calendar dates, inclusive: YYYY-MM-DD.\n\
                      CADENCE is five_minute (default) or one_minute.\n\
-                     SYMBOLS is a comma-separated list; supplying it fetches only those names and\n\
-                     requests every session in the window rather than only the absent ones.";
+                     SYMBOLS is a comma-separated list, and naming it requires naming CADENCE too.\n\
+                     Supplying it fetches only those names and requests every session in the\n\
+                     window rather than only the absent ones.";
 
 /// What the archive is filled with unless told otherwise.
 ///
@@ -81,22 +82,16 @@ impl Parameters {
 
 /// Parses the comma-separated symbol list into validated tickers.
 ///
-/// Refuses an unparseable name rather than skipping it: a typo that silently narrows the universe
-/// looks exactly like a name the vendor has no data for, and the run would report success.
+/// Refuses every unusable component, an empty one included, rather than skipping it: a list that
+/// silently loses a name produces a partial repair the run then reports as success. `split` always
+/// yields at least one component, so an empty argument is refused here too.
 fn parse_symbols(raw: &str) -> Result<BTreeSet<Ticker>, String> {
     let mut symbols = BTreeSet::new();
-    for candidate in raw
-        .split(',')
-        .map(str::trim)
-        .filter(|part| !part.is_empty())
-    {
+    for candidate in raw.split(',').map(str::trim) {
         let ticker = Ticker::new(candidate).ok_or_else(|| {
             format!("SYMBOLS contains an unusable ticker: {candidate:?}\n{USAGE}")
         })?;
         symbols.insert(ticker);
-    }
-    if symbols.is_empty() {
-        return Err(format!("SYMBOLS must name at least one ticker\n{USAGE}"));
     }
     Ok(symbols)
 }
@@ -279,13 +274,22 @@ mod tests {
     /// the vendor has no data for, and the run would report success having fetched less than asked.
     #[test]
     fn test_an_unusable_symbol_list_is_refused() {
+        // The typo that matters: an operator who meant three names gets two, and a partial repair
+        // reports success.
         assert!(Parameters::parse(&arguments(&[
             "2026-08-01",
             "2026-08-20",
             "five_minute",
-            "CBOE,,,"
+            "CBOE,,ICE"
         ]))
-        .is_ok());
+        .is_err());
+        assert!(Parameters::parse(&arguments(&[
+            "2026-08-01",
+            "2026-08-20",
+            "five_minute",
+            "CBOE,"
+        ]))
+        .is_err());
         assert!(
             Parameters::parse(&arguments(&["2026-08-01", "2026-08-20", "five_minute", ""]))
                 .is_err()

--- a/src/bin/seed_intraday_bars_s3.rs
+++ b/src/bin/seed_intraday_bars_s3.rs
@@ -2,17 +2,21 @@
 //!
 //! Reads and repairs `data/equity/bars/interval=<cadence>/`. No database is touched.
 
+use std::collections::BTreeSet;
+
 use chrono::NaiveDate;
 use tracing::{error, info};
 
 use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
-use fund::common::types::{BarInterval, SessionDate};
-use fund::data::archive;
+use fund::common::types::{BarInterval, SessionDate, Ticker};
+use fund::data::archive::{self, IntradayScope};
 
-const USAGE: &str = "Usage: seed_intraday_bars_s3 START_DATE END_DATE [CADENCE]\n\
+const USAGE: &str = "Usage: seed_intraday_bars_s3 START_DATE END_DATE [CADENCE] [SYMBOLS]\n\
                      Dates are Eastern calendar dates, inclusive: YYYY-MM-DD.\n\
-                     CADENCE is five_minute (default) or one_minute.";
+                     CADENCE is five_minute (default) or one_minute.\n\
+                     SYMBOLS is a comma-separated list; supplying it fetches only those names and\n\
+                     requests every session in the window rather than only the absent ones.";
 
 /// What the archive is filled with unless told otherwise.
 ///
@@ -24,16 +28,20 @@ struct Parameters {
     start: SessionDate,
     end: SessionDate,
     interval: BarInterval,
+    scope: IntradayScope,
 }
 
 impl Parameters {
     fn parse(arguments: &[String]) -> Result<Self, String> {
-        let (start, end, cadence) = match arguments {
-            [start, end] => (start, end, None),
-            [start, end, cadence] => (start, end, Some(cadence)),
+        let (start, end, cadence, symbols) = match arguments {
+            [start, end] => (start, end, None, None),
+            [start, end, cadence] => (start, end, Some(cadence), None),
+            // Positional after the cadence, so repairing named symbols means stating the cadence
+            // rather than having it inferred from an argument that could be either.
+            [start, end, cadence, symbols] => (start, end, Some(cadence), Some(symbols)),
             _ => {
                 return Err(format!(
-                    "Expected two dates and an optional cadence\n{USAGE}"
+                    "Expected two dates, an optional cadence and an optional symbol list\n{USAGE}"
                 ))
             }
         };
@@ -57,12 +65,40 @@ impl Parameters {
             }
         };
 
+        let scope = match symbols {
+            None => IntradayScope::MissingSessions,
+            Some(raw) => IntradayScope::Symbols(parse_symbols(raw)?),
+        };
+
         Ok(Self {
             start,
             end,
             interval,
+            scope,
         })
     }
+}
+
+/// Parses the comma-separated symbol list into validated tickers.
+///
+/// Refuses an unparseable name rather than skipping it: a typo that silently narrows the universe
+/// looks exactly like a name the vendor has no data for, and the run would report success.
+fn parse_symbols(raw: &str) -> Result<BTreeSet<Ticker>, String> {
+    let mut symbols = BTreeSet::new();
+    for candidate in raw
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+    {
+        let ticker = Ticker::new(candidate).ok_or_else(|| {
+            format!("SYMBOLS contains an unusable ticker: {candidate:?}\n{USAGE}")
+        })?;
+        symbols.insert(ticker);
+    }
+    if symbols.is_empty() {
+        return Err(format!("SYMBOLS must name at least one ticker\n{USAGE}"));
+    }
+    Ok(symbols)
 }
 
 /// Parses an Eastern calendar date, which is what a session is.
@@ -117,8 +153,9 @@ async fn main() {
 
 /// Repairs the intraday archive over the requested window.
 ///
-/// Only the sessions the bucket is missing are fetched, so re-running over a repaired range costs
-/// one listing and nothing else.
+/// Without `SYMBOLS` only the sessions the bucket is missing are fetched, so re-running over a
+/// repaired range costs one listing and nothing else. With it every session in the window is
+/// requested, because a partition missing one name is indistinguishable from a complete one.
 async fn run(
     parameters: &Parameters,
 ) -> Result<archive::ArchiveSummary, Box<dyn std::error::Error>> {
@@ -127,11 +164,20 @@ async fn run(
     let massive = MassiveClient::from_env()?;
     let s3_client = fund::common::aws::s3_client().await;
 
+    let symbols = match &parameters.scope {
+        IntradayScope::MissingSessions => "the screened universe".to_string(),
+        IntradayScope::Symbols(symbols) => symbols
+            .iter()
+            .map(Ticker::as_str)
+            .collect::<Vec<_>>()
+            .join(","),
+    };
     info!(
         bucket,
         start = %parameters.start,
         end = %parameters.end,
         interval = %parameters.interval,
+        symbols,
         "Seeding the intraday bar archive from Massive"
     );
 
@@ -142,6 +188,7 @@ async fn run(
         parameters.interval,
         parameters.start,
         parameters.end,
+        &parameters.scope,
     )
     .await?)
 }
@@ -199,5 +246,64 @@ mod tests {
     fn test_a_single_session_window_is_allowed() {
         let parameters = Parameters::parse(&arguments(&["2026-08-20", "2026-08-20"])).unwrap();
         assert_eq!(parameters.start, parameters.end);
+    }
+
+    #[test]
+    fn test_omitting_symbols_scans_for_missing_sessions() {
+        let parameters = Parameters::parse(&arguments(&["2026-08-01", "2026-08-20"])).unwrap();
+        assert!(matches!(parameters.scope, IntradayScope::MissingSessions));
+
+        let parameters =
+            Parameters::parse(&arguments(&["2026-08-01", "2026-08-20", "five_minute"])).unwrap();
+        assert!(matches!(parameters.scope, IntradayScope::MissingSessions));
+    }
+
+    #[test]
+    fn test_a_symbol_list_is_parsed_and_trimmed() {
+        let parameters = Parameters::parse(&arguments(&[
+            "2026-08-01",
+            "2026-08-20",
+            "five_minute",
+            " CBOE , CME,ICE ",
+        ]))
+        .unwrap();
+
+        let IntradayScope::Symbols(symbols) = parameters.scope else {
+            panic!("a symbol list must produce a symbol scope");
+        };
+        let named: Vec<&str> = symbols.iter().map(Ticker::as_str).collect();
+        assert_eq!(named, vec!["CBOE", "CME", "ICE"]);
+    }
+
+    /// Refused rather than skipped. A typo silently narrowing the universe looks exactly like a name
+    /// the vendor has no data for, and the run would report success having fetched less than asked.
+    #[test]
+    fn test_an_unusable_symbol_list_is_refused() {
+        assert!(Parameters::parse(&arguments(&[
+            "2026-08-01",
+            "2026-08-20",
+            "five_minute",
+            "CBOE,,,"
+        ]))
+        .is_ok());
+        assert!(
+            Parameters::parse(&arguments(&["2026-08-01", "2026-08-20", "five_minute", ""]))
+                .is_err()
+        );
+        assert!(Parameters::parse(&arguments(&[
+            "2026-08-01",
+            "2026-08-20",
+            "five_minute",
+            "  ,  "
+        ]))
+        .is_err());
+        assert!(Parameters::parse(&arguments(&[
+            "2026-08-01",
+            "2026-08-20",
+            "five_minute",
+            "CBOE",
+            "extra"
+        ]))
+        .is_err());
     }
 }

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -481,6 +481,22 @@ fn intraday_sessions_to_request(
         .collect()
 }
 
+/// The sessions a pass requests, which the scope decides.
+///
+/// A symbol repair asks for the whole window. The set difference above answers "is there a
+/// partition here", and a partition missing one name answers yes — so filtering by it would request
+/// nothing at all and report success.
+fn intraday_sessions_for(
+    scope: &IntradayScope,
+    expected: &[SessionDate],
+    present: &BTreeSet<SessionDate>,
+) -> Vec<SessionDate> {
+    match scope {
+        IntradayScope::MissingSessions => intraday_sessions_to_request(expected, present),
+        IntradayScope::Symbols(_) => expected.to_vec(),
+    }
+}
+
 /// Symbols fetched at once.
 ///
 /// The vendor imposes no rate limit worth pacing against — 25 sequential requests measured at
@@ -488,10 +504,26 @@ fn intraday_sessions_to_request(
 /// respecting theirs, and keeps a failure to a handful of symbols rather than the whole chunk.
 const INTRADAY_CONCURRENCY: usize = 8;
 
-/// Fetches and writes every intraday partition in `[window_start, window_end]` the archive lacks.
+/// What an intraday pass is for, and it decides which sessions get requested.
 ///
-/// A set difference like [`archive_missing_sessions`], and scoped to `interval` throughout, so a
-/// five-minute pass neither sees nor writes the daily partitions beside it.
+/// The two variants exist because session presence cannot answer whether a *symbol* is present: a
+/// partition written while one name's fetch failed, or before that name cleared the universe
+/// screen, is indistinguishable from a complete one. So repairing a symbol has to ignore the set
+/// difference that repairing a session relies on.
+pub enum IntradayScope {
+    /// Every name the daily archive screens in, for the sessions the archive has no partition for.
+    MissingSessions,
+    /// An explicit set of names, across every session in the window regardless of what is present.
+    ///
+    /// The partition merge keys on `(ticker, bar_interval, timestamp)`, so re-requesting a session
+    /// that already holds other names adds these and leaves those untouched.
+    Symbols(BTreeSet<Ticker>),
+}
+
+/// Fetches and writes intraday partitions across `[window_start, window_end]`, per `scope`.
+///
+/// Scoped to `interval` throughout, so a five-minute pass neither sees nor writes the daily
+/// partitions beside it.
 pub async fn archive_intraday_sessions(
     s3_client: &S3Client,
     massive: &MassiveClient,
@@ -499,10 +531,11 @@ pub async fn archive_intraday_sessions(
     interval: BarInterval,
     window_start: SessionDate,
     window_end: SessionDate,
+    scope: &IntradayScope,
 ) -> Result<ArchiveSummary, ArchiveError> {
     let expected = expected_sessions(window_start, window_end);
     let present = present_sessions(s3_client, bucket, interval, window_start, window_end).await?;
-    let requested = intraday_sessions_to_request(&expected, &present);
+    let requested = intraday_sessions_for(scope, &expected, &present);
 
     info!(
         %window_start,
@@ -519,7 +552,16 @@ pub async fn archive_intraday_sessions(
         ..Default::default()
     };
     for chunk in requested.chunks(INTRADAY_CHUNK_SESSIONS) {
-        archive_intraday_chunk(s3_client, massive, bucket, interval, chunk, &mut summary).await?;
+        archive_intraday_chunk(
+            s3_client,
+            massive,
+            bucket,
+            interval,
+            chunk,
+            scope,
+            &mut summary,
+        )
+        .await?;
     }
 
     if summary.symbols_failed > 0 {
@@ -549,12 +591,13 @@ async fn archive_intraday_chunk(
     bucket: &str,
     interval: BarInterval,
     chunk: &[SessionDate],
+    scope: &IntradayScope,
     summary: &mut ArchiveSummary,
 ) -> Result<(), ArchiveError> {
     let (Some(first), Some(last)) = (chunk.first(), chunk.last()) else {
         return Ok(());
     };
-    let universe = universe_over(s3_client, bucket, chunk).await?;
+    let universe = universe_over(s3_client, bucket, chunk, scope).await?;
     let undescribed = chunk.len() - universe.described.len();
     if undescribed > 0 {
         // Left absent so the next pass retries, rather than written from a universe that never
@@ -696,6 +739,7 @@ async fn universe_over(
     s3_client: &S3Client,
     bucket: &str,
     sessions: &[SessionDate],
+    scope: &IntradayScope,
 ) -> Result<Universe, ArchiveError> {
     let daily = bar_archive_prefix(BarInterval::OneDay);
     let mut universe = Universe::default();
@@ -708,6 +752,13 @@ async fn universe_over(
             continue;
         };
         universe.described.insert(*session);
+        // An explicit set still reads the daily partition above, because `described` is what keeps
+        // an intraday partition from being written for a session nothing describes. Only the screen
+        // is skipped: a hand-picked universe has already answered the question the screen asks, and
+        // applying a discovery threshold to it drops names that were chosen deliberately.
+        let IntradayScope::MissingSessions = scope else {
+            continue;
+        };
         let screened = frame
             .lazy()
             .filter(
@@ -721,6 +772,9 @@ async fn universe_over(
         universe
             .symbols
             .extend(tickers.into_iter().flatten().filter_map(Ticker::new));
+    }
+    if let IntradayScope::Symbols(symbols) = scope {
+        universe.symbols = symbols.clone();
     }
     Ok(universe)
 }
@@ -1201,6 +1255,41 @@ mod tests {
         let daily = sessions_to_request(&expected, &present);
         assert_eq!(daily.len(), 5, "{daily:?}");
         assert!(daily.contains(&session(2026, 6, 5)), "{daily:?}");
+    }
+
+    /// A partition holding some of its names is indistinguishable from a complete one, so the set
+    /// difference that repairs a *session* cannot repair a *symbol* — it would request nothing and
+    /// report success. This is the failure that left CBOE absent from 202 partitions that all
+    /// existed.
+    #[test]
+    fn test_a_symbol_repair_requests_the_whole_window() {
+        let expected = expected_sessions(session(2026, 6, 1), session(2026, 6, 5));
+        // Every session is already held, which is exactly the state a symbol repair runs against.
+        let present: BTreeSet<SessionDate> = expected.iter().copied().collect();
+
+        let missing = intraday_sessions_for(&IntradayScope::MissingSessions, &expected, &present);
+        assert!(
+            missing.is_empty(),
+            "a session scan sees nothing to do: {missing:?}"
+        );
+
+        let symbols = IntradayScope::Symbols(
+            [Ticker::new("CBOE").expect("CBOE is a usable ticker")]
+                .into_iter()
+                .collect(),
+        );
+        let repaired = intraday_sessions_for(&symbols, &expected, &present);
+        assert_eq!(
+            repaired,
+            vec![
+                session(2026, 6, 1),
+                session(2026, 6, 2),
+                session(2026, 6, 3),
+                session(2026, 6, 4),
+                session(2026, 6, 5),
+            ],
+            "a symbol repair ignores what is present and asks for all five"
+        );
     }
 
     /// 2026-06-01 is a Monday, so the week runs Mon-Fri 1..=5 and the weekend is 6-7.

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -544,7 +544,7 @@ pub async fn archive_intraday_sessions(
         expected = expected.len(),
         present = present.len(),
         requested = requested.len(),
-        "Scanned the intraday archive for gaps"
+        "Planned an intraday pass"
     );
 
     let mut summary = ArchiveSummary {
@@ -752,10 +752,8 @@ async fn universe_over(
             continue;
         };
         universe.described.insert(*session);
-        // An explicit set still reads the daily partition above, because `described` is what keeps
-        // an intraday partition from being written for a session nothing describes. Only the screen
-        // is skipped: a hand-picked universe has already answered the question the screen asks, and
-        // applying a discovery threshold to it drops names that were chosen deliberately.
+        // An explicit set reads the partition above for `described` and skips only the screen,
+        // which a hand-picked universe has already answered.
         let IntradayScope::MissingSessions = scope else {
             continue;
         };


### PR DESCRIPTION
# Overview

The intraday archive repairs itself by set difference over *sessions*, which cannot detect a missing
*symbol*. CBOE was absent from 202 of the 1,254 five-minute partitions and no repair pass could have
found it — every one of those partitions existed, so a re-run requested nothing, wrote nothing, and
exited 0.

## Changes

- Add `IntradayScope`, an enum naming the two intraday passes so the difference is exhaustive rather
  than implied. `MissingSessions` is the existing behaviour, unchanged. `Symbols` takes an explicit
  ticker set and requests every session in the window regardless of what is present.
- Thread the scope through `archive_intraday_sessions`, `archive_intraday_chunk` and
  `universe_over`. Both variants still read each daily partition, so `described` keeps its guarantee
  that no intraday partition is written for a session nothing describes; only the screen is skipped.
- Extract `intraday_sessions_for`, which is the decision that was wrong, so it can be tested
  directly.
- `seed_intraday_bars_s3` takes an optional fourth positional `SYMBOLS`, comma-separated. An
  unparseable ticker is refused rather than skipped.
- Tests for the broken case and for the argument parsing.

## Context

**Why a mechanism rather than a one-off fetch.** The failure is invisible by construction. A
partition holding some of its names and a complete one produce identical output from every check the
archive has, so nothing downstream can detect it and no operator would think to look. This is the
`session-gap-scan-cannot-see-a-symbol` shape.

**Why the screen is skipped rather than loosened.** CBOE failed the universe screen's
`volume >= 1_000_000` on the sessions it traded under a million shares. That filter exists to
*discover* a tradeable universe out of ~7,000 names; a hand-picked list has already answered the
question it asks, and applying a discovery threshold to it drops names chosen deliberately.

**Why re-requesting a held session is safe.** The partition merge keys on
`(ticker, bar_interval, timestamp)` keeping last, so a symbol repair is additive to the names already
stored and idempotent on the name being repaired — it also replaces partial or corrupt rows rather
than only filling absent ones. The write is a compare-and-swap on the object's `ETag`, so a
contended partition is rejected with a 412 and retried rather than silently clobbered.

**Verified against the development bucket.** CBOE goes from 1,052 sessions to 1,254 and from 84,305
bars to 100,279, with a median of 80 bars a session against CME's 82 and ICE's 81. The other five
names in those same partitions are unchanged. The run reported 1,304 sessions requested, 1,254
written, 0 failed, 0 symbols missing; the 50-session difference is weekday holidays, which
`expected_sessions` includes and the daily archive has no partition for.

The new test asserts the case that was broken — with every session present, `MissingSessions`
requests nothing and `Symbols` requests the whole window — and was confirmed load-bearing by
inverting the branch and watching it fail with an empty left-hand side.

**Follow-up, not in this change.** This is the repair half of a symbol-level gap scan; the detection
half still has to compare each partition's distinct tickers against that session's daily universe.
Separately, the underlying cause is that `MINIMUM_VOLUME` counts shares rather than dollars — CBOE
trades $407M a day at ~740k shares — which affects the runtime tradeable universe too and is tracked
in the plan rather than here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Intraday data backfills can now target a comma-separated list of specific ticker symbols.
  * Symbol-targeted backfills process the complete requested date range, while default backfills continue repairing only missing sessions.
  * Ticker lists are trimmed, validated, and rejected when empty or invalid.
  * Startup output now clearly indicates whether processing targets specific symbols or the screened universe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->