### PR TITLE
Carry a failed partition write instead of discarding the pass

### DIFF
--- a/src/bin/seed_intraday_bars_s3.rs
+++ b/src/bin/seed_intraday_bars_s3.rs
@@ -162,7 +162,13 @@ async fn main() {
                 summary.bars_written,
                 summary.symbols_failed
             );
-            0
+            // `sessions_without_data` is not a fault here: this pass requests holidays deliberately
+            // and they answer empty, unlike the quote pass, which samples the published calendar.
+            if summary.sessions_failed.is_empty() && summary.symbols_failed == 0 {
+                0
+            } else {
+                1
+            }
         }
         Err(error) => {
             error!(%error, "Seeding the intraday bar archive failed");

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -171,7 +171,8 @@ pub struct ArchiveSummary {
     pub sessions_without_data: usize,
     /// Sessions whose fetch or write failed, carried rather than fatal.
     ///
-    /// A caller that treats a non-empty list as success will report a pass that wrote nothing.
+    /// Treat a non-empty list as an incomplete pass: `Ok` means the pass ran to the end, not that
+    /// every requested session was written.
     pub sessions_failed: Vec<SessionDate>,
     /// Bars written across every partition this pass touched.
     pub bars_written: usize,
@@ -434,7 +435,12 @@ async fn archive_chunk(
                 warn!(key, attempts, %session, "Partition contended; the next pass will retry it");
                 summary.sessions_failed.push(session);
             }
-            Err(error) => return Err(error),
+            // Carried like contention above, so one session's fault costs that session rather than
+            // every session after it. The pass is only complete if `sessions_failed` is empty.
+            Err(error) => {
+                warn!(%error, %session, "Partition write failed; this session was not archived");
+                summary.sessions_failed.push(session);
+            }
         }
     }
     Ok(())
@@ -821,9 +827,10 @@ async fn write_partitions(
                 summary.sessions_failed.push(session);
             }
             // Carried for the same reason contention is: one session's write says nothing about the
-            // next one's, and a systemic fault has already failed the chunk's universe read.
+            // next one's. A fault that breaks writes but not reads is carried too and costs the rest
+            // of the pass, which `sessions_failed` reports rather than hides.
             Ok((session, _, Err(error))) => {
-                warn!(%error, %session, "Partition write failed; the next pass will retry it");
+                warn!(%error, %session, "Partition write failed; this session was not archived");
                 summary.sessions_failed.push(session);
             }
             Err(error) => {
@@ -1262,7 +1269,10 @@ pub struct QuoteArchiveSummary {
     pub sessions_written: usize,
     /// Sessions that could not be summarized: a holiday, or one the daily archive cannot describe.
     pub sessions_without_data: usize,
-    /// Sessions whose write lost a race, carried rather than fatal.
+    /// Sessions whose write failed, carried rather than fatal.
+    ///
+    /// Treat a non-empty list as an incomplete pass: `Ok` means the pass ran to the end, not that
+    /// every requested session was summarized.
     pub sessions_failed: Vec<SessionDate>,
     /// Summary rows written across both cadences.
     pub summaries_written: usize,
@@ -1567,13 +1577,15 @@ async fn write_quote_partitions(
         .await
         {
             Ok(()) => written += rows.len(),
+            // Both arms leave the session unsummarized at this cadence. A scope that skips sessions
+            // already present will not return to it, so re-running is the operator's to decide.
             Err(ArchiveError::Contended { key, attempts }) => {
-                warn!(key, attempts, %session, "Quote partition contended; the next pass will retry it");
+                warn!(key, attempts, %session, "Quote partition contended; this session was not summarized");
                 summary.sessions_failed.push(session);
                 return Ok(());
             }
             Err(error) => {
-                warn!(%error, %session, "Quote partition write failed; the next pass will retry it");
+                warn!(%error, %session, "Quote partition write failed; this session was not summarized");
                 summary.sessions_failed.push(session);
                 return Ok(());
             }

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -169,7 +169,9 @@ pub struct ArchiveSummary {
     pub sessions_written: usize,
     /// Sessions that were requested and returned no bars — holidays, and anything Massive lacks.
     pub sessions_without_data: usize,
-    /// Sessions whose request failed outright, carried rather than fatal.
+    /// Sessions whose fetch or write failed, carried rather than fatal.
+    ///
+    /// A caller that treats a non-empty list as success will report a pass that wrote nothing.
     pub sessions_failed: Vec<SessionDate>,
     /// Bars written across every partition this pass touched.
     pub bars_written: usize,
@@ -818,7 +820,12 @@ async fn write_partitions(
                 warn!(key, attempts, %session, "Partition contended; the next pass will retry it");
                 summary.sessions_failed.push(session);
             }
-            Ok((_, _, Err(error))) => return Err(error),
+            // Carried for the same reason contention is: one session's write says nothing about the
+            // next one's, and a systemic fault has already failed the chunk's universe read.
+            Ok((session, _, Err(error))) => {
+                warn!(%error, %session, "Partition write failed; the next pass will retry it");
+                summary.sessions_failed.push(session);
+            }
             Err(error) => {
                 return Err(ArchiveError::Write {
                     bucket: bucket.to_string(),
@@ -1565,7 +1572,11 @@ async fn write_quote_partitions(
                 summary.sessions_failed.push(session);
                 return Ok(());
             }
-            Err(error) => return Err(error),
+            Err(error) => {
+                warn!(%error, %session, "Quote partition write failed; the next pass will retry it");
+                summary.sessions_failed.push(session);
+                return Ok(());
+            }
         }
     }
 


### PR DESCRIPTION
# Overview

## Changes

- Carry a failed partition write into `sessions_failed` rather than returning it, so one transient S3 fault costs one session instead of the whole pass
- Apply the same to the quote write path, which carries the identical trap
- Exit non-zero from `seed_intraday_bars_s3` on `sessions_failed` or `symbols_failed`, matching `seed_quotes_s3`
- Correct the `sessions_failed` docstring, which described fetch failures only

## Context

A whole-market five-minute widening ran 5h25m, rewrote 1,013 partitions from 2021-08-24 to 2025-08-27, then hit a transient S3 streaming error reading the 2025-08-29 partition and discarded the sweep:

```
failed to read s3://.../interval=five_minute/year=2025/month=08/day=29/data.parquet: streaming error
```

Nothing written was lost or corrupted — the durable boundary is clean, confirmed by object size in S3 rather than read off the log. What was lost was the run.

`write_partitions` carried `ArchiveError::Contended` and returned everything else. Contention is the one fault it anticipated, so a fault it did not anticipate ended the pass. The retry loop in `write_merged` does not cover this: it retries the compare-and-swap at the `put`, and this failed at the `read` preceding it. This is the same defect as the scan-path one fixed in #1102, still live on the write path.

Carrying every write error is safe because a systemic fault cannot reach that arm. `universe_over` is `?`-propagated and runs per chunk before any write, so bad credentials or a missing bucket fail there having written nothing. What reaches the arm is a fault against a single key — which is the argument contention already relies on.

That forced the exit code. With write failures non-fatal, `Ok(Some(summary)) => 0` would report success for a pass whose every session failed, so the bar binary's exit status had to become load-bearing in the same change. `sessions_without_data` stays out of the condition for the reason #1105 established: this pass requests holidays deliberately and they answer empty, unlike the quote pass, which samples the published calendar.

### Verification

`devenv tasks run checks:all` passes, coverage 80.8%.

No automated test covers the carried path, and this is worth stating plainly rather than leaving to be discovered. The defect is in error propagation across an async S3 boundary, and this module has no test double for one — every test in `archive.rs` is a pure-function test. Extracting a classifier purely to create a seam would produce a test asserting that every variant is carried, which is a tautology of the kind #1102 caught. A real regression test wants `StaticReplayClient` from `aws-smithy-runtime`'s test-util feature; that is a new dev-dependency and deferred by agreement, not overlooked.

The behavioural verification is the resume run of the remaining 242 sessions, which is starting now against the development bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9MuPyHx1o8E6X9cPZcCNZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Seeding operations now correctly report failures when sessions or symbols cannot be processed.
  * Sessions with no available data are no longer incorrectly marked as failures.
  * Partition write errors are recorded per session, allowing other sessions to continue processing.
  * Failed sessions can be retried in subsequent runs instead of stopping the entire operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->