### PR TITLE
Give the archive an S3 test double, and the regression test #1106 could not have

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,6 +2873,7 @@ dependencies = [
  "http 1.5.0",
  "mockito",
  "ndarray 0.16.1",
+ "percent-encoding",
  "polars",
  "rand 0.10.2",
  "reqwest 0.13.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,23 +642,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-protocol-test",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "bytes",
  "h2 0.3.27",
  "h2 0.4.15",
  "http 0.2.12",
  "http 1.5.0",
  "http-body 0.4.6",
+ "http-body 1.0.1",
  "hyper 0.14.32",
  "hyper 1.10.1",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.9",
  "hyper-util",
+ "indexmap",
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower",
@@ -683,6 +689,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
  "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-protocol-test"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76511a0e223ce78deb6a78b8afebda99cb737cfbc8a58d96dcb190f012dd40a"
+dependencies = [
+ "assert-json-diff",
+ "aws-smithy-runtime-api",
+ "base64-simd",
+ "cbor-diag",
+ "ciborium",
+ "http 0.2.12",
+ "pretty_assertions",
+ "regex-lite",
+ "roxmltree",
+ "serde_json",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1058,6 +1083,15 @@ checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1504,6 +1538,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor-diag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1619,33 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -2320,6 +2400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,6 +2863,8 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
+ "aws-smithy-http-client",
+ "aws-smithy-types",
  "axum",
  "burn",
  "chrono",
@@ -5652,6 +5740,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6432,6 +6530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6802,6 +6909,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "separator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
+
+[[package]]
 name = "seq-macro"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6853,6 +6966,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -9017,6 +9131,12 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,11 @@ axum = "0.8"
 
 [dev-dependencies]
 aws-credential-types = "1.2.14"
+# `test-util` supplies the scripted HTTP client that lets `data::archive` be tested at all: the
+# module is almost entirely S3 round trips and every other test in it is a pure-function test.
+# This crate rather than `aws-smithy-runtime`, whose re-export is the `http` 0.x variant.
+aws-smithy-http-client = { version = "1.2", features = ["test-util"] }
+aws-smithy-types = "1.6"
 http = "1"
 mockito = "1.7"
 serial_test = "4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,9 @@ aws-credential-types = "1.2.14"
 aws-smithy-http-client = { version = "1.2", features = ["test-util"] }
 aws-smithy-types = "1.6"
 http = "1"
+# A real decoder rather than undoing `%3D` by hand: RFC 3986 allows either hex case, so a scripted
+# request that stops matching would make the test pass while injecting nothing.
+percent-encoding = "2.3"
 mockito = "1.7"
 serial_test = "4.0"
 tower = { version = "0.5", features = ["util"] }

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -1879,6 +1879,7 @@ mod tests {
     use aws_smithy_http_client::test_util::infallible_client_fn;
     use aws_smithy_types::body::SdkBody;
     use chrono::NaiveDate;
+    use percent_encoding::percent_decode_str;
 
     fn session(year: i32, month: u32, day: u32) -> SessionDate {
         SessionDate::from_date(
@@ -1895,9 +1896,9 @@ mod tests {
     ) -> S3Client {
         let http_client = infallible_client_fn(move |request| {
             let method = request.method().clone();
-            // Undone rather than matched against: S3 percent-encodes the `=` in every hive
+            // Decoded rather than matched against: S3 percent-encodes the `=` in every hive
             // segment, so a key built by `date_partitioned_key` never matches the wire form.
-            let key = request.uri().path().replace("%3D", "=");
+            let key = percent_decode_str(request.uri().path()).decode_utf8_lossy();
             respond(&method, &key)
         });
         S3Client::from_conf(
@@ -1949,7 +1950,7 @@ mod tests {
     /// what ended a five-hour whole-market pass four fifths of the way through.
     #[tokio::test]
     async fn test_a_failed_partition_write_costs_only_its_own_session() {
-        let doomed = session(2026, 8, 19);
+        let doomed = session(2026, 9, 3);
         let doomed_key =
             date_partitioned_key(&bar_archive_prefix(BarInterval::FiveMinute), doomed.date());
         let client = scripted_s3_client(move |method, key| {
@@ -1968,15 +1969,12 @@ mod tests {
             }
         });
 
-        let partitions: Vec<(SessionDate, Vec<EquityBar>)> = [
-            session(2026, 8, 18),
-            doomed,
-            session(2026, 8, 20),
-            session(2026, 8, 21),
-        ]
-        .into_iter()
-        .map(|at| (at, vec![one_bar("AAPL", at)]))
-        .collect();
+        // More partitions than [`INTRADAY_WRITE_CONCURRENCY`], so work is still queued when the
+        // failure lands — a defect that stopped scheduling the rest would leave the count short.
+        let partitions: Vec<(SessionDate, Vec<EquityBar>)> = (1..=20)
+            .map(|day| session(2026, 9, day))
+            .map(|at| (at, vec![one_bar("AAPL", at)]))
+            .collect();
 
         let mut summary = ArchiveSummary::default();
         let outcome = write_partitions(
@@ -1989,8 +1987,10 @@ mod tests {
         .await;
 
         assert!(outcome.is_ok(), "one bad session must not end the pass");
-        assert_eq!(summary.sessions_written, 3);
-        assert_eq!(summary.sessions_failed, vec![doomed]);
+        assert_eq!(summary.sessions_written, 19);
+        // The literal, not `doomed`: an expectation carried from the fixture moves with it, so
+        // relocating the scripted failure would keep this passing without meaning to.
+        assert_eq!(summary.sessions_failed, vec![session(2026, 9, 3)]);
     }
 
     /// The stored layout, pinned to literals. Everything already written lives at these keys, and a

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -1876,12 +1876,121 @@ async fn put_bytes(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aws_smithy_http_client::test_util::infallible_client_fn;
+    use aws_smithy_types::body::SdkBody;
     use chrono::NaiveDate;
 
     fn session(year: i32, month: u32, day: u32) -> SessionDate {
         SessionDate::from_date(
             NaiveDate::from_ymd_opt(year, month, day).expect("test date must be valid"),
         )
+    }
+
+    /// An S3 client answering from `respond` instead of the network, given the method and the key.
+    ///
+    /// Dispatched on the request rather than replayed in order, because `write_partitions` runs
+    /// [`INTRADAY_WRITE_CONCURRENCY`] writes at once and an ordered script would race them.
+    fn scripted_s3_client(
+        respond: impl Fn(&http::Method, &str) -> http::Response<SdkBody> + Send + Sync + 'static,
+    ) -> S3Client {
+        let http_client = infallible_client_fn(move |request| {
+            let method = request.method().clone();
+            // Undone rather than matched against: S3 percent-encodes the `=` in every hive
+            // segment, so a key built by `date_partitioned_key` never matches the wire form.
+            let key = request.uri().path().replace("%3D", "=");
+            respond(&method, &key)
+        });
+        S3Client::from_conf(
+            aws_sdk_s3::Config::builder()
+                .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
+                .region(aws_sdk_s3::config::Region::new("us-east-1"))
+                .credentials_provider(aws_sdk_s3::config::Credentials::new(
+                    "test-key",
+                    "test-secret",
+                    None,
+                    None,
+                    "test",
+                ))
+                .http_client(http_client)
+                .build(),
+        )
+    }
+
+    /// Absent, so `write_merged` takes its `Precondition::Absent` path and writes without a merge.
+    fn no_such_key() -> http::Response<SdkBody> {
+        http::Response::builder()
+            .status(404)
+            .body(SdkBody::from(
+                "<Error><Code>NoSuchKey</Code><Message>absent</Message></Error>",
+            ))
+            .expect("a canned response must build")
+    }
+
+    fn one_bar(ticker_symbol: &str, at: SessionDate) -> EquityBar {
+        EquityBar::new(
+            Ticker::new(ticker_symbol).expect("a test ticker must parse"),
+            BarInterval::FiveMinute,
+            at.midnight(),
+            100.0,
+            101.0,
+            99.0,
+            100.5,
+            1_000,
+            None,
+            None,
+        )
+        .expect("a coherent candle must construct")
+    }
+
+    /// One session's write failing must cost that session and no other.
+    ///
+    /// The regression test #1106 could not have: before it, any non-contention error returned from
+    /// `write_partitions`, so a single transient fault discarded every session after it — which is
+    /// what ended a five-hour whole-market pass four fifths of the way through.
+    #[tokio::test]
+    async fn test_a_failed_partition_write_costs_only_its_own_session() {
+        let doomed = session(2026, 8, 19);
+        let doomed_key =
+            date_partitioned_key(&bar_archive_prefix(BarInterval::FiveMinute), doomed.date());
+        let client = scripted_s3_client(move |method, key| {
+            if method == http::Method::PUT && key.ends_with(&doomed_key) {
+                http::Response::builder()
+                    .status(500)
+                    .body(SdkBody::from("<Error><Code>InternalError</Code></Error>"))
+                    .expect("a canned response must build")
+            } else if method == http::Method::PUT {
+                http::Response::builder()
+                    .status(200)
+                    .body(SdkBody::empty())
+                    .expect("a canned response must build")
+            } else {
+                no_such_key()
+            }
+        });
+
+        let partitions: Vec<(SessionDate, Vec<EquityBar>)> = [
+            session(2026, 8, 18),
+            doomed,
+            session(2026, 8, 20),
+            session(2026, 8, 21),
+        ]
+        .into_iter()
+        .map(|at| (at, vec![one_bar("AAPL", at)]))
+        .collect();
+
+        let mut summary = ArchiveSummary::default();
+        let outcome = write_partitions(
+            &client,
+            "test-bucket",
+            BarInterval::FiveMinute,
+            partitions,
+            &mut summary,
+        )
+        .await;
+
+        assert!(outcome.is_ok(), "one bad session must not end the pass");
+        assert_eq!(summary.sessions_written, 3);
+        assert_eq!(summary.sessions_failed, vec![doomed]);
     }
 
     /// The stored layout, pinned to literals. Everything already written lives at these keys, and a


### PR DESCRIPTION
# Overview

First of four pull requests for the seed binary refactor (task 4). This one adds the test harness the
rest of the task will be verified with, and pays off the debt #1106 left behind.

## Changes

- Add `aws-smithy-http-client` with `test-util` as a dev-dependency
- Add a scripted S3 client to `data::archive`'s tests, dispatching on the request rather than replaying a fixed script
- Add the regression test for #1106: a failed partition write costs its own session and no other

## Context

`data::archive` is almost entirely S3 round trips, and every one of its tests was a pure-function test. That is why #1106 shipped its carry-versus-fatal fix with no test of its own, and why I could not demonstrate that fix was load-bearing at the time. Task 4 is about to rewrite this module's scope handling, so the harness comes first.

### The double dispatches on the request, not on order

`StaticReplayClient` answers sequentially, but `write_partitions` runs `INTRADAY_WRITE_CONCURRENCY` writes at once through a `JoinSet`. An ordered script would race them and flake. `infallible_client_fn` matched on method and key is deterministic however the futures interleave.

### The first version passed for the wrong reason

Worth recording, because it is precisely the failure mode this test exists to catch. It reported **four** sessions written where three were expected — the doomed `PUT` had succeeded and the injected failure never fired. S3 percent-encodes the `=` in every hive segment, so a key built by `date_partitioned_key` never matches the wire form:

```
/data/equity/bars/interval%3Dfive_minute/year%3D2026/month%3D08/day%3D19/data.parquet
```

Rather than guess a second time I printed the paths and read them. The client now undoes that encoding, with a comment saying why. Had the count not been asserted, this test would have shipped green and inert.

### Verification

`devenv tasks run checks:all` passes. Coverage **80.81% → 81.22%** — the test reaches code nothing previously exercised.

Proved load-bearing by restoring `Err(error) => return Err(error)` in `write_partitions` and watching it fail on the assertion that one bad session must not end the pass, then restoring.

### On the dependency choice

The plan named `aws-smithy-runtime`, but in 1.12 its re-export of `infallible_client_fn` is the `http` 0.x variant while this tree's `http` dev-dependency is version 1. The helpers now live in `aws-smithy-http-client`; pinned to the 1.2.0 already resolved in `Cargo.lock`, so no existing version moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9MuPyHx1o8E6X9cPZcCNZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added regression coverage ensuring a failed partition write does not prevent other sessions from being written.
  * Failed sessions are now reported individually while successful sessions continue completing.

* **Tests**
  * Added simulated storage responses for success, missing-object, and server-error scenarios.
  * Verified that three of four sessions are written when one session encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->