### PR TITLE
Fold the quoted book into a spread archive

### DIFF
--- a/src/bin/seed_quotes_s3.rs
+++ b/src/bin/seed_quotes_s3.rs
@@ -157,7 +157,14 @@ async fn main() {
                 summary.symbols_failed,
                 summary.quotes_folded
             );
-            0
+            // Non-zero on an incomplete pass, because the partition it wrote reads as complete to
+            // everything downstream and the exit code is the only signal automation sees.
+            if summary.symbols_failed > 0 || !summary.sessions_failed.is_empty() {
+                eprintln!("Incomplete: re-run the affected sessions to fill the missing symbols");
+                1
+            } else {
+                0
+            }
         }
         Err(error) => {
             error!(%error, "Seeding the quote archive failed");
@@ -175,9 +182,8 @@ async fn run(
     parameters: &Parameters,
 ) -> Result<Option<archive::QuoteArchiveSummary>, Box<dyn std::error::Error>> {
     let credentials = AlpacaCredentials::from_env()?;
-    // Pinned to SIP rather than read from `ALPACA_DATA_FEED`. IEX carries a few percent of volume
-    // and its best bid and offer is not the national one, so a feed chosen by an environment
-    // variable would put two incomparable spread series under one key.
+    // SIP is pinned, not read from `ALPACA_DATA_FEED`: IEX's best bid and offer is not the national
+    // one, so an environment variable could put two incomparable series under one key.
     let market_data = MarketDataClient::new(credentials.clone(), DataFeed::Sip);
     let days = TradingClient::from_env(credentials)
         .fetch_calendar(parameters.start.date(), parameters.end.date())

--- a/src/bin/seed_quotes_s3.rs
+++ b/src/bin/seed_quotes_s3.rs
@@ -1,0 +1,372 @@
+//! Folds the quoted book from Alpaca into the S3 spread archive, session by session.
+//!
+//! Reads and writes `data/equity/quotes/interval=<cadence>/`. No database is touched.
+
+use std::collections::BTreeSet;
+
+use chrono::NaiveDate;
+use tracing::{error, info};
+
+use fund::common::alpaca::{AlpacaCredentials, DataFeed, MarketDataClient, TradingClient};
+use fund::common::log::init_tracing;
+use fund::common::types::{LiquidityFloor, QuoteSummary, SessionDate, Ticker};
+use fund::data::archive;
+use fund::data::calendar::TradingCalendar;
+use fund::data::quotes;
+
+const USAGE: &str = "Usage: seed_quotes_s3 START_DATE END_DATE [STRIDE [SYMBOLS]]\n\
+                     Dates are Eastern calendar dates, inclusive: YYYY-MM-DD.\n\
+                     STRIDE samples every Nth trading session from START_DATE (default 1).\n\
+                     A stride that is a multiple of 5 samples one weekday forever; 21 does not.\n\
+                     SYMBOLS is a comma-separated list, and naming it requires naming STRIDE too.\n\
+                     Naming symbols measures rather than archives: it prints what those names read\n\
+                     and writes nothing, because a partition holding only them would read as a\n\
+                     complete session to the next pass.";
+
+/// Sessions between samples unless told otherwise, which is every session.
+const DEFAULT_STRIDE: usize = 1;
+
+/// What the run does, which the `SYMBOLS` argument selects.
+#[derive(Debug, PartialEq, Eq)]
+enum Mode {
+    /// Fold the screened universe for every sampled session and write both cadences.
+    Archive,
+    /// Fold only these names and print what they read, touching no partition.
+    Measure(BTreeSet<Ticker>),
+}
+
+struct Parameters {
+    start: SessionDate,
+    end: SessionDate,
+    stride: usize,
+    mode: Mode,
+}
+
+impl Parameters {
+    fn parse(arguments: &[String]) -> Result<Self, String> {
+        let (start, end, stride, symbols) = match arguments {
+            [start, end] => (start, end, None, None),
+            [start, end, stride] => (start, end, Some(stride), None),
+            // Positional after the stride, so measuring named symbols means stating the stride
+            // rather than having it inferred from an argument that could be either.
+            [start, end, stride, symbols] => (start, end, Some(stride), Some(symbols)),
+            _ => {
+                return Err(format!(
+                    "Expected two dates, an optional stride and an optional symbol list\n{USAGE}"
+                ))
+            }
+        };
+
+        let start = session(start, "START_DATE")?;
+        let end = session(end, "END_DATE")?;
+        if start > end {
+            return Err(format!("START_DATE must not be after END_DATE\n{USAGE}"));
+        }
+
+        let stride = match stride.map(|raw| raw.trim()) {
+            None => DEFAULT_STRIDE,
+            Some(raw) => raw
+                .parse::<usize>()
+                .ok()
+                .filter(|stride| *stride > 0)
+                .ok_or_else(|| {
+                    format!("STRIDE must be a positive whole number, got {raw:?}\n{USAGE}")
+                })?,
+        };
+
+        let mode = match symbols.map(|raw| raw.trim()) {
+            None => Mode::Archive,
+            Some(raw) => Mode::Measure(parse_symbols(raw)?),
+        };
+
+        Ok(Self {
+            start,
+            end,
+            stride,
+            mode,
+        })
+    }
+}
+
+/// Parses the comma-separated symbol list into validated tickers.
+///
+/// Refuses every unusable component, an empty one included, rather than skipping it: a list that
+/// silently loses a name measures fewer than it reports.
+fn parse_symbols(raw: &str) -> Result<BTreeSet<Ticker>, String> {
+    let mut symbols = BTreeSet::new();
+    for candidate in raw.split(',').map(str::trim) {
+        let ticker = Ticker::new(candidate).ok_or_else(|| {
+            format!("SYMBOLS contains an unusable ticker: {candidate:?}\n{USAGE}")
+        })?;
+        symbols.insert(ticker);
+    }
+    Ok(symbols)
+}
+
+/// Parses an Eastern calendar date, which is what a session is.
+fn session(raw: &str, name: &str) -> Result<SessionDate, String> {
+    NaiveDate::parse_from_str(raw.trim(), "%Y-%m-%d")
+        .map(SessionDate::from_date)
+        .map_err(|_| format!("{name} must be YYYY-MM-DD, got {raw:?}\n{USAGE}"))
+}
+
+/// Every `stride`-th published session in the window, anchored at the oldest.
+///
+/// Anchored at the start rather than the end so re-running the same window samples the same
+/// sessions: a sample that shifts under a longer window cannot be extended without refetching what
+/// is already archived.
+fn sample(
+    calendar: &TradingCalendar,
+    start: SessionDate,
+    end: SessionDate,
+    stride: usize,
+) -> Vec<SessionDate> {
+    calendar
+        .trading_days_in_range(start, end)
+        .into_iter()
+        .step_by(stride)
+        .collect()
+}
+
+#[tokio::main]
+async fn main() {
+    fund::common::crypto::install_default_crypto_provider();
+    let tracing_guard = init_tracing("seed-quotes-s3.log", Some("info"), "seed-quotes-s3");
+
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let parameters = match Parameters::parse(&arguments) {
+        Ok(parameters) => parameters,
+        Err(message) => {
+            eprintln!("{message}");
+            drop(tracing_guard);
+            std::process::exit(2);
+        }
+    };
+
+    let code = match run(&parameters).await {
+        // `None` when nothing was archived, which is what a measurement run always reports.
+        Ok(None) => 0,
+        Ok(Some(summary)) => {
+            println!(
+                "requested {} sessions, wrote {}, {} without data, {} failed, {} summaries, {} symbols missing, {} quotes folded",
+                summary.sessions_requested,
+                summary.sessions_written,
+                summary.sessions_without_data,
+                summary.sessions_failed.len(),
+                summary.summaries_written,
+                summary.symbols_failed,
+                summary.quotes_folded
+            );
+            0
+        }
+        Err(error) => {
+            error!(%error, "Seeding the quote archive failed");
+            eprintln!("Seeding the quote archive failed: {error}");
+            1
+        }
+    };
+
+    drop(tracing_guard);
+    std::process::exit(code);
+}
+
+/// Folds the sampled sessions, or measures the named symbols across them.
+async fn run(
+    parameters: &Parameters,
+) -> Result<Option<archive::QuoteArchiveSummary>, Box<dyn std::error::Error>> {
+    let credentials = AlpacaCredentials::from_env()?;
+    // Pinned to SIP rather than read from `ALPACA_DATA_FEED`. IEX carries a few percent of volume
+    // and its best bid and offer is not the national one, so a feed chosen by an environment
+    // variable would put two incomparable spread series under one key.
+    let market_data = MarketDataClient::new(credentials.clone(), DataFeed::Sip);
+    let days = TradingClient::from_env(credentials)
+        .fetch_calendar(parameters.start.date(), parameters.end.date())
+        .await?;
+    let calendar = TradingCalendar::from_days(days);
+    let sampled = sample(
+        &calendar,
+        parameters.start,
+        parameters.end,
+        parameters.stride,
+    );
+
+    info!(
+        start = %parameters.start,
+        end = %parameters.end,
+        stride = parameters.stride,
+        published = calendar.len(),
+        sampled = sampled.len(),
+        "Sampled the sessions to fold"
+    );
+
+    match &parameters.mode {
+        Mode::Measure(symbols) => {
+            measure(&market_data, &calendar, &sampled, symbols).await;
+            Ok(None)
+        }
+        Mode::Archive => {
+            let bucket = std::env::var("AWS_S3_BUCKET_NAME")
+                .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+            let s3_client = fund::common::aws::s3_client().await;
+            Ok(Some(
+                archive::archive_quote_sessions(
+                    &s3_client,
+                    &market_data,
+                    &calendar,
+                    &bucket,
+                    &sampled,
+                    LiquidityFloor::CURRENT,
+                )
+                .await?,
+            ))
+        }
+    }
+}
+
+/// Folds the named symbols and prints their session figures, writing nothing.
+///
+/// Sequential on purpose: this is for reading a handful of numbers off real data, and a run whose
+/// symbols interleave is harder to compare against a reference than one that is slower.
+async fn measure(
+    market_data: &MarketDataClient,
+    calendar: &TradingCalendar,
+    sampled: &[SessionDate],
+    symbols: &BTreeSet<Ticker>,
+) {
+    println!(
+        "{:<8}{:<12}{:>10}{:>10}{:>10}{:>10}{:>10}{:>10}{:>12}",
+        "ticker",
+        "session",
+        "mean_bp",
+        "median_bp",
+        "p90_bp",
+        "first_bp",
+        "min_bp",
+        "quotes",
+        "covered_s"
+    );
+    for session in sampled {
+        let Some((open, close)) = quotes::trading_hours(calendar, *session) else {
+            println!("{session}: not a published session");
+            continue;
+        };
+        for ticker in symbols {
+            match quotes::fold_session(market_data, ticker, *session, open, close).await {
+                Ok((summaries, fetch)) => {
+                    print_session_row(ticker, *session, &summaries, fetch.received)
+                }
+                // Padded through `as_str`/`to_string`, because both Display impls delegate to an
+                // inner type that ignores the width and would run the two columns together.
+                Err(error) => println!(
+                    "{:<8}{:<12} failed: {error}",
+                    ticker.as_str(),
+                    session.to_string()
+                ),
+            }
+        }
+    }
+}
+
+/// Prints one fold: its session row, plus the two intraday buckets worth reading beside it.
+///
+/// A session mean hides the shape the five-minute cadence exists to expose — AAPL quotes four times
+/// wider at the open than at midday. `first` is the earliest bucket that carried a book, which is
+/// the opening one only for a name quoting from 09:30; `min` is the tightest anywhere in the day.
+fn print_session_row(
+    ticker: &Ticker,
+    session: SessionDate,
+    summaries: &[QuoteSummary],
+    quotes_folded: usize,
+) {
+    let Some((row, buckets)) = summaries.split_last() else {
+        println!(
+            "{:<8}{:<12} no quotes",
+            ticker.as_str(),
+            session.to_string()
+        );
+        return;
+    };
+    let basis_points = |summary: &QuoteSummary| summary.quoted_spread_basis_points_mean().value();
+    let opening = buckets.first().map(basis_points).unwrap_or(f64::NAN);
+    let tightest = buckets
+        .iter()
+        .map(basis_points)
+        .fold(f64::NAN, |narrowest, bucket| bucket.min(narrowest));
+    println!(
+        "{:<8}{:<12}{:>10.2}{:>10.2}{:>10.2}{:>10.2}{:>10.2}{:>10}{:>12.0}",
+        ticker.as_str(),
+        session.to_string(),
+        basis_points(row),
+        row.quoted_spread_basis_points_median().value(),
+        row.quoted_spread_basis_points_ninetieth_percentile()
+            .value(),
+        opening,
+        tightest,
+        quotes_folded,
+        row.covered_seconds()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arguments(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn test_defaults_to_every_session_and_the_screened_universe() {
+        let parameters = Parameters::parse(&arguments(&["2026-08-03", "2026-08-21"]))
+            .expect("two dates are enough");
+        assert_eq!(parameters.stride, 1);
+        assert_eq!(parameters.mode, Mode::Archive);
+    }
+
+    #[test]
+    fn test_naming_symbols_measures_rather_than_archives() {
+        let parameters = Parameters::parse(&arguments(&[
+            "2026-08-03",
+            "2026-08-21",
+            "21",
+            " AAPL , cboe ",
+        ]))
+        .expect("a stride and two symbols");
+        assert_eq!(parameters.stride, 21);
+        let Mode::Measure(symbols) = parameters.mode else {
+            panic!("naming symbols must not archive");
+        };
+        assert_eq!(symbols.len(), 2, "lowercase is normalized, not rejected");
+        assert!(symbols.contains(&Ticker::new("CBOE").unwrap()));
+    }
+
+    #[test]
+    fn test_a_stride_that_samples_nothing_is_refused() {
+        assert!(Parameters::parse(&arguments(&["2026-08-03", "2026-08-21", "0"])).is_err());
+        assert!(Parameters::parse(&arguments(&["2026-08-03", "2026-08-21", "-1"])).is_err());
+        assert!(Parameters::parse(&arguments(&["2026-08-03", "2026-08-21", "many"])).is_err());
+    }
+
+    #[test]
+    fn test_an_unusable_symbol_refuses_the_whole_list() {
+        assert!(
+            Parameters::parse(&arguments(&["2026-08-03", "2026-08-21", "1", "AAPL,,CBOE"]))
+                .is_err(),
+            "an empty component is a typo, not a separator"
+        );
+        assert!(Parameters::parse(&arguments(&[
+            "2026-08-03",
+            "2026-08-21",
+            "1",
+            "AAPL,TOOLONGNAME"
+        ]))
+        .is_err());
+    }
+
+    #[test]
+    fn test_dates_must_be_eastern_calendar_dates_in_order() {
+        assert!(Parameters::parse(&arguments(&["2026-08-21", "2026-08-03"])).is_err());
+        assert!(Parameters::parse(&arguments(&["2026-08-21T00:00:00Z", "2026-08-21"])).is_err());
+        assert!(Parameters::parse(&arguments(&["2026-08-21"])).is_err());
+    }
+}

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -1,6 +1,6 @@
 //! The Alpaca integration: credentials, the trading API, and the market data API.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::num::NonZeroU32;
 
 use chrono::{DateTime, NaiveDate, NaiveTime, TimeZone, Utc};
@@ -27,7 +27,8 @@ const HEADER_SECRET_KEY: &str = "APCA-API-SECRET-KEY";
 /// Failures reaching or interpreting an Alpaca endpoint.
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
-    /// The request never produced a response: connection refused, timed out, TLS failure.
+    /// The request produced no usable response: connection refused, timed out, TLS failure, or a
+    /// body that did not arrive intact.
     #[error("Alpaca request failed: {0}")]
     Request(#[from] reqwest::Error),
     /// Alpaca answered with a non-success status.
@@ -36,6 +37,26 @@ pub enum ClientError {
     /// Alpaca answered successfully with something that could not be interpreted.
     #[error("Alpaca response could not be parsed: {0}")]
     Parse(String),
+}
+
+impl ClientError {
+    /// Whether another attempt could succeed where this one did not.
+    ///
+    /// A body that did not arrive and a body that is not JSON are one error to `reqwest`, so both
+    /// land in [`ClientError::Request`] and both are retried. [`ClientError::Parse`] is what this
+    /// module raises about a response it *did* read whole, which repeating cannot change.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            ClientError::Api { status, .. } => *status == 429 || (500..600).contains(status),
+            ClientError::Request(_) => true,
+            ClientError::Parse(_) => false,
+        }
+    }
+}
+
+/// Pause before a page's next attempt, growing with the attempt number.
+fn page_retry_delay(attempt: usize) -> std::time::Duration {
+    std::time::Duration::from_millis(250 << attempt.min(4))
 }
 
 /// Builds the shared HTTP client.
@@ -2001,6 +2022,110 @@ impl std::fmt::Display for PriceSource {
     }
 }
 
+/// Rows per quote page. The endpoint's maximum.
+const QUOTES_PAGE_SIZE: usize = 10_000;
+
+/// Page bound for the quote cursor, so a token that never clears cannot loop forever.
+///
+/// Ten million quotes for one name over one session, against a measured worst case of 904,543
+/// (XLI, 2026-08-20). Generous because the tail is nothing like the median: the same session's
+/// quote counts ranged from 7,337 to that, and the count tracks price level and tick size rather
+/// than dollar volume.
+const QUOTES_PAGE_LIMIT: usize = 1_000;
+
+/// One tick of the consolidated quote stream, carrying no ticker.
+///
+/// Its own type rather than an [`EquityQuote`] because a single name-session runs to most of a
+/// million of these, and cloning a [`Ticker`] into every one is an allocation per row for a field
+/// the caller named in the request.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct QuoteTick {
+    timestamp: DateTime<Utc>,
+    bid_price: f64,
+    ask_price: f64,
+    bid_size: i32,
+    ask_size: i32,
+}
+
+impl QuoteTick {
+    /// Constructs a `QuoteTick`, refusing a book no spread can be read off.
+    ///
+    /// `None` rather than an error because these are refused in bulk and counted, not reported one
+    /// by one: a crossed consolidated book is ordinary around the open, where 20 of AAPL's first
+    /// 30,126 quotes on 2026-08-20 were crossed.
+    pub fn new(
+        timestamp: DateTime<Utc>,
+        bid_price: f64,
+        ask_price: f64,
+        bid_size: i32,
+        ask_size: i32,
+    ) -> Option<Self> {
+        let usable = |price: f64| price.is_finite() && price > 0.0;
+        if !usable(bid_price) || !usable(ask_price) || bid_price > ask_price {
+            return None;
+        }
+        if bid_size < 0 || ask_size < 0 {
+            return None;
+        }
+        Some(Self {
+            timestamp,
+            bid_price,
+            ask_price,
+            bid_size,
+            ask_size,
+        })
+    }
+
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
+    }
+
+    pub fn bid_size(&self) -> i32 {
+        self.bid_size
+    }
+
+    pub fn ask_size(&self) -> i32 {
+        self.ask_size
+    }
+
+    /// The quoted width of the book.
+    pub fn spread(&self) -> f64 {
+        self.ask_price - self.bid_price
+    }
+
+    /// The midpoint, which [`QuoteTick::new`] has already established is a positive price.
+    pub fn mid_price(&self) -> f64 {
+        (self.bid_price + self.ask_price) / 2.0
+    }
+}
+
+/// Attempts per quote page before the fetch gives up on the whole symbol.
+///
+/// Four, because the page is the unit that fails: one session of AAPL is 118 pages and a single
+/// dropped connection anywhere in the chain used to cost the name. Bounded rather than generous —
+/// a page that fails four times running is not a blip.
+const QUOTES_PAGE_ATTEMPTS: usize = 4;
+
+/// One page and what it took to get it.
+struct FetchedPage {
+    page: QuotesResponse,
+    retries: usize,
+}
+
+/// What one quote fetch moved, which is the only trace of it that survives.
+///
+/// The ticks themselves are handed to the caller's fold and dropped; these counts are what remains
+/// to say whether the fold saw a whole session. `rejected` is the tally [`QuoteTick::new`] refused,
+/// and `retries` is how many pages had to be asked for twice — a run where it climbs is a feed
+/// degrading, which no other number here would show.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct QuoteFetch {
+    pub received: usize,
+    pub rejected: usize,
+    pub pages: usize,
+    pub retries: usize,
+}
+
 /// Rows per corporate-actions page. The endpoint's maximum.
 const CORPORATE_ACTIONS_PAGE_SIZE: usize = 1_000;
 
@@ -2014,6 +2139,47 @@ const CORPORATE_ACTIONS_PAGE_LIMIT: usize = 200;
 /// feed, so a recent window excludes it without being told to.
 const BOUNDARY_ACTION_TYPES: &str =
     "name_change,spin_off,rights_distribution,unit_split,reorganization";
+
+/// The historical-quotes envelope: rows keyed by symbol, plus the cursor.
+///
+/// `quotes` is absent rather than empty when a window holds none, which a name that had not listed
+/// yet produces for every session before it did.
+#[derive(Debug, Deserialize)]
+struct QuotesResponse {
+    quotes: Option<HashMap<String, Vec<HistoricalQuotePayload>>>,
+    next_page_token: Option<String>,
+}
+
+/// One row of the historical quote stream, in the feed's own abbreviations.
+///
+/// Only the five fields a spread is read off are taken. The exchange codes, condition flags, and
+/// tape identifier are parsed past: the SIP feed returns the consolidated best bid and offer, so
+/// the venue behind each side is not what this measures.
+#[derive(Debug, Deserialize)]
+struct HistoricalQuotePayload {
+    #[serde(rename = "t")]
+    timestamp: Option<DateTime<Utc>>,
+    #[serde(rename = "bp", default)]
+    bid_price: f64,
+    #[serde(rename = "ap", default)]
+    ask_price: f64,
+    #[serde(rename = "bs", default)]
+    bid_size: i32,
+    #[serde(rename = "as", default)]
+    ask_size: i32,
+}
+
+impl HistoricalQuotePayload {
+    fn into_tick(self) -> Option<QuoteTick> {
+        QuoteTick::new(
+            self.timestamp?,
+            self.bid_price,
+            self.ask_price,
+            self.bid_size,
+            self.ask_size,
+        )
+    }
+}
 
 /// The corporate-actions envelope: categories keyed by name, plus the cursor.
 #[derive(Debug, Deserialize)]
@@ -2292,6 +2458,130 @@ impl MarketDataClient {
 
         Err(ClientError::Parse(format!(
             "corporate action pagination did not end within {CORPORATE_ACTIONS_PAGE_LIMIT} pages"
+        )))
+    }
+
+    /// Fetches one page, retrying the page itself while the failure is transient.
+    ///
+    /// Retried here rather than by the caller because the caller's unit is the whole symbol: AAPL
+    /// is 118 pages over one session, so restarting it to recover one dropped connection discards
+    /// 117 pages of work and gives the largest names both the highest failure odds and the dearest
+    /// recovery. The token identifies the page, so resuming at it is exact.
+    async fn quote_page(
+        &self,
+        url: &str,
+        query: &[(&str, &str)],
+        ticker: &Ticker,
+        page: usize,
+    ) -> Result<FetchedPage, ClientError> {
+        let mut retries = 0usize;
+        let mut last_error = None;
+        for attempt in 0..QUOTES_PAGE_ATTEMPTS {
+            let outcome = match error_for_status(self.get(url).query(query).send().await?).await {
+                // Kept as `Request` rather than flattened to `Parse`. A connection dropped part-way
+                // through a body arrives here, and calling that unparseable cost twelve names their
+                // retries on the first real run.
+                Ok(response) => response
+                    .json::<QuotesResponse>()
+                    .await
+                    .map_err(ClientError::Request),
+                Err(error) => Err(error),
+            };
+            match outcome {
+                Ok(page) => return Ok(FetchedPage { page, retries }),
+                Err(error) if error.is_transient() => {
+                    retries += 1;
+                    debug!(%ticker, page, attempt, %error, "Retrying a quote page");
+                    last_error = Some(error);
+                    tokio::time::sleep(page_retry_delay(attempt)).await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        // The last real failure, not a summary of them. Reporting exhaustion as a parse error would
+        // tell the caller a transport fault is permanent, which is the bug this retry exists for.
+        Err(last_error.expect("a failed attempt records its error"))
+    }
+
+    /// Streams one symbol's quotes over `[start, end)` through `accept`, oldest first.
+    ///
+    /// A fold rather than a `Vec` because the volume forbids collecting: AAPL alone printed 846,305
+    /// quotes on 2026-08-20, which is 110MB of JSON, and the archive wants a dozen numbers out of
+    /// it. Each page is dropped once `accept` has seen it, so peak memory is one page.
+    ///
+    /// Ticks arrive in ascending time order, which every time-weighted fold downstream depends on,
+    /// and unusable books are refused here so `accept` only ever sees a quote worth weighing.
+    pub async fn fetch_quotes<F>(
+        &self,
+        ticker: &Ticker,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        mut accept: F,
+    ) -> Result<QuoteFetch, ClientError>
+    where
+        F: FnMut(QuoteTick),
+    {
+        let url = format!("{}/v2/stocks/quotes", self.base_url);
+        let start_text = start.to_rfc3339();
+        let end_text = end.to_rfc3339();
+        let page_size = QUOTES_PAGE_SIZE.to_string();
+        let feed = self.feed.as_str();
+
+        let mut fetch = QuoteFetch::default();
+        let mut page_token: Option<String> = None;
+
+        for _ in 1..=QUOTES_PAGE_LIMIT {
+            let mut query: Vec<(&str, &str)> = vec![
+                ("symbols", ticker.as_str()),
+                ("start", start_text.as_str()),
+                ("end", end_text.as_str()),
+                ("limit", page_size.as_str()),
+                ("feed", feed),
+                // Stated rather than inherited. The fold weighs each quote by the time until the
+                // next one, so a descending page would silently weigh every tick at zero.
+                ("sort", "asc"),
+            ];
+            if let Some(token) = page_token.as_deref() {
+                query.push(("page_token", token));
+            }
+
+            let payload = self
+                .quote_page(&url, &query, ticker, fetch.pages + 1)
+                .await?;
+            fetch.retries += payload.retries;
+            let payload = payload.page;
+
+            fetch.pages += 1;
+            let rows = payload
+                .quotes
+                .and_then(|mut symbols| symbols.remove(ticker.as_str()))
+                .unwrap_or_default();
+            fetch.received += rows.len();
+            for row in rows {
+                match row.into_tick() {
+                    Some(tick) => accept(tick),
+                    None => fetch.rejected += 1,
+                }
+            }
+
+            let Some(token) = payload.next_page_token else {
+                if fetch.rejected > 0 {
+                    // Ordinary around the open and not worth a warning, but the ratio is the only
+                    // signal that would distinguish a bad feed day from a normal one.
+                    debug!(
+                        %ticker,
+                        rejected = fetch.rejected,
+                        received = fetch.received,
+                        "Dropped quotes no spread can be read off"
+                    );
+                }
+                return Ok(fetch);
+            };
+            page_token = Some(token);
+        }
+
+        Err(ClientError::Parse(format!(
+            "{ticker} quote pagination did not end within {QUOTES_PAGE_LIMIT} pages"
         )))
     }
 
@@ -4107,5 +4397,241 @@ mod tests {
         assert!(boundary_for(&boundaries, "SPCX").is_some());
         first.assert_async().await;
         second.assert_async().await;
+    }
+
+    fn quote_window() -> (DateTime<Utc>, DateTime<Utc>) {
+        (
+            Utc.with_ymd_and_hms(2026, 8, 20, 13, 30, 0).unwrap(),
+            Utc.with_ymd_and_hms(2026, 8, 20, 20, 0, 0).unwrap(),
+        )
+    }
+
+    /// Collects what the fold would have seen, which no production caller does — the whole point of
+    /// the streaming signature is that a name-session's ticks never exist all at once.
+    async fn collect_quotes(base_url: String) -> (Vec<QuoteTick>, Result<QuoteFetch, ClientError>) {
+        let (start, end) = quote_window();
+        let mut ticks = Vec::new();
+        let fetch = client(base_url)
+            .fetch_quotes(&ticker("AAPL"), start, end, |tick| ticks.push(tick))
+            .await;
+        (ticks, fetch)
+    }
+
+    #[tokio::test]
+    async fn test_quote_pagination_folds_every_page_in_order() {
+        let mut server = mockito::Server::new_async().await;
+        let second = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_query(mockito::Matcher::UrlEncoded(
+                "page_token".into(),
+                "page-two".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"quotes":{"AAPL":[
+                    {"t":"2026-08-20T13:30:02Z","bp":100.02,"ap":100.06,"bs":3,"as":4}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+        let first = server
+            .mock("GET", mockito::Matcher::Any)
+            // Pinned because the fold weighs each quote by the time until the next one, so a
+            // descending page would weigh every tick at zero and read as a session with no book.
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("sort".into(), "asc".into()),
+                mockito::Matcher::UrlEncoded("feed".into(), "iex".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"quotes":{"AAPL":[
+                    {"t":"2026-08-20T13:30:00Z","bp":100.00,"ap":100.05,"bs":1,"as":2}
+                ]},"next_page_token":"page-two"}"#,
+            )
+            .create_async()
+            .await;
+
+        let (ticks, fetch) = collect_quotes(server.url()).await;
+        let fetch = fetch.expect("both pages must parse");
+
+        assert_eq!(fetch.received, 2);
+        assert_eq!(fetch.rejected, 0);
+        assert_eq!(fetch.pages, 2);
+        assert_eq!(ticks.len(), 2);
+        assert!(ticks[0].timestamp() < ticks[1].timestamp());
+        assert_eq!(ticks[0].bid_size(), 1);
+        first.assert_async().await;
+        second.assert_async().await;
+    }
+
+    /// A crossed consolidated book is ordinary around the open — 20 of AAPL's first 30,126 quotes
+    /// on 2026-08-20 were crossed — so these are counted rather than raised, and never reach a fold
+    /// that would read a negative spread off them.
+    #[tokio::test]
+    async fn test_books_no_spread_can_be_read_off_are_counted_not_delivered() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"quotes":{"AAPL":[
+                    {"t":"2026-08-20T13:30:00Z","bp":100.10,"ap":100.05,"bs":1,"as":2},
+                    {"t":"2026-08-20T13:30:01Z","bp":0,"ap":100.05,"bs":1,"as":2},
+                    {"t":"2026-08-20T13:30:02Z","bp":100.00,"ap":100.05,"bs":-1,"as":2},
+                    {"bp":100.00,"ap":100.05,"bs":1,"as":2},
+                    {"t":"2026-08-20T13:30:04Z","bp":100.00,"ap":100.05,"bs":1,"as":2}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+
+        let (ticks, fetch) = collect_quotes(server.url()).await;
+        let fetch = fetch.expect("a page of mostly unusable books still parses");
+
+        assert_eq!(fetch.received, 5);
+        assert_eq!(fetch.rejected, 4, "crossed, zero, signed size, undated");
+        assert_eq!(ticks.len(), 1);
+        assert_eq!(ticks[0].spread(), 100.05 - 100.00);
+        mock.assert_async().await;
+    }
+
+    /// The endpoint omits `quotes` entirely rather than returning it empty, which every session
+    /// before a name listed produces.
+    #[tokio::test]
+    async fn test_a_window_with_no_quotes_is_an_empty_fold_rather_than_an_error() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"quotes":null,"next_page_token":null}"#)
+            .create_async()
+            .await;
+
+        let (ticks, fetch) = collect_quotes(server.url()).await;
+        let fetch = fetch.expect("an empty window is an answer");
+
+        assert_eq!(
+            fetch,
+            QuoteFetch {
+                received: 0,
+                rejected: 0,
+                pages: 1,
+                retries: 0
+            }
+        );
+        assert!(ticks.is_empty());
+        mock.assert_async().await;
+    }
+
+    /// The first real run lost twelve names to `error decoding response body` — a connection
+    /// dropped part-way through a page — because this arrived as [`ClientError::Parse`], which the
+    /// archive treats as permanent and never retries. It is a transport failure and must say so.
+    #[tokio::test]
+    async fn test_a_body_that_does_not_arrive_intact_is_a_transport_failure() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"quotes":{"AAPL":[{"t":"2026-08-20T13:30:00Z","#)
+            .expect(QUOTES_PAGE_ATTEMPTS)
+            .create_async()
+            .await;
+
+        let (_, fetch) = collect_quotes(server.url()).await;
+
+        assert!(
+            matches!(fetch, Err(ClientError::Request(_))),
+            "a truncated body is transport, not content: {fetch:?}"
+        );
+        // Exhausting the page's attempts must still report the transport failure itself, so the
+        // symbol-level retry above it can act on it.
+        mock.assert_async().await;
+    }
+
+    #[test]
+    fn test_only_a_throttle_or_a_server_fault_is_worth_asking_again_for() {
+        let api = |status| ClientError::Api {
+            status,
+            body: String::new(),
+        };
+        assert!(api(429).is_transient(), "throttled");
+        assert!(api(503).is_transient(), "server fault");
+        assert!(!api(403).is_transient(), "an entitlement");
+        assert!(!api(422).is_transient(), "a malformed window");
+        assert!(!ClientError::Parse("page limit".to_string()).is_transient());
+    }
+
+    /// AAPL is 118 pages over one session, so restarting the symbol to recover one dropped
+    /// connection discards 117 pages. The token names the page, so resuming at it is exact — and
+    /// the ticks either side of the failure must both survive.
+    #[tokio::test]
+    async fn test_a_dropped_page_is_retried_without_losing_the_pages_before_it() {
+        let mut server = mockito::Server::new_async().await;
+        let second = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_query(mockito::Matcher::UrlEncoded(
+                "page_token".into(),
+                "page-two".into(),
+            ))
+            .with_status(500)
+            .with_body("upstream fell over")
+            .expect(1)
+            .create_async()
+            .await;
+        let recovered = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_query(mockito::Matcher::UrlEncoded(
+                "page_token".into(),
+                "page-two".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"quotes":{"AAPL":[
+                    {"t":"2026-08-20T13:30:02Z","bp":100.02,"ap":100.06,"bs":3,"as":4}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+        let first = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"quotes":{"AAPL":[
+                    {"t":"2026-08-20T13:30:00Z","bp":100.00,"ap":100.05,"bs":1,"as":2}
+                ]},"next_page_token":"page-two"}"#,
+            )
+            .create_async()
+            .await;
+
+        let (ticks, fetch) = collect_quotes(server.url()).await;
+        let fetch = fetch.expect("a retried page must not fail the symbol");
+
+        assert_eq!(fetch.retries, 1, "the 500 was retried");
+        assert_eq!(fetch.pages, 2, "a retry is not a second page");
+        assert_eq!(ticks.len(), 2, "page one's tick survived the failure");
+        first.assert_async().await;
+        second.assert_async().await;
+        recovered.assert_async().await;
+    }
+
+    #[test]
+    fn test_a_locked_book_is_usable_and_a_crossed_one_is_not() {
+        let at = Utc.with_ymd_and_hms(2026, 8, 20, 13, 30, 0).unwrap();
+        let locked = QuoteTick::new(at, 100.0, 100.0, 1, 1).expect("a locked book is legal");
+        assert_eq!(locked.spread(), 0.0);
+        assert_eq!(locked.mid_price(), 100.0);
+        assert_eq!(QuoteTick::new(at, 100.1, 100.0, 1, 1), None, "crossed");
+        assert_eq!(
+            QuoteTick::new(at, f64::NAN, 100.0, 1, 1),
+            None,
+            "non-finite"
+        );
     }
 }

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -2467,6 +2467,31 @@ impl MarketDataClient {
     /// is 118 pages over one session, so restarting it to recover one dropped connection discards
     /// 117 pages of work and gives the largest names both the highest failure odds and the dearest
     /// recovery. The token identifies the page, so resuming at it is exact.
+    /// One attempt at one page, with every failure mode expressed as the returned error.
+    ///
+    /// Separated from the retry loop so there is one place an attempt can fail from. A connection
+    /// reset during `send` is the same transport fault as a body that arrives truncated, and the
+    /// two have to be indistinguishable here or only one of them gets retried.
+    async fn attempt_quote_page(
+        &self,
+        url: &str,
+        query: &[(&str, &str)],
+    ) -> Result<QuotesResponse, ClientError> {
+        let response = self
+            .get(url)
+            .query(query)
+            .send()
+            .await
+            .map_err(ClientError::Request)?;
+        // `Request`, not `Parse`: calling a dropped body unparseable cost twelve names their
+        // retries on the first real run.
+        error_for_status(response)
+            .await?
+            .json::<QuotesResponse>()
+            .await
+            .map_err(ClientError::Request)
+    }
+
     async fn quote_page(
         &self,
         url: &str,
@@ -2477,17 +2502,9 @@ impl MarketDataClient {
         let mut retries = 0usize;
         let mut last_error = None;
         for attempt in 0..QUOTES_PAGE_ATTEMPTS {
-            let outcome = match error_for_status(self.get(url).query(query).send().await?).await {
-                // Kept as `Request` rather than flattened to `Parse`. A connection dropped part-way
-                // through a body arrives here, and calling that unparseable cost twelve names their
-                // retries on the first real run.
-                Ok(response) => response
-                    .json::<QuotesResponse>()
-                    .await
-                    .map_err(ClientError::Request),
-                Err(error) => Err(error),
-            };
-            match outcome {
+            // No `?` anywhere in here. Every way the attempt can fail has to reach the match below
+            // or it escapes the retry it was written for -- which is how the send arm was missed.
+            match self.attempt_quote_page(url, query).await {
                 Ok(page) => return Ok(FetchedPage { page, retries }),
                 Err(error) if error.is_transient() => {
                     retries += 1;
@@ -4538,7 +4555,9 @@ mod tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"quotes":{"AAPL":[{"t":"2026-08-20T13:30:00Z","#)
-            .expect(QUOTES_PAGE_ATTEMPTS)
+            // Four, spelled out. Taking it from `QUOTES_PAGE_ATTEMPTS` would let the constant drop
+            // to one and this test would still pass while proving no retry happened at all.
+            .expect(4)
             .create_async()
             .await;
 

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -1014,6 +1014,169 @@ impl EquityQuote {
     }
 }
 
+/// A rate in hundredths of a percent, which is what every spread and cost figure is quoted in.
+///
+/// A type rather than an `f64` because the same spread is `0.0001` as a fraction and `1.0` as basis
+/// points, and nothing about a bare float says which was meant. Non-negative: the rates this carries
+/// are widths and costs, and [`EquityQuote::new`] has already refused the crossed book that would
+/// produce a negative one.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct BasisPoints(f64);
+
+impl BasisPoints {
+    pub fn new(value: f64) -> Option<Self> {
+        (value.is_finite() && value >= 0.0).then_some(Self(value))
+    }
+
+    /// The rate `numerator / denominator` expressed in basis points.
+    ///
+    /// `None` on a denominator of zero rather than an infinity, so a midpoint that should never
+    /// have been zero fails where it is computed instead of downstream of it.
+    pub fn from_ratio(numerator: f64, denominator: f64) -> Option<Self> {
+        if denominator == 0.0 {
+            return None;
+        }
+        Self::new(numerator / denominator * 10_000.0)
+    }
+
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for BasisPoints {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{:.2}bp", self.0)
+    }
+}
+
+/// What the quoted book looked like for one name over one bar, folded from the ticks.
+///
+/// Every average here is weighted by how long the quote prevailed rather than by how many times it
+/// printed, because quote traffic is dominated by flickering that no order ever interacts with. The
+/// two denominators travel with the averages for that reason: `quote_count` is how many updates
+/// arrived and `covered_seconds` is how much of the bar a quote was standing at all.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QuoteSummary {
+    ticker: Ticker,
+    bar_interval: BarInterval,
+    /// UTC timestamp of the period this summary opens, matching the bar it describes.
+    timestamp: DateTime<Utc>,
+    quoted_spread_mean: f64,
+    quoted_spread_basis_points_mean: BasisPoints,
+    quoted_spread_basis_points_median: BasisPoints,
+    quoted_spread_basis_points_ninetieth_percentile: BasisPoints,
+    bid_size_mean: f64,
+    ask_size_mean: f64,
+    quote_count: i64,
+    covered_seconds: f64,
+}
+
+impl QuoteSummary {
+    /// Constructs a `QuoteSummary`, rejecting a fold that cannot have come from real quotes.
+    ///
+    /// A bar nothing was quoted across has no summary rather than a zero-weighted one, so
+    /// `covered_seconds` must be positive; `quote_count` may be zero, which is an illiquid name
+    /// still showing the quote it posted in an earlier bar.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        ticker: Ticker,
+        bar_interval: BarInterval,
+        timestamp: DateTime<Utc>,
+        quoted_spread_mean: f64,
+        quoted_spread_basis_points_mean: BasisPoints,
+        quoted_spread_basis_points_median: BasisPoints,
+        quoted_spread_basis_points_ninetieth_percentile: BasisPoints,
+        bid_size_mean: f64,
+        ask_size_mean: f64,
+        quote_count: i64,
+        covered_seconds: f64,
+    ) -> Result<Self, InconsistentRecordError> {
+        for (name, value) in [
+            ("mean quoted spread", quoted_spread_mean),
+            ("mean bid size", bid_size_mean),
+            ("mean ask size", ask_size_mean),
+        ] {
+            if !value.is_finite() || value < 0.0 {
+                return Err(reject(format!(
+                    "{name} {value} is not a non-negative number"
+                )));
+            }
+        }
+        if !covered_seconds.is_finite() || covered_seconds <= 0.0 {
+            return Err(reject(format!(
+                "covered seconds {covered_seconds} is not a positive number"
+            )));
+        }
+        if quote_count < 0 {
+            return Err(reject(format!("quote count {quote_count} is negative")));
+        }
+        if quoted_spread_basis_points_median > quoted_spread_basis_points_ninetieth_percentile {
+            return Err(reject(format!(
+                "median spread {quoted_spread_basis_points_median} exceeds the ninetieth percentile {quoted_spread_basis_points_ninetieth_percentile}"
+            )));
+        }
+
+        Ok(Self {
+            ticker,
+            bar_interval,
+            timestamp,
+            quoted_spread_mean,
+            quoted_spread_basis_points_mean,
+            quoted_spread_basis_points_median,
+            quoted_spread_basis_points_ninetieth_percentile,
+            bid_size_mean,
+            ask_size_mean,
+            quote_count,
+            covered_seconds,
+        })
+    }
+
+    pub fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    pub fn bar_interval(&self) -> BarInterval {
+        self.bar_interval
+    }
+
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
+    }
+
+    pub fn quoted_spread_mean(&self) -> f64 {
+        self.quoted_spread_mean
+    }
+
+    pub fn quoted_spread_basis_points_mean(&self) -> BasisPoints {
+        self.quoted_spread_basis_points_mean
+    }
+
+    pub fn quoted_spread_basis_points_median(&self) -> BasisPoints {
+        self.quoted_spread_basis_points_median
+    }
+
+    pub fn quoted_spread_basis_points_ninetieth_percentile(&self) -> BasisPoints {
+        self.quoted_spread_basis_points_ninetieth_percentile
+    }
+
+    pub fn bid_size_mean(&self) -> f64 {
+        self.bid_size_mean
+    }
+
+    pub fn ask_size_mean(&self) -> f64 {
+        self.ask_size_mean
+    }
+
+    pub fn quote_count(&self) -> i64 {
+        self.quote_count
+    }
+
+    pub fn covered_seconds(&self) -> f64 {
+        self.covered_seconds
+    }
+}
+
 /// The most recent trade in a symbol, as one snapshot reported it.
 ///
 /// The timestamp is not optional because the last trade is what the pass prices on whenever the
@@ -1883,6 +2046,53 @@ mod tests {
         assert!(quote(103.0, 102.0, 5, 5).is_err(), "crossed book");
         assert!(quote(f64::NAN, 102.0, 5, 5).is_err(), "non-finite bid");
         assert!(quote(100.0, 102.0, -1, 5).is_err(), "negative size");
+    }
+
+    #[test]
+    fn test_basis_points_converts_a_ratio_and_refuses_an_unusable_one() {
+        // AAPL midday on 2026-08-20: a nine-cent book on a $317 midpoint.
+        let measured = BasisPoints::from_ratio(0.09, 317.455).unwrap();
+        assert!((measured.value() - 2.835).abs() < 0.001, "{measured}");
+        assert_eq!(BasisPoints::from_ratio(0.01, 0.0), None, "zero midpoint");
+        assert_eq!(BasisPoints::new(-0.5), None, "a width is not signed");
+        assert_eq!(BasisPoints::new(f64::NAN), None, "non-finite");
+    }
+
+    fn summary(
+        median: f64,
+        ninetieth: f64,
+        quote_count: i64,
+        covered_seconds: f64,
+    ) -> Result<QuoteSummary, InconsistentRecordError> {
+        QuoteSummary::new(
+            ticker("AAPL"),
+            BarInterval::FiveMinute,
+            Utc::now(),
+            0.09,
+            BasisPoints::new(2.84).unwrap(),
+            BasisPoints::new(median).unwrap(),
+            BasisPoints::new(ninetieth).unwrap(),
+            480.0,
+            80.0,
+            quote_count,
+            covered_seconds,
+        )
+    }
+
+    /// Zero arrivals is an illiquid name still showing an earlier bar's quote, which is a real
+    /// reading. Zero covered seconds is a bar nothing was quoted across, which is not a reading at
+    /// all — every average in it would be a division by zero wearing a number's clothes.
+    #[test]
+    fn test_summary_separates_no_arrivals_from_no_coverage() {
+        assert!(summary(2.5, 6.0, 0, 300.0).is_ok(), "no arrivals");
+        assert!(summary(2.5, 6.0, 12, 0.0).is_err(), "no coverage");
+        assert!(summary(2.5, 6.0, -1, 300.0).is_err(), "negative count");
+    }
+
+    #[test]
+    fn test_summary_refuses_quantiles_out_of_order() {
+        assert!(summary(6.0, 2.5, 12, 300.0).is_err());
+        assert!(summary(2.5, 2.5, 12, 300.0).is_ok(), "a flat book ties");
     }
 
     #[test]

--- a/src/data.rs
+++ b/src/data.rs
@@ -11,6 +11,7 @@ pub mod calendar;
 pub mod details;
 pub mod export;
 pub mod purge;
+pub mod quotes;
 pub mod splits;
 pub mod truncate;
 pub mod universe;

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -15,8 +15,11 @@ use tracing::{info, warn};
 use crate::common::alpaca::MarketDataClient;
 use crate::common::aws::{date_from_partitioned_key, date_partitioned_key};
 use crate::common::massive::MassiveClient;
-use crate::common::types::{BarInterval, EquityBar, LiquidityFloor, SessionDate, Ticker};
-use crate::data::{bars, boundaries, splits};
+use crate::common::types::{
+    BarInterval, EquityBar, LiquidityFloor, QuoteSummary, SessionDate, Ticker,
+};
+use crate::data::calendar::TradingCalendar;
+use crate::data::{bars, boundaries, quotes, splits};
 
 /// Root of the bar archive, never a partition prefix on its own — [`bar_archive_prefix`] adds the
 /// cadence, and a key built without one collides with every other cadence of the same session.
@@ -216,7 +219,7 @@ fn sessions_to_request(
         .collect()
 }
 
-/// Sessions the archive already holds within `[start, end]`.
+/// Sessions the bar archive already holds within `[start, end]`.
 async fn present_sessions(
     s3_client: &S3Client,
     bucket: &str,
@@ -226,7 +229,18 @@ async fn present_sessions(
 ) -> Result<BTreeSet<SessionDate>, ArchiveError> {
     // Scoped to the cadence being repaired. Listing the whole bar tree would count an intraday
     // partition as a daily session already present, and the gap scan would stop fetching it.
-    let prefix = bar_archive_prefix(interval);
+    present_partitions(s3_client, bucket, &bar_archive_prefix(interval), start, end).await
+}
+
+/// Sessions that have a partition under `prefix` within `[start, end]`.
+async fn present_partitions(
+    s3_client: &S3Client,
+    bucket: &str,
+    prefix: &str,
+    start: SessionDate,
+    end: SessionDate,
+) -> Result<BTreeSet<SessionDate>, ArchiveError> {
+    let prefix = prefix.to_string();
     let mut present = BTreeSet::new();
     let mut pages = s3_client
         .list_objects_v2()
@@ -1203,6 +1217,294 @@ fn merge_or_replace(
     }
 }
 
+/// Root of the quote-summary archive, beside the bars rather than under them.
+///
+/// `data/equity/bars` is Massive's and this is Alpaca's. One prefix for both would put two vendors'
+/// opinions of the same session under one key, and make whichever job ran second the one that
+/// mattered.
+pub const QUOTE_ARCHIVE_PREFIX: &str = "data/equity/quotes";
+
+/// The archive prefix for one summary cadence, hive-partitioned like the bars.
+pub fn quote_archive_prefix(interval: BarInterval) -> String {
+    format!("{QUOTE_ARCHIVE_PREFIX}/interval={interval}")
+}
+
+/// Names folded at once.
+///
+/// Eight because the endpoint's throughput is the ceiling rather than ours: measured at roughly
+/// 100,000 quotes a second on 2026-08-20, and thirty-two concurrent fetches moved no more than
+/// eight did. More concurrency buys only memory, since each fold holds its session's observations.
+const QUOTE_CONCURRENCY: usize = 8;
+
+/// Attempts per symbol before a session gives up on it.
+///
+/// The second line of defence, not the first: [`MarketDataClient::fetch_quotes`] already retries
+/// the individual page, so what reaches here has failed a page four times running. Load-bearing for
+/// the same reason the intraday one is — nothing downstream can tell a session summarized without
+/// one of its names from a complete one.
+const QUOTE_SYMBOL_ATTEMPTS: usize = 3;
+
+/// What one quote-archiving pass accomplished.
+///
+/// Its own type rather than [`ArchiveSummary`], because the units differ where it matters:
+/// `quotes_folded` counts ticks that were fetched and discarded, and it is the number that decides
+/// whether a backfill is affordable. A session yields roughly 79 summaries per name and hundreds of
+/// thousands of quotes to produce them.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct QuoteArchiveSummary {
+    /// Sessions with no summary yet, and therefore requested.
+    pub sessions_requested: usize,
+    /// Sessions whose summaries were written.
+    pub sessions_written: usize,
+    /// Sessions that could not be summarized: a holiday, or one the daily archive cannot describe.
+    pub sessions_without_data: usize,
+    /// Sessions whose write lost a race, carried rather than fatal.
+    pub sessions_failed: Vec<SessionDate>,
+    /// Summary rows written across both cadences.
+    pub summaries_written: usize,
+    /// Symbols whose quotes could not be fetched after every attempt.
+    pub symbols_failed: usize,
+    /// Quotes folded and discarded, which is what the pass actually cost.
+    pub quotes_folded: usize,
+}
+
+/// Folds the quoted book for every session in `sessions` the archive has no summary for.
+///
+/// Session-major rather than ticker-major, unlike the intraday bar pass: a quote request is already
+/// bounded to one session's hours, so there is nothing to gain by holding a chunk of them.
+///
+/// Regular hours only, taken from the calendar so an early close is 3.5 hours rather than 6.5. The
+/// overnight book is an order of magnitude wider and would swamp any session mean it entered.
+pub async fn archive_quote_sessions(
+    s3_client: &S3Client,
+    market_data: &MarketDataClient,
+    calendar: &TradingCalendar,
+    bucket: &str,
+    sessions: &[SessionDate],
+    floor: LiquidityFloor,
+) -> Result<QuoteArchiveSummary, ArchiveError> {
+    let (Some(first), Some(last)) = (sessions.first(), sessions.last()) else {
+        return Ok(QuoteArchiveSummary::default());
+    };
+    let present = present_partitions(
+        s3_client,
+        bucket,
+        &quote_archive_prefix(BarInterval::OneDay),
+        *first,
+        *last,
+    )
+    .await?;
+    let requested: Vec<SessionDate> = sessions
+        .iter()
+        .copied()
+        .filter(|session| !present.contains(session))
+        .collect();
+
+    info!(
+        window_start = %first,
+        window_end = %last,
+        offered = sessions.len(),
+        present = present.len(),
+        requested = requested.len(),
+        "Planned a quote pass"
+    );
+
+    let mut summary = QuoteArchiveSummary {
+        sessions_requested: requested.len(),
+        ..Default::default()
+    };
+    for session in requested {
+        archive_quote_session(
+            s3_client,
+            market_data,
+            calendar,
+            bucket,
+            session,
+            floor,
+            &mut summary,
+        )
+        .await?;
+    }
+
+    if summary.symbols_failed > 0 {
+        // Warned separately, because this is the outcome nothing re-requests: the partition exists,
+        // so the next pass reads the session as present and never looks inside it.
+        warn!(
+            symbols_failed = summary.symbols_failed,
+            "Some symbols are absent from the summaries this pass wrote; re-run those sessions to repair them"
+        );
+    }
+    info!(
+        sessions_requested = summary.sessions_requested,
+        sessions_written = summary.sessions_written,
+        sessions_without_data = summary.sessions_without_data,
+        sessions_failed = summary.sessions_failed.len(),
+        summaries_written = summary.summaries_written,
+        symbols_failed = summary.symbols_failed,
+        quotes_folded = summary.quotes_folded,
+        "Quote archive updated"
+    );
+    Ok(summary)
+}
+
+/// One session: screen the universe, fold every name's book, write both cadences.
+#[allow(clippy::too_many_arguments)]
+async fn archive_quote_session(
+    s3_client: &S3Client,
+    market_data: &MarketDataClient,
+    calendar: &TradingCalendar,
+    bucket: &str,
+    session: SessionDate,
+    floor: LiquidityFloor,
+    summary: &mut QuoteArchiveSummary,
+) -> Result<(), ArchiveError> {
+    let Some((open, close)) = quotes::trading_hours(calendar, session) else {
+        // A holiday, or a date the fetched calendar does not reach. Neither is a fault, and both
+        // are why the pass counts them rather than failing.
+        summary.sessions_without_data += 1;
+        return Ok(());
+    };
+
+    let daily_key = date_partitioned_key(&bar_archive_prefix(BarInterval::OneDay), session.date());
+    let Some(daily) = read_partition(s3_client, bucket, &daily_key).await? else {
+        // Left unwritten so a later pass retries, rather than summarized against a universe that
+        // never included whatever traded only on the session the daily archive is missing.
+        warn!(%session, "No daily partition to screen against; leaving the session unsummarized");
+        summary.sessions_without_data += 1;
+        return Ok(());
+    };
+    let universe = screen_partition(daily, floor)?;
+    if universe.is_empty() {
+        summary.sessions_without_data += 1;
+        return Ok(());
+    }
+
+    info!(%session, %open, %close, universe = universe.len(), "Folding a session's quoted book");
+    let folded = fold_universe(market_data, session, open, close, &universe, summary).await;
+    if folded.is_empty() {
+        summary.sessions_without_data += 1;
+        return Ok(());
+    }
+    write_quote_partitions(s3_client, bucket, session, folded, summary).await
+}
+
+/// Fans out over the universe, folding each name's session and keeping only the summaries.
+async fn fold_universe(
+    market_data: &MarketDataClient,
+    session: SessionDate,
+    open: DateTime<Utc>,
+    close: DateTime<Utc>,
+    universe: &BTreeSet<Ticker>,
+    summary: &mut QuoteArchiveSummary,
+) -> Vec<QuoteSummary> {
+    let mut pending: Vec<Ticker> = universe.iter().cloned().collect();
+    let mut tasks = tokio::task::JoinSet::new();
+    let mut folded: Vec<QuoteSummary> = Vec::new();
+
+    loop {
+        while tasks.len() < QUOTE_CONCURRENCY {
+            let Some(ticker) = pending.pop() else { break };
+            let client = market_data.clone();
+            tasks.spawn(async move {
+                let mut last_error = None;
+                for attempt in 0..QUOTE_SYMBOL_ATTEMPTS {
+                    match quotes::fold_session(&client, &ticker, session, open, close).await {
+                        Ok(folded) => return Ok(folded),
+                        Err(error) => {
+                            if !error.is_transient() {
+                                return Err((ticker, error));
+                            }
+                            last_error = Some(error);
+                        }
+                    }
+                    tokio::time::sleep(retry_delay(attempt)).await;
+                }
+                Err((
+                    ticker,
+                    last_error.expect("a failed attempt records its error"),
+                ))
+            });
+        }
+        let Some(finished) = tasks.join_next().await else {
+            break;
+        };
+        match finished {
+            Ok(Ok((summaries, fetch))) => {
+                summary.quotes_folded += fetch.received;
+                folded.extend(summaries);
+            }
+            // One symbol's failure costs that symbol, not the session — the other names are already
+            // fetched, and discarding them would mean paying for them twice.
+            Ok(Err((ticker, error))) => {
+                summary.symbols_failed += 1;
+                warn!(%ticker, %session, %error, "A symbol's quote fetch failed; continuing the session");
+            }
+            Err(error) => {
+                summary.symbols_failed += 1;
+                warn!(%error, %session, "A quote fold task did not complete");
+            }
+        }
+    }
+    folded
+}
+
+/// Writes a session's summaries, one partition per cadence, five-minute first.
+///
+/// The order is the recovery rule, not a preference. Presence is read off the daily prefix, so a
+/// pass that dies between the two writes leaves the session looking absent and the next pass redoes
+/// both — where the reverse order would mark it done with its intraday half missing.
+async fn write_quote_partitions(
+    s3_client: &S3Client,
+    bucket: &str,
+    session: SessionDate,
+    folded: Vec<QuoteSummary>,
+    summary: &mut QuoteArchiveSummary,
+) -> Result<(), ArchiveError> {
+    let mut intraday: Vec<QuoteSummary> = Vec::new();
+    let mut daily: Vec<QuoteSummary> = Vec::new();
+    let mut unexpected = 0usize;
+    for row in folded {
+        match row.bar_interval() {
+            BarInterval::FiveMinute => intraday.push(row),
+            BarInterval::OneDay => daily.push(row),
+            // The fold emits exactly the two cadences above; a third is this module's own bug.
+            BarInterval::OneMinute => unexpected += 1,
+        }
+    }
+    if unexpected > 0 {
+        warn!(unexpected, %session, "Discarded quote summaries at a cadence the archive has no prefix for");
+    }
+
+    let mut written = 0usize;
+    for (interval, rows) in [
+        (BarInterval::FiveMinute, intraday),
+        (BarInterval::OneDay, daily),
+    ] {
+        if rows.is_empty() {
+            continue;
+        }
+        let frame = quotes::summaries_to_dataframe(&rows)?;
+        let key = date_partitioned_key(&quote_archive_prefix(interval), session.date());
+        match write_merged(s3_client, bucket, key, frame, |existing, fetched, key| {
+            merge_or_replace(existing, fetched, key)
+        })
+        .await
+        {
+            Ok(()) => written += rows.len(),
+            Err(ArchiveError::Contended { key, attempts }) => {
+                warn!(key, attempts, %session, "Quote partition contended; the next pass will retry it");
+                summary.sessions_failed.push(session);
+                return Ok(());
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    summary.sessions_written += 1;
+    summary.summaries_written += written;
+    Ok(())
+}
+
 /// Fetches the whole splits table and writes it, keeping each row's earliest `first_seen`.
 ///
 /// Not a gap scan like [`archive_missing_sessions`], because there are no gaps to find: the feed
@@ -1509,6 +1811,31 @@ mod tests {
             date_partitioned_key(&bar_archive_prefix(BarInterval::FiveMinute), date),
             "data/equity/bars/interval=five_minute/year=2026/month=08/day=19/data.parquet"
         );
+    }
+
+    /// Quotes are Alpaca's opinion and bars are Massive's. A shared key would put two vendors'
+    /// accounts of one session at one address, and the date inverse must still read the tail so a
+    /// listing recovers the session.
+    #[test]
+    fn test_quote_partitions_sit_beside_the_bars_rather_than_among_them() {
+        let date = NaiveDate::from_ymd_opt(2026, 8, 19).expect("test date must be valid");
+
+        assert_eq!(
+            date_partitioned_key(&quote_archive_prefix(BarInterval::OneDay), date),
+            "data/equity/quotes/interval=one_day/year=2026/month=08/day=19/data.parquet"
+        );
+        assert_eq!(
+            date_partitioned_key(&quote_archive_prefix(BarInterval::FiveMinute), date),
+            "data/equity/quotes/interval=five_minute/year=2026/month=08/day=19/data.parquet"
+        );
+        for interval in BarInterval::ALL {
+            let quotes = date_partitioned_key(&quote_archive_prefix(interval), date);
+            assert_ne!(
+                quotes,
+                date_partitioned_key(&bar_archive_prefix(interval), date)
+            );
+            assert_eq!(date_from_partitioned_key(&quotes), Some(date));
+        }
     }
 
     /// Two cadences of one session must not collide, which is the whole reason the segment exists.

--- a/src/data/quotes.rs
+++ b/src/data/quotes.rs
@@ -1,0 +1,646 @@
+//! The quoted book folded on ingest: ticks in, a dozen numbers per bar out.
+//!
+//! Quotes come from Alpaca rather than Massive; see [`crate::common::alpaca`] for that split.
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use chrono_tz::America::New_York;
+use polars::prelude::*;
+use tracing::warn;
+
+use crate::common::alpaca::{ClientError, MarketDataClient, QuoteFetch, QuoteTick};
+use crate::common::types::{BarInterval, BasisPoints, QuoteSummary, SessionDate, Ticker};
+use crate::data::calendar::TradingCalendar;
+
+/// Seconds in one intraday bucket, matching the five-minute bar grid the archive is built on.
+const BUCKET_SECONDS: i64 = 300;
+
+/// The upper quantile every summary reports beside its median.
+const UPPER_QUANTILE: f64 = 0.9;
+
+/// The column set and order every quote partition is written in.
+///
+/// Declared rather than enforced: nothing projects onto it yet, because nothing reads these
+/// partitions back. What it buys today is that [`summaries_to_dataframe`] is pinned to it by test,
+/// so the shape cannot drift before the reader that will have to project exists.
+pub const QUOTE_FRAME_COLUMNS: [(&str, DataType); 11] = [
+    ("ticker", DataType::String),
+    ("bar_interval", DataType::String),
+    ("timestamp", DataType::Int64),
+    ("quoted_spread_mean", DataType::Float64),
+    ("quoted_spread_basis_points_mean", DataType::Float64),
+    ("quoted_spread_basis_points_median", DataType::Float64),
+    (
+        "quoted_spread_basis_points_ninetieth_percentile",
+        DataType::Float64,
+    ),
+    ("bid_size_mean", DataType::Float64),
+    ("ask_size_mean", DataType::Float64),
+    ("quote_count", DataType::Int64),
+    ("covered_seconds", DataType::Float64),
+];
+
+/// One bar's worth of quoted book, weighed by prevailing time rather than by update count.
+///
+/// The weighting is the whole point of the type. A name's quote traffic is dominated by flicker no
+/// order ever interacts with — AAPL's spread at the open reads 3.44bp weighted by time and 2.99bp
+/// weighted by count, and the second number describes the message rate rather than the market.
+#[derive(Debug, Default)]
+struct SpreadAccumulator {
+    covered_seconds: f64,
+    spread_weighted: f64,
+    spread_basis_points_weighted: f64,
+    bid_size_weighted: f64,
+    ask_size_weighted: f64,
+    quote_count: i64,
+    /// `(spread in basis points, seconds it prevailed)`, which the quantiles are read off.
+    observations: Vec<(f64, f64)>,
+}
+
+impl SpreadAccumulator {
+    /// Records that `tick` was the standing book for `seconds`.
+    fn add(&mut self, tick: &QuoteTick, spread_basis_points: f64, seconds: f64) {
+        self.covered_seconds += seconds;
+        self.spread_weighted += tick.spread() * seconds;
+        self.spread_basis_points_weighted += spread_basis_points * seconds;
+        self.bid_size_weighted += f64::from(tick.bid_size()) * seconds;
+        self.ask_size_weighted += f64::from(tick.ask_size()) * seconds;
+        self.observations.push((spread_basis_points, seconds));
+    }
+
+    /// Takes everything `other` accumulated, leaving it empty.
+    ///
+    /// How the session figure is built: it is the merge of its own buckets rather than a second
+    /// pass, so the two cadences cannot disagree about the session they describe.
+    fn absorb(&mut self, other: &mut Self) {
+        self.covered_seconds += other.covered_seconds;
+        self.spread_weighted += other.spread_weighted;
+        self.spread_basis_points_weighted += other.spread_basis_points_weighted;
+        self.bid_size_weighted += other.bid_size_weighted;
+        self.ask_size_weighted += other.ask_size_weighted;
+        self.quote_count += other.quote_count;
+        self.observations.append(&mut other.observations);
+    }
+
+    /// Reduces the fold to a summary, or `None` when there is nothing coherent to report.
+    ///
+    /// Sorts in place, so the observations are left ordered by spread for whoever absorbs them.
+    fn summarize(
+        &mut self,
+        ticker: &Ticker,
+        bar_interval: BarInterval,
+        timestamp: DateTime<Utc>,
+    ) -> Option<QuoteSummary> {
+        if self.covered_seconds <= 0.0 {
+            return None;
+        }
+        self.observations
+            .sort_unstable_by(|left, right| left.0.total_cmp(&right.0));
+
+        let weight = self.covered_seconds;
+        let summary = QuoteSummary::new(
+            ticker.clone(),
+            bar_interval,
+            timestamp,
+            self.spread_weighted / weight,
+            BasisPoints::new(self.spread_basis_points_weighted / weight)?,
+            BasisPoints::new(quantile(&self.observations, weight, 0.5)?)?,
+            BasisPoints::new(quantile(&self.observations, weight, UPPER_QUANTILE)?)?,
+            self.bid_size_weighted / weight,
+            self.ask_size_weighted / weight,
+            self.quote_count,
+            weight,
+        );
+        match summary {
+            Ok(summary) => Some(summary),
+            // A fold that cannot make a coherent summary is this module's bug, not the feed's, and
+            // dropping the bar keeps one arithmetic slip from poisoning a whole session's archive.
+            Err(error) => {
+                warn!(%ticker, %bar_interval, %timestamp, %error, "Discarded an incoherent quote fold");
+                None
+            }
+        }
+    }
+}
+
+/// The spread that `quantile` of the fold's time was spent at or below.
+///
+/// No interpolation: the reported figure is one an order could actually have faced, which matters
+/// more here than a smooth estimate because a spread is quantized to the tick. `observations` must
+/// already be sorted by spread.
+fn quantile(observations: &[(f64, f64)], weight: f64, quantile: f64) -> Option<f64> {
+    if weight <= 0.0 {
+        return None;
+    }
+    let target = weight * quantile;
+    let mut cumulative = 0.0;
+    for (spread_basis_points, seconds) in observations {
+        cumulative += seconds;
+        if cumulative >= target {
+            return Some(*spread_basis_points);
+        }
+    }
+    // Reachable only through floating-point drift in the running sum, since the last observation's
+    // cumulative weight is `weight` itself and the target never exceeds it.
+    observations.last().map(|(spread, _)| *spread)
+}
+
+/// Accumulates one name's session into a five-minute grid and the session that grid sums to.
+///
+/// Fed tick by tick and never holding them: the ticks a session's fetch delivers run to most of a
+/// million, and what survives is one summary per bucket.
+pub struct SessionFold {
+    ticker: Ticker,
+    session: SessionDate,
+    open: DateTime<Utc>,
+    close: DateTime<Utc>,
+    buckets: Vec<SpreadAccumulator>,
+    previous: Option<QuoteTick>,
+    out_of_order: usize,
+}
+
+impl SessionFold {
+    /// Opens a fold over `[open, close)`, which must be a positive interval.
+    ///
+    /// The bounds are the session's own trading hours, so an early close is 3.5 hours of buckets
+    /// rather than 6.5 — folding to a fixed 16:00 would weigh three hours of post-close book into
+    /// a figure that is supposed to describe the session.
+    pub fn new(
+        ticker: Ticker,
+        session: SessionDate,
+        open: DateTime<Utc>,
+        close: DateTime<Utc>,
+    ) -> Option<Self> {
+        let span = (close - open).num_milliseconds();
+        if span <= 0 {
+            return None;
+        }
+        // Rounded up, so a session whose close does not land on the grid keeps its short last
+        // bucket rather than dropping the minutes past the final boundary.
+        let bucket_milliseconds = BUCKET_SECONDS * 1_000;
+        let buckets = ((span + bucket_milliseconds - 1) / bucket_milliseconds) as usize;
+        Some(Self {
+            ticker,
+            session,
+            open,
+            close,
+            buckets: (0..buckets).map(|_| SpreadAccumulator::default()).collect(),
+            previous: None,
+            out_of_order: 0,
+        })
+    }
+
+    /// Accepts the next tick, which closes out the interval the previous one prevailed for.
+    ///
+    /// A tick older than the one before it is counted and dropped rather than weighed: the fold
+    /// measures forward from each quote to the next, so a backwards step would subtract time.
+    pub fn push(&mut self, tick: QuoteTick) {
+        if let Some(previous) = self.previous {
+            if tick.timestamp() < previous.timestamp() {
+                self.out_of_order += 1;
+                return;
+            }
+            self.weigh(&previous, tick.timestamp());
+        }
+        if let Some(index) = self.bucket_index(tick.timestamp()) {
+            self.buckets[index].quote_count += 1;
+        }
+        self.previous = Some(tick);
+    }
+
+    /// Closes the fold, returning the five-minute summaries followed by the session's.
+    ///
+    /// The session summary is the merge of the buckets rather than a separate accumulation, so the
+    /// two cadences describe the same weight by construction.
+    pub fn finish(mut self) -> Vec<QuoteSummary> {
+        if let Some(previous) = self.previous.take() {
+            // The standing quote prevails to the close; nothing else marks the end of its interval.
+            self.weigh(&previous, self.close);
+        }
+        if self.out_of_order > 0 {
+            warn!(
+                ticker = %self.ticker,
+                session = %self.session,
+                out_of_order = self.out_of_order,
+                "Dropped quotes that arrived older than the one before them"
+            );
+        }
+
+        let mut session = SpreadAccumulator::default();
+        let mut summaries = Vec::with_capacity(self.buckets.len() + 1);
+        for (index, mut bucket) in std::mem::take(&mut self.buckets).into_iter().enumerate() {
+            let opens_at = self.open + Duration::seconds(BUCKET_SECONDS * index as i64);
+            if let Some(summary) = bucket.summarize(&self.ticker, BarInterval::FiveMinute, opens_at)
+            {
+                summaries.push(summary);
+            }
+            session.absorb(&mut bucket);
+        }
+        summaries.extend(session.summarize(
+            &self.ticker,
+            BarInterval::OneDay,
+            daily_stamp(self.session),
+        ));
+        summaries
+    }
+
+    /// Weighs `quote` across every bucket its prevailing interval touches.
+    ///
+    /// Split rather than assigned whole, so a quote standing across a boundary contributes to both
+    /// buckets — which is what makes the five-minute rows sum back to the session row.
+    fn weigh(&mut self, quote: &QuoteTick, until: DateTime<Utc>) {
+        let from = quote.timestamp().max(self.open);
+        let until = until.min(self.close);
+        if until <= from {
+            return;
+        }
+        let Some(spread_basis_points) = BasisPoints::from_ratio(quote.spread(), quote.mid_price())
+        else {
+            return;
+        };
+
+        let mut cursor = from;
+        while cursor < until {
+            let Some(index) = self.bucket_index(cursor) else {
+                return;
+            };
+            let boundary =
+                (self.open + Duration::seconds(BUCKET_SECONDS * (index as i64 + 1))).min(until);
+            // Nanoseconds, not milliseconds: truncating loses a quarter of one per quote, which
+            // cost AAPL 211 seconds of a 23,400-second session. One bucket cannot overflow it.
+            let seconds = (boundary - cursor)
+                .num_nanoseconds()
+                .expect("an interval of at most one bucket fits in nanoseconds")
+                as f64
+                / 1e9;
+            self.buckets[index].add(quote, spread_basis_points.value(), seconds);
+            cursor = boundary;
+        }
+    }
+
+    /// Which bucket an instant falls in, or `None` outside the session.
+    fn bucket_index(&self, instant: DateTime<Utc>) -> Option<usize> {
+        if instant < self.open || instant >= self.close {
+            return None;
+        }
+        let offset = (instant - self.open).num_milliseconds() / (BUCKET_SECONDS * 1_000);
+        let index = usize::try_from(offset).ok()?;
+        (index < self.buckets.len()).then_some(index)
+    }
+}
+
+/// The instant the archive stamps a session's daily row at, which is 16:00 Eastern.
+///
+/// Not the session's own close. An early-close day still carries a 16:00 stamp in the daily bar
+/// archive — 2025-11-28 does — so reading the calendar here would put the summary three hours from
+/// the bar it is meant to join.
+fn daily_stamp(session: SessionDate) -> DateTime<Utc> {
+    let local_close = session
+        .date()
+        .and_hms_opt(16, 0, 0)
+        .expect("16:00 is a valid wall-clock time");
+    New_York
+        .from_local_datetime(&local_close)
+        .earliest()
+        .map(|zoned| zoned.with_timezone(&Utc))
+        .unwrap_or_else(|| local_close.and_utc())
+}
+
+/// The UTC instants bounding one session's regular hours, or `None` if it did not trade.
+///
+/// Read from the published calendar rather than assumed, so an early close bounds at 13:00 and the
+/// three hours of post-close book that follow it never enter a session figure.
+pub fn trading_hours(
+    calendar: &TradingCalendar,
+    session: SessionDate,
+) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+    let day = calendar.session(session)?;
+    let eastern = |time| {
+        New_York
+            .from_local_datetime(&session.date().and_time(time))
+            .earliest()
+            .map(|zoned| zoned.with_timezone(&Utc))
+    };
+    Some((eastern(day.session_open())?, eastern(day.session_close())?))
+}
+
+/// Folds one name's session, holding the ticks only long enough to weigh each one.
+///
+/// The pair it returns is the summaries and what they cost: the tick count is the only trace the
+/// fetch leaves, and it is what decides whether a wider backfill is affordable.
+pub async fn fold_session(
+    market_data: &MarketDataClient,
+    ticker: &Ticker,
+    session: SessionDate,
+    open: DateTime<Utc>,
+    close: DateTime<Utc>,
+) -> Result<(Vec<QuoteSummary>, QuoteFetch), ClientError> {
+    let Some(mut fold) = SessionFold::new(ticker.clone(), session, open, close) else {
+        return Err(ClientError::Parse(format!(
+            "{session} spans no time between {open} and {close}"
+        )));
+    };
+    let fetch = market_data
+        .fetch_quotes(ticker, open, close, |tick| fold.push(tick))
+        .await?;
+    Ok((fold.finish(), fetch))
+}
+
+/// Builds the canonical quote frame, in [`QUOTE_FRAME_COLUMNS`] order.
+pub fn summaries_to_dataframe(summaries: &[QuoteSummary]) -> Result<DataFrame, PolarsError> {
+    let mut tickers: Vec<String> = Vec::with_capacity(summaries.len());
+    let mut intervals: Vec<String> = Vec::with_capacity(summaries.len());
+    let mut timestamps: Vec<i64> = Vec::with_capacity(summaries.len());
+    let mut spread_means: Vec<f64> = Vec::with_capacity(summaries.len());
+    let mut basis_point_means: Vec<f64> = Vec::with_capacity(summaries.len());
+    let mut medians: Vec<f64> = Vec::with_capacity(summaries.len());
+    let mut ninetieths: Vec<f64> = Vec::with_capacity(summaries.len());
+    let mut bid_sizes: Vec<f64> = Vec::with_capacity(summaries.len());
+    let mut ask_sizes: Vec<f64> = Vec::with_capacity(summaries.len());
+    let mut counts: Vec<i64> = Vec::with_capacity(summaries.len());
+    let mut covered: Vec<f64> = Vec::with_capacity(summaries.len());
+
+    for summary in summaries {
+        tickers.push(summary.ticker().to_string());
+        intervals.push(summary.bar_interval().as_str().to_string());
+        timestamps.push(summary.timestamp().timestamp_millis());
+        spread_means.push(summary.quoted_spread_mean());
+        basis_point_means.push(summary.quoted_spread_basis_points_mean().value());
+        medians.push(summary.quoted_spread_basis_points_median().value());
+        ninetieths.push(
+            summary
+                .quoted_spread_basis_points_ninetieth_percentile()
+                .value(),
+        );
+        bid_sizes.push(summary.bid_size_mean());
+        ask_sizes.push(summary.ask_size_mean());
+        counts.push(summary.quote_count());
+        covered.push(summary.covered_seconds());
+    }
+
+    DataFrame::new(vec![
+        Column::new("ticker".into(), tickers),
+        Column::new("bar_interval".into(), intervals),
+        Column::new("timestamp".into(), timestamps),
+        Column::new("quoted_spread_mean".into(), spread_means),
+        Column::new("quoted_spread_basis_points_mean".into(), basis_point_means),
+        Column::new("quoted_spread_basis_points_median".into(), medians),
+        Column::new(
+            "quoted_spread_basis_points_ninetieth_percentile".into(),
+            ninetieths,
+        ),
+        Column::new("bid_size_mean".into(), bid_sizes),
+        Column::new("ask_size_mean".into(), ask_sizes),
+        Column::new("quote_count".into(), counts),
+        Column::new("covered_seconds".into(), covered),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chrono::NaiveDate;
+
+    /// Spreads are ratios of decimal prices no binary float represents exactly, so the fold's
+    /// arithmetic lands within a rounding error of the literal rather than on it.
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    fn ticker() -> Ticker {
+        Ticker::new("AAPL").expect("AAPL is a valid ticker")
+    }
+
+    fn session() -> SessionDate {
+        SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 8, 20).expect("a real date"))
+    }
+
+    fn at(minute: u32, second: u32) -> DateTime<Utc> {
+        session()
+            .date()
+            .and_hms_opt(13, minute, second)
+            .expect("a valid wall clock")
+            .and_utc()
+    }
+
+    fn tick(minute: u32, bid: f64, ask: f64, bid_size: i32, ask_size: i32) -> QuoteTick {
+        QuoteTick::new(at(minute, 0), bid, ask, bid_size, ask_size).expect("a usable book")
+    }
+
+    /// Two quotes over two buckets: a ten-basis-point book standing from 13:30 to 13:36, then a
+    /// two-basis-point book standing to the 13:40 close.
+    fn folded() -> Vec<QuoteSummary> {
+        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(40, 0))
+            .expect("a positive session");
+        fold.push(tick(30, 99.95, 100.05, 100, 200));
+        fold.push(tick(36, 99.99, 100.01, 300, 400));
+        fold.finish()
+    }
+
+    #[test]
+    fn test_a_quote_standing_across_a_boundary_is_split_between_both_buckets() {
+        let summaries = folded();
+        assert_eq!(summaries.len(), 3, "two buckets and the session");
+
+        // The 13:30 book prevailed 360 seconds, 300 of them in the first bucket and 60 in the
+        // second. Assigning it whole to either one would leave a bucket at 600 or 0 seconds.
+        assert_eq!(summaries[0].covered_seconds(), 300.0);
+        assert_eq!(summaries[1].covered_seconds(), 300.0);
+        assert_close(summaries[0].quoted_spread_basis_points_mean().value(), 10.0);
+        assert_close(summaries[1].quoted_spread_basis_points_mean().value(), 3.6);
+    }
+
+    /// The property that makes two cadences safe to publish side by side: they describe the same
+    /// weight, because the session figure is the merge of the buckets rather than a second pass.
+    #[test]
+    fn test_the_five_minute_rows_sum_back_to_the_session_row() {
+        let summaries = folded();
+        let session_summary = summaries.last().expect("a session summary");
+        assert_eq!(session_summary.bar_interval(), BarInterval::OneDay);
+
+        let buckets = &summaries[..summaries.len() - 1];
+        let covered: f64 = buckets.iter().map(QuoteSummary::covered_seconds).sum();
+        assert_eq!(covered, session_summary.covered_seconds());
+        assert_eq!(covered, 600.0);
+
+        let weighted: f64 = buckets
+            .iter()
+            .map(|bucket| {
+                bucket.quoted_spread_basis_points_mean().value() * bucket.covered_seconds()
+            })
+            .sum();
+        assert_close(weighted / covered, 6.8);
+        assert_close(
+            session_summary.quoted_spread_basis_points_mean().value(),
+            6.8,
+        );
+    }
+
+    /// Weighting by count instead would read 6.0 here. It reads 6.0 on AAPL's open too, against a
+    /// time-weighted 3.44 — the count is a message rate, not a market.
+    #[test]
+    fn test_the_mean_is_weighted_by_time_rather_than_by_update_count() {
+        let session_summary = folded().pop().expect("a session summary");
+        assert_close(
+            session_summary.quoted_spread_basis_points_mean().value(),
+            6.8,
+        );
+        assert!(
+            (session_summary.quoted_spread_basis_points_mean().value() - 6.0).abs() > 0.5,
+            "the unweighted mean of 10bp and 2bp is 6.0"
+        );
+        assert_close(session_summary.quoted_spread_mean(), 0.068);
+        assert_close(session_summary.bid_size_mean(), 180.0);
+        assert_close(session_summary.ask_size_mean(), 280.0);
+    }
+
+    /// Read off prevailing time, not off the update stream: the two-basis-point book held 240 of
+    /// the second bucket's 300 seconds, so it is the median even though it is one quote of two.
+    #[test]
+    fn test_the_quantiles_are_weighted_by_time_too() {
+        let summaries = folded();
+        assert_close(
+            summaries[1].quoted_spread_basis_points_median().value(),
+            2.0,
+        );
+        assert_close(
+            summaries[1]
+                .quoted_spread_basis_points_ninetieth_percentile()
+                .value(),
+            10.0,
+        );
+    }
+
+    /// Nothing else marks the end of the last quote's interval, so without this the session loses
+    /// however long the final book stood — four minutes of the ten here.
+    #[test]
+    fn test_the_last_quote_prevails_to_the_close() {
+        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(40, 0))
+            .expect("a positive session");
+        fold.push(tick(30, 99.95, 100.05, 100, 200));
+        let session_summary = fold.finish().pop().expect("a session summary");
+        assert_eq!(session_summary.covered_seconds(), 600.0);
+        assert_eq!(session_summary.quote_count(), 1);
+    }
+
+    /// The fold measures forward from each quote to the next, so a backwards step would subtract
+    /// time from the bucket it landed in.
+    #[test]
+    fn test_a_tick_older_than_the_one_before_it_is_dropped() {
+        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(40, 0))
+            .expect("a positive session");
+        fold.push(tick(30, 99.95, 100.05, 100, 200));
+        fold.push(tick(36, 99.99, 100.01, 300, 400));
+        fold.push(tick(33, 99.00, 101.00, 100, 100));
+        let summaries = fold.finish();
+
+        let session_summary = summaries.last().expect("a session summary");
+        assert_eq!(session_summary.quote_count(), 2, "the third is not counted");
+        assert_eq!(session_summary.covered_seconds(), 600.0);
+        assert_close(
+            session_summary.quoted_spread_basis_points_mean().value(),
+            6.8,
+        );
+    }
+
+    /// A name that stops quoting has bars with no book at all, and a zero-weighted row would put a
+    /// zero spread into a cost model rather than an absence.
+    #[test]
+    fn test_a_bucket_no_quote_stood_across_produces_no_row() {
+        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(45, 0))
+            .expect("a positive session");
+        fold.push(tick(40, 99.95, 100.05, 100, 200));
+        let summaries = fold.finish();
+
+        // Three buckets exist; only the one holding the quote and the session are summarized.
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].timestamp(), at(40, 0));
+        assert_eq!(summaries[0].covered_seconds(), 300.0);
+    }
+
+    /// A quote arriving before the fold opens still prevails into it, but only the part inside the
+    /// session is weighed — otherwise a pre-open book would stretch the denominator.
+    #[test]
+    fn test_weight_outside_the_session_bounds_is_not_counted() {
+        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(40, 0))
+            .expect("a positive session");
+        fold.push(QuoteTick::new(at(20, 0), 99.95, 100.05, 100, 200).expect("a usable book"));
+        let session_summary = fold.finish().pop().expect("a session summary");
+        assert_eq!(session_summary.covered_seconds(), 600.0);
+        assert_eq!(
+            session_summary.quote_count(),
+            0,
+            "it arrived before the session opened"
+        );
+    }
+
+    /// Found against real data, not in review. Truncating each interval to a whole millisecond
+    /// cost AAPL 211 seconds of a 23,400-second session on 2026-08-20 — a quarter of a millisecond
+    /// per quote, 846,000 times — while every mean it fed still looked entirely plausible.
+    #[test]
+    fn test_sub_millisecond_intervals_are_weighed_rather_than_truncated() {
+        let opens = at(30, 0);
+        let mut fold = SessionFold::new(
+            ticker(),
+            session(),
+            opens,
+            opens + Duration::milliseconds(1),
+        )
+        .expect("a positive session");
+        fold.push(QuoteTick::new(opens, 99.95, 100.05, 100, 200).expect("a usable book"));
+        fold.push(
+            QuoteTick::new(
+                opens + Duration::nanoseconds(500_000),
+                99.99,
+                100.01,
+                100,
+                200,
+            )
+            .expect("a usable book"),
+        );
+
+        let session_summary = fold
+            .finish()
+            .pop()
+            .expect("half a millisecond of book is still book");
+        assert_close(session_summary.covered_seconds(), 0.001);
+        assert_close(
+            session_summary.quoted_spread_basis_points_mean().value(),
+            6.0,
+        );
+    }
+
+    #[test]
+    fn test_a_session_with_no_span_is_refused() {
+        assert!(SessionFold::new(ticker(), session(), at(40, 0), at(40, 0)).is_none());
+        assert!(SessionFold::new(ticker(), session(), at(40, 0), at(30, 0)).is_none());
+    }
+
+    /// Pinned to the stamp the daily bar archive actually carries, which 2025-11-28 shows is 16:00
+    /// Eastern even though that session closed at 13:00.
+    #[test]
+    fn test_the_session_row_is_stamped_where_the_daily_bar_is() {
+        let early_close =
+            SessionDate::from_date(NaiveDate::from_ymd_opt(2025, 11, 28).expect("a real date"));
+        assert_eq!(
+            daily_stamp(early_close).to_rfc3339(),
+            "2025-11-28T21:00:00+00:00"
+        );
+        assert_eq!(
+            daily_stamp(session()).to_rfc3339(),
+            "2026-08-20T20:00:00+00:00"
+        );
+    }
+
+    #[test]
+    fn test_the_frame_column_set_and_order_is_fixed() {
+        let frame = summaries_to_dataframe(&folded()).expect("a frame");
+        let names: Vec<&str> = frame.get_column_names_str();
+        let expected: Vec<&str> = QUOTE_FRAME_COLUMNS.iter().map(|(name, _)| *name).collect();
+        assert_eq!(names, expected);
+        assert_eq!(frame.height(), 3);
+    }
+}

--- a/src/data/quotes.rs
+++ b/src/data/quotes.rs
@@ -67,11 +67,12 @@ impl SpreadAccumulator {
         self.observations.push((spread_basis_points, seconds));
     }
 
-    /// Takes everything `other` accumulated, leaving it empty.
+    /// Takes everything `other` accumulated, consuming it.
     ///
     /// How the session figure is built: it is the merge of its own buckets rather than a second
-    /// pass, so the two cadences cannot disagree about the session they describe.
-    fn absorb(&mut self, other: &mut Self) {
+    /// pass, so the two cadences cannot disagree about the session they describe. By value rather
+    /// than by `&mut`, so a bucket cannot be absorbed twice and double-count itself.
+    fn absorb(&mut self, mut other: Self) {
         self.covered_seconds += other.covered_seconds;
         self.spread_weighted += other.spread_weighted;
         self.spread_basis_points_weighted += other.spread_basis_points_weighted;
@@ -233,7 +234,7 @@ impl SessionFold {
             {
                 summaries.push(summary);
             }
-            session.absorb(&mut bucket);
+            session.absorb(bucket);
         }
         summaries.extend(session.summarize(
             &self.ticker,


### PR DESCRIPTION
# Overview

Measures the bid-ask spread instead of assuming it. Every study to date costs against `EFFECTIVE_SPREAD_BASIS_POINTS = 10.0`, one literal in one binary, derived from Roll over the whole archive — and at least one strategy was retired on that assumption rather than on an absence of signal.

## Changes

- `common::types`: `BasisPoints`, a validated non-negative rate whose `from_ratio` refuses a zero denominator, so no spread figure is ever a bare `f64`; and `QuoteSummary`, which refuses a fold with no coverage or quantiles out of order.
- `common::alpaca`: `QuoteTick` (carrying no `Ticker`, because a name-session is up to 850k of them), `fetch_quotes` streaming pages through a caller's fold, per-page retry at the page's own token, and `ClientError::is_transient` so the error answers for its own kind.
- `data::quotes`: the fold. Time-weighted throughout, splitting each quote's prevailing interval across bucket boundaries so the five-minute rows sum back to the session row by construction rather than by a second pass.
- `data::archive`: `data/equity/quotes/`, session-major, both cadences over the existing compare-and-swap. Five-minute is written first so a pass that dies between the two writes leaves the session looking absent and the next pass redoes it.
- `bin/seed_quotes_s3`: archive mode over a session stride, plus a measure mode that writes nothing.

## Context

**Time-weighted, including the quantiles.** Quote traffic is dominated by flicker no order interacts with — AAPL's opening bucket reads 3.44bp time-weighted against 2.99bp count-weighted, and the second number describes the message rate rather than the market.

**Both cadences, and the five-minute one earns its place immediately.** Costing the retired overnight effect at its universe's session mean gives 4.04bp gross against 4.67bp, a marginal loss that looks worth reopening. But it buys at the close and sells at the open, and those buckets cost 4.81bp and 14.64bp — so the round trip is 9.73bp and the original verdict stands. A session mean would have resurrected a dead strategy.

**What the measurement says about the 10bp literal.** It was an accurate mean for the universe it was derived on (10.16bp measured, within 2%). The defect is transferring it: the screen task 1 shipped now costs 13.62bp, the overnight study's liquid variant costs 4.67bp, and the deciles span 0.22bp to 321bp.

**Regular hours only**, from the published calendar so an early close bounds at 13:00; the overnight book is an order of magnitude wider and would swamp any session figure. **SIP is pinned** rather than read from `ALPACA_DATA_FEED`, because IEX's best bid and offer is not the national one. **Naming symbols measures rather than archives** — a partition holding only the named names would read as complete to the next pass, the defect #1102 fixed for bars, avoided here by construction.

### Three defects found by running against the feed

None was visible to a passing test suite, and all three shipped plausible-looking numbers.

1. `num_milliseconds()` truncated each prevailing interval — a quarter of a millisecond per quote over AAPL's 846,305 discarded **211 seconds of a 23,400-second session**, and the mean it fed read 1.12bp against a true 1.13bp. Caught by diffing against an independently written reference that agreed to the last digit on everything else.
2. `reqwest` reports a body that did not arrive through the same error as a body that is not JSON. Flattening both to `ClientError::Parse` and calling `Parse` permanent cost **12 names their retries**, and the partition they were missing from read as complete.
3. A retry restarted the whole symbol. AAPL is 118 pages, so one dropped page discarded 117 pages of work — giving the largest names both the highest failure odds and the dearest recovery.

The last two share a cause with the findings on #1101 and #1102: a sentence written about what the code does, then reasoned from without checking.

### Verification

`devenv tasks run checks:all` passes; coverage 80.8% overall, `data/quotes.rs` 90.3%, `common/alpaca.rs` 94.7%. Every new assertion was proven load-bearing by breaking the code and watching it fail.

Against real Alpaca SIP data rather than fixtures: the fold matches an independent Python reference to the last printed digit on mean, median, ninetieth percentile and quote count for AAPL, CBOE, MAA and SBSW, and the archived partitions reproduce those figures exactly. CBOE reads 17.6bp, independently confirming the Roll estimate that motivated this work.

Seeded to the development bucket: 2026-08-17 to 2026-08-21, **1.4B quotes folded into 697,569 summary rows**, every one of 8,730 name-sessions carrying a complete 78-bucket grid plus its session row.

### Deliberately not included

No end-of-day schedule wiring, and no `scan_quote_symbols` equivalent to `scan_intraday_symbols` — so a name that fails every retry leaves a partition that still reads as complete. The page-level retry took failures from twelve per session to zero, and building a repair mode against a problem that no longer reproduces is speculative.

The seeded week is a **provisional cost basis**: it cannot detect whether spreads have trended across the archive's five years, and if they have narrowed it prices old strategies too cheaply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9MuPyHx1o8E6X9cPZcCNZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added historical quote data processing with spread, midpoint, bid/ask size, coverage, and percentile statistics.
  - Added five-minute and daily quote summaries for supported trading sessions.
  - Added quote data archiving with session screening, retries, and holiday handling.
  - Added a command-line tool to archive quote sessions or measure selected symbols across date ranges.
  - Added validation and reporting for malformed quotes, incomplete data, and session-level failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->