### PR TITLE
Let a quote repair widen a session it did not seed

### DIFF
--- a/src/bin/seed_quotes_s3.rs
+++ b/src/bin/seed_quotes_s3.rs
@@ -51,14 +51,16 @@ struct Parameters {
 
 impl Parameters {
     fn parse(arguments: &[String]) -> Result<Self, String> {
-        let (start, end, stride, symbols, mode) = match arguments {
-            [start, end] => (start, end, None, None, None),
-            [start, end, stride] => (start, end, Some(stride), None, None),
+        // `named` pairs the symbol list with its mode, because a mode without symbols is not a
+        // state the arguments can express and should not be a branch anyone has to read.
+        let (start, end, stride, named) = match arguments {
+            [start, end] => (start, end, None, None),
+            [start, end, stride] => (start, end, Some(stride), None),
             // Positional after the stride, so measuring named symbols means stating the stride
             // rather than having it inferred from an argument that could be either.
-            [start, end, stride, symbols] => (start, end, Some(stride), Some(symbols), None),
+            [start, end, stride, symbols] => (start, end, Some(stride), Some((symbols, None))),
             [start, end, stride, symbols, mode] => {
-                (start, end, Some(stride), Some(symbols), Some(mode))
+                (start, end, Some(stride), Some((symbols, Some(mode))))
             }
             _ => {
                 return Err(format!(
@@ -84,18 +86,20 @@ impl Parameters {
                 })?,
         };
 
-        // Trimmed before matching, so a whitespace-padded mode word is not read as something else.
-        let mode = match (symbols.map(|raw| raw.trim()), mode.map(|raw| raw.trim())) {
-            (None, None) => Mode::Archive,
-            (None, Some(_)) => {
-                return Err(format!("MODE requires a symbol list to act on\n{USAGE}"))
-            }
-            (Some(raw), None) | (Some(raw), Some("measure")) => Mode::Measure(parse_symbols(raw)?),
-            (Some(raw), Some("repair")) => Mode::Repair(parse_symbols(raw)?),
-            (Some(_), Some(other)) => {
-                return Err(format!(
-                    "MODE must be measure or repair, got {other:?}\n{USAGE}"
-                ))
+        let mode = match named {
+            None => Mode::Archive,
+            Some((symbols, mode)) => {
+                let symbols = parse_symbols(symbols)?;
+                // Trimmed before matching, so a padded mode word is not read as an unknown one.
+                match mode.map(|raw| raw.trim()) {
+                    None | Some("measure") => Mode::Measure(symbols),
+                    Some("repair") => Mode::Repair(symbols),
+                    Some(other) => {
+                        return Err(format!(
+                            "MODE must be measure or repair, got {other:?}\n{USAGE}"
+                        ))
+                    }
+                }
             }
         };
 
@@ -411,16 +415,17 @@ mod tests {
         .is_err());
     }
 
-    /// A mode with nothing to act on is a mistake worth refusing rather than a no-op: the caller
-    /// meant to name symbols and did not.
+    /// A mode names what to do with a symbol list, so the two travel together and "a mode with no
+    /// symbols" is not a state the arguments can express. What is left to refuse is a sixth one.
     #[test]
-    fn test_a_mode_without_symbols_is_refused() {
+    fn test_arguments_past_the_mode_are_refused() {
         assert!(Parameters::parse(&arguments(&[
             "2026-08-03",
             "2026-08-21",
             "21",
-            "",
-            "repair"
+            "AAPL",
+            "repair",
+            "extra"
         ]))
         .is_err());
     }

--- a/src/bin/seed_quotes_s3.rs
+++ b/src/bin/seed_quotes_s3.rs
@@ -10,29 +10,36 @@ use tracing::{error, info};
 use fund::common::alpaca::{AlpacaCredentials, DataFeed, MarketDataClient, TradingClient};
 use fund::common::log::init_tracing;
 use fund::common::types::{LiquidityFloor, QuoteSummary, SessionDate, Ticker};
-use fund::data::archive;
+use fund::data::archive::{self, QuoteScope};
 use fund::data::calendar::TradingCalendar;
 use fund::data::quotes;
 
-const USAGE: &str = "Usage: seed_quotes_s3 START_DATE END_DATE [STRIDE [SYMBOLS]]\n\
+const USAGE: &str = "Usage: seed_quotes_s3 START_DATE END_DATE [STRIDE [SYMBOLS [MODE]]]\n\
                      Dates are Eastern calendar dates, inclusive: YYYY-MM-DD.\n\
                      STRIDE samples every Nth trading session from START_DATE (default 1).\n\
                      A stride that is a multiple of 5 samples one weekday forever; 21 does not.\n\
                      SYMBOLS is a comma-separated list, and naming it requires naming STRIDE too.\n\
-                     Naming symbols measures rather than archives: it prints what those names read\n\
-                     and writes nothing, because a partition holding only them would read as a\n\
-                     complete session to the next pass.";
+                     MODE applies only with SYMBOLS, and is one of two reserved lowercase words:\n\
+                       measure  print what those names read and write nothing (the default)\n\
+                       repair   fold them into the sessions that already have a partition\n\
+                     A repair never creates a partition: one holding only the named symbols would\n\
+                     read as a complete session to every later pass.";
 
 /// Sessions between samples unless told otherwise, which is every session.
 const DEFAULT_STRIDE: usize = 1;
 
-/// What the run does, which the `SYMBOLS` argument selects.
+/// What the run does, which the `SYMBOLS` and `MODE` arguments select.
+///
+/// `Measure` is the default for a named symbol list rather than `Repair`, because the safe reading
+/// of "I named some symbols" is "show me these", and writing is the irreversible half.
 #[derive(Debug, PartialEq, Eq)]
 enum Mode {
     /// Fold the screened universe for every sampled session and write both cadences.
     Archive,
     /// Fold only these names and print what they read, touching no partition.
     Measure(BTreeSet<Ticker>),
+    /// Fold only these names into the sampled sessions that already have a partition.
+    Repair(BTreeSet<Ticker>),
 }
 
 struct Parameters {
@@ -44,15 +51,18 @@ struct Parameters {
 
 impl Parameters {
     fn parse(arguments: &[String]) -> Result<Self, String> {
-        let (start, end, stride, symbols) = match arguments {
-            [start, end] => (start, end, None, None),
-            [start, end, stride] => (start, end, Some(stride), None),
+        let (start, end, stride, symbols, mode) = match arguments {
+            [start, end] => (start, end, None, None, None),
+            [start, end, stride] => (start, end, Some(stride), None, None),
             // Positional after the stride, so measuring named symbols means stating the stride
             // rather than having it inferred from an argument that could be either.
-            [start, end, stride, symbols] => (start, end, Some(stride), Some(symbols)),
+            [start, end, stride, symbols] => (start, end, Some(stride), Some(symbols), None),
+            [start, end, stride, symbols, mode] => {
+                (start, end, Some(stride), Some(symbols), Some(mode))
+            }
             _ => {
                 return Err(format!(
-                    "Expected two dates, an optional stride and an optional symbol list\n{USAGE}"
+                    "Expected two dates, an optional stride, symbol list and mode\n{USAGE}"
                 ))
             }
         };
@@ -74,9 +84,19 @@ impl Parameters {
                 })?,
         };
 
-        let mode = match symbols.map(|raw| raw.trim()) {
-            None => Mode::Archive,
-            Some(raw) => Mode::Measure(parse_symbols(raw)?),
+        // Trimmed before matching, so a whitespace-padded mode word is not read as something else.
+        let mode = match (symbols.map(|raw| raw.trim()), mode.map(|raw| raw.trim())) {
+            (None, None) => Mode::Archive,
+            (None, Some(_)) => {
+                return Err(format!("MODE requires a symbol list to act on\n{USAGE}"))
+            }
+            (Some(raw), None) | (Some(raw), Some("measure")) => Mode::Measure(parse_symbols(raw)?),
+            (Some(raw), Some("repair")) => Mode::Repair(parse_symbols(raw)?),
+            (Some(_), Some(other)) => {
+                return Err(format!(
+                    "MODE must be measure or repair, got {other:?}\n{USAGE}"
+                ))
+            }
         };
 
         Ok(Self {
@@ -160,7 +180,9 @@ async fn main() {
             // Non-zero on an incomplete pass, because the partition it wrote reads as complete to
             // everything downstream and the exit code is the only signal automation sees.
             if summary.symbols_failed > 0 || !summary.sessions_failed.is_empty() {
-                eprintln!("Incomplete: re-run the affected sessions to fill the missing symbols");
+                eprintln!(
+                    "Incomplete: re-run the affected sessions with the missing symbols and `repair`"
+                );
                 1
             } else {
                 0
@@ -205,28 +227,29 @@ async fn run(
         "Sampled the sessions to fold"
     );
 
-    match &parameters.mode {
+    let scope = match &parameters.mode {
         Mode::Measure(symbols) => {
             measure(&market_data, &calendar, &sampled, symbols).await;
-            Ok(None)
+            return Ok(None);
         }
-        Mode::Archive => {
-            let bucket = std::env::var("AWS_S3_BUCKET_NAME")
-                .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
-            let s3_client = fund::common::aws::s3_client().await;
-            Ok(Some(
-                archive::archive_quote_sessions(
-                    &s3_client,
-                    &market_data,
-                    &calendar,
-                    &bucket,
-                    &sampled,
-                    LiquidityFloor::CURRENT,
-                )
-                .await?,
-            ))
-        }
-    }
+        Mode::Archive => QuoteScope::ScreenedUniverse(LiquidityFloor::CURRENT),
+        Mode::Repair(symbols) => QuoteScope::Symbols(symbols.clone()),
+    };
+
+    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let s3_client = fund::common::aws::s3_client().await;
+    Ok(Some(
+        archive::archive_quote_sessions(
+            &s3_client,
+            &market_data,
+            &calendar,
+            &bucket,
+            &sampled,
+            &scope,
+        )
+        .await?,
+    ))
 }
 
 /// Folds the named symbols and prints their session figures, writing nothing.
@@ -344,6 +367,62 @@ mod tests {
         };
         assert_eq!(symbols.len(), 2, "lowercase is normalized, not rejected");
         assert!(symbols.contains(&Ticker::new("CBOE").unwrap()));
+    }
+
+    /// Writing is the irreversible half, so it must be asked for by name. A run that meant to
+    /// measure and silently repaired instead would rewrite partitions across a whole window.
+    #[test]
+    fn test_repairing_must_be_asked_for_explicitly() {
+        let measured = Parameters::parse(&arguments(&["2026-08-03", "2026-08-21", "21", "AAPL"]))
+            .expect("symbols without a mode parse");
+        assert!(
+            matches!(measured.mode, Mode::Measure(_)),
+            "the safe default"
+        );
+
+        let explicit = Parameters::parse(&arguments(&[
+            "2026-08-03",
+            "2026-08-21",
+            "21",
+            "AAPL",
+            " repair ",
+        ]))
+        .expect("a trimmed mode word parses");
+        assert!(matches!(explicit.mode, Mode::Repair(_)));
+
+        assert!(
+            Parameters::parse(&arguments(&[
+                "2026-08-03",
+                "2026-08-21",
+                "21",
+                "AAPL",
+                "Repair"
+            ]))
+            .is_err(),
+            "the words are lowercase, so an uppercase one is a typo rather than a mode"
+        );
+        assert!(Parameters::parse(&arguments(&[
+            "2026-08-03",
+            "2026-08-21",
+            "21",
+            "AAPL",
+            "write"
+        ]))
+        .is_err());
+    }
+
+    /// A mode with nothing to act on is a mistake worth refusing rather than a no-op: the caller
+    /// meant to name symbols and did not.
+    #[test]
+    fn test_a_mode_without_symbols_is_refused() {
+        assert!(Parameters::parse(&arguments(&[
+            "2026-08-03",
+            "2026-08-21",
+            "21",
+            "",
+            "repair"
+        ]))
+        .is_err());
     }
 
     #[test]

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -1279,10 +1279,8 @@ pub enum QuoteScope {
     ScreenedUniverse(LiquidityFloor),
     /// An explicit set of names, folded only into sessions that *already* have a partition.
     ///
-    /// Two things this repairs, and the second is the one that recurs: a name whose fetch failed,
-    /// and a name a widened screen now admits. Task 4 replaces the price floor with a spread bound
-    /// and task 6 makes the floor a declared rank — both add names to sessions already seeded, and
-    /// without this each of them would mean refetching whole sessions.
+    /// Repairs both a name whose fetch failed and a name a widened screen now admits, without
+    /// refetching the sessions those names are missing from.
     Symbols(BTreeSet<Ticker>),
 }
 
@@ -1326,12 +1324,16 @@ pub async fn archive_quote_sessions(
         "Planned a quote pass"
     );
     if let QuoteScope::Symbols(symbols) = scope {
-        let unsummarized = sessions.len() - requested.len();
-        if unsummarized > 0 {
-            // Named rather than counted silently: a repair that quietly skips most of its window
-            // looks identical to one that had nothing to do.
+        let unsummarized: Vec<SessionDate> = sessions
+            .iter()
+            .copied()
+            .filter(|session| !present.contains(session))
+            .collect();
+        if !unsummarized.is_empty() {
+            // Dated, not counted: a repair that skips most of its window looks identical to one
+            // that had nothing to do, and a count cannot say which sessions to seed.
             warn!(
-                unsummarized,
+                sessions = ?unsummarized,
                 symbols = symbols.len(),
                 "Some offered sessions have no quote partition to repair; seed them first"
             );

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -1268,10 +1268,30 @@ pub struct QuoteArchiveSummary {
     pub quotes_folded: usize,
 }
 
-/// Folds the quoted book for every session in `sessions` the archive has no summary for.
+/// What a quote pass is for, which decides both the names it folds and the sessions it touches.
+///
+/// The two variants exist because a partition's presence cannot answer whether a *symbol* is in it:
+/// one written while a name's fetch failed, or before that name cleared the screen, reads exactly
+/// like a complete one. So the seeding pass and the repairing pass want opposite session sets.
+#[derive(Debug, Clone, PartialEq)]
+pub enum QuoteScope {
+    /// Every name the daily archive screens in, for the sessions that have no summary yet.
+    ScreenedUniverse(LiquidityFloor),
+    /// An explicit set of names, folded only into sessions that *already* have a partition.
+    ///
+    /// Two things this repairs, and the second is the one that recurs: a name whose fetch failed,
+    /// and a name a widened screen now admits. Task 4 replaces the price floor with a spread bound
+    /// and task 6 makes the floor a declared rank — both add names to sessions already seeded, and
+    /// without this each of them would mean refetching whole sessions.
+    Symbols(BTreeSet<Ticker>),
+}
+
+/// Folds the quoted book across `sessions`, per `scope`.
 ///
 /// Session-major rather than ticker-major, unlike the intraday bar pass: a quote request is already
-/// bounded to one session's hours, so there is nothing to gain by holding a chunk of them.
+/// bounded to one session's hours, so there is nothing to gain by holding a chunk of them. That is
+/// also why the never-create rule lands here at session selection rather than at the write, where
+/// [`writable_sessions`] has to enforce it for bars — a session-major pass knows before it fetches.
 ///
 /// Regular hours only, taken from the calendar so an early close is 3.5 hours rather than 6.5. The
 /// overnight book is an order of magnitude wider and would swamp any session mean it entered.
@@ -1281,7 +1301,7 @@ pub async fn archive_quote_sessions(
     calendar: &TradingCalendar,
     bucket: &str,
     sessions: &[SessionDate],
-    floor: LiquidityFloor,
+    scope: &QuoteScope,
 ) -> Result<QuoteArchiveSummary, ArchiveError> {
     let (Some(first), Some(last)) = (sessions.first(), sessions.last()) else {
         return Ok(QuoteArchiveSummary::default());
@@ -1294,20 +1314,29 @@ pub async fn archive_quote_sessions(
         *last,
     )
     .await?;
-    let requested: Vec<SessionDate> = sessions
-        .iter()
-        .copied()
-        .filter(|session| !present.contains(session))
-        .collect();
+    let requested = quote_sessions_for(scope, sessions, &present);
 
     info!(
         window_start = %first,
         window_end = %last,
         offered = sessions.len(),
-        present = present.len(),
+        already_summarized = present.len(),
         requested = requested.len(),
+        repairing = matches!(scope, QuoteScope::Symbols(_)),
         "Planned a quote pass"
     );
+    if let QuoteScope::Symbols(symbols) = scope {
+        let unsummarized = sessions.len() - requested.len();
+        if unsummarized > 0 {
+            // Named rather than counted silently: a repair that quietly skips most of its window
+            // looks identical to one that had nothing to do.
+            warn!(
+                unsummarized,
+                symbols = symbols.len(),
+                "Some offered sessions have no quote partition to repair; seed them first"
+            );
+        }
+    }
 
     let mut summary = QuoteArchiveSummary {
         sessions_requested: requested.len(),
@@ -1320,7 +1349,7 @@ pub async fn archive_quote_sessions(
             calendar,
             bucket,
             session,
-            floor,
+            scope,
             &mut summary,
         )
         .await?;
@@ -1347,7 +1376,28 @@ pub async fn archive_quote_sessions(
     Ok(summary)
 }
 
-/// One session: screen the universe, fold every name's book, write both cadences.
+/// The sessions a pass touches, which the scope decides — and the two want opposite sets.
+///
+/// Seeding takes the sessions with no summary. A repair takes exactly those that have one: it
+/// fetches only the names it was given, so a partition it created would hold those and nothing
+/// else, and read as complete to every later pass. Split out from the S3 call so the rule that
+/// prevents that is testable without a bucket.
+fn quote_sessions_for(
+    scope: &QuoteScope,
+    sessions: &[SessionDate],
+    present: &BTreeSet<SessionDate>,
+) -> Vec<SessionDate> {
+    sessions
+        .iter()
+        .copied()
+        .filter(|session| match scope {
+            QuoteScope::ScreenedUniverse(_) => !present.contains(session),
+            QuoteScope::Symbols(_) => present.contains(session),
+        })
+        .collect()
+}
+
+/// One session: derive the universe from the scope, fold every name's book, write both cadences.
 #[allow(clippy::too_many_arguments)]
 async fn archive_quote_session(
     s3_client: &S3Client,
@@ -1355,7 +1405,7 @@ async fn archive_quote_session(
     calendar: &TradingCalendar,
     bucket: &str,
     session: SessionDate,
-    floor: LiquidityFloor,
+    scope: &QuoteScope,
     summary: &mut QuoteArchiveSummary,
 ) -> Result<(), ArchiveError> {
     let Some((open, close)) = quotes::trading_hours(calendar, session) else {
@@ -1365,15 +1415,23 @@ async fn archive_quote_session(
         return Ok(());
     };
 
-    let daily_key = date_partitioned_key(&bar_archive_prefix(BarInterval::OneDay), session.date());
-    let Some(daily) = read_partition(s3_client, bucket, &daily_key).await? else {
-        // Left unwritten so a later pass retries, rather than summarized against a universe that
-        // never included whatever traded only on the session the daily archive is missing.
-        warn!(%session, "No daily partition to screen against; leaving the session unsummarized");
-        summary.sessions_without_data += 1;
-        return Ok(());
+    let universe = match scope {
+        QuoteScope::ScreenedUniverse(floor) => {
+            let key =
+                date_partitioned_key(&bar_archive_prefix(BarInterval::OneDay), session.date());
+            let Some(daily) = read_partition(s3_client, bucket, &key).await? else {
+                // Left unwritten so a later pass retries, rather than summarized against a universe
+                // that never included whatever traded only on the session the daily archive lacks.
+                warn!(%session, "No daily partition to screen against; leaving the session unsummarized");
+                summary.sessions_without_data += 1;
+                return Ok(());
+            };
+            screen_partition(daily, *floor)?
+        }
+        // Taken as given rather than intersected with the daily partition: a name that did not
+        // trade answers with no quotes and produces no summary, which is the same outcome.
+        QuoteScope::Symbols(symbols) => symbols.clone(),
     };
-    let universe = screen_partition(daily, floor)?;
     if universe.is_empty() {
         summary.sessions_without_data += 1;
         return Ok(());
@@ -1836,6 +1894,33 @@ mod tests {
             );
             assert_eq!(date_from_partitioned_key(&quotes), Some(date));
         }
+    }
+
+    /// The two scopes want opposite session sets, and getting it backwards is the defect #1102 was
+    /// written for: a repair fetches only the names it was given, so a partition it created would
+    /// hold those and nothing else, and read as a complete session to every later pass.
+    #[test]
+    fn test_a_repair_writes_only_where_a_partition_already_exists() {
+        let sessions = [
+            session(2026, 8, 17),
+            session(2026, 8, 18),
+            session(2026, 8, 19),
+        ];
+        let present: BTreeSet<SessionDate> = [session(2026, 8, 18)].into_iter().collect();
+
+        let seeding = QuoteScope::ScreenedUniverse(LiquidityFloor::CURRENT);
+        let repairing = QuoteScope::Symbols(tickers(&["AAPL"]));
+
+        assert_eq!(
+            quote_sessions_for(&seeding, &sessions, &present),
+            vec![session(2026, 8, 17), session(2026, 8, 19)],
+            "seeding takes the sessions with nothing in them"
+        );
+        assert_eq!(
+            quote_sessions_for(&repairing, &sessions, &present),
+            vec![session(2026, 8, 18)],
+            "repairing takes exactly the sessions that already have one"
+        );
     }
 
     /// Two cadences of one session must not collide, which is the whole reason the segment exists.


### PR DESCRIPTION
# Overview

Stacked on #1103. Adds the symbol-scoped path into an already-seeded quote session, so widening the screen costs the marginal names rather than a full refetch.

## Changes

- `QuoteScope`, carrying the two intents a pass can have: `ScreenedUniverse(LiquidityFloor)` and `Symbols(BTreeSet<Ticker>)`.
- `quote_sessions_for`, split out from the S3 call so the never-create rule is testable without a bucket — the same reason `coverage_of` was extracted in #1102.
- `seed_quotes_s3` gains a `MODE` argument, `measure` (the default when symbols are named) or `repair`.

## Context

**Why this was deferred and why that was wrong.** I left it out of #1103 on the grounds that the failure it repairs — a name whose fetch died — stopped happening once page-level retry landed. That reasoned about only one consumer. Screen changes are the second, they are scheduled rather than hypothetical, and they are the one that recurs: task 4 replaces the price floor with a spread bound, task 6 makes the floor a declared rank, and both add names to sessions already seeded.

The cost decides it. Dropping the $10 price floor admits ~83 names a session — minutes through a repair, and 14 hours of refetching across a stride-63 seed without one. The circle cannot be sequenced around either: the screen cannot be settled before task 4 has spread data, and the data cannot be seeded cheaply before the screen is settled.

**The two scopes want opposite session sets.** Seeding takes the sessions with no summary; a repair takes exactly those that have one. A repair that *created* a partition would fill it with only the names it was handed, and every later pass would read that as a complete session — the defect #1102 fixed for bars, arriving by a different route.

**The rule lands at session selection, not at the write.** That differs from `writable_sessions` for bars, and not stylistically: the bar pass is ticker-major across a chunk and cannot know which sessions it will answer for until the fetches return, while a quote pass is session-major and knows before it fetches anything.

**`measure` stays the default for a named symbol list.** The safe reading of "I named some symbols" is "show me these", and writing is the irreversible half.

### Verification

`devenv tasks run checks:all` passes, coverage 80.8%. The never-create rule was proven load-bearing by inverting the filter and watching the test fail.

Against the development bucket rather than only in tests:

- Repairing `VOX,DIHP` into 2026-08-20 and 2026-08-21 took those sessions from 1,729 and 1,691 names to **1,731 and 1,693**, left 08-17 through 08-19 untouched, did not disturb AAPL, and kept five-minute rows at exactly **78.0 per name**.
- Offering a ten-day window containing three unseeded sessions repaired the five with partitions, warned by name about the three without, and left the object count at **five** — no thin partition manufactured.

Both names were chosen because they are real cases of the screen leaking: VOX quotes 4.46bp at dollar-volume rank 2,000 and DIHP 4.35bp at rank 9,000, both tighter than the median screened name at 9.35bp, and both excluded today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9MuPyHx1o8E6X9cPZcCNZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for repairing quote data for explicitly selected symbols.
  * Quote seeding continues to use the screened daily universe.
  * Symbol-scoped runs default to read-only measurement unless repair mode is selected.
* **Bug Fixes**
  * Added validation for unsupported modes and missing symbols.
  * Improved handling and warnings for sessions that cannot be repaired.
  * Updated incomplete-run guidance to identify affected sessions and recommend repair mode.
* **Tests**
  * Added coverage for mode defaults, repair behavior, invalid modes, and missing-symbol scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->