### PR TITLE
Detect symbol-level gaps in the intraday archive

### DIFF
--- a/src/bin/seed_intraday_bars_s3.rs
+++ b/src/bin/seed_intraday_bars_s3.rs
@@ -9,7 +9,7 @@ use tracing::{error, info};
 
 use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
-use fund::common::types::{BarInterval, SessionDate, Ticker};
+use fund::common::types::{BarInterval, LiquidityFloor, SessionDate, Ticker};
 use fund::data::archive::{self, IntradayScope};
 
 const USAGE: &str = "Usage: seed_intraday_bars_s3 START_DATE END_DATE [CADENCE [SYMBOLS]]\n\
@@ -17,7 +17,10 @@ const USAGE: &str = "Usage: seed_intraday_bars_s3 START_DATE END_DATE [CADENCE [
                      CADENCE is five_minute (default) or one_minute.\n\
                      SYMBOLS is a comma-separated list, and naming it requires naming CADENCE too.\n\
                      Supplying it fetches only those names and requests every session in the\n\
-                     window rather than only the absent ones.";
+                     window rather than only the absent ones.\n\
+                     SYMBOLS may instead be one of two words:\n\
+                       scan    report which names each partition lacks, and write nothing\n\
+                       repair  scan, then fetch the names the scan reported";
 
 /// What the archive is filled with unless told otherwise.
 ///
@@ -25,11 +28,25 @@ const USAGE: &str = "Usage: seed_intraday_bars_s3 START_DATE END_DATE [CADENCE [
 /// five: 95.8% of names clear 99% of regular-session buckets at five, against 33.2% at one.
 const DEFAULT_CADENCE: BarInterval = BarInterval::FiveMinute;
 
+/// What the run does, which the `SYMBOLS` argument selects.
+///
+/// `Scan` writes nothing, so it is the safe way to size a repair before one rewrites a partition
+/// per session across the window.
+#[derive(Debug, PartialEq, Eq)]
+enum Mode {
+    /// Fetch, per the scope: the absent sessions, or an explicit set of names across all of them.
+    Seed(IntradayScope),
+    /// Report per-session coverage and stop.
+    Scan,
+    /// Report per-session coverage, then fetch whatever names it reported missing.
+    Repair,
+}
+
 struct Parameters {
     start: SessionDate,
     end: SessionDate,
     interval: BarInterval,
-    scope: IntradayScope,
+    mode: Mode,
 }
 
 impl Parameters {
@@ -66,16 +83,20 @@ impl Parameters {
             }
         };
 
-        let scope = match symbols {
-            None => IntradayScope::MissingSessions,
-            Some(raw) => IntradayScope::Symbols(parse_symbols(raw)?),
+        // The two words are checked before the symbol parser, which would otherwise reject them as
+        // unusable tickers -- both are valid ticker shapes, so the order is what separates them.
+        let mode = match symbols.map(String::as_str) {
+            None => Mode::Seed(IntradayScope::MissingSessions),
+            Some("scan") => Mode::Scan,
+            Some("repair") => Mode::Repair,
+            Some(raw) => Mode::Seed(IntradayScope::Symbols(parse_symbols(raw)?)),
         };
 
         Ok(Self {
             start,
             end,
             interval,
-            scope,
+            mode,
         })
     }
 }
@@ -156,10 +177,35 @@ async fn run(
 ) -> Result<archive::ArchiveSummary, Box<dyn std::error::Error>> {
     let bucket = std::env::var("AWS_S3_BUCKET_NAME")
         .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
-    let massive = MassiveClient::from_env()?;
     let s3_client = fund::common::aws::s3_client().await;
 
-    let symbols = match &parameters.scope {
+    let scope = match &parameters.mode {
+        Mode::Seed(scope) => scope.clone(),
+        Mode::Scan | Mode::Repair => {
+            let scan = archive::scan_intraday_symbols(
+                &s3_client,
+                &bucket,
+                parameters.interval,
+                parameters.start,
+                parameters.end,
+                LiquidityFloor::CURRENT,
+            )
+            .await?;
+            report(&scan);
+            if parameters.mode == Mode::Scan {
+                return Ok(archive::ArchiveSummary::default());
+            }
+            let missing = scan.missing_symbols();
+            if missing.is_empty() {
+                println!("Nothing to repair.");
+                return Ok(archive::ArchiveSummary::default());
+            }
+            IntradayScope::Symbols(missing)
+        }
+    };
+
+    let massive = MassiveClient::from_env()?;
+    let symbols = match &scope {
         IntradayScope::MissingSessions => "the screened universe".to_string(),
         IntradayScope::Symbols(symbols) => symbols
             .iter()
@@ -183,9 +229,46 @@ async fn run(
         parameters.interval,
         parameters.start,
         parameters.end,
-        &parameters.scope,
+        &scope,
     )
     .await?)
+}
+
+/// Prints the scan: the counts, then every session that is short a name.
+///
+/// Per-session as well as the union, because the two answer different questions — the union is what
+/// the repair takes, while one session short fifty names and fifty sessions short one are the same
+/// union and very different faults.
+fn report(scan: &archive::SymbolScan) {
+    let counts = scan.counts();
+    println!(
+        "scanned {} sessions: {} complete, {} partial, {} absent, {} undescribed",
+        counts.complete + counts.partial + counts.absent + counts.undescribed,
+        counts.complete,
+        counts.partial,
+        counts.absent,
+        counts.undescribed
+    );
+
+    for (session, coverage) in scan.coverage() {
+        match coverage {
+            archive::SessionCoverage::Partial(missing) => {
+                let names: Vec<&str> = missing.iter().map(Ticker::as_str).collect();
+                println!("  {session}: short {} — {}", names.len(), names.join(","));
+            }
+            archive::SessionCoverage::Absent => println!("  {session}: no partition"),
+            archive::SessionCoverage::Undescribed => {
+                println!("  {session}: no daily partition to screen against")
+            }
+            archive::SessionCoverage::Complete => {}
+        }
+    }
+
+    let missing = scan.missing_symbols();
+    println!(
+        "{} distinct names missing from at least one session",
+        missing.len()
+    );
 }
 
 #[cfg(test)]
@@ -246,11 +329,60 @@ mod tests {
     #[test]
     fn test_omitting_symbols_scans_for_missing_sessions() {
         let parameters = Parameters::parse(&arguments(&["2026-08-01", "2026-08-20"])).unwrap();
-        assert!(matches!(parameters.scope, IntradayScope::MissingSessions));
+        assert!(matches!(
+            parameters.mode,
+            Mode::Seed(IntradayScope::MissingSessions)
+        ));
 
         let parameters =
             Parameters::parse(&arguments(&["2026-08-01", "2026-08-20", "five_minute"])).unwrap();
-        assert!(matches!(parameters.scope, IntradayScope::MissingSessions));
+        assert!(matches!(
+            parameters.mode,
+            Mode::Seed(IntradayScope::MissingSessions)
+        ));
+    }
+
+    /// Both words are valid ticker shapes, so only the order of the match separates them from a
+    /// one-name repair list. A `scan` parsed as a ticker would fetch a symbol that does not exist
+    /// and report a clean run.
+    #[test]
+    fn test_the_two_mode_words_are_modes_and_not_tickers() {
+        let scan = Parameters::parse(&arguments(&[
+            "2026-08-01",
+            "2026-08-20",
+            "five_minute",
+            "scan",
+        ]))
+        .unwrap();
+        assert_eq!(scan.mode, Mode::Scan);
+
+        let repair = Parameters::parse(&arguments(&[
+            "2026-08-01",
+            "2026-08-20",
+            "five_minute",
+            "repair",
+        ]))
+        .unwrap();
+        assert_eq!(repair.mode, Mode::Repair);
+    }
+
+    /// The words are exact, so a name that merely contains one is still a ticker. `SCAN` is a
+    /// plausible symbol and must not silently become a mode.
+    #[test]
+    fn test_a_ticker_resembling_a_mode_word_is_still_a_ticker() {
+        let parameters = Parameters::parse(&arguments(&[
+            "2026-08-01",
+            "2026-08-20",
+            "five_minute",
+            "SCAN",
+        ]))
+        .unwrap();
+
+        let Mode::Seed(IntradayScope::Symbols(symbols)) = parameters.mode else {
+            panic!("an uppercase name must parse as a symbol list");
+        };
+        let named: Vec<&str> = symbols.iter().map(Ticker::as_str).collect();
+        assert_eq!(named, vec!["SCAN"]);
     }
 
     #[test]
@@ -263,7 +395,7 @@ mod tests {
         ]))
         .unwrap();
 
-        let IntradayScope::Symbols(symbols) = parameters.scope else {
+        let Mode::Seed(IntradayScope::Symbols(symbols)) = parameters.mode else {
             panic!("a symbol list must produce a symbol scope");
         };
         let named: Vec<&str> = symbols.iter().map(Ticker::as_str).collect();

--- a/src/bin/seed_intraday_bars_s3.rs
+++ b/src/bin/seed_intraday_bars_s3.rs
@@ -18,7 +18,8 @@ const USAGE: &str = "Usage: seed_intraday_bars_s3 START_DATE END_DATE [CADENCE [
                      SYMBOLS is a comma-separated list, and naming it requires naming CADENCE too.\n\
                      Supplying it fetches only those names and requests every session in the\n\
                      window rather than only the absent ones.\n\
-                     SYMBOLS may instead be one of two words:\n\
+                     SYMBOLS may instead be one of two reserved lowercase words, matched\n\
+                     exactly so an uppercase name of the same spelling is still a ticker:\n\
                        scan    report which names each partition lacks, and write nothing\n\
                        repair  scan, then fetch the names the scan reported";
 
@@ -83,9 +84,9 @@ impl Parameters {
             }
         };
 
-        // The two words are checked before the symbol parser, which would otherwise reject them as
-        // unusable tickers -- both are valid ticker shapes, so the order is what separates them.
-        let mode = match symbols.map(String::as_str) {
+        // Trimmed and matched before the symbol parser. Both words are valid ticker shapes, so
+        // order separates them -- and untrimmed, " scan " would parse as a symbol and fetch nothing.
+        let mode = match symbols.map(|raw| raw.trim()) {
             None => Mode::Seed(IntradayScope::MissingSessions),
             Some("scan") => Mode::Scan,
             Some("repair") => Mode::Repair,
@@ -144,7 +145,10 @@ async fn main() {
     };
 
     let code = match run(&parameters).await {
-        Ok(summary) => {
+        // `None` when no fetching pass ran, which is a scan or a repair that found nothing. Printing
+        // the summary anyway reported every counter as zero and read as a failed run.
+        Ok(None) => 0,
+        Ok(Some(summary)) => {
             println!(
                 "requested {} sessions, wrote {}, {} without data, {} failed, {} bars, {} symbols missing",
                 summary.sessions_requested,
@@ -174,10 +178,17 @@ async fn main() {
 /// requested, because a partition missing one name is indistinguishable from a complete one.
 async fn run(
     parameters: &Parameters,
-) -> Result<archive::ArchiveSummary, Box<dyn std::error::Error>> {
+) -> Result<Option<archive::ArchiveSummary>, Box<dyn std::error::Error>> {
     let bucket = std::env::var("AWS_S3_BUCKET_NAME")
         .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
     let s3_client = fund::common::aws::s3_client().await;
+
+    // Built before the scan, which in repair mode is thousands of reads: an unset credential should
+    // fail in the first second rather than after it. A scan writes nothing and never needs one.
+    let massive = match parameters.mode {
+        Mode::Scan => None,
+        Mode::Seed(_) | Mode::Repair => Some(MassiveClient::from_env()?),
+    };
 
     let scope = match &parameters.mode {
         Mode::Seed(scope) => scope.clone(),
@@ -193,18 +204,18 @@ async fn run(
             .await?;
             report(&scan);
             if parameters.mode == Mode::Scan {
-                return Ok(archive::ArchiveSummary::default());
+                return Ok(None);
             }
             let missing = scan.missing_symbols();
             if missing.is_empty() {
                 println!("Nothing to repair.");
-                return Ok(archive::ArchiveSummary::default());
+                return Ok(None);
             }
             IntradayScope::Symbols(missing)
         }
     };
 
-    let massive = MassiveClient::from_env()?;
+    let massive = massive.expect("every mode that fetches builds a client above");
     let symbols = match &scope {
         IntradayScope::MissingSessions => "the screened universe".to_string(),
         IntradayScope::Symbols(symbols) => symbols
@@ -222,17 +233,25 @@ async fn run(
         "Seeding the intraday bar archive from Massive"
     );
 
-    Ok(archive::archive_intraday_sessions(
-        &s3_client,
-        &massive,
-        &bucket,
-        parameters.interval,
-        parameters.start,
-        parameters.end,
-        &scope,
-    )
-    .await?)
+    Ok(Some(
+        archive::archive_intraday_sessions(
+            &s3_client,
+            &massive,
+            &bucket,
+            parameters.interval,
+            parameters.start,
+            parameters.end,
+            &scope,
+        )
+        .await?,
+    ))
 }
+
+/// Missing names printed per session before the line is truncated.
+///
+/// A session short over a thousand names produced a multi-kilobyte line that buried the counts
+/// above it. The full count is always printed; the union at the end is the actionable list.
+const NAMES_SHOWN_PER_SESSION: usize = 12;
 
 /// Prints the scan: the counts, then every session that is short a name.
 ///
@@ -253,8 +272,22 @@ fn report(scan: &archive::SymbolScan) {
     for (session, coverage) in scan.coverage() {
         match coverage {
             archive::SessionCoverage::Partial(missing) => {
-                let names: Vec<&str> = missing.iter().map(Ticker::as_str).collect();
-                println!("  {session}: short {} — {}", names.len(), names.join(","));
+                let shown: Vec<&str> = missing
+                    .iter()
+                    .take(NAMES_SHOWN_PER_SESSION)
+                    .map(Ticker::as_str)
+                    .collect();
+                let elided = missing.len().saturating_sub(shown.len());
+                let suffix = if elided > 0 {
+                    format!(" and {elided} more")
+                } else {
+                    String::new()
+                };
+                println!(
+                    "  {session}: short {} — {}{suffix}",
+                    missing.len(),
+                    shown.join(",")
+                );
             }
             archive::SessionCoverage::Absent => println!("  {session}: no partition"),
             archive::SessionCoverage::Undescribed => {
@@ -262,6 +295,14 @@ fn report(scan: &archive::SymbolScan) {
             }
             archive::SessionCoverage::Complete => {}
         }
+    }
+
+    if !scan.failed().is_empty() {
+        // Loud, because a repair driven by this scan repairs only what the readable sessions named.
+        println!(
+            "WARNING: {} sessions could not be read; this picture is incomplete",
+            scan.failed().len()
+        );
     }
 
     let missing = scan.missing_symbols();
@@ -361,6 +402,30 @@ mod tests {
             "2026-08-20",
             "five_minute",
             "repair",
+        ]))
+        .unwrap();
+        assert_eq!(repair.mode, Mode::Repair);
+    }
+
+    /// `parse_symbols` trims and `Ticker::new` uppercases, so an untrimmed mode word parsed as a
+    /// symbol list becomes `Ticker("SCAN")` — a name that does not exist, fetched, written as
+    /// nothing, and reported as a clean pass.
+    #[test]
+    fn test_a_mode_word_with_surrounding_whitespace_is_still_a_mode() {
+        let scan = Parameters::parse(&arguments(&[
+            "2026-08-01",
+            "2026-08-20",
+            "five_minute",
+            "  scan  ",
+        ]))
+        .unwrap();
+        assert_eq!(scan.mode, Mode::Scan);
+
+        let repair = Parameters::parse(&arguments(&[
+            "2026-08-01",
+            "2026-08-20",
+            "five_minute",
+            " repair\t",
         ]))
         .unwrap();
         assert_eq!(repair.mode, Mode::Repair);

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -2,7 +2,7 @@
 //!
 //! One partition per session and cadence under `data/equity/bars/interval=/year=/month=/day=/`.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Cursor;
 
 use aws_sdk_s3::operation::get_object::GetObjectError;
@@ -508,6 +508,7 @@ const INTRADAY_CONCURRENCY: usize = 8;
 /// partition written while one name's fetch failed, or before that name cleared the universe
 /// screen, is indistinguishable from a complete one. So repairing a symbol has to ignore the set
 /// difference that repairing a session relies on.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IntradayScope {
     /// Every name the daily archive screens in, for the sessions the archive has no partition for.
     MissingSessions,
@@ -701,6 +702,7 @@ async fn archive_intraday_chunk(
         );
     }
 
+    let mut writable = Vec::new();
     for (session, bars_for_session) in by_session {
         // A bar dated outside the chunk is a vendor answering beyond the range asked for. Writing it
         // would put rows in a partition this pass never claimed and never verified.
@@ -709,18 +711,67 @@ async fn archive_intraday_chunk(
         if !universe.described.contains(&session) {
             continue;
         }
-        let frame = bars::bars_to_dataframe(&bars_for_session)?;
-        let rows = frame.height();
-        match write_partition(s3_client, bucket, interval, session, frame).await {
-            Ok(()) => {
+        writable.push((session, bars::bars_to_dataframe(&bars_for_session)?));
+    }
+
+    write_partitions(s3_client, bucket, interval, writable, summary).await
+}
+
+/// Partitions written at once.
+///
+/// Concurrency is safe by construction rather than by scheduling: each write is a compare-and-swap
+/// on the object's ETag, so a racing pass is rejected with a `412` and retried instead of being
+/// silently clobbered. Bounded because the frames are held in memory until their write lands.
+const INTRADAY_WRITE_CONCURRENCY: usize = 8;
+
+/// Writes one partition per session, several at a time, folding the outcomes into `summary`.
+///
+/// Split out from the chunk because a repair pass over a full window is dominated by this loop:
+/// #1100 measured roughly twenty-five minutes for one ticker over 1,254 sessions, essentially all of
+/// it a sequential read-merge-write per partition.
+async fn write_partitions(
+    s3_client: &S3Client,
+    bucket: &str,
+    interval: BarInterval,
+    partitions: Vec<(SessionDate, DataFrame)>,
+    summary: &mut ArchiveSummary,
+) -> Result<(), ArchiveError> {
+    let mut queued = partitions.into_iter();
+    let mut writes = tokio::task::JoinSet::new();
+
+    loop {
+        while writes.len() < INTRADAY_WRITE_CONCURRENCY {
+            let Some((session, frame)) = queued.next() else {
+                break;
+            };
+            let client = s3_client.clone();
+            let bucket = bucket.to_string();
+            let rows = frame.height();
+            writes.spawn(async move {
+                let written = write_partition(&client, &bucket, interval, session, frame).await;
+                (session, rows, written)
+            });
+        }
+        let Some(finished) = writes.join_next().await else {
+            break;
+        };
+        match finished {
+            Ok((_, rows, Ok(()))) => {
                 summary.sessions_written += 1;
                 summary.bars_written += rows;
             }
-            Err(ArchiveError::Contended { key, attempts }) => {
+            Ok((session, _, Err(ArchiveError::Contended { key, attempts }))) => {
                 warn!(key, attempts, %session, "Partition contended; the next pass will retry it");
                 summary.sessions_failed.push(session);
             }
-            Err(error) => return Err(error),
+            Ok((_, _, Err(error))) => return Err(error),
+            Err(error) => {
+                return Err(ArchiveError::Write {
+                    bucket: bucket.to_string(),
+                    key: bar_archive_prefix(interval),
+                    message: format!("a partition write task did not complete: {error}"),
+                })
+            }
         }
     }
     Ok(())
@@ -798,6 +849,184 @@ fn screen_partition(
         .flatten()
         .filter_map(Ticker::new)
         .collect())
+}
+
+/// Sessions scanned at once.
+///
+/// Two reads a session against S3, and the scan is read-only, so this bounds our own concurrency
+/// rather than protecting anything. A full archive sweep is ~2,500 reads and sequential it is
+/// twenty minutes of latency for no work.
+const SCAN_CONCURRENCY: usize = 16;
+
+/// Which names each intraday partition lacks against the daily universe for its own session.
+///
+/// The difference [`intraday_sessions_to_request`] cannot express: a partition written while one
+/// symbol's fetch failed is present, non-empty, and short a name. See
+/// `session_gap_scan_cannot_see_a_symbol` for the incident that motivated it.
+///
+/// `floor` is a parameter rather than the archive's own pin because this reads and never writes, so
+/// it cannot leave an inconsistent partition behind. Scanning at a floor *wider* than the one the
+/// archive was ingested at reports names that were never fetched, which is a backfill list rather
+/// than a fault — that is how the archive gets widened after a screen change.
+pub async fn scan_intraday_symbols(
+    s3_client: &S3Client,
+    bucket: &str,
+    interval: BarInterval,
+    window_start: SessionDate,
+    window_end: SessionDate,
+    floor: LiquidityFloor,
+) -> Result<SymbolScan, ArchiveError> {
+    let sessions = expected_sessions(window_start, window_end);
+    info!(
+        %window_start,
+        %window_end,
+        interval = %interval,
+        sessions = sessions.len(),
+        "Scanning intraday partitions for symbol-level gaps"
+    );
+
+    let mut queued = sessions.into_iter();
+    let mut scans = tokio::task::JoinSet::new();
+    let mut coverage = BTreeMap::new();
+
+    loop {
+        while scans.len() < SCAN_CONCURRENCY {
+            let Some(session) = queued.next() else { break };
+            let client = s3_client.clone();
+            let bucket = bucket.to_string();
+            scans.spawn(async move {
+                let coverage = session_coverage(&client, &bucket, interval, session, floor).await;
+                (session, coverage)
+            });
+        }
+        let Some(finished) = scans.join_next().await else {
+            break;
+        };
+        match finished {
+            Ok((session, result)) => {
+                coverage.insert(session, result?);
+            }
+            Err(error) => {
+                return Err(ArchiveError::Read {
+                    bucket: bucket.to_string(),
+                    key: bar_archive_prefix(interval),
+                    message: format!("a scan task did not complete: {error}"),
+                })
+            }
+        }
+    }
+
+    Ok(SymbolScan { coverage })
+}
+
+/// One session's coverage: read the daily partition, screen it, and difference the intraday one.
+async fn session_coverage(
+    s3_client: &S3Client,
+    bucket: &str,
+    interval: BarInterval,
+    session: SessionDate,
+    floor: LiquidityFloor,
+) -> Result<SessionCoverage, ArchiveError> {
+    let daily_key = date_partitioned_key(&bar_archive_prefix(BarInterval::OneDay), session.date());
+    let Some(daily) = read_partition(s3_client, bucket, &daily_key).await? else {
+        return Ok(SessionCoverage::Undescribed);
+    };
+    let expected = screen_partition(daily, floor)?;
+
+    let intraday_key = date_partitioned_key(&bar_archive_prefix(interval), session.date());
+    let Some(intraday) = read_partition(s3_client, bucket, &intraday_key).await? else {
+        return Ok(SessionCoverage::Absent);
+    };
+    let present = partition_tickers(&intraday)?;
+
+    let missing: BTreeSet<Ticker> = expected.difference(&present).cloned().collect();
+    Ok(if missing.is_empty() {
+        SessionCoverage::Complete
+    } else {
+        SessionCoverage::Partial(missing)
+    })
+}
+
+/// The distinct tickers a partition holds, unscreened.
+///
+/// The record of what was fetched, which is what a coverage scan compares a screen against.
+fn partition_tickers(frame: &DataFrame) -> Result<BTreeSet<Ticker>, ArchiveError> {
+    let tickers = frame.column("ticker")?.str()?;
+    Ok(tickers
+        .into_iter()
+        .flatten()
+        .filter_map(Ticker::new)
+        .collect())
+}
+
+/// Whether one session's intraday partition holds every name the daily archive screens in.
+///
+/// Four states rather than a boolean, because the repairs differ and only the first two are visible
+/// to a scan that works by set difference over sessions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionCoverage {
+    /// The daily archive has no partition for this session, so completeness is unanswerable.
+    Undescribed,
+    /// No intraday partition at all — what [`intraday_sessions_to_request`] already finds.
+    Absent,
+    /// Every screened name is present.
+    Complete,
+    /// A partition exists and is short these names, which is the hole nothing downstream can see.
+    Partial(BTreeSet<Ticker>),
+}
+
+/// How many sessions fell into each coverage state.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ScanCounts {
+    pub undescribed: usize,
+    pub absent: usize,
+    pub complete: usize,
+    pub partial: usize,
+}
+
+/// Per-session coverage across a window, and the symbols a repair pass should be given.
+#[derive(Debug, Default)]
+pub struct SymbolScan {
+    coverage: BTreeMap<SessionDate, SessionCoverage>,
+}
+
+impl SymbolScan {
+    pub fn coverage(&self) -> &BTreeMap<SessionDate, SessionCoverage> {
+        &self.coverage
+    }
+
+    /// Every name missing from at least one partition, which is what [`IntradayScope::Symbols`]
+    /// takes.
+    ///
+    /// A union rather than a per-session list because the repair requests its symbols across the
+    /// whole window anyway — a name missing from one session costs nothing extra to ask for on the
+    /// others, and the merge leaves what is already there untouched.
+    pub fn missing_symbols(&self) -> BTreeSet<Ticker> {
+        self.coverage
+            .values()
+            .filter_map(|coverage| match coverage {
+                SessionCoverage::Partial(missing) => Some(missing),
+                SessionCoverage::Undescribed
+                | SessionCoverage::Absent
+                | SessionCoverage::Complete => None,
+            })
+            .flatten()
+            .cloned()
+            .collect()
+    }
+
+    pub fn counts(&self) -> ScanCounts {
+        let mut counts = ScanCounts::default();
+        for coverage in self.coverage.values() {
+            match coverage {
+                SessionCoverage::Undescribed => counts.undescribed += 1,
+                SessionCoverage::Absent => counts.absent += 1,
+                SessionCoverage::Complete => counts.complete += 1,
+                SessionCoverage::Partial(_) => counts.partial += 1,
+            }
+        }
+        counts
+    }
 }
 
 /// The names to fetch, and the sessions the daily archive could actually describe.
@@ -1527,6 +1756,125 @@ mod tests {
             screened,
             BTreeSet::from([Ticker::new("CBOE").unwrap()]),
             "OBDC turns over $49.2M, just under the floor; SNDL clears $60M and fails on price"
+        );
+    }
+
+    fn scan_of(entries: &[(SessionDate, SessionCoverage)]) -> SymbolScan {
+        SymbolScan {
+            coverage: entries.iter().cloned().collect(),
+        }
+    }
+
+    fn tickers(names: &[&str]) -> BTreeSet<Ticker> {
+        names
+            .iter()
+            .map(|name| Ticker::new(name).expect("a valid test ticker"))
+            .collect()
+    }
+
+    /// The whole point of the task: a partition that exists and is short two names reads as
+    /// `Partial`, where the session-level scan sees only that a partition is there.
+    #[test]
+    fn test_a_partition_short_two_names_is_partial_not_complete() {
+        let expected = tickers(&["AAPL", "CBOE", "MSFT", "NVDA"]);
+        let present = tickers(&["AAPL", "MSFT"]);
+
+        let missing: BTreeSet<Ticker> = expected.difference(&present).cloned().collect();
+
+        assert_eq!(missing, tickers(&["CBOE", "NVDA"]));
+    }
+
+    /// An extra name is not a gap. The archive over-fetches by unioning the screened universe
+    /// across a chunk, so every partition holds names its own session did not screen in — treating
+    /// that as a difference in either direction would report the whole archive as broken.
+    #[test]
+    fn test_a_partition_holding_more_than_the_screen_expects_is_complete() {
+        let coverage = SessionCoverage::Complete;
+        let expected = tickers(&["AAPL"]);
+        let present = tickers(&["AAPL", "MSFT", "NVDA"]);
+
+        let missing: BTreeSet<Ticker> = expected.difference(&present).cloned().collect();
+
+        assert!(missing.is_empty());
+        assert_eq!(coverage, SessionCoverage::Complete);
+    }
+
+    /// A repair is given the union across the window, and only from partitions that exist. An
+    /// absent session contributes nothing: it is repaired by fetching the session, not the symbol.
+    #[test]
+    fn test_missing_symbols_unions_partials_and_ignores_every_other_state() {
+        let scan = scan_of(&[
+            (session(2026, 8, 17), SessionCoverage::Undescribed),
+            (session(2026, 8, 18), SessionCoverage::Absent),
+            (session(2026, 8, 19), SessionCoverage::Complete),
+            (
+                session(2026, 8, 20),
+                SessionCoverage::Partial(tickers(&["CBOE", "NVDA"])),
+            ),
+            (
+                session(2026, 8, 21),
+                SessionCoverage::Partial(tickers(&["NVDA", "TW"])),
+            ),
+        ]);
+
+        assert_eq!(scan.missing_symbols(), tickers(&["CBOE", "NVDA", "TW"]));
+        assert_eq!(
+            scan.counts(),
+            ScanCounts {
+                undescribed: 1,
+                absent: 1,
+                complete: 1,
+                partial: 2,
+            }
+        );
+    }
+
+    /// A clean archive asks for no repair at all, so the pass it would drive is skipped rather than
+    /// requesting every session in the window for an empty symbol set.
+    #[test]
+    fn test_a_clean_scan_names_no_symbols() {
+        let scan = scan_of(&[
+            (session(2026, 8, 20), SessionCoverage::Complete),
+            (session(2026, 8, 21), SessionCoverage::Complete),
+        ]);
+
+        assert!(scan.missing_symbols().is_empty());
+        assert_eq!(scan.counts().complete, 2);
+    }
+
+    /// `Absent` and `Partial` must stay distinguishable: the first is a session the existing scan
+    /// already repairs, the second is one it reports as complete forever.
+    #[test]
+    fn test_an_absent_partition_is_not_an_empty_partial() {
+        let scan = scan_of(&[
+            (session(2026, 8, 20), SessionCoverage::Absent),
+            (
+                session(2026, 8, 21),
+                SessionCoverage::Partial(tickers(&["CBOE"])),
+            ),
+        ]);
+
+        let counts = scan.counts();
+        assert_eq!(counts.absent, 1);
+        assert_eq!(counts.partial, 1);
+        assert_eq!(scan.missing_symbols(), tickers(&["CBOE"]));
+    }
+
+    #[test]
+    fn test_partition_tickers_reads_distinct_names_without_screening_them() {
+        let partition = df![
+            "ticker" => ["CBOE", "CBOE", "OBDC", "SNDL"],
+            "close_price" => [290.0_f64, 291.0, 11.3, 1.50],
+            "volume" => [900_000_i64, 800_000, 4_350_000, 40_000_000],
+        ]
+        .unwrap();
+
+        let held = partition_tickers(&partition).unwrap();
+
+        assert_eq!(
+            held,
+            tickers(&["CBOE", "OBDC", "SNDL"]),
+            "the screen belongs to the daily side of the comparison, not this one"
         );
     }
 

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -709,11 +709,21 @@ async fn archive_intraday_chunk(
     }
 
     let mut writable = Vec::new();
+    let mut skipped = Vec::new();
     for (session, bars_for_session) in by_session {
-        if !writable_sessions(session, scope, &universe.described, present) {
-            continue;
+        if writable_sessions(session, scope, &universe.described, present) {
+            writable.push((session, bars_for_session));
+        } else {
+            skipped.push(session);
         }
-        writable.push((session, bars::bars_to_dataframe(&bars_for_session)?));
+    }
+    if !skipped.is_empty() {
+        // These were fetched and are about to be discarded, and they land in no counter, so the
+        // summary alone cannot tell an operator a whole-universe pass is still owed for them.
+        warn!(
+            sessions = ?skipped,
+            "Bars were fetched for sessions this pass may not write; run a missing-sessions pass for them"
+        );
     }
 
     write_partitions(s3_client, bucket, interval, writable, summary).await
@@ -721,17 +731,9 @@ async fn archive_intraday_chunk(
 
 /// Whether this pass may write the partition for `session`.
 ///
-/// Two refusals, and the second is what a symbol repair needs. A session the *daily* archive cannot
-/// describe is skipped because a partition written from a universe that never covered it would look
-/// complete and never be revisited — that also drops a bar dated outside the chunk, which is the
-/// vendor answering beyond the range asked for.
-///
-/// A symbol repair additionally refuses to *create* a partition. It requests the whole window on
-/// purpose, since a partition short one name looks complete, but it fetches only the named symbols —
-/// so writing where nothing existed produces a partition holding those names and nothing else, which
-/// then reads as present to [`intraday_sessions_to_request`] and is never filled. Repairing the
-/// 2026-08-21 gap manufactured exactly that: an absent session became one short 1,335 names. An
-/// absent session needs [`IntradayScope::MissingSessions`], which fetches the whole universe.
+/// An undescribed session is refused whatever the scope, because nothing can say what a complete
+/// partition for it would hold. A symbol repair additionally refuses to *create* one: it fetches
+/// only the named symbols, so an absent session needs [`IntradayScope::MissingSessions`] instead.
 fn writable_sessions(
     session: SessionDate,
     scope: &IntradayScope,
@@ -751,19 +753,19 @@ fn writable_sessions(
 ///
 /// Concurrency is safe by construction rather than by scheduling: each write is a compare-and-swap
 /// on the object's ETag, so a racing pass is rejected with a `412` and retried instead of being
-/// silently clobbered. Bounded because the frames are held in memory until their write lands.
+/// silently clobbered.
 const INTRADAY_WRITE_CONCURRENCY: usize = 8;
 
 /// Writes one partition per session, several at a time, folding the outcomes into `summary`.
 ///
-/// Split out from the chunk because a repair pass over a full window is dominated by this loop:
-/// #1100 measured roughly twenty-five minutes for one ticker over 1,254 sessions, essentially all of
-/// it a sequential read-merge-write per partition.
+/// Takes bars rather than frames and converts as a slot opens, so the frames alive at once are the
+/// ones in flight rather than the whole chunk — converting up front peaked at
+/// [`INTRADAY_CHUNK_SESSIONS`] frames beside the bars they were built from.
 async fn write_partitions(
     s3_client: &S3Client,
     bucket: &str,
     interval: BarInterval,
-    partitions: Vec<(SessionDate, DataFrame)>,
+    partitions: Vec<(SessionDate, Vec<EquityBar>)>,
     summary: &mut ArchiveSummary,
 ) -> Result<(), ArchiveError> {
     let mut queued = partitions.into_iter();
@@ -771,9 +773,10 @@ async fn write_partitions(
 
     loop {
         while writes.len() < INTRADAY_WRITE_CONCURRENCY {
-            let Some((session, frame)) = queued.next() else {
+            let Some((session, bars_for_session)) = queued.next() else {
                 break;
             };
+            let frame = bars::bars_to_dataframe(&bars_for_session)?;
             let client = s3_client.clone();
             let bucket = bucket.to_string();
             let rows = frame.height();
@@ -891,13 +894,9 @@ const SCAN_CONCURRENCY: usize = 16;
 /// Which names each intraday partition lacks against the daily universe for its own session.
 ///
 /// The difference [`intraday_sessions_to_request`] cannot express: a partition written while one
-/// symbol's fetch failed is present, non-empty, and short a name. See
-/// `session_gap_scan_cannot_see_a_symbol` for the incident that motivated it.
-///
-/// `floor` is a parameter rather than the archive's own pin because this reads and never writes, so
-/// it cannot leave an inconsistent partition behind. Scanning at a floor *wider* than the one the
-/// archive was ingested at reports names that were never fetched, which is a backfill list rather
-/// than a fault — that is how the archive gets widened after a screen change.
+/// symbol's fetch failed is present, non-empty, and short a name. `floor` is a parameter because
+/// this reads and never writes, so scanning wider than the archive was ingested at yields a
+/// backfill list rather than a fault.
 pub async fn scan_intraday_symbols(
     s3_client: &S3Client,
     bucket: &str,
@@ -918,6 +917,7 @@ pub async fn scan_intraday_symbols(
     let mut queued = sessions.into_iter();
     let mut scans = tokio::task::JoinSet::new();
     let mut coverage = BTreeMap::new();
+    let mut failed = BTreeSet::new();
 
     loop {
         while scans.len() < SCAN_CONCURRENCY {
@@ -933,8 +933,14 @@ pub async fn scan_intraday_symbols(
             break;
         };
         match finished {
-            Ok((session, result)) => {
-                coverage.insert(session, result?);
+            Ok((session, Ok(result))) => {
+                coverage.insert(session, result);
+            }
+            // Carried, not fatal. A missing object already reads as `Ok(None)`, so what arrives here
+            // is a transient S3 fault, and propagating it would discard every session behind it.
+            Ok((session, Err(error))) => {
+                warn!(%session, %error, "A session could not be scanned; carrying it as failed");
+                failed.insert(session);
             }
             Err(error) => {
                 return Err(ArchiveError::Read {
@@ -946,7 +952,13 @@ pub async fn scan_intraday_symbols(
         }
     }
 
-    Ok(SymbolScan { coverage })
+    if !failed.is_empty() {
+        warn!(
+            failed = failed.len(),
+            "Some sessions could not be scanned; anything driven by this scan is acting on a partial picture"
+        );
+    }
+    Ok(SymbolScan { coverage, failed })
 }
 
 /// One session's coverage: read the daily partition, screen it, and difference the intraday one.
@@ -967,19 +979,27 @@ async fn session_coverage(
     let Some(intraday) = read_partition(s3_client, bucket, &intraday_key).await? else {
         return Ok(SessionCoverage::Absent);
     };
-    let present = partition_tickers(&intraday)?;
+    Ok(coverage_of(&expected, &partition_tickers(&intraday)?))
+}
 
-    let missing: BTreeSet<Ticker> = expected.difference(&present).cloned().collect();
-    Ok(if missing.is_empty() {
+/// Classifies a session from the two ticker sets, so the comparison is testable without S3.
+///
+/// One-directional: a partition holding *more* than its own session screened in is complete, not
+/// wrong. The archive unions the screened universe across a chunk, so that is every partition.
+fn coverage_of(expected: &BTreeSet<Ticker>, present: &BTreeSet<Ticker>) -> SessionCoverage {
+    let missing: BTreeSet<Ticker> = expected.difference(present).cloned().collect();
+    if missing.is_empty() {
         SessionCoverage::Complete
     } else {
         SessionCoverage::Partial(missing)
-    })
+    }
 }
 
 /// The distinct tickers a partition holds, unscreened.
 ///
-/// The record of what was fetched, which is what a coverage scan compares a screen against.
+/// Unparseable names are dropped rather than refused, and that is safe only because
+/// [`screen_partition`] builds the other side of the comparison through the same [`Ticker::new`] —
+/// anything this cannot read is absent from both sets, so it can never read as a gap.
 fn partition_tickers(frame: &DataFrame) -> Result<BTreeSet<Ticker>, ArchiveError> {
     let tickers = frame.column("ticker")?.str()?;
     Ok(tickers
@@ -1015,14 +1035,23 @@ pub struct ScanCounts {
 }
 
 /// Per-session coverage across a window, and the symbols a repair pass should be given.
+///
+/// `failed` is the sessions whose partitions could not be read. They are carried rather than fatal,
+/// so one throttled response does not discard a sweep, but a repair driven by a scan that has any
+/// is acting on an incomplete picture.
 #[derive(Debug, Default)]
 pub struct SymbolScan {
     coverage: BTreeMap<SessionDate, SessionCoverage>,
+    failed: BTreeSet<SessionDate>,
 }
 
 impl SymbolScan {
     pub fn coverage(&self) -> &BTreeMap<SessionDate, SessionCoverage> {
         &self.coverage
+    }
+
+    pub fn failed(&self) -> &BTreeSet<SessionDate> {
+        &self.failed
     }
 
     /// Every name missing from at least one partition, which is what [`IntradayScope::Symbols`]
@@ -1851,6 +1880,7 @@ mod tests {
     fn scan_of(entries: &[(SessionDate, SessionCoverage)]) -> SymbolScan {
         SymbolScan {
             coverage: entries.iter().cloned().collect(),
+            failed: BTreeSet::new(),
         }
     }
 
@@ -1865,12 +1895,15 @@ mod tests {
     /// `Partial`, where the session-level scan sees only that a partition is there.
     #[test]
     fn test_a_partition_short_two_names_is_partial_not_complete() {
-        let expected = tickers(&["AAPL", "CBOE", "MSFT", "NVDA"]);
-        let present = tickers(&["AAPL", "MSFT"]);
+        let coverage = coverage_of(
+            &tickers(&["AAPL", "CBOE", "MSFT", "NVDA"]),
+            &tickers(&["AAPL", "MSFT"]),
+        );
 
-        let missing: BTreeSet<Ticker> = expected.difference(&present).cloned().collect();
-
-        assert_eq!(missing, tickers(&["CBOE", "NVDA"]));
+        assert_eq!(
+            coverage,
+            SessionCoverage::Partial(tickers(&["CBOE", "NVDA"]))
+        );
     }
 
     /// An extra name is not a gap. The archive over-fetches by unioning the screened universe
@@ -1878,13 +1911,8 @@ mod tests {
     /// that as a difference in either direction would report the whole archive as broken.
     #[test]
     fn test_a_partition_holding_more_than_the_screen_expects_is_complete() {
-        let coverage = SessionCoverage::Complete;
-        let expected = tickers(&["AAPL"]);
-        let present = tickers(&["AAPL", "MSFT", "NVDA"]);
+        let coverage = coverage_of(&tickers(&["AAPL"]), &tickers(&["AAPL", "MSFT", "NVDA"]));
 
-        let missing: BTreeSet<Ticker> = expected.difference(&present).cloned().collect();
-
-        assert!(missing.is_empty());
         assert_eq!(coverage, SessionCoverage::Complete);
     }
 

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -558,6 +558,7 @@ pub async fn archive_intraday_sessions(
             interval,
             chunk,
             scope,
+            &present,
             &mut summary,
         )
         .await?;
@@ -584,6 +585,10 @@ pub async fn archive_intraday_sessions(
 }
 
 /// One chunk: derive the universe, fan out over it, then write a partition per session.
+///
+/// `present` is the sessions the archive already holds a partition for, which a symbol repair needs
+/// in order *not* to write one — see [`writable_sessions`].
+#[allow(clippy::too_many_arguments)]
 async fn archive_intraday_chunk(
     s3_client: &S3Client,
     massive: &MassiveClient,
@@ -591,6 +596,7 @@ async fn archive_intraday_chunk(
     interval: BarInterval,
     chunk: &[SessionDate],
     scope: &IntradayScope,
+    present: &BTreeSet<SessionDate>,
     summary: &mut ArchiveSummary,
 ) -> Result<(), ArchiveError> {
     let (Some(first), Some(last)) = (chunk.first(), chunk.last()) else {
@@ -704,17 +710,41 @@ async fn archive_intraday_chunk(
 
     let mut writable = Vec::new();
     for (session, bars_for_session) in by_session {
-        // A bar dated outside the chunk is a vendor answering beyond the range asked for. Writing it
-        // would put rows in a partition this pass never claimed and never verified.
-        // Skipped when the daily archive could not describe the session: a partition written from a
-        // universe that never covered it would look complete and never be revisited.
-        if !universe.described.contains(&session) {
+        if !writable_sessions(session, scope, &universe.described, present) {
             continue;
         }
         writable.push((session, bars::bars_to_dataframe(&bars_for_session)?));
     }
 
     write_partitions(s3_client, bucket, interval, writable, summary).await
+}
+
+/// Whether this pass may write the partition for `session`.
+///
+/// Two refusals, and the second is what a symbol repair needs. A session the *daily* archive cannot
+/// describe is skipped because a partition written from a universe that never covered it would look
+/// complete and never be revisited — that also drops a bar dated outside the chunk, which is the
+/// vendor answering beyond the range asked for.
+///
+/// A symbol repair additionally refuses to *create* a partition. It requests the whole window on
+/// purpose, since a partition short one name looks complete, but it fetches only the named symbols —
+/// so writing where nothing existed produces a partition holding those names and nothing else, which
+/// then reads as present to [`intraday_sessions_to_request`] and is never filled. Repairing the
+/// 2026-08-21 gap manufactured exactly that: an absent session became one short 1,335 names. An
+/// absent session needs [`IntradayScope::MissingSessions`], which fetches the whole universe.
+fn writable_sessions(
+    session: SessionDate,
+    scope: &IntradayScope,
+    described: &BTreeSet<SessionDate>,
+    present: &BTreeSet<SessionDate>,
+) -> bool {
+    if !described.contains(&session) {
+        return false;
+    }
+    match scope {
+        IntradayScope::MissingSessions => true,
+        IntradayScope::Symbols(_) => present.contains(&session),
+    }
 }
 
 /// Partitions written at once.
@@ -1757,6 +1787,65 @@ mod tests {
             BTreeSet::from([Ticker::new("CBOE").unwrap()]),
             "OBDC turns over $49.2M, just under the floor; SNDL clears $60M and fails on price"
         );
+    }
+
+    /// The bug this cost a backfill to find. A symbol repair fetches only the named symbols, so
+    /// writing where no partition existed leaves one holding those names and nothing else — which
+    /// then reads as present and is never filled. Repairing 2026-08-21 turned an absent session into
+    /// one short 1,335 names.
+    #[test]
+    fn test_a_symbol_repair_never_creates_a_partition() {
+        let session = session(2026, 8, 21);
+        let described = BTreeSet::from([session]);
+        let absent = BTreeSet::new();
+        let repair = IntradayScope::Symbols(tickers(&["CBOE", "NVDA"]));
+
+        assert!(
+            !writable_sessions(session, &repair, &described, &absent),
+            "a repair must leave an absent session absent, so the session scan still fetches it"
+        );
+        assert!(
+            writable_sessions(
+                session,
+                &IntradayScope::MissingSessions,
+                &described,
+                &absent
+            ),
+            "the whole-universe pass is the one that may create it"
+        );
+    }
+
+    /// The repair still writes where a partition exists — that is the merge it is for.
+    #[test]
+    fn test_a_symbol_repair_writes_into_a_partition_that_exists() {
+        let session = session(2026, 8, 20);
+        let described = BTreeSet::from([session]);
+        let present = BTreeSet::from([session]);
+        let repair = IntradayScope::Symbols(tickers(&["CBOE"]));
+
+        assert!(writable_sessions(session, &repair, &described, &present));
+    }
+
+    /// An undescribed session is refused whatever the scope, because nothing can say what a
+    /// complete partition for it would hold.
+    #[test]
+    fn test_an_undescribed_session_is_never_written() {
+        let session = session(2026, 8, 20);
+        let described = BTreeSet::new();
+        let present = BTreeSet::from([session]);
+
+        assert!(!writable_sessions(
+            session,
+            &IntradayScope::MissingSessions,
+            &described,
+            &present
+        ));
+        assert!(!writable_sessions(
+            session,
+            &IntradayScope::Symbols(tickers(&["CBOE"])),
+            &described,
+            &present
+        ));
     }
 
     fn scan_of(entries: &[(SessionDate, SessionCoverage)]) -> SymbolScan {


### PR DESCRIPTION
# Overview

Task 2 of the laboratory expansion: give the intraday archive a scan that can see a *symbol*-level
hole, parallelise the write path so acting on it is affordable, and backfill the archive to the
liquidity floor #1101 introduced.

## Changes

- Add `scan_intraday_symbols`, which reads each session's daily partition, screens it, and
  differences the result against the distinct tickers the intraday partition actually holds
- Add `SessionCoverage` with four states — `Undescribed`, `Absent`, `Complete`, `Partial` — because
  the repairs differ and only `Partial` contributes to the symbol set a repair is given
- Take the `LiquidityFloor` as a parameter here where the write path pins it: a scan reads and never
  writes, so scanning at a floor wider than the archive was ingested at yields a backfill list
- Write partitions eight at a time, on the compare-and-swap that already guards them
- Add `scan` and `repair` as `SYMBOLS` values on `seed_intraday_bars_s3`, checked before the symbol
  parser because both are valid ticker shapes
- Fix `writable_sessions`: a symbol repair must never *create* a partition (see below)

## Context

**The defect.** The archive repairs itself by set difference over sessions, so a partition written
while one symbol's fetch failed is indistinguishable from a complete one. #1100 built the repair
half — `IntradayScope::Symbols` fetches named tickers across a window — but it has to be *told*
which name is missing, and it knew only because the gap had been queried for by hand.

**Why it blocks the rest of the arc.** The residual return panel is fitted cross-sectionally, per
session. A name silently absent from a partition does not degrade that fit, it biases it, and it
biases it in a way that looks exactly like a real cross-sectional effect.

**Measured against the real archive, before and after.** A full scan of 2021-08-23 to 2026-08-21
over 1,305 sessions:

| | before | after |
|---|---|---|
| sessions complete | 0 | **1,146** |
| sessions partial | 1,254 | 109 |
| sessions absent | 1 | 0 |
| distinct names missing | 1,655 | **32** |

Every partition was short before, median 108 names, because the archive was ingested under the
share-count screen and is now read under the dollar screen. The backfill ran month by month: 61
months, roughly 28 minutes, 29.07M bars, zero symbol failures.

**The residual is permanent and worth recognising.** All 109 remaining sessions are short exactly
one name, and the names are venue test symbols — ZVZZT, ZTEST, ZAZZT, ZBZX, ZEXIT, ZJZZT, ZWZZT,
ATEST, CTEST, MTEST, NTEST, PTEST — which print to the consolidated tape, clear the dollar screen on
the daily side, and have no intraday bars to fetch. A dozen genuine oddities sit alongside (NXUS,
NHYB, USCA, CBOX, AVGOP). A future scan reporting about one name a session is healthy; anything
above that is real, which is what the backfill bought.

**A bug this found by causing it.** The backfill ran the repair over a window containing 2026-08-21,
which had no partition at all. The pass wrote one, and the session went from absent to short 1,335
names — a fresh instance of the very defect the scan was built to detect, manufactured by the
repair. `IntradayScope::Symbols` requests the whole window on purpose, but fetches only the *named*
symbols, so writing where nothing existed leaves a partition holding those and nothing else, which
then reads as present and is never filled. `writable_sessions` now separates the two refusals: an
undescribed session is refused whatever the scope, and a symbol repair additionally refuses to
create a partition. An absent session needs the whole-universe pass. The damaged partition was
deleted and re-seeded with 171,097 bars, and the table above is the scan after that.

`devenv tasks run checks:all` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `scan` mode to identify intraday sessions with missing or incomplete symbol data.
  - Added `repair` mode to target and restore missing symbols in existing sessions.
  - Added detailed coverage reports showing complete, partial, absent, and undescribed sessions.
  - Added support for displaying the number of distinct symbols requiring attention.

- **Bug Fixes**
  - Repairs no longer create new partial partitions when the target session does not already exist.
  - Improved intraday archive updates with concurrent processing while preserving error tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->