### PR TITLE
Fetch the whole market rather than the screen's opinion of it

### DIFF
--- a/src/bin/seed_intraday_bars_s3.rs
+++ b/src/bin/seed_intraday_bars_s3.rs
@@ -18,10 +18,11 @@ const USAGE: &str = "Usage: seed_intraday_bars_s3 START_DATE END_DATE [CADENCE [
                      SYMBOLS is a comma-separated list, and naming it requires naming CADENCE too.\n\
                      Supplying it fetches only those names and requests every session in the\n\
                      window rather than only the absent ones.\n\
-                     SYMBOLS may instead be one of two reserved lowercase words, matched\n\
+                     SYMBOLS may instead be one of three reserved lowercase words, matched\n\
                      exactly so an uppercase name of the same spelling is still a ticker:\n\
                        scan    report which names each partition lacks, and write nothing\n\
-                       repair  scan, then fetch the names the scan reported";
+                       repair  scan, then fetch the names the scan reported\n\
+                       all     every name the daily archive holds, every session in the window";
 
 /// What the archive is filled with unless told otherwise.
 ///
@@ -90,6 +91,7 @@ impl Parameters {
             None => Mode::Seed(IntradayScope::MissingSessions),
             Some("scan") => Mode::Scan,
             Some("repair") => Mode::Repair,
+            Some("all") => Mode::Seed(IntradayScope::WholeMarket),
             Some(raw) => Mode::Seed(IntradayScope::Symbols(parse_symbols(raw)?)),
         };
 
@@ -217,7 +219,8 @@ async fn run(
 
     let massive = massive.expect("every mode that fetches builds a client above");
     let symbols = match &scope {
-        IntradayScope::MissingSessions => "the screened universe".to_string(),
+        IntradayScope::MissingSessions => "every name, absent sessions only".to_string(),
+        IntradayScope::WholeMarket => "every name, every session".to_string(),
         IntradayScope::Symbols(symbols) => symbols
             .iter()
             .map(Ticker::as_str)

--- a/src/bin/seed_intraday_bars_s3.rs
+++ b/src/bin/seed_intraday_bars_s3.rs
@@ -22,7 +22,9 @@ const USAGE: &str = "Usage: seed_intraday_bars_s3 START_DATE END_DATE [CADENCE [
                      exactly so an uppercase name of the same spelling is still a ticker:\n\
                        scan    report which names each partition lacks, and write nothing\n\
                        repair  scan, then fetch the names the scan reported\n\
-                       all     every name the daily archive holds, every session in the window";
+                       all     every name the daily archive holds, for every session in the\n\
+                               window it can describe -- a session the daily archive is missing\n\
+                               is left alone, because nothing can say what a complete one holds";
 
 /// What the archive is filled with unless told otherwise.
 ///
@@ -451,6 +453,36 @@ mod tests {
         };
         let named: Vec<&str> = symbols.iter().map(Ticker::as_str).collect();
         assert_eq!(named, vec!["SCAN"]);
+    }
+
+    /// `all` is what widens the archive past what any screen would have admitted, and `ALL` is a
+    /// plausible ticker, so the same exact-match rule has to hold for it as for `scan`.
+    #[test]
+    fn test_all_widens_the_archive_and_its_uppercase_is_a_ticker() {
+        let parameters = Parameters::parse(&arguments(&[
+            "2026-08-01",
+            "2026-08-20",
+            "five_minute",
+            " all ",
+        ]))
+        .unwrap();
+        assert!(matches!(
+            parameters.mode,
+            Mode::Seed(IntradayScope::WholeMarket)
+        ));
+
+        let parameters = Parameters::parse(&arguments(&[
+            "2026-08-01",
+            "2026-08-20",
+            "five_minute",
+            "ALL",
+        ]))
+        .unwrap();
+        let Mode::Seed(IntradayScope::Symbols(symbols)) = parameters.mode else {
+            panic!("an uppercase name must not widen the archive");
+        };
+        let named: Vec<&str> = symbols.iter().map(Ticker::as_str).collect();
+        assert_eq!(named, vec!["ALL"]);
     }
 
     #[test]

--- a/src/bin/seed_quotes_s3.rs
+++ b/src/bin/seed_quotes_s3.rs
@@ -21,9 +21,11 @@ const USAGE: &str = "Usage: seed_quotes_s3 START_DATE END_DATE [STRIDE [SYMBOLS 
                      SYMBOLS is a comma-separated list, and naming it requires naming STRIDE too.\n\
                      SYMBOLS may instead be the reserved lowercase word `all`, matched exactly so\n\
                      an uppercase name of the same spelling is still a ticker:\n\
-                       all      every name the daily archive holds, every sampled session,\n\
-                                widening any session already summarized rather than skipping it\n\
-                     MODE applies only with a symbol list, and is one of two reserved words:\n\
+                       all      every name the daily archive holds, for every sampled session it\n\
+                                can describe, widening one already summarized rather than\n\
+                                skipping it; a session the daily archive is missing is left alone\n\
+                     MODE applies only with a symbol list, and is one of two reserved lowercase\n\
+                     words, matched exactly on the same terms as `all`:\n\
                        measure  print what those names read and write nothing (the default)\n\
                        repair   fold them into the sessions that already have a partition\n\
                      A repair never creates a partition: one holding only the named symbols would\n\
@@ -199,7 +201,14 @@ async fn main() {
             );
             // Non-zero on an incomplete pass, because the partition it wrote reads as complete to
             // everything downstream and the exit code is the only signal automation sees.
-            if summary.symbols_failed > 0 || !summary.sessions_failed.is_empty() {
+            //
+            // `sessions_without_data` counts here where it would not on the bar path: the sample
+            // is drawn from the published calendar, so a session that answers with nothing is a
+            // missing daily partition or an empty fold, never a holiday.
+            if summary.symbols_failed > 0
+                || !summary.sessions_failed.is_empty()
+                || summary.sessions_without_data > 0
+            {
                 eprintln!(
                     "Incomplete: re-run the affected sessions with the missing symbols and `repair`"
                 );

--- a/src/bin/seed_quotes_s3.rs
+++ b/src/bin/seed_quotes_s3.rs
@@ -19,11 +19,16 @@ const USAGE: &str = "Usage: seed_quotes_s3 START_DATE END_DATE [STRIDE [SYMBOLS 
                      STRIDE samples every Nth trading session from START_DATE (default 1).\n\
                      A stride that is a multiple of 5 samples one weekday forever; 21 does not.\n\
                      SYMBOLS is a comma-separated list, and naming it requires naming STRIDE too.\n\
-                     MODE applies only with SYMBOLS, and is one of two reserved lowercase words:\n\
+                     SYMBOLS may instead be the reserved lowercase word `all`, matched exactly so\n\
+                     an uppercase name of the same spelling is still a ticker:\n\
+                       all      every name the daily archive holds, every sampled session,\n\
+                                widening any session already summarized rather than skipping it\n\
+                     MODE applies only with a symbol list, and is one of two reserved words:\n\
                        measure  print what those names read and write nothing (the default)\n\
                        repair   fold them into the sessions that already have a partition\n\
                      A repair never creates a partition: one holding only the named symbols would\n\
-                     read as a complete session to every later pass.";
+                     read as a complete session to every later pass. `all` may, because what it\n\
+                     writes is the whole market.";
 
 /// Sessions between samples unless told otherwise, which is every session.
 const DEFAULT_STRIDE: usize = 1;
@@ -36,6 +41,8 @@ const DEFAULT_STRIDE: usize = 1;
 enum Mode {
     /// Fold the screened universe for every sampled session and write both cadences.
     Archive,
+    /// Fold every name the daily archive holds, widening sessions already summarized.
+    WholeMarket,
     /// Fold only these names and print what they read, touching no partition.
     Measure(BTreeSet<Ticker>),
     /// Fold only these names into the sampled sessions that already have a partition.
@@ -88,6 +95,15 @@ impl Parameters {
 
         let mode = match named {
             None => Mode::Archive,
+            // Matched before the symbol parser, and exactly: `ALL` is a valid ticker shape, so
+            // order is what separates the reserved word from a name spelled the same way.
+            Some((symbols, None)) if symbols.trim() == "all" => Mode::WholeMarket,
+            Some((symbols, Some(mode))) if symbols.trim() == "all" => {
+                return Err(format!(
+                    "MODE applies to a symbol list, not to `all`, got {:?}\n{USAGE}",
+                    mode.trim()
+                ))
+            }
             Some((symbols, mode)) => {
                 let symbols = parse_symbols(symbols)?;
                 // Trimmed before matching, so a padded mode word is not read as an unknown one.
@@ -237,6 +253,7 @@ async fn run(
             return Ok(None);
         }
         Mode::Archive => QuoteScope::ScreenedUniverse(LiquidityFloor::CURRENT),
+        Mode::WholeMarket => QuoteScope::WholeMarket,
         Mode::Repair(symbols) => QuoteScope::Symbols(symbols.clone()),
     };
 
@@ -417,6 +434,35 @@ mod tests {
 
     /// A mode names what to do with a symbol list, so the two travel together and "a mode with no
     /// symbols" is not a state the arguments can express. What is left to refuse is a sixth one.
+    /// The word is what widens the archive past its own screen, and `ALL` is a valid ticker shape,
+    /// so the lowercase form has to be matched exactly and before the symbol parser sees it.
+    #[test]
+    fn test_all_is_a_reserved_word_and_its_uppercase_is_a_ticker() {
+        let widening = Parameters::parse(&arguments(&["2026-08-17", "2026-08-21", "1", " all "]))
+            .expect("a trimmed reserved word parses");
+        assert_eq!(widening.mode, Mode::WholeMarket);
+
+        let named = Parameters::parse(&arguments(&["2026-08-17", "2026-08-21", "1", "ALL"]))
+            .expect("uppercase stays a ticker");
+        let Mode::Measure(symbols) = named.mode else {
+            panic!("an uppercase name must not widen the archive");
+        };
+        assert!(symbols.contains(&Ticker::new("ALL").unwrap()));
+    }
+
+    /// A mode says what to do with named symbols, and `all` is not a list of them.
+    #[test]
+    fn test_a_mode_alongside_all_is_refused() {
+        assert!(Parameters::parse(&arguments(&[
+            "2026-08-17",
+            "2026-08-21",
+            "1",
+            "all",
+            "repair"
+        ]))
+        .is_err());
+    }
+
     #[test]
     fn test_arguments_past_the_mode_are_refused() {
         assert!(Parameters::parse(&arguments(&[

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -505,7 +505,7 @@ fn intraday_sessions_for(
 ) -> Vec<SessionDate> {
     match scope {
         IntradayScope::MissingSessions => intraday_sessions_to_request(expected, present),
-        IntradayScope::Symbols(_) => expected.to_vec(),
+        IntradayScope::Symbols(_) | IntradayScope::WholeMarket => expected.to_vec(),
     }
 }
 
@@ -518,19 +518,24 @@ const INTRADAY_CONCURRENCY: usize = 8;
 
 /// What an intraday pass is for, and it decides which sessions get requested.
 ///
-/// The two variants exist because session presence cannot answer whether a *symbol* is present: a
-/// partition written while one name's fetch failed, or before that name cleared the universe
-/// screen, is indistinguishable from a complete one. So repairing a symbol has to ignore the set
-/// difference that repairing a session relies on.
+/// Session presence cannot answer whether a *symbol* is present: a partition written while one
+/// name's fetch failed is indistinguishable from a complete one. So the variants that repair a
+/// symbol have to ignore the set difference that filling a missing session relies on.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IntradayScope {
-    /// Every name the daily archive screens in, for the sessions the archive has no partition for.
+    /// Every name the daily archive holds, for the sessions the archive has no partition for.
     MissingSessions,
     /// An explicit set of names, across every session in the window regardless of what is present.
     ///
     /// The partition merge keys on `(ticker, bar_interval, timestamp)`, so re-requesting a session
     /// that already holds other names adds these and leaves those untouched.
     Symbols(BTreeSet<Ticker>),
+    /// Every name the daily archive holds, across every session in the window.
+    ///
+    /// What [`IntradayScope::MissingSessions`] cannot express: a partition that exists but is
+    /// narrower than the daily archive it was built beside. Unlike a symbol repair this may create
+    /// a partition, because the one it creates is the whole market rather than a named handful.
+    WholeMarket,
 }
 
 /// Fetches and writes intraday partitions across `[window_start, window_end]`, per `scope`.
@@ -747,7 +752,7 @@ async fn archive_intraday_chunk(
 ///
 /// An undescribed session is refused whatever the scope, because nothing can say what a complete
 /// partition for it would hold. A symbol repair additionally refuses to *create* one: it fetches
-/// only the named symbols, so an absent session needs [`IntradayScope::MissingSessions`] instead.
+/// only the named symbols, so an absent session needs a whole-market scope instead.
 fn writable_sessions(
     session: SessionDate,
     scope: &IntradayScope,
@@ -758,7 +763,9 @@ fn writable_sessions(
         return false;
     }
     match scope {
-        IntradayScope::MissingSessions => true,
+        // Both fetch every name the daily partition holds, so a partition either creates whole or
+        // is merged into whole; neither can leave one that only looks complete.
+        IntradayScope::MissingSessions | IntradayScope::WholeMarket => true,
         IntradayScope::Symbols(_) => present.contains(&session),
     }
 }
@@ -824,12 +831,12 @@ async fn write_partitions(
     Ok(())
 }
 
-/// The names that traded across `sessions`, read from the daily archive and screened per session.
+/// The names that traded across `sessions`, read from the daily archive and not screened.
 ///
-/// **A fetch universe, deliberately wider than any study population.** Screened session by session
-/// rather than on a trailing average, so a name that traded heavily on one day is fetched for the
-/// chunk. That is the safe direction for an archive: an unfetched bar cannot be recovered later,
-/// and every study screens again on its own terms when it reads.
+/// **Unscreened on purpose, matching the daily archive it is read from.** An unfetched bar cannot be
+/// recovered later and every study screens on its own terms when it reads, so the only screen that
+/// can cost anything here is one applied too early. A liquidity floor at ingest also made widening
+/// it a backfill rather than a setting, which is a bill this archive has now paid twice.
 ///
 /// **Survivorship-free by construction.** The daily partitions are whole-market and were written on
 /// the day, so a name that has since delisted is still present in the sessions it traded. Taking the
@@ -852,16 +859,12 @@ async fn universe_over(
             continue;
         };
         universe.described.insert(*session);
-        // An explicit set reads the partition above for `described` and skips only the screen,
-        // which a hand-picked universe has already answered.
-        let IntradayScope::MissingSessions = scope else {
+        // An explicit set reads the partition above only for `described`; it has already answered
+        // which names it wants.
+        if matches!(scope, IntradayScope::Symbols(_)) {
             continue;
-        };
-        // Pinned rather than threaded up: the archive is one shared object per session, so
-        // widening the floor means backfilling it rather than reconfiguring a caller.
-        universe
-            .symbols
-            .extend(screen_partition(frame, LiquidityFloor::CURRENT)?);
+        }
+        universe.symbols.extend(partition_tickers(&frame)?);
     }
     if let IntradayScope::Symbols(symbols) = scope {
         universe.symbols = symbols.clone();
@@ -1277,6 +1280,12 @@ pub struct QuoteArchiveSummary {
 pub enum QuoteScope {
     /// Every name the daily archive screens in, for the sessions that have no summary yet.
     ScreenedUniverse(LiquidityFloor),
+    /// Every name the daily archive holds, across every session in the window.
+    ///
+    /// The screen decides what is fetched, so a spread it excluded cannot be read back off the
+    /// archive — this is how a name outside it gets measured at all. May write over an existing
+    /// session, unlike [`QuoteScope::Symbols`], because what it writes is the whole market.
+    WholeMarket,
     /// An explicit set of names, folded only into sessions that *already* have a partition.
     ///
     /// Repairs both a name whose fetch failed and a name a widened screen now admits, without
@@ -1395,6 +1404,9 @@ fn quote_sessions_for(
         .filter(|session| match scope {
             QuoteScope::ScreenedUniverse(_) => !present.contains(session),
             QuoteScope::Symbols(_) => present.contains(session),
+            // Neither filter: widening a session already summarized is the whole point, and a
+            // session with nothing in it is answered whole rather than skipped.
+            QuoteScope::WholeMarket => true,
         })
         .collect()
 }
@@ -1418,21 +1430,24 @@ async fn archive_quote_session(
     };
 
     let universe = match scope {
-        QuoteScope::ScreenedUniverse(floor) => {
+        // Taken as given rather than intersected with the daily partition: a name that did not
+        // trade answers with no quotes and produces no summary, which is the same outcome.
+        QuoteScope::Symbols(symbols) => symbols.clone(),
+        QuoteScope::ScreenedUniverse(_) | QuoteScope::WholeMarket => {
             let key =
                 date_partitioned_key(&bar_archive_prefix(BarInterval::OneDay), session.date());
             let Some(daily) = read_partition(s3_client, bucket, &key).await? else {
                 // Left unwritten so a later pass retries, rather than summarized against a universe
                 // that never included whatever traded only on the session the daily archive lacks.
-                warn!(%session, "No daily partition to screen against; leaving the session unsummarized");
+                warn!(%session, "No daily partition to read a universe from; leaving the session unsummarized");
                 summary.sessions_without_data += 1;
                 return Ok(());
             };
-            screen_partition(daily, *floor)?
+            match scope {
+                QuoteScope::ScreenedUniverse(floor) => screen_partition(daily, *floor)?,
+                _ => partition_tickers(&daily)?,
+            }
         }
-        // Taken as given rather than intersected with the daily partition: a name that did not
-        // trade answers with no quotes and produces no summary, which is the same outcome.
-        QuoteScope::Symbols(symbols) => symbols.clone(),
     };
     if universe.is_empty() {
         summary.sessions_without_data += 1;
@@ -1896,6 +1911,52 @@ mod tests {
             );
             assert_eq!(date_from_partitioned_key(&quotes), Some(date));
         }
+    }
+
+    /// A whole-market pass exists to widen partitions that already exist, so unlike the other two
+    /// it filters on nothing. Skipping the present ones would make it a no-op against a seeded
+    /// archive, which is exactly the state it is run against.
+    #[test]
+    fn test_a_whole_market_quote_pass_takes_every_session_offered() {
+        let sessions = [
+            session(2026, 8, 17),
+            session(2026, 8, 18),
+            session(2026, 8, 19),
+        ];
+        let present: BTreeSet<SessionDate> = [session(2026, 8, 18)].into_iter().collect();
+
+        assert_eq!(
+            quote_sessions_for(&QuoteScope::WholeMarket, &sessions, &present),
+            sessions.to_vec()
+        );
+    }
+
+    /// The same asymmetry on the bar side: a named repair may not create a partition because it
+    /// would hold only those names, while a whole-market pass may because its partition is whole.
+    #[test]
+    fn test_a_whole_market_bar_pass_may_create_a_partition_where_a_repair_may_not() {
+        let described: BTreeSet<SessionDate> = [session(2026, 8, 19)].into_iter().collect();
+        let absent = BTreeSet::new();
+
+        assert!(writable_sessions(
+            session(2026, 8, 19),
+            &IntradayScope::WholeMarket,
+            &described,
+            &absent
+        ));
+        assert!(!writable_sessions(
+            session(2026, 8, 19),
+            &IntradayScope::Symbols(tickers(&["AAPL"])),
+            &described,
+            &absent
+        ));
+        // Undescribed refuses both: nothing can say what a complete partition would hold.
+        assert!(!writable_sessions(
+            session(2026, 8, 20),
+            &IntradayScope::WholeMarket,
+            &described,
+            &absent
+        ));
     }
 
     /// The two scopes want opposite session sets, and getting it backwards is the defect #1102 was

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -831,17 +831,11 @@ async fn write_partitions(
     Ok(())
 }
 
-/// The names that traded across `sessions`, read from the daily archive and not screened.
+/// Every name the daily archive holds across `sessions`, unscreened.
 ///
-/// **Unscreened on purpose, matching the daily archive it is read from.** An unfetched bar cannot be
-/// recovered later and every study screens on its own terms when it reads, so the only screen that
-/// can cost anything here is one applied too early. A liquidity floor at ingest also made widening
-/// it a backfill rather than a setting, which is a bill this archive has now paid twice.
-///
-/// **Survivorship-free by construction.** The daily partitions are whole-market and were written on
-/// the day, so a name that has since delisted is still present in the sessions it traded. Taking the
-/// list from today's market instead would sample only the survivors — and a pair that blew up is
-/// exactly the one a convergence study must not drop.
+/// Survivorship-free by construction: the partitions are whole-market and were written on the day,
+/// so a name that has since delisted is still there in the sessions it traded. Taking the list from
+/// today's market instead would sample only the survivors.
 async fn universe_over(
     s3_client: &S3Client,
     bucket: &str,
@@ -1423,8 +1417,8 @@ async fn archive_quote_session(
     summary: &mut QuoteArchiveSummary,
 ) -> Result<(), ArchiveError> {
     let Some((open, close)) = quotes::trading_hours(calendar, session) else {
-        // A holiday, or a date the fetched calendar does not reach. Neither is a fault, and both
-        // are why the pass counts them rather than failing.
+        // A date the calendar does not publish. Counted rather than fatal, so one unusable session
+        // does not cost the rest of the window.
         summary.sessions_without_data += 1;
         return Ok(());
     };


### PR DESCRIPTION
# Overview

The agreed next step was to widen the five-minute bar archive to every name and run one unscreened quote pass. **Neither command could do it** — both would have reported success having done nothing.

## Changes

- `IntradayScope::WholeMarket` and `QuoteScope::WholeMarket`: every name the daily archive holds, across every session in the window.
- Both reached by the reserved lowercase word `all` in the `SYMBOLS` slot, matched exactly so `ALL` remains a ticker.
- The intraday ingest screen is **deleted**: `universe_over` reads `partition_tickers` instead of `screen_partition(.., CURRENT)`.
- `writable_sessions` and `quote_sessions_for` admit the new scopes.

## Context

**Why the sequence could not run.** `seed_intraday_bars_s3` over the archive requested 50 sessions of 1,305 weekdays against 1,255 partitions — the holidays, which answer empty. `MissingSessions` is a set difference over sessions, so a partition that exists is never requested however narrow it is. `seed_quotes_s3` over the seeded week reported `requested: 0` for the same reason. Both also pinned the universe at `LiquidityFloor::CURRENT`, so even a session they did request would have fetched ~1,700 names of ~12,150.

**Why a whole-market scope may create a partition when a symbol repair may not.** That distinction is what #1102 and #1104 were about: a partition holding only the named symbols reads as a complete session to every later pass. A whole-market partition does not have that problem, because it is complete. Same rule, reached from the other side.

**Why the bar screen is deleted rather than parameterised.** The intraday seed is manual — nothing in `devenv.nix`, `schema.sql` or `tools/` schedules it — and the daily archive it reads from has always been whole-market at 12,153 names while its intraday neighbour held 1,691. A floor there only ever decided what could not be recovered later, and made widening a backfill rather than a setting, which this archive has now paid for twice. Quotes keep the floor as a parameter because they genuinely need both widths: unscreened once to learn which names are tradeable by measured spread, screened for the seed, since sixty sessions of 300bp names would cost 85 hours to acquire what nothing at this horizon can trade.

### Verification

`devenv tasks run checks:all` passes; coverage 80.8%. Both new rules were checked by inverting them and watching the tests fail.

Against the development bucket rather than only in tests — the same commands that planned nothing now plan the work:

| | before | after |
|---|---|---|
| `seed_quotes_s3 2026-08-17 2026-08-21 1 all` | `requested: 0` | `requested: 5`, universe **12,144** |
| `seed_intraday_bars_s3 2026-08-17 2026-08-21 five_minute all` | 0 of 5 present sessions | `requested: 5`, universe **12,562** |

The bar universe is larger because a chunk unions the names that traded on any of its sessions.

### Follow-up, not included

After the backfill, `seed_intraday_bars_s3 ... scan` still screens its expectation at `LiquidityFloor::CURRENT`. It reports `Complete` correctly — `coverage_of` is one-directional — but only ever *verifies* the screened subset, so the unscreened names have no gap detection. `scan_intraday_symbols` already takes a floor as a parameter; what is missing is a way to say so from the command line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9MuPyHx1o8E6X9cPZcCNZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `all` symbol option to archive complete market data across the requested sessions.
  * Whole-market archiving now includes all available tickers, including those without liquidity screening, and can create or expand missing market partitions.
  * Intraday and quote archiving support whole-market session selection.
* **Bug Fixes**
  * Improved handling of missing sessions and existing summaries when expanding archived data.
  * Preserved ticker-specific repair restrictions.
* **Documentation**
  * Updated command-line usage guidance and scope logging for whole-market and missing-session runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->