### PR TITLE
Resolve a quote request as of its session rather than as of today

### DIFF
--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -2528,11 +2528,15 @@ impl MarketDataClient {
     ///
     /// Ticks arrive in ascending time order, which every time-weighted fold downstream depends on,
     /// and unusable books are refused here so `accept` only ever sees a quote worth weighing.
+    ///
+    /// `asof` is the day whose mapping resolves `ticker`, and must be the session being fetched:
+    /// the default is today, which would read a historical window through today's symbol table.
     pub async fn fetch_quotes<F>(
         &self,
         ticker: &Ticker,
         start: DateTime<Utc>,
         end: DateTime<Utc>,
+        asof: NaiveDate,
         mut accept: F,
     ) -> Result<QuoteFetch, ClientError>
     where
@@ -2541,6 +2545,7 @@ impl MarketDataClient {
         let url = format!("{}/v2/stocks/quotes", self.base_url);
         let start_text = start.to_rfc3339();
         let end_text = end.to_rfc3339();
+        let asof_text = asof.to_string();
         let page_size = QUOTES_PAGE_SIZE.to_string();
         let feed = self.feed.as_str();
 
@@ -2557,6 +2562,9 @@ impl MarketDataClient {
                 // Stated rather than inherited. The fold weighs each quote by the time until the
                 // next one, so a descending page would silently weigh every tick at zero.
                 ("sort", "asc"),
+                // Stated for the same reason: the default is today, and a ticker reassigned since
+                // the session would resolve to the company holding it now.
+                ("asof", asof_text.as_str()),
             ];
             if let Some(token) = page_token.as_deref() {
                 query.push(("page_token", token));
@@ -4429,7 +4437,9 @@ mod tests {
         let (start, end) = quote_window();
         let mut ticks = Vec::new();
         let fetch = client(base_url)
-            .fetch_quotes(&ticker("AAPL"), start, end, |tick| ticks.push(tick))
+            .fetch_quotes(&ticker("AAPL"), start, end, date(2026, 8, 20), |tick| {
+                ticks.push(tick)
+            })
             .await;
         (ticks, fetch)
     }
@@ -4481,6 +4491,36 @@ mod tests {
         assert_eq!(ticks[0].bid_size(), 1);
         first.assert_async().await;
         second.assert_async().await;
+    }
+
+    /// The default resolves a ticker through today's symbol table, so a name reassigned since the
+    /// session would answer with the company holding it now rather than the one that traded.
+    #[tokio::test]
+    async fn test_quotes_are_resolved_as_of_the_session_rather_than_today() {
+        let mut server = mockito::Server::new_async().await;
+        let page = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_query(mockito::Matcher::UrlEncoded(
+                "asof".into(),
+                "2026-08-20".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"quotes":{"AAPL":[
+                    {"t":"2026-08-20T13:30:00Z","bp":100.00,"ap":100.05,"bs":1,"as":2}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+
+        let (ticks, fetch) = collect_quotes(server.url()).await;
+
+        assert_eq!(fetch.expect("the page must parse").received, 1);
+        assert_eq!(ticks.len(), 1);
+        // The mock only answers a request carrying the session's own date, so reaching this line
+        // is the assertion; `assert_async` names the failure when it does not.
+        page.assert_async().await;
     }
 
     /// A crossed consolidated book is ordinary around the open — 20 of AAPL's first 30,126 quotes

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -2562,8 +2562,7 @@ impl MarketDataClient {
                 // Stated rather than inherited. The fold weighs each quote by the time until the
                 // next one, so a descending page would silently weigh every tick at zero.
                 ("sort", "asc"),
-                // Stated for the same reason: the default is today, and a ticker reassigned since
-                // the session would resolve to the company holding it now.
+                // The default is today, so a reassigned ticker resolves to its current owner.
                 ("asof", as_of_text.as_str()),
             ];
             if let Some(token) = page_token.as_deref() {

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -2529,14 +2529,14 @@ impl MarketDataClient {
     /// Ticks arrive in ascending time order, which every time-weighted fold downstream depends on,
     /// and unusable books are refused here so `accept` only ever sees a quote worth weighing.
     ///
-    /// `asof` is the day whose mapping resolves `ticker`, and must be the session being fetched:
+    /// `as_of` is the day whose mapping resolves `ticker`, and must be the session being fetched:
     /// the default is today, which would read a historical window through today's symbol table.
     pub async fn fetch_quotes<F>(
         &self,
         ticker: &Ticker,
         start: DateTime<Utc>,
         end: DateTime<Utc>,
-        asof: NaiveDate,
+        as_of: NaiveDate,
         mut accept: F,
     ) -> Result<QuoteFetch, ClientError>
     where
@@ -2545,7 +2545,7 @@ impl MarketDataClient {
         let url = format!("{}/v2/stocks/quotes", self.base_url);
         let start_text = start.to_rfc3339();
         let end_text = end.to_rfc3339();
-        let asof_text = asof.to_string();
+        let as_of_text = as_of.to_string();
         let page_size = QUOTES_PAGE_SIZE.to_string();
         let feed = self.feed.as_str();
 
@@ -2564,7 +2564,7 @@ impl MarketDataClient {
                 ("sort", "asc"),
                 // Stated for the same reason: the default is today, and a ticker reassigned since
                 // the session would resolve to the company holding it now.
-                ("asof", asof_text.as_str()),
+                ("asof", as_of_text.as_str()),
             ];
             if let Some(token) = page_token.as_deref() {
                 query.push(("page_token", token));

--- a/src/data/quotes.rs
+++ b/src/data/quotes.rs
@@ -341,7 +341,7 @@ pub async fn fold_session(
         )));
     };
     let fetch = market_data
-        .fetch_quotes(ticker, open, close, |tick| fold.push(tick))
+        .fetch_quotes(ticker, open, close, session.date(), |tick| fold.push(tick))
         .await?;
     Ok((fold.finish(), fetch))
 }


### PR DESCRIPTION
# Overview

## Changes

- Send `asof` on the Alpaca quote request, set to the session being fetched, instead of inheriting a default of the current day
- Pass the session date from `fold_session` at the domain boundary, as a `NaiveDate`, since `common::alpaca` is transport
- Add a test pinning the parameter to the session's own date

## Context

Alpaca resolves a queried symbol through a mapping whose default is the current day — the documented example is FB to META. We never sent `asof`, so every historical quote request read a past window through today's symbol table, while the universe for that request came from the daily archive partition for that session, which is survivorship-free and holds tickers as they stood on the day. The request was historically correct on one side and anachronistic on the other.

Both failure modes select for exactly the names the survivorship-free archive exists to preserve:

- **Renamed** — the 2021 partition says `FB`, and `FB` maps nowhere today, so the answer is empty.
- **Reused** — a ticker freed by a delisting and reassigned answers with whoever holds it now.

An empty answer for a delisted name is indistinguishable from a name that simply did not quote, which is the same invisible-gap class as the symbol-level scan problem in #1102.

### Nothing already stored is affected, and this was measured rather than assumed

All five seeded sessions are 2026-08-17..21 against a 2026-08-23 fetch, so `asof`-default and `asof`-session differ by at most six days. Two checks against the live API:

- Every one of the **12,144 names** on 2026-08-17 re-fetched both ways over a one-minute window at the open — `answered without asof: 12138, with asof: 12138, symbols differing: 0`.
- The **25 thinnest names** by quote count — SPAC units, warrants and rights, the class most prone to ticker churn — compared across the entire session, matching exactly.

This is short of a guarantee: the full check covers a one-minute window on one of five sessions. Re-fetching all five in full would cost ~9.5 hours to defend against a mapping change that would have had to occur within six days and leave quote counts identical, which is not a trade I would make without a reason to suspect one.

### Massive needs no equivalent

`asof` is an Alpaca concept and every bar path goes to Massive, which resolves point-in-time already. Proven against the same rename:

| session | FB | META |
|---|---|---|
| 2021-10-15 | $324.76, 21.6M shares | $14.78, 178k shares |
| 2023-10-16 | absent | $321.15, 16.5M shares |

Two different companies under `META` on either side of 2022-06-09, and Facebook's history under `FB` where it belongs. Resolution through today's mapping would have put Facebook's price under `META` in 2021.

The remaining Alpaca historical call sites are corporate actions and account activity, where symbol mapping either does not apply or is itself the thing being reported.

### Verification

`devenv tasks run checks:all` passes, coverage 80.8%.

The new assertion was proved load-bearing by reintroducing the defect — sending `Utc::now().date_naive()` in place of the session — and watching the test FAIL, then restoring it. Worth recording that the first attempt at that proof used `sed`, which silently failed to modify the file and reported a pass both times; the discrepancy was caught because a test passing with the bug present was the specific thing being checked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9MuPyHx1o8E6X9cPZcCNZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Historical quote requests now use the selected trading session date when resolving ticker symbols.
  - Improved accuracy when retrieving quotes for past market sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->