### PR TITLE
Screen the equity universe on dollars traded rather than shares

### DIFF
--- a/.sqlx/query-bd49fae29eed3ea4b9a367b3661fde11a7a19a839c528a91bb4d5fb01c1f1926.json
+++ b/.sqlx/query-bd49fae29eed3ea4b9a367b3661fde11a7a19a839c528a91bb4d5fb01c1f1926.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT ticker AS \"ticker!\",\n               MIN(close_price) AS \"minimum_close_price!\",\n               AVG(volume::double precision) AS \"average_volume!\"\n        FROM equity_bars\n        WHERE bar_interval = $1\n          AND timestamp >= $2\n        GROUP BY ticker\n        ",
+  "query": "\n        SELECT ticker AS \"ticker!\",\n               MIN(close_price) AS \"minimum_close_price!\",\n               AVG(close_price * volume::double precision) AS \"average_dollar_volume!\"\n        FROM equity_bars\n        WHERE bar_interval = $1\n          AND timestamp >= $2\n        GROUP BY ticker\n        ",
   "describe": {
     "columns": [
       {
@@ -15,7 +15,7 @@
       },
       {
         "ordinal": 2,
-        "name": "average_volume!",
+        "name": "average_dollar_volume!",
         "type_info": "Float8"
       }
     ],
@@ -31,5 +31,5 @@
       null
     ]
   },
-  "hash": "88dd6cda793c7db3901d1ab580ed898bead0454332d56d1904ac54ecd70cd2b2"
+  "hash": "bd49fae29eed3ea4b9a367b3661fde11a7a19a839c528a91bb4d5fb01c1f1926"
 }

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -8,18 +8,55 @@ use rust_decimal::Decimal;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
-/// Liquidity thresholds defining the modeled and served equity universe.
+/// The boundary of the modeled and served equity universe: the price and daily notional a name
+/// must clear.
 ///
-/// Training applies them per row and inference per ticker average; both sides must use the same
-/// values, or the scaler and model learn dynamics the service never predicts.
-///
-/// The *comparison* has to match too, and matching values are not enough on their own. All three
-/// readers — `filter_training_bars`, `filter_equity_bars`, and `LiquidityRow::is_liquid` — admit the
-/// threshold itself, so a ticker averaging exactly $10.00 is in the universe, in the training set,
-/// and predicted for. Each has a boundary test, because this is the kind of skew that costs one
-/// character and shows up only at the edge of the population.
-pub const MINIMUM_CLOSE_PRICE: f64 = 10.0;
-pub const MINIMUM_VOLUME: f64 = 1_000_000.0;
+/// One value rather than two arguments, because the pair is meaningless apart and every screen
+/// compares against both. Volume is counted in dollars traded, never in shares: a share count is a
+/// liquidity measure divided by price, so it excludes expensive names that trade freely.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LiquidityFloor {
+    minimum_close_price: f64,
+    minimum_dollar_volume: f64,
+}
+
+impl LiquidityFloor {
+    /// The floor every path uses until a caller declares its own.
+    ///
+    /// Both figures are conventions rather than measurements, and the notional one drifts with the
+    /// market it screens: it admitted 20.6% of priced names in 2022 and 23.0% in 2026, as
+    /// market-wide dollar volume nearly doubled.
+    pub const CURRENT: Self = Self {
+        minimum_close_price: 10.0,
+        minimum_dollar_volume: 50_000_000.0,
+    };
+
+    /// Returns `None` unless both bounds are finite and non-negative; zero admits everything.
+    pub fn new(minimum_close_price: f64, minimum_dollar_volume: f64) -> Option<Self> {
+        let usable = |bound: f64| bound.is_finite() && bound >= 0.0;
+        (usable(minimum_close_price) && usable(minimum_dollar_volume)).then_some(Self {
+            minimum_close_price,
+            minimum_dollar_volume,
+        })
+    }
+
+    /// Whether a name trading at `close_price` on `dollar_volume` is inside the universe.
+    ///
+    /// Both bounds are inclusive, and this is the only place that comparison is written. Every
+    /// screen that reached for the constants separately was free to differ on the boundary, and the
+    /// one that did admitted a name to training and then refused to predict for it.
+    pub fn admits(&self, close_price: f64, dollar_volume: f64) -> bool {
+        close_price >= self.minimum_close_price && dollar_volume >= self.minimum_dollar_volume
+    }
+
+    pub fn minimum_close_price(&self) -> f64 {
+        self.minimum_close_price
+    }
+
+    pub fn minimum_dollar_volume(&self) -> f64 {
+        self.minimum_dollar_volume
+    }
+}
 
 /// Serializes a [`Decimal`] as a JSON number rather than a quoted string.
 ///
@@ -1366,6 +1403,53 @@ mod tests {
 
     fn session(year: i32, month: u32, day: u32) -> SessionDate {
         SessionDate::from_date(NaiveDate::from_ymd_opt(year, month, day).unwrap())
+    }
+
+    /// Both bounds admit the threshold itself. Every screen defers to this comparison, so an
+    /// exclusive test here would admit a name to training and then refuse to predict for it.
+    #[test]
+    fn test_a_floor_admits_a_name_sitting_exactly_on_it() {
+        let floor = LiquidityFloor::new(10.0, 50_000_000.0).unwrap();
+
+        assert!(floor.admits(10.0, 50_000_000.0));
+        assert!(!floor.admits(9.99, 50_000_000.0));
+        assert!(!floor.admits(10.0, 49_999_999.0));
+    }
+
+    /// The two bounds are independent, which is what makes an expensive thin name and a cheap heavy
+    /// one each excluded for their own reason.
+    #[test]
+    fn test_each_bound_rejects_on_its_own() {
+        let floor = LiquidityFloor::new(10.0, 50_000_000.0).unwrap();
+
+        assert!(!floor.admits(500.0, 30_000_000.0), "expensive but untraded");
+        assert!(
+            !floor.admits(2.0, 900_000_000.0),
+            "heavily traded but cheap"
+        );
+        assert!(floor.admits(290.0, 261_000_000.0));
+    }
+
+    #[test]
+    fn test_a_floor_refuses_a_bound_that_is_not_a_usable_number() {
+        assert!(LiquidityFloor::new(-1.0, 50_000_000.0).is_none());
+        assert!(LiquidityFloor::new(10.0, f64::NAN).is_none());
+        assert!(LiquidityFloor::new(10.0, f64::INFINITY).is_none());
+        assert!(
+            LiquidityFloor::new(0.0, 0.0).is_some(),
+            "a floor of zero admits everything, which is a screen and not an error"
+        );
+    }
+
+    /// The shipped floor is what every path screens against until a caller declares its own, so a
+    /// change to it changes the traded universe and must be a deliberate edit rather than a drift.
+    #[test]
+    fn test_the_current_floor_is_ten_dollars_and_fifty_million() {
+        assert_eq!(LiquidityFloor::CURRENT.minimum_close_price(), 10.0);
+        assert_eq!(
+            LiquidityFloor::CURRENT.minimum_dollar_volume(),
+            50_000_000.0
+        );
     }
 
     #[derive(Serialize, Deserialize)]

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -726,8 +726,12 @@ async fn archive_intraday_chunk(
     Ok(())
 }
 
-/// The names that traded across `sessions`, read from the daily archive and screened as the model
-/// screens them.
+/// The names that traded across `sessions`, read from the daily archive and screened per session.
+///
+/// **A fetch universe, deliberately wider than any study population.** Screened session by session
+/// rather than on a trailing average, so a name that traded heavily on one day is fetched for the
+/// chunk. That is the safe direction for an archive: an unfetched bar cannot be recovered later,
+/// and every study screens again on its own terms when it reads.
 ///
 /// **Survivorship-free by construction.** The daily partitions are whole-market and were written on
 /// the day, so a name that has since delisted is still present in the sessions it traded. Taking the
@@ -755,9 +759,8 @@ async fn universe_over(
         let IntradayScope::MissingSessions = scope else {
             continue;
         };
-        // Pinned rather than threaded up to the caller. The intraday archive is one shared object
-        // per session, not a per-study artifact, so two seeds run at different floors would leave a
-        // partition nothing can describe; widening the floor means backfilling, not reconfiguring.
+        // Pinned rather than threaded up: the archive is one shared object per session, so
+        // widening the floor means backfilling it rather than reconfiguring a caller.
         universe
             .symbols
             .extend(screen_partition(frame, LiquidityFloor::CURRENT)?);

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -15,9 +15,7 @@ use tracing::{info, warn};
 use crate::common::alpaca::MarketDataClient;
 use crate::common::aws::{date_from_partitioned_key, date_partitioned_key};
 use crate::common::massive::MassiveClient;
-use crate::common::types::{
-    BarInterval, EquityBar, SessionDate, Ticker, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME,
-};
+use crate::common::types::{BarInterval, EquityBar, LiquidityFloor, SessionDate, Ticker};
 use crate::data::{bars, boundaries, splits};
 
 /// Root of the bar archive, never a partition prefix on its own — [`bar_archive_prefix`] adds the
@@ -757,24 +755,46 @@ async fn universe_over(
         let IntradayScope::MissingSessions = scope else {
             continue;
         };
-        let screened = frame
-            .lazy()
-            .filter(
-                col("close_price")
-                    .gt_eq(lit(MINIMUM_CLOSE_PRICE))
-                    .and(col("volume").gt_eq(lit(MINIMUM_VOLUME))),
-            )
-            .select([col("ticker")])
-            .collect()?;
-        let tickers = screened.column("ticker")?.str()?;
+        // Pinned rather than threaded up to the caller. The intraday archive is one shared object
+        // per session, not a per-study artifact, so two seeds run at different floors would leave a
+        // partition nothing can describe; widening the floor means backfilling, not reconfiguring.
         universe
             .symbols
-            .extend(tickers.into_iter().flatten().filter_map(Ticker::new));
+            .extend(screen_partition(frame, LiquidityFloor::CURRENT)?);
     }
     if let IntradayScope::Symbols(symbols) = scope {
         universe.symbols = symbols.clone();
     }
     Ok(universe)
+}
+
+/// The names in one daily partition that clear the liquidity thresholds.
+///
+/// Notional is the per-row product, not a trailing average, because a partition is one session and
+/// there is no window to average over — the runtime screen in [`crate::data::universe`] is the one
+/// that smooths.
+fn screen_partition(
+    frame: DataFrame,
+    floor: LiquidityFloor,
+) -> Result<BTreeSet<Ticker>, ArchiveError> {
+    let screened = frame
+        .lazy()
+        .filter(
+            col("close_price")
+                .gt_eq(lit(floor.minimum_close_price()))
+                .and(
+                    (col("close_price") * col("volume").cast(DataType::Float64))
+                        .gt_eq(lit(floor.minimum_dollar_volume())),
+                ),
+        )
+        .select([col("ticker")])
+        .collect()?;
+    let tickers = screened.column("ticker")?.str()?;
+    Ok(tickers
+        .into_iter()
+        .flatten()
+        .filter_map(Ticker::new)
+        .collect())
 }
 
 /// The names to fetch, and the sessions the daily archive could actually describe.
@@ -1481,6 +1501,29 @@ mod tests {
         assert_eq!(
             without_data, 1,
             "the unrequested 06-03 must not stand in for the empty 06-02"
+        );
+    }
+
+    /// The intraday repair universe is screened on notional, at the three names' measured figures.
+    /// CBOE moves 900,000 shares and is in it; OBDC moves nearly five times as many and is not. The
+    /// retired share-count floor answered both the other way round, and OBDC is the one the archive
+    /// spent its five-minute fetches on.
+    #[test]
+    fn test_the_partition_screen_counts_dollars_not_shares() {
+        let partition = df![
+            "ticker" => ["CBOE", "OBDC", "SNDL"],
+            "close_price" => [290.0_f64, 11.3, 1.50],
+            "volume" => [900_000_i64, 4_350_000, 40_000_000],
+        ]
+        .unwrap();
+
+        let screened =
+            screen_partition(partition, LiquidityFloor::new(10.0, 50_000_000.0).unwrap()).unwrap();
+
+        assert_eq!(
+            screened,
+            BTreeSet::from([Ticker::new("CBOE").unwrap()]),
+            "OBDC turns over $49.2M, just under the floor; SNDL clears $60M and fails on price"
         );
     }
 

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::common::alpaca::{ClientError, TradableAssets, TradingClient};
 use crate::common::journal::{Journal, Observation, UniverseRefreshed};
-use crate::common::types::{BarInterval, SessionDate, Ticker, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
+use crate::common::types::{BarInterval, LiquidityFloor, SessionDate, Ticker};
 use crate::data::cache::DailyCache;
 
 /// Trailing window over which liquidity is averaged.
@@ -32,28 +32,29 @@ pub enum UniverseError {
 
 /// One ticker's liquidity over the trailing window.
 ///
-/// Price is summarised by its minimum and volume by its average. A price is a level, so one that
-/// ever fell below the floor disqualifies the name; volume is a flow, where one quiet session says
-/// nothing about tradability.
+/// Price is summarised by its minimum and dollar volume by its average. A price is a level, so one
+/// that ever fell below the floor disqualifies the name; dollar volume is a flow, where one quiet
+/// session says nothing about tradability.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LiquidityRow {
     ticker: Ticker,
     minimum_close_price: f64,
-    average_volume: f64,
+    average_dollar_volume: f64,
 }
 
 impl LiquidityRow {
-    pub fn new(ticker: Ticker, minimum_close_price: f64, average_volume: f64) -> Self {
+    pub fn new(ticker: Ticker, minimum_close_price: f64, average_dollar_volume: f64) -> Self {
         Self {
             ticker,
             minimum_close_price,
-            average_volume,
+            average_dollar_volume,
         }
     }
 
-    /// Whether this ticker clears both liquidity thresholds.
-    fn is_liquid(&self) -> bool {
-        self.minimum_close_price >= MINIMUM_CLOSE_PRICE && self.average_volume >= MINIMUM_VOLUME
+    /// Whether this ticker clears `floor`, screening price on the window's minimum rather than its
+    /// average, which is the stricter of the two.
+    fn is_liquid(&self, floor: LiquidityFloor) -> bool {
+        floor.admits(self.minimum_close_price, self.average_dollar_volume)
     }
 }
 
@@ -72,15 +73,19 @@ pub struct Universe {
 impl Universe {
     /// Composes the three filters, all of which are necessary.
     ///
-    /// Alpaca must permit it, we must hold bars for it, and it must clear the same liquidity
-    /// thresholds the model trained on — a universe wider than the training population means
-    /// predicting on names the scaler never saw.
-    pub fn build(assets: &TradableAssets, liquidity: &[LiquidityRow]) -> Self {
+    /// Alpaca must permit it, we must hold bars for it, and it must clear `floor` — which has to be
+    /// the floor the model was fitted against, because a universe wider than the training
+    /// population means predicting on names the scaler never saw.
+    pub fn build(
+        assets: &TradableAssets,
+        liquidity: &[LiquidityRow],
+        floor: LiquidityFloor,
+    ) -> Self {
         let mut tickers = Vec::new();
         let mut shortable = HashSet::new();
 
         for row in liquidity {
-            if !row.is_liquid() {
+            if !row.is_liquid(floor) {
                 continue;
             }
             if !assets.is_tradable(&row.ticker) {
@@ -142,11 +147,12 @@ impl Universe {
     }
 }
 
-/// Reads per-ticker minimum close and average volume over the trailing window.
+/// Reads per-ticker minimum close and average dollar volume over the trailing window.
 ///
 /// Read over daily bars specifically: the liquidity thresholds are calibrated on daily dynamics,
-/// and averaging intraday bars would compare a per-minute volume against a per-day threshold and
-/// reject the entire universe.
+/// and averaging intraday bars would compare a per-bar notional against a per-day threshold and
+/// reject the entire universe. The product is taken per session and then averaged, because the
+/// average of a product is not the product of the averages once price and volume move together.
 pub async fn load_liquidity(
     pool: &PgPool,
     as_of: SessionDate,
@@ -156,7 +162,7 @@ pub async fn load_liquidity(
         r#"
         SELECT ticker AS "ticker!",
                MIN(close_price) AS "minimum_close_price!",
-               AVG(volume::double precision) AS "average_volume!"
+               AVG(close_price * volume::double precision) AS "average_dollar_volume!"
         FROM equity_bars
         WHERE bar_interval = $1
           AND timestamp >= $2
@@ -172,7 +178,7 @@ pub async fn load_liquidity(
         .into_iter()
         .filter_map(|row| {
             Ticker::new(&row.ticker).map(|ticker| {
-                LiquidityRow::new(ticker, row.minimum_close_price, row.average_volume)
+                LiquidityRow::new(ticker, row.minimum_close_price, row.average_dollar_volume)
             })
         })
         .collect())
@@ -182,14 +188,19 @@ pub async fn load_liquidity(
 ///
 /// Warmed by the pre-open handler and refreshed on demand by anything that finds it cold, so a
 /// restart mid-session repopulates rather than trading an empty universe until the next morning.
-#[derive(Default)]
+/// The floor is held here rather than passed per call, so every rebuild within a process screens
+/// the same way.
 pub struct UniverseCache {
     inner: DailyCache<Universe>,
+    floor: LiquidityFloor,
 }
 
 impl UniverseCache {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(floor: LiquidityFloor) -> Self {
+        Self {
+            inner: DailyCache::default(),
+            floor,
+        }
     }
 
     /// Returns today's universe, rebuilding it if the cache is cold or was filled on an earlier
@@ -217,7 +228,7 @@ impl UniverseCache {
                 || async {
                     let assets = client.fetch_tradable_assets().await?;
                     let liquidity = load_liquidity(pool, today).await?;
-                    let universe = Universe::build(&assets, &liquidity);
+                    let universe = Universe::build(&assets, &liquidity, self.floor);
 
                     info!(
                         alpaca_tradable = assets.tradable_count(),
@@ -244,7 +255,10 @@ impl UniverseCache {
                             Observation::UniverseRefreshed(UniverseRefreshed {
                                 alpaca_tradable: assets.tradable_count(),
                                 alpaca_shortable: assets.shortable_count(),
-                                liquid: liquidity.iter().filter(|row| row.is_liquid()).count(),
+                                liquid: liquidity
+                                    .iter()
+                                    .filter(|row| row.is_liquid(self.floor))
+                                    .count(),
                                 universe_size: universe.len(),
                                 admitted,
                                 removed,
@@ -274,6 +288,12 @@ mod tests {
         Ticker::new(raw).expect("test ticker must be valid")
     }
 
+    /// Pinned to literals rather than `LiquidityFloor::CURRENT`, so these tests fail if the screen
+    /// changes rather than moving with it.
+    fn floor() -> LiquidityFloor {
+        LiquidityFloor::new(10.0, 50_000_000.0).expect("test floor must be valid")
+    }
+
     fn assets() -> TradableAssets {
         TradableAssets::from_sets(
             HashSet::from([
@@ -288,12 +308,12 @@ mod tests {
     }
 
     fn liquid(symbol: &str) -> LiquidityRow {
-        LiquidityRow::new(ticker(symbol), 100.0, 5_000_000.0)
+        LiquidityRow::new(ticker(symbol), 100.0, 500_000_000.0)
     }
 
     #[test]
     fn test_build_keeps_liquid_tradable_tickers() {
-        let universe = Universe::build(&assets(), &[liquid("AAPL"), liquid("MSFT")]);
+        let universe = Universe::build(&assets(), &[liquid("AAPL"), liquid("MSFT")], floor());
         assert_eq!(universe.tickers(), &[ticker("AAPL"), ticker("MSFT")]);
         assert_eq!(universe.len(), 2);
     }
@@ -302,7 +322,7 @@ mod tests {
     /// not enter the universe even though nothing about it is wrong.
     #[test]
     fn test_build_excludes_tickers_without_history() {
-        let universe = Universe::build(&assets(), &[liquid("AAPL")]);
+        let universe = Universe::build(&assets(), &[liquid("AAPL")], floor());
         assert!(!universe.tickers().contains(&ticker("NVDA")));
     }
 
@@ -310,7 +330,7 @@ mod tests {
     /// a delisting produces.
     #[test]
     fn test_build_excludes_tickers_alpaca_will_not_trade() {
-        let universe = Universe::build(&assets(), &[liquid("AAPL"), liquid("GONE")]);
+        let universe = Universe::build(&assets(), &[liquid("AAPL"), liquid("GONE")], floor());
         assert!(!universe.tickers().contains(&ticker("GONE")));
     }
 
@@ -318,28 +338,43 @@ mod tests {
     /// expensive-but-untraded name are each excluded for their own reason.
     #[test]
     fn test_build_applies_both_liquidity_thresholds() {
-        let cheap = LiquidityRow::new(ticker("PENNY"), MINIMUM_CLOSE_PRICE - 0.01, 50_000_000.0);
-        let thin = LiquidityRow::new(ticker("THIN"), 500.0, MINIMUM_VOLUME - 1.0);
+        let cheap = LiquidityRow::new(ticker("PENNY"), 9.99, 900_000_000.0);
+        let thin = LiquidityRow::new(ticker("THIN"), 500.0, 49_999_999.0);
 
-        let universe = Universe::build(&assets(), &[liquid("AAPL"), cheap, thin]);
+        let universe = Universe::build(&assets(), &[liquid("AAPL"), cheap, thin], floor());
 
         assert_eq!(universe.tickers(), &[ticker("AAPL")]);
     }
 
     #[test]
     fn test_thresholds_are_inclusive_at_the_boundary() {
-        let exactly_at_threshold =
-            LiquidityRow::new(ticker("AAPL"), MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME);
-        let universe = Universe::build(&assets(), &[exactly_at_threshold]);
+        let exactly_at_threshold = LiquidityRow::new(ticker("AAPL"), 10.0, 50_000_000.0);
+        let universe = Universe::build(&assets(), &[exactly_at_threshold], floor());
         assert_eq!(universe.len(), 1, "the threshold itself must pass");
+    }
+
+    /// The reason the screen counts dollars. CBOE trades ~1M shares a day at ~$290, which is $290M
+    /// of notional and under the retired one-million-share floor on most sessions; a $12 name at
+    /// four million shares is $48M and was admitted by it. The old screen inverted both.
+    #[test]
+    fn test_dollar_volume_admits_expensive_names_and_drops_cheap_heavy_ones() {
+        let expensive = LiquidityRow::new(ticker("MSFT"), 290.0, 290_000_000.0);
+        let cheap_and_heavy = LiquidityRow::new(ticker("NVDA"), 12.0, 48_000_000.0);
+
+        let universe = Universe::build(&assets(), &[expensive, cheap_and_heavy], floor());
+
+        assert_eq!(universe.tickers(), &[ticker("MSFT")]);
     }
 
     /// The short leg needs both Alpaca flags. A tradable-but-not-shortable name stays in the
     /// universe for the long leg and is excluded from the shortable subset.
     #[test]
     fn test_shortable_is_a_subset_of_tradable() {
-        let universe =
-            Universe::build(&assets(), &[liquid("AAPL"), liquid("MSFT"), liquid("NVDA")]);
+        let universe = Universe::build(
+            &assets(),
+            &[liquid("AAPL"), liquid("MSFT"), liquid("NVDA")],
+            floor(),
+        );
         assert!(universe.is_shortable(&ticker("AAPL")));
         assert!(universe.is_shortable(&ticker("MSFT")));
         assert!(
@@ -352,8 +387,11 @@ mod tests {
 
     #[test]
     fn test_tickers_are_sorted_and_stable() {
-        let universe =
-            Universe::build(&assets(), &[liquid("NVDA"), liquid("AAPL"), liquid("MSFT")]);
+        let universe = Universe::build(
+            &assets(),
+            &[liquid("NVDA"), liquid("AAPL"), liquid("MSFT")],
+            floor(),
+        );
         assert_eq!(
             universe.tickers(),
             &[ticker("AAPL"), ticker("MSFT"), ticker("NVDA")]
@@ -362,15 +400,15 @@ mod tests {
 
     #[test]
     fn test_empty_inputs_produce_an_empty_universe() {
-        assert!(Universe::build(&assets(), &[]).is_empty());
-        assert!(Universe::build(&TradableAssets::default(), &[liquid("AAPL")]).is_empty());
+        assert!(Universe::build(&assets(), &[], floor()).is_empty());
+        assert!(Universe::build(&TradableAssets::default(), &[liquid("AAPL")], floor()).is_empty());
     }
 
     #[tokio::test]
     async fn test_cache_serves_installed_universe_without_fetching() {
-        let cache = UniverseCache::new();
+        let cache = UniverseCache::new(floor());
         let now = "2026-06-10T14:00:00Z".parse::<DateTime<Utc>>().unwrap();
-        let universe = Universe::build(&assets(), &[liquid("AAPL")]);
+        let universe = Universe::build(&assets(), &[liquid("AAPL")], floor());
         cache.install(now, universe).await;
 
         // Unreachable client and pool: a cache hit must touch neither.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -140,7 +140,7 @@ impl ServiceState {
             artifact_prefix,
             model_version,
             calendar_cache: CalendarCache::new(),
-            universe_cache: UniverseCache::new(),
+            universe_cache: UniverseCache::new(crate::common::types::LiquidityFloor::CURRENT),
             close_history_cache: CloseHistoryCache::new(),
             split_table_cache: SplitTableCache::new(),
             boundary_table_cache: BoundaryTableCache::new(),
@@ -513,12 +513,9 @@ async fn run_inference(
 
     let consolidated = predict::consolidate_data(equity_bars, equity_details)
         .map_err(|error| at("consolidate")(error.to_string()))?;
-    let filtered = predict::filter_equity_bars(
-        consolidated,
-        crate::common::types::MINIMUM_CLOSE_PRICE,
-        crate::common::types::MINIMUM_VOLUME,
-    )
-    .map_err(|error| at("filter_bars")(error.to_string()))?;
+    let filtered =
+        predict::filter_equity_bars(consolidated, crate::common::types::LiquidityFloor::CURRENT)
+            .map_err(|error| at("filter_bars")(error.to_string()))?;
     let trained = predict::filter_to_trained_tickers(filtered, model_state)
         .map_err(|error| at("filter_tickers")(error.to_string()))?;
 

--- a/src/laboratory/dataset.rs
+++ b/src/laboratory/dataset.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use tracing::warn;
 
 use crate::common::aws::date_partitioned_key;
-use crate::common::types::{BarInterval, SessionDate, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
+use crate::common::types::{BarInterval, LiquidityFloor, SessionDate};
 use crate::data::{adjust, archive, bars, details, truncate};
 use crate::models::tide::data::{clean_data, engineer_features, Target, TrainingFraction};
 use crate::models::tide::fit::{filter_training_bars, fit, FitResult};
@@ -223,7 +223,7 @@ async fn read_window(
 
     let equity_details = details::details_to_dataframe(&details::parse_embedded_details()?)?;
     let consolidated = consolidate_data(equity_bars, equity_details)?;
-    let filtered = filter_training_bars(consolidated, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME)?;
+    let filtered = filter_training_bars(consolidated, LiquidityFloor::CURRENT)?;
 
     let fingerprint = fingerprint_of(
         &filtered,

--- a/src/models/tide/fit.rs
+++ b/src/models/tide/fit.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use polars::prelude::*;
 
+use crate::common::types::LiquidityFloor;
 use crate::models::tide::configuration::ModelParameters;
 use crate::models::tide::data::{
     apply_scaling, clean_data, demean_target, encode_categoricals, engineer_features,
@@ -140,8 +141,7 @@ fn build_mapping(data: &DataFrame, column: &str) -> Result<CategoryMapping, Tide
 /// cleaning.
 pub fn filter_training_bars(
     data: DataFrame,
-    minimum_close_price: f64,
-    minimum_volume: f64,
+    floor: LiquidityFloor,
 ) -> Result<DataFrame, TideError> {
     let close_prices = data.column("close_price")?.cast(&DataType::Float64)?;
     let close_prices = close_prices.f64()?;
@@ -154,8 +154,9 @@ pub fn filter_training_bars(
         .zip(volumes)
         .zip(tickers)
         .map(|((close_price, volume), ticker)| {
-            close_price.is_some_and(|value| value >= minimum_close_price)
-                && volume.is_some_and(|value| value >= minimum_volume)
+            close_price
+                .zip(volume)
+                .is_some_and(|(price, shares)| floor.admits(price, price * shares))
                 && ticker
                     .is_some_and(|value| !value.chars().any(|character| character.is_lowercase()))
         })
@@ -235,6 +236,13 @@ pub fn write_artifact_json(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pinned to literals rather than `LiquidityFloor::CURRENT`, so these tests fail if the screen
+    /// changes rather than moving with it.
+    fn floor(minimum_close_price: f64, minimum_dollar_volume: f64) -> LiquidityFloor {
+        LiquidityFloor::new(minimum_close_price, minimum_dollar_volume)
+            .expect("test floor must be valid")
+    }
 
     /// The fraction the trainer runs with, so the tests exercise the split production uses.
     fn training_fraction() -> TrainingFraction {
@@ -436,11 +444,11 @@ mod tests {
             Column::new("ticker".into(), vec!["AAA", "AAA", "BBB"]),
             Column::new("timestamp".into(), vec![0_i64, 86_400_000, 0]),
             Column::new("close_price".into(), vec![0.5_f64, 1.0, 250.0]),
-            Column::new("volume".into(), vec![100_000.0_f64, 100_000.0, 50_000.0]),
+            Column::new("volume".into(), vec![100_000.0_f64, 100_000.0, 200.0]),
         ])
         .unwrap();
 
-        let filtered = filter_training_bars(data, 1.0, 100_000.0).unwrap();
+        let filtered = filter_training_bars(data, floor(1.0, 100_000.0)).unwrap();
         assert_eq!(filtered.height(), 1);
         let tickers: Vec<&str> = filtered
             .column("ticker")
@@ -460,6 +468,29 @@ mod tests {
         assert_eq!(close, vec![1.0]);
     }
 
+    /// The second threshold is notional, not share count. HIGH trades 200 shares at $250 and is
+    /// admitted; LOW trades 4,000 at $12 and is not, though it moves twenty times the shares.
+    #[test]
+    fn test_filter_training_bars_screens_on_dollars_not_shares() {
+        let data = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["HIGH", "LOW"]),
+            Column::new("timestamp".into(), vec![0_i64, 0]),
+            Column::new("close_price".into(), vec![250.0_f64, 12.0]),
+            Column::new("volume".into(), vec![200.0_f64, 4_000.0]),
+        ])
+        .unwrap();
+
+        let filtered = filter_training_bars(data, floor(1.0, 48_001.0)).unwrap();
+        let tickers: Vec<&str> = filtered
+            .column("ticker")
+            .unwrap()
+            .str()
+            .unwrap()
+            .into_no_null_iter()
+            .collect();
+        assert_eq!(tickers, vec!["HIGH"]);
+    }
+
     #[test]
     fn test_filter_training_bars_drops_lowercase_tickers() {
         // Tickers containing lowercase letters are distinct instruments that would collide
@@ -475,7 +506,7 @@ mod tests {
         ])
         .unwrap();
 
-        let filtered = filter_training_bars(data, 1.0, 100_000.0).unwrap();
+        let filtered = filter_training_bars(data, floor(1.0, 100_000.0)).unwrap();
         let tickers: Vec<&str> = filtered
             .column("ticker")
             .unwrap()

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -1,7 +1,10 @@
 //! Running the TiDE model: from stored market history to rows in `equity_predictions`.
 //!
-//! Screens against the same [`crate::common::types::LiquidityFloor`] the fit was given, so a drift
-//! cannot train the scaler on dynamics the service never predicts.
+//! The [`crate::common::types::LiquidityFloor`] is passed in and the artifact does not record the
+//! one it was fitted against, so an artifact older than the current floor is served under a screen
+//! it never saw. [`filter_to_trained_tickers`] is what bounds that: it intersects against the
+//! artifact's own vocabulary, so a stale floor narrows the served set rather than handing the
+//! scaler a name it never trained on.
 
 use burn::backend::NdArray;
 use chrono::{DateTime, Utc};

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -1,7 +1,7 @@
 //! Running the TiDE model: from stored market history to rows in `equity_predictions`.
 //!
-//! Applies the same liquidity thresholds training does, read from [`crate::common::types`] so a
-//! drift cannot train the scaler on dynamics the service never predicts.
+//! Screens against the same [`crate::common::types::LiquidityFloor`] the fit was given, so a drift
+//! cannot train the scaler on dynamics the service never predicts.
 
 use burn::backend::NdArray;
 use chrono::{DateTime, Utc};
@@ -10,7 +10,7 @@ use sqlx::PgPool;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::common::types::{EquityPrediction, SessionDate, Ticker};
+use crate::common::types::{EquityPrediction, LiquidityFloor, SessionDate, Ticker};
 
 use crate::models::tide::artifact::ModelState;
 use crate::models::tide::data::{Data, DatasetKind};
@@ -180,16 +180,16 @@ fn duplicated_tickers(bars: &DataFrame) -> Result<Vec<String>, PredictionError> 
     Ok(names)
 }
 
-/// Drops tickers whose trailing averages fall below the liquidity thresholds.
+/// Drops tickers whose trailing averages fall below `floor`.
 ///
-/// **Both bounds are inclusive**, matching [`crate::models::tide::fit::filter_training_bars`]: an
-/// exclusive test here would train on a ticker and then refuse to predict for it at exactly the
-/// threshold. [`crate::data::universe::LiquidityRow`] screens price on the window's *minimum*, which
-/// is the stricter test, so every name the universe admits still reaches this one.
+/// Screens the *average* close where [`crate::data::universe::LiquidityRow`] screens the window's
+/// minimum, which is the stricter test, so every name the universe admits still reaches this one.
+/// Both bounds are inclusive, as in [`LiquidityFloor::admits`] — polars needs the thresholds as
+/// expressions, so this is one of the two screens that cannot call it and has a boundary test
+/// instead.
 pub fn filter_equity_bars(
     data: DataFrame,
-    minimum_average_close_price: f64,
-    minimum_average_volume: f64,
+    floor: LiquidityFloor,
 ) -> Result<DataFrame, PredictionError> {
     let before_count = data.height();
 
@@ -199,15 +199,14 @@ pub fn filter_equity_bars(
         .group_by([col("ticker")])
         .agg([
             col("close_price").mean().alias("average_close_price"),
-            col("volume")
-                .cast(DataType::Float64)
+            (col("close_price") * col("volume").cast(DataType::Float64))
                 .mean()
-                .alias("average_volume"),
+                .alias("average_dollar_volume"),
         ])
         .filter(
             col("average_close_price")
-                .gt_eq(lit(minimum_average_close_price))
-                .and(col("average_volume").gt_eq(lit(minimum_average_volume))),
+                .gt_eq(lit(floor.minimum_close_price()))
+                .and(col("average_dollar_volume").gt_eq(lit(floor.minimum_dollar_volume()))),
         )
         .select([col("ticker")])
         .collect()
@@ -606,6 +605,13 @@ pub async fn load_predictions_between(
 mod tests {
     use super::*;
 
+    /// Pinned to literals rather than `LiquidityFloor::CURRENT`, so these tests fail if the screen
+    /// changes rather than moving with it.
+    fn floor(minimum_close_price: f64, minimum_dollar_volume: f64) -> LiquidityFloor {
+        LiquidityFloor::new(minimum_close_price, minimum_dollar_volume)
+            .expect("test floor must be valid")
+    }
+
     /// A scaler over `daily_return` alone, which is all `unscale_and_sort_quantiles` reads.
     ///
     /// Built through the validated constructor, so a future tightening of the `Scaler` contract
@@ -634,10 +640,12 @@ mod tests {
         ])
         .unwrap();
 
-        let result = filter_equity_bars(data, 10.0, 1_000_000.0).unwrap();
+        let result = filter_equity_bars(data, floor(10.0, 50_000_000.0)).unwrap();
         assert_eq!(result.height(), 4);
     }
 
+    /// The price floor is the only thing dropping PENNY here: it turns over $140M a session, well
+    /// clear of the notional threshold, and still fails on a $5.50 average close.
     #[test]
     fn test_filter_equity_bars_below_close_threshold() {
         let data = DataFrame::new(vec![
@@ -646,12 +654,12 @@ mod tests {
             Column::new("close_price".into(), vec![5.0, 6.0, 200.0, 210.0]),
             Column::new(
                 "volume".into(),
-                vec![2_000_000i64, 3_000_000, 5_000_000, 4_000_000],
+                vec![20_000_000i64, 30_000_000, 5_000_000, 4_000_000],
             ),
         ])
         .unwrap();
 
-        let result = filter_equity_bars(data, 10.0, 1_000_000.0).unwrap();
+        let result = filter_equity_bars(data, floor(10.0, 50_000_000.0)).unwrap();
         assert_eq!(result.height(), 2);
         let tickers: Vec<&str> = result
             .column("ticker")
@@ -663,17 +671,23 @@ mod tests {
         assert!(tickers.iter().all(|ticker| *ticker == "GOOG"));
     }
 
+    /// LOW moves 3.5 million shares a session against GOOG's 4.5 million and is still the one
+    /// dropped, because at $12 that is $42M of notional. A share-count screen kept it and dropped
+    /// names like GOOG that cost more.
     #[test]
-    fn test_filter_equity_bars_below_volume_threshold() {
+    fn test_filter_equity_bars_below_dollar_volume_threshold() {
         let data = DataFrame::new(vec![
             Column::new("ticker".into(), vec!["LOW", "LOW", "GOOG", "GOOG"]),
             Column::new("timestamp".into(), vec![1000i64, 2000, 1000, 2000]),
-            Column::new("close_price".into(), vec![50.0, 60.0, 200.0, 210.0]),
-            Column::new("volume".into(), vec![100i64, 200, 5_000_000, 4_000_000]),
+            Column::new("close_price".into(), vec![12.0, 12.0, 200.0, 210.0]),
+            Column::new(
+                "volume".into(),
+                vec![3_000_000i64, 4_000_000, 5_000_000, 4_000_000],
+            ),
         ])
         .unwrap();
 
-        let result = filter_equity_bars(data, 10.0, 1_000_000.0).unwrap();
+        let result = filter_equity_bars(data, floor(10.0, 50_000_000.0)).unwrap();
         assert_eq!(result.height(), 2);
         let tickers: Vec<&str> = result
             .column("ticker")
@@ -691,25 +705,17 @@ mod tests {
     /// exactly $10.00 was admitted to the universe, trained on, and dropped at inference.
     #[test]
     fn test_filter_equity_bars_keeps_a_ticker_exactly_at_both_thresholds() {
-        use crate::common::types::{MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
-
         // Two bars either side of each threshold, so the averages land on it exactly rather than
-        // near it: (9 + 11)/2 = 10.00 and (500k + 1.5M)/2 = 1,000,000.
+        // near it: (8 + 12)/2 = 10.00 and ($40M + $60M)/2 = $50,000,000.
         let data = DataFrame::new(vec![
             Column::new("ticker".into(), vec!["EDGE", "EDGE"]),
             Column::new("timestamp".into(), vec![1000i64, 2000]),
-            Column::new(
-                "close_price".into(),
-                vec![MINIMUM_CLOSE_PRICE - 1.0, MINIMUM_CLOSE_PRICE + 1.0],
-            ),
-            Column::new(
-                "volume".into(),
-                vec![(MINIMUM_VOLUME / 2.0) as i64, (MINIMUM_VOLUME * 1.5) as i64],
-            ),
+            Column::new("close_price".into(), vec![8.0, 12.0]),
+            Column::new("volume".into(), vec![5_000_000i64, 5_000_000]),
         ])
         .unwrap();
 
-        let result = filter_equity_bars(data, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME).unwrap();
+        let result = filter_equity_bars(data, floor(10.0, 50_000_000.0)).unwrap();
 
         assert_eq!(
             result.height(),
@@ -728,7 +734,7 @@ mod tests {
         ])
         .unwrap();
 
-        let result = filter_equity_bars(data, 10.0, 1_000_000.0).unwrap();
+        let result = filter_equity_bars(data, floor(10.0, 50_000_000.0)).unwrap();
         assert_eq!(result.height(), 0);
     }
 
@@ -1203,7 +1209,7 @@ mod tests {
         ])
         .unwrap();
 
-        let result = filter_equity_bars(data, 10.0, 1_000_000.0).unwrap();
+        let result = filter_equity_bars(data, floor(10.0, 50_000_000.0)).unwrap();
         assert_eq!(result.height(), 0);
     }
 
@@ -1217,7 +1223,7 @@ mod tests {
         ])
         .unwrap();
 
-        let result = filter_equity_bars(data, 10.0, 1_000_000.0).unwrap();
+        let result = filter_equity_bars(data, floor(10.0, 50_000_000.0)).unwrap();
         assert_eq!(result.height(), 1);
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -275,16 +275,29 @@ pub async fn seed_correlated_bars(pool: &PgPool, tickers: &[&str], sessions: i64
 
 /// Inserts one daily bar for a ticker at a specific date, for gap and alignment tests.
 pub async fn seed_bar(pool: &PgPool, ticker: &str, date: SessionDate, close: f64) {
+    seed_bar_with_volume(pool, ticker, date, close, 5_000_000).await;
+}
+
+/// [`seed_bar`] with the share count spelled out, for the liquidity aggregates that read it.
+pub async fn seed_bar_with_volume(
+    pool: &PgPool,
+    ticker: &str,
+    date: SessionDate,
+    close: f64,
+    volume: i64,
+) {
     let timestamp = session_close(date);
     sqlx::query(
         "INSERT INTO equity_bars \
          (ticker, bar_interval, timestamp, open_price, high_price, low_price, close_price, volume) \
-         VALUES ($1, 'one_day', $2, $3, $3, $3, $3, 5000000) \
-         ON CONFLICT (ticker, bar_interval, timestamp) DO UPDATE SET close_price = EXCLUDED.close_price",
+         VALUES ($1, 'one_day', $2, $3, $3, $3, $3, $4) \
+         ON CONFLICT (ticker, bar_interval, timestamp) \
+         DO UPDATE SET close_price = EXCLUDED.close_price, volume = EXCLUDED.volume",
     )
     .bind(ticker)
     .bind(timestamp)
     .bind(close)
+    .bind(volume)
     .execute(pool)
     .await
     .expect("Failed to seed an equity bar");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -292,7 +292,9 @@ pub async fn seed_bar_with_volume(
          (ticker, bar_interval, timestamp, open_price, high_price, low_price, close_price, volume) \
          VALUES ($1, 'one_day', $2, $3, $3, $3, $3, $4) \
          ON CONFLICT (ticker, bar_interval, timestamp) \
-         DO UPDATE SET close_price = EXCLUDED.close_price, volume = EXCLUDED.volume",
+         DO UPDATE SET open_price = EXCLUDED.open_price, high_price = EXCLUDED.high_price, \
+                       low_price = EXCLUDED.low_price, close_price = EXCLUDED.close_price, \
+                       volume = EXCLUDED.volume",
     )
     .bind(ticker)
     .bind(timestamp)

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -416,9 +416,41 @@ async fn test_liquidity_reports_the_window_low_not_its_average() {
         vec![universe::LiquidityRow::new(
             ticker("AAAA"),
             1.38,
-            5_000_000.0
+            53_380_000.0
         )],
         "the averaged close would have reported 10.676 and passed the floor"
+    );
+}
+
+/// Dollar volume is the per-session product averaged, never the averaged price times the averaged
+/// share count. The two coincide whenever volume is flat and diverge exactly when it is not — a
+/// name whose heavy sessions are its cheap ones is the case the screen has to get right.
+#[tokio::test]
+#[serial]
+async fn test_liquidity_averages_the_session_product_not_the_product_of_averages() {
+    let pool = fresh_pool().await;
+    let today = SessionDate::at(Utc::now());
+    for (offset, close, volume) in [(-1, 100.0, 1_000_000), (0, 10.0, 100_000_000)] {
+        common::seed_bar_with_volume(
+            &pool,
+            "AAAA",
+            today.plus_calendar_days(offset),
+            close,
+            volume,
+        )
+        .await;
+    }
+
+    let liquidity = universe::load_liquidity(&pool, today).await.unwrap();
+
+    assert_eq!(
+        liquidity,
+        vec![universe::LiquidityRow::new(
+            ticker("AAAA"),
+            10.0,
+            550_000_000.0
+        )],
+        "the product of the averages would have reported 2,777,500,000"
     );
 }
 

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -15,6 +15,7 @@ use fund::common::alpaca::{
 };
 use fund::common::journal::Journal;
 use fund::common::types::CloseReason;
+use fund::common::types::LiquidityFloor;
 use fund::common::types::{BarInterval, SessionDate, Ticker};
 use fund::data::adjust::SplitTable;
 use fund::data::bars;
@@ -165,9 +166,13 @@ fn universe_of(tickers: &[&str]) -> Universe {
     let assets = TradableAssets::from_sets(symbols.clone(), symbols);
     let liquidity: Vec<LiquidityRow> = tickers
         .iter()
-        .map(|raw| LiquidityRow::new(ticker(raw), 100.0, 5_000_000.0))
+        .map(|raw| LiquidityRow::new(ticker(raw), 100.0, 500_000_000.0))
         .collect();
-    Universe::build(&assets, &liquidity)
+    Universe::build(
+        &assets,
+        &liquidity,
+        LiquidityFloor::new(10.0, 50_000_000.0).expect("test floor must be valid"),
+    )
 }
 
 /// The whole entry half, end to end: history from the database, prices and orders from Alpaca, the


### PR DESCRIPTION
# Overview

Task 1 of the laboratory expansion: replace the share-count liquidity screen with one that counts
dollars traded, and turn the two floors into a value the screens take rather than a global they read.

## Changes

- Replace `MINIMUM_CLOSE_PRICE` / `MINIMUM_VOLUME` with `LiquidityFloor` in `common::types` — the
  price and notional bounds as one validated value with private fields, whose `admits` owns the
  inclusive comparison the four screens previously each wrote for themselves
- Screen on average daily dollar volume at $50M in place of one million shares, taking the product
  per session and then averaging it rather than multiplying the two averages
- Thread the floor through all four screens as an argument: the runtime universe
  (`Universe::build`, `UniverseCache::new`), the archive's ingest filter (`screen_partition`, newly
  extracted so it can be tested at all), and the two model filters (`filter_training_bars`,
  `filter_equity_bars`)
- Pin the archive's ingest screen to `LiquidityFloor::CURRENT` rather than accepting it from the
  caller, because the intraday archive is one shared object per session and two seeds at different
  floors would leave a partition nothing can describe
- Add `seed_bar_with_volume` and a `load_liquidity` integration test proving the aggregate is
  `AVG(close_price * volume)` and not the product of the averages — the existing fixture seeded a
  constant volume, under which the two are indistinguishable
- Regenerate the `.sqlx` offline cache for the changed `load_liquidity` query

## Context

**Why this is first.** It changes the population every downstream task measures. The planned
cross-sectional factor panel fits a size factor on exactly the quantity the screen cuts on, so a
universe that systematically excludes high-priced names does not merely shrink that fit — it biases
it in a way that reads as a real cross-sectional effect.

**Measured, not assumed.** DuckDB over the S3 daily archive, 1,255 sessions, 2021-08-23 to
2026-08-21, 13.4M rows.

| | share screen | $50M dollar screen |
|---|---|---|
| runtime universe, trailing 30 days, of 12,824 names with history | 1,735 | 1,848 |
| rows admitted, per session, whole archive | 1,696,684 | 1,719,626 (+1.4%) |

Universe-size-neutral, so ingestion cost does not move. Membership churns hard even so: 1,414 in
both, 321 admitted only by the share screen, 434 only by the dollar screen. The dollar-only admits
are MPWR, MELI, AZO, BLK, REGN — $500M to $1.1B a day on under a million shares. The share-only
drops are $10-13 names turning over $37-49M. Per session over the whole archive, CBOE cleared the
share screen on 227 sessions of 1,255 and clears the dollar screen on 1,179; NDAQ goes 1,057 to
1,251. The $10 price floor still binds: 130 names clear $50M of notional with a sub-$10 close.

**Test discipline.** Every new assertion was proved load-bearing by reverting the screen it covers to
share semantics, watching it fail, and restoring — including flipping `admits` from `>=` to `>` to
confirm the boundary tests bite. Expectations are pinned to literals rather than to the constants
under test, which is a fix to two pre-existing tests that moved with the value they were checking.
`devenv tasks run checks:all` passes.

**What this deliberately does not settle.** $50M is a convention, not a measurement — it was chosen
so the universe count matched the retired one-million-share screen, which calibrates one arbitrary
number against another. Worse, an absolute notional level is not a stable screen. The same $50M
admitted 20.6% of priced names in 2022 and 23.0% in 2026 as market-wide dollar volume nearly doubled;
the dollar volume at rank 1500 went from $35.0M to $76.3M over the same span, so a fixed floor was
about a top-1250 screen at the start of the archive and a top-1850 screen at the end.

The seam for fixing that is what the `LiquidityFloor` threading buys: swapping the constant every
caller passes for a value a study declares and journals is a change at the call sites, not a refactor
of the screens. Three directions are recorded against tasks 4, 5, and 6 of the plan — a rank is the
better primitive than a level, the runtime should read the floor from the fitted artifact rather than
carry its own knob, and a swept floor is an arm that owes the multiple-testing registry an entry.
Elasticity, for whoever sets it next: $25M admits 2,450 names, $50M admits 1,848, $100M admits 1,249.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Liquidity screening now uses configurable minimum price and dollar-volume thresholds.
  * Screening evaluates traded dollar value, allowing expensive, lower-volume assets when appropriate.
  * Added validation and boundary handling for liquidity thresholds.

* **Bug Fixes**
  * Corrected average liquidity calculations to average each session’s price-volume value.
  * Updated training and prediction filters to apply consistent dollar-volume screening.

* **Tests**
  * Expanded coverage for threshold boundaries and price-volume screening scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->