### PR TITLE
Give every pass one summary, one completeness rule, and a calendar to judge it by

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -989,11 +989,13 @@ in {
     # downtime cost the same nothing -- then trains against that window and uploads a model.tar.gz
     # the service loads directly. A gap older than the window is `data:seed:s3`, which floors at two
     # years.
-    # The bars need no Alpaca credentials: the grouped endpoint answers by date, so there is no
-    # symbol list to build and therefore no broker to ask for one. That is also why the archive scan
-    # decides which sessions to request from weekends rather than from the published trading
-    # calendar. The series-boundary table does need them, because Massive reports splits and nothing
-    # else -- but it warns and skips when they are absent rather than failing the run.
+    # The bars themselves need no Alpaca credentials: the grouped endpoint answers by date, so there
+    # is no symbol list to build and therefore no broker to ask for one. The trading calendar does,
+    # and without it the scan requests holidays, which answer empty forever and cannot be told apart
+    # from a session Massive is missing. Both the calendar and the series-boundary table warn and
+    # skip when the credentials are absent rather than failing the run -- a repair that requests a
+    # few holidays is a better trade than no repair at all. The seed binaries, which are run
+    # deliberately rather than nightly, require the calendar instead of degrading.
     # The former Python/tinygrad workflow and its Prefect block registration are retired.
     "models:tide:train".exec = ''
       set -euo pipefail

--- a/src/bin/seed_equity_bars_s3.rs
+++ b/src/bin/seed_equity_bars_s3.rs
@@ -5,8 +5,10 @@
 //! cannot cover: a bucket with nothing in it, and an outage older than the training lookback.
 //!
 //! Usage: `seed_equity_bars_s3 [start YYYY-MM-DD] [end YYYY-MM-DD]`
-//! With no arguments the window is the last [`DEFAULT_ARCHIVE_LOOKBACK_DAYS`] days ending today
-//! (US/Eastern), which is the answer to "just make the archive right".
+//! With no arguments the window is the last [`DEFAULT_ARCHIVE_LOOKBACK_DAYS`] days ending on the
+//! session before today (US/Eastern), which is the answer to "just make the archive right" — today's
+//! daily bar is stamped at the close and does not exist before it. Needs Alpaca credentials for the
+//! trading calendar, so holidays are never requested.
 //!
 //! Needs Massive and AWS credentials and no database, so it runs from either VM or a laptop. The
 //! work itself is [`fund::data::archive::archive_missing_sessions`] — the same call the trainer
@@ -57,17 +59,28 @@ fn parse_date(value: &str) -> Result<SessionDate, String> {
         .map_err(|error| format!("Invalid date '{value}': expected YYYY-MM-DD ({error})"))
 }
 
+/// The most recent session whose daily bar can already exist.
+///
+/// A daily bar is stamped at the close, so the current session has none until 16:00 Eastern.
+/// Defaulting to today made a pre-close run request a session with no data, which the calendar-filtered
+/// pass reports as a fault rather than as a holiday. An explicitly named date is left alone: an
+/// operator who asks for today is asking for a session with no data, and being told so is correct.
+fn last_final_session(today: SessionDate) -> SessionDate {
+    today.plus_calendar_days(-1)
+}
+
 /// Parses the optional positional date arguments.
 ///
 /// `today` is a parameter rather than read from the clock here, because a function that reads the
 /// wall clock cannot be tested across the hours where the Eastern date and the UTC date disagree.
 fn parse_arguments(arguments: &[String], today: SessionDate) -> Result<ArchiveRange, String> {
+    let latest = last_final_session(today);
     match arguments {
         [] => ArchiveRange::new(
-            today.plus_calendar_days(-DEFAULT_ARCHIVE_LOOKBACK_DAYS),
-            today,
+            latest.plus_calendar_days(-DEFAULT_ARCHIVE_LOOKBACK_DAYS),
+            latest,
         ),
-        [start] => ArchiveRange::new(parse_date(start)?, today),
+        [start] => ArchiveRange::new(parse_date(start)?, latest),
         [start, end] => ArchiveRange::new(parse_date(start)?, parse_date(end)?),
         _ => Err(format!("Too many arguments\n{USAGE}")),
     }
@@ -103,9 +116,9 @@ async fn main() {
                 "Equity bar archive seeded"
             );
             // A run that stepped over a session leaves exactly the hole this tool exists to close,
-            // and the exit code is the operator's only signal that the range needs re-running. A
-            // session with no data is not counted: holidays land there and always will, which is
-            // what `SessionSource::Weekdays` says and why this reads the archive's rule.
+            // and the exit code is the operator's only signal that the range needs re-running. The
+            // calendar excludes holidays before anything is requested, so a session reported without
+            // data is one the vendor is missing rather than one the market was shut for.
             if summary.is_complete() {
                 0
             } else {
@@ -172,7 +185,7 @@ async fn trading_calendar(
     let days = TradingClient::from_env(credentials)
         .fetch_calendar(start.date(), end.date())
         .await?;
-    Ok(TradingCalendar::from_days(days))
+    Ok(TradingCalendar::covering(days, start, end))
 }
 
 #[cfg(test)]
@@ -185,23 +198,39 @@ mod tests {
         )
     }
 
+    /// The default stops the day before, because today's daily bar is stamped at the close and does
+    /// not exist before it. Ending on today made a pre-close run request a session with no data,
+    /// which the calendar-filtered pass reports as a fault rather than as a holiday.
     #[test]
-    fn test_no_arguments_covers_the_default_lookback_ending_today() {
-        let today = session(2026, 8, 6);
-        let range = parse_arguments(&[], today).unwrap();
-        assert_eq!(range.end, today);
+    fn test_no_arguments_end_on_the_session_before_today() {
+        let range = parse_arguments(&[], session(2026, 8, 6)).unwrap();
+
+        assert_eq!(range.end, session(2026, 8, 5));
         assert_eq!(
             range.start,
-            today.plus_calendar_days(-DEFAULT_ARCHIVE_LOOKBACK_DAYS)
+            session(2026, 8, 5).plus_calendar_days(-DEFAULT_ARCHIVE_LOOKBACK_DAYS)
         );
     }
 
     #[test]
-    fn test_one_argument_runs_from_that_date_to_today() {
-        let today = session(2026, 8, 6);
-        let range = parse_arguments(&["2026-01-02".to_string()], today).unwrap();
+    fn test_one_argument_runs_from_that_date_to_the_last_final_session() {
+        let range = parse_arguments(&["2026-01-02".to_string()], session(2026, 8, 6)).unwrap();
+
         assert_eq!(range.start, session(2026, 1, 2));
-        assert_eq!(range.end, today);
+        assert_eq!(range.end, session(2026, 8, 5));
+    }
+
+    /// An explicit date is left alone. An operator naming today is asking for a session with no
+    /// data, and the run reporting that is the exit code telling the truth rather than a defect.
+    #[test]
+    fn test_an_explicit_end_date_is_taken_as_given() {
+        let range = parse_arguments(
+            &["2026-08-01".to_string(), "2026-08-06".to_string()],
+            session(2026, 8, 6),
+        )
+        .unwrap();
+
+        assert_eq!(range.end, session(2026, 8, 6));
     }
 
     #[test]

--- a/src/bin/seed_equity_bars_s3.rs
+++ b/src/bin/seed_equity_bars_s3.rs
@@ -16,10 +16,12 @@
 use chrono::{NaiveDate, Utc};
 use tracing::{error, info};
 
+use fund::common::alpaca::{AlpacaCredentials, TradingClient};
 use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
 use fund::common::types::SessionDate;
 use fund::data::archive;
+use fund::data::calendar::TradingCalendar;
 
 const USAGE: &str = "Usage: seed_equity_bars_s3 [start YYYY-MM-DD] [end YYYY-MM-DD]";
 
@@ -93,17 +95,18 @@ async fn main() {
     let code = match run(&range).await {
         Ok(summary) => {
             info!(
-                sessions_requested = summary.sessions_requested,
-                sessions_written = summary.sessions_written,
-                sessions_without_data = summary.sessions_without_data,
-                sessions_failed = summary.sessions_failed.len(),
-                bars_written = summary.bars_written,
+                sessions_requested = summary.sessions_requested(),
+                sessions_written = summary.sessions_written(),
+                sessions_without_data = summary.sessions_without_data(),
+                sessions_failed = summary.sessions_failed().len(),
+                bars_written = summary.output().rows_written(),
                 "Equity bar archive seeded"
             );
             // A run that stepped over a session leaves exactly the hole this tool exists to close,
             // and the exit code is the operator's only signal that the range needs re-running. A
-            // session with no data is not counted: holidays land there and always will.
-            if summary.sessions_failed.is_empty() {
+            // session with no data is not counted: holidays land there and always will, which is
+            // what `SessionSource::Weekdays` says and why this reads the archive's rule.
+            if summary.is_complete() {
                 0
             } else {
                 1
@@ -124,27 +127,52 @@ async fn main() {
 
 /// Repairs the archive over `range` and returns what the pass accomplished.
 ///
-/// Reads `AWS_S3_BUCKET_NAME` and the Massive credentials from the environment, and writes bar
-/// partitions under `data/equity/bars/interval=one_day/`. No database is touched. Only the sessions the bucket is
-/// missing are fetched, so the cost of a run is the size of the gap rather than the size of the
-/// range, and re-running over a repaired range is close to free.
-async fn run(range: &ArchiveRange) -> Result<archive::ArchiveSummary, Box<dyn std::error::Error>> {
+/// Reads `AWS_S3_BUCKET_NAME`, the Massive credentials and the Alpaca credentials from the
+/// environment, and writes bar partitions under `data/equity/bars/interval=one_day/`. No database is
+/// touched. Only the sessions the bucket is missing are fetched, so the cost of a run is the size of
+/// the gap rather than the size of the range, and re-running over a repaired range is close to free.
+///
+/// Alpaca answers only for the trading calendar: without it the pass would request holidays, which
+/// answer empty forever and cannot be told apart from a session Massive is missing.
+async fn run(range: &ArchiveRange) -> Result<archive::PassSummary, Box<dyn std::error::Error>> {
     let bucket = std::env::var("AWS_S3_BUCKET_NAME")
         .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
     let massive = MassiveClient::from_env()?;
     let s3_client = fund::common::aws::s3_client().await;
+    let calendar = trading_calendar(range.start, range.end).await?;
 
     info!(
         bucket,
         start = %range.start,
         end = %range.end,
+        sessions = calendar.len(),
         "Seeding the equity bar archive from Massive"
     );
 
-    Ok(
-        archive::archive_missing_sessions(&s3_client, &massive, &bucket, range.start, range.end)
-            .await?,
+    Ok(archive::archive_missing_sessions(
+        &s3_client,
+        &massive,
+        &bucket,
+        range.start,
+        range.end,
+        Some(&calendar),
     )
+    .await?)
+}
+
+/// Fetches the published sessions over the window, so holidays are never requested.
+///
+/// One request covering the whole range: `/v2/calendar` is unpaginated and answers 1990 through 2029
+/// in a single call, so even a five-year seed costs one round trip.
+async fn trading_calendar(
+    start: SessionDate,
+    end: SessionDate,
+) -> Result<TradingCalendar, Box<dyn std::error::Error>> {
+    let credentials = AlpacaCredentials::from_env()?;
+    let days = TradingClient::from_env(credentials)
+        .fetch_calendar(start.date(), end.date())
+        .await?;
+    Ok(TradingCalendar::from_days(days))
 }
 
 #[cfg(test)]

--- a/src/bin/seed_intraday_bars_s3.rs
+++ b/src/bin/seed_intraday_bars_s3.rs
@@ -172,8 +172,8 @@ async fn main() {
                 summary.output().rows_written(),
                 summary.symbols_failed()
             );
-            // One rule, in the archive: this pass requests holidays deliberately and they answer
-            // empty, which `SessionSource::Weekdays` is what says.
+            // One rule, in the archive. The supplied calendar excludes holidays before the pass
+            // requests anything, so a session reported without data is a real gap.
             if summary.is_complete() {
                 0
             } else {
@@ -277,7 +277,7 @@ async fn trading_calendar(
     let days = TradingClient::from_env(credentials)
         .fetch_calendar(start.date(), end.date())
         .await?;
-    Ok(TradingCalendar::from_days(days))
+    Ok(TradingCalendar::covering(days, start, end))
 }
 
 /// Missing names printed per session before the line is truncated.

--- a/src/bin/seed_intraday_bars_s3.rs
+++ b/src/bin/seed_intraday_bars_s3.rs
@@ -7,10 +7,12 @@ use std::collections::BTreeSet;
 use chrono::NaiveDate;
 use tracing::{error, info};
 
+use fund::common::alpaca::{AlpacaCredentials, TradingClient};
 use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
 use fund::common::types::{BarInterval, LiquidityFloor, SessionDate, Ticker};
 use fund::data::archive::{self, NameSelection, Scope, SessionSelection};
+use fund::data::calendar::TradingCalendar;
 
 const USAGE: &str = "Usage: seed_intraday_bars_s3 START_DATE END_DATE [CADENCE [SYMBOLS]]\n\
                      Dates are Eastern calendar dates, inclusive: YYYY-MM-DD.\n\
@@ -163,16 +165,16 @@ async fn main() {
         Ok(Some(summary)) => {
             println!(
                 "requested {} sessions, wrote {}, {} without data, {} failed, {} bars, {} symbols missing",
-                summary.sessions_requested,
-                summary.sessions_written,
-                summary.sessions_without_data,
-                summary.sessions_failed.len(),
-                summary.bars_written,
-                summary.symbols_failed
+                summary.sessions_requested(),
+                summary.sessions_written(),
+                summary.sessions_without_data(),
+                summary.sessions_failed().len(),
+                summary.output().rows_written(),
+                summary.symbols_failed()
             );
-            // `sessions_without_data` is not a fault here: this pass requests holidays deliberately
-            // and they answer empty, unlike the quote pass, which samples the published calendar.
-            if summary.sessions_failed.is_empty() && summary.symbols_failed == 0 {
+            // One rule, in the archive: this pass requests holidays deliberately and they answer
+            // empty, which `SessionSource::Weekdays` is what says.
+            if summary.is_complete() {
                 0
             } else {
                 1
@@ -196,16 +198,19 @@ async fn main() {
 /// missing one name is indistinguishable from a complete one, so those are the ones to fold into.
 async fn run(
     parameters: &Parameters,
-) -> Result<Option<archive::ArchiveSummary>, Box<dyn std::error::Error>> {
+) -> Result<Option<archive::PassSummary>, Box<dyn std::error::Error>> {
     let bucket = std::env::var("AWS_S3_BUCKET_NAME")
         .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
     let s3_client = fund::common::aws::s3_client().await;
 
     // Built before the scan, which in repair mode is thousands of reads: an unset credential should
-    // fail in the first second rather than after it. A scan writes nothing and never needs one.
-    let massive = match parameters.mode {
-        Mode::Scan => None,
-        Mode::Seed(_) | Mode::Repair => Some(MassiveClient::from_env()?),
+    // fail in the first second rather than after it. A scan writes nothing and never needs either.
+    let (massive, calendar) = match parameters.mode {
+        Mode::Scan => (None, None),
+        Mode::Seed(_) | Mode::Repair => (
+            Some(MassiveClient::from_env()?),
+            Some(trading_calendar(parameters.start, parameters.end).await?),
+        ),
     };
 
     let scope = match &parameters.mode {
@@ -234,12 +239,14 @@ async fn run(
     };
 
     let massive = massive.expect("every mode that fetches builds a client above");
+    let calendar = calendar.expect("every mode that fetches builds a calendar above");
     info!(
         bucket,
         start = %parameters.start,
         end = %parameters.end,
         interval = %parameters.interval,
         %scope,
+        sessions = calendar.len(),
         "Seeding the intraday bar archive from Massive"
     );
 
@@ -252,9 +259,25 @@ async fn run(
             parameters.start,
             parameters.end,
             &scope,
+            Some(&calendar),
         )
         .await?,
     ))
+}
+
+/// Fetches the published sessions over the window, so holidays are never requested.
+///
+/// One request covering the whole range: `/v2/calendar` is unpaginated and answers 1990 through 2029
+/// in a single call, so even a five-year backfill costs one round trip.
+async fn trading_calendar(
+    start: SessionDate,
+    end: SessionDate,
+) -> Result<TradingCalendar, Box<dyn std::error::Error>> {
+    let credentials = AlpacaCredentials::from_env()?;
+    let days = TradingClient::from_env(credentials)
+        .fetch_calendar(start.date(), end.date())
+        .await?;
+    Ok(TradingCalendar::from_days(days))
 }
 
 /// Missing names printed per session before the line is truncated.

--- a/src/bin/seed_quotes_s3.rs
+++ b/src/bin/seed_quotes_s3.rs
@@ -189,32 +189,35 @@ async fn main() {
         // `None` when nothing was archived, which is what a measurement run always reports.
         Ok(None) => 0,
         Ok(Some(summary)) => {
+            let (summaries_written, quotes_folded) = match summary.output() {
+                archive::PassOutput::Quotes {
+                    summaries_written,
+                    quotes_folded,
+                } => (*summaries_written, *quotes_folded),
+                // Unreachable through `archive_quote_sessions`, and printed rather than panicked so
+                // a mislabelled summary costs two zeroes in a line rather than the run.
+                archive::PassOutput::Bars { .. } => (0, 0),
+            };
             println!(
                 "requested {} sessions, wrote {}, {} without data, {} failed, {} summaries, {} symbols missing, {} quotes folded",
-                summary.sessions_requested,
-                summary.sessions_written,
-                summary.sessions_without_data,
-                summary.sessions_failed.len(),
-                summary.summaries_written,
-                summary.symbols_failed,
-                summary.quotes_folded
+                summary.sessions_requested(),
+                summary.sessions_written(),
+                summary.sessions_without_data(),
+                summary.sessions_failed().len(),
+                summaries_written,
+                summary.symbols_failed(),
+                quotes_folded
             );
             // Non-zero on an incomplete pass, because the partition it wrote reads as complete to
-            // everything downstream and the exit code is the only signal automation sees.
-            //
-            // `sessions_without_data` counts here where it would not on the bar path: the sample
-            // is drawn from the published calendar, so a session that answers with nothing is a
-            // missing daily partition or an empty fold, never a holiday.
-            if summary.symbols_failed > 0
-                || !summary.sessions_failed.is_empty()
-                || summary.sessions_without_data > 0
-            {
+            // everything downstream and the exit code is the only signal automation sees. What
+            // counts as incomplete is the archive's rule now, not this binary's.
+            if summary.is_complete() {
+                0
+            } else {
                 eprintln!(
                     "Incomplete: re-run the affected sessions with the missing symbols and `repair`"
                 );
                 1
-            } else {
-                0
             }
         }
         Err(error) => {
@@ -231,7 +234,7 @@ async fn main() {
 /// Folds the sampled sessions, or measures the named symbols across them.
 async fn run(
     parameters: &Parameters,
-) -> Result<Option<archive::QuoteArchiveSummary>, Box<dyn std::error::Error>> {
+) -> Result<Option<archive::PassSummary>, Box<dyn std::error::Error>> {
     let credentials = AlpacaCredentials::from_env()?;
     // SIP is pinned, not read from `ALPACA_DATA_FEED`: IEX's best bid and offer is not the national
     // one, so an environment variable could put two incomparable series under one key.

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -132,7 +132,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             .fetch_calendar(window_start.date(), session.date())
             .await
         {
-            Ok(days) => Some(TradingCalendar::from_days(days)),
+            Ok(days) => Some(TradingCalendar::covering(days, window_start, session)),
             Err(error) => {
                 warn!(%error, "Trading calendar unavailable; the repair will request holidays too");
                 None

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -8,20 +8,21 @@
 //! Frames are built through [`fund::data::bars::bars_to_dataframe`], shared with the application:
 //! if the two diverged, the model would train on columns the inference path does not produce.
 //!
-//! Nothing here touches a database or Alpaca — Massive answers by date, so there is no symbol list
-//! to build and no broker to ask for one. That is also why [`fund::data::archive`] decides which
-//! sessions to request from weekends rather than from the published trading calendar.
+//! Nothing here touches a database, and Alpaca is optional — Massive answers bars by date, so there
+//! is no symbol list to build. The trading calendar and the boundary table do need a broker key, and
+//! both warn and carry on without one: a repair that also requests holidays beats no repair.
 
 use burn::module::AutodiffModule;
 use burn::tensor::backend::Backend;
 use chrono::Utc;
 use tracing::{error, info, warn};
 
-use fund::common::alpaca::{AlpacaCredentials, MarketDataClient};
+use fund::common::alpaca::{AlpacaCredentials, MarketDataClient, TradingClient};
 use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
 use fund::common::types::SessionDate;
 use fund::data::archive;
+use fund::data::calendar::TradingCalendar;
 use fund::data::details;
 use fund::laboratory::dataset;
 use fund::laboratory::journal as laboratory;
@@ -123,6 +124,25 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // year; a night with no new partition trains on 364 days instead of 365, which is a far better
     // outcome than publishing no model because Massive was briefly unreachable.
     let window_start = session.plus_calendar_days(-lookback_days);
+    // Fetched here rather than required, unlike the seed binaries. Without it the pass requests
+    // holidays and reports them as sessions without data; with a broker key absent entirely that is
+    // still a better trade than skipping the repair, which is the same call the boundary stage makes.
+    let calendar = match AlpacaCredentials::from_env() {
+        Ok(credentials) => match TradingClient::from_env(credentials)
+            .fetch_calendar(window_start.date(), session.date())
+            .await
+        {
+            Ok(days) => Some(TradingCalendar::from_days(days)),
+            Err(error) => {
+                warn!(%error, "Trading calendar unavailable; the repair will request holidays too");
+                None
+            }
+        },
+        Err(error) => {
+            warn!(%error, "No Alpaca credentials; the repair will request holidays too");
+            None
+        }
+    };
     match MassiveClient::from_env() {
         Ok(massive) => {
             match archive::archive_missing_sessions(
@@ -131,14 +151,15 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 &bucket,
                 window_start,
                 session,
+                calendar.as_ref(),
             )
             .await
             {
                 Ok(summary) => info!(
-                    sessions_written = summary.sessions_written,
-                    sessions_without_data = summary.sessions_without_data,
-                    sessions_failed = summary.sessions_failed.len(),
-                    bars_written = summary.bars_written,
+                    sessions_written = summary.sessions_written(),
+                    sessions_without_data = summary.sessions_without_data(),
+                    sessions_failed = summary.sessions_failed().len(),
+                    bars_written = summary.output().rows_written(),
                     "Archive repaired"
                 ),
                 Err(error) => {

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -119,6 +119,16 @@ pub enum ArchiveError {
     },
     #[error("gave up on {key} after {attempts} concurrent writes by another pass")]
     Contended { key: String, attempts: usize },
+    /// The trading calendar does not span the window, so which dates trade is unanswerable.
+    ///
+    /// Fatal rather than carried, unlike a failed session: a calendar short of the window drops real
+    /// sessions from the request and the pass would report a complete run over a window it never
+    /// covered — the one failure the summary itself cannot show.
+    #[error("the trading calendar does not cover {start} to {end}")]
+    Calendar {
+        start: SessionDate,
+        end: SessionDate,
+    },
     /// The upstream feed failed, before any bucket was touched.
     ///
     /// The vendor is carried because two of them supply this archive, and an operator reading the
@@ -351,32 +361,25 @@ fn expected_sessions(start: SessionDate, end: SessionDate) -> Vec<SessionDate> {
 
 /// The sessions a pass should be able to answer for, filtered by `calendar` when it has one.
 ///
-/// `calendar` must span the window: `is_trading_day` answers `false` outside its published horizon,
-/// so one fetched for a narrower range would quietly discard real sessions. That case is warned
-/// about rather than trusted, because a pass that requests nothing otherwise reports success.
+/// Refused rather than narrowed when the calendar does not span the window: `is_trading_day` answers
+/// `false` outside its published horizon, so a short calendar would drop real sessions, shrink
+/// `sessions_requested`, and leave the pass reporting a complete run over a window it never covered.
 fn sessions_in_window(
     start: SessionDate,
     end: SessionDate,
     calendar: Option<&TradingCalendar>,
-) -> Vec<SessionDate> {
+) -> Result<Vec<SessionDate>, ArchiveError> {
     let weekdays = expected_sessions(start, end);
     let Some(calendar) = calendar else {
-        return weekdays;
+        return Ok(weekdays);
     };
-    let trading: Vec<SessionDate> = weekdays
-        .iter()
-        .copied()
-        .filter(|session| calendar.is_trading_day(*session))
-        .collect();
-    if trading.is_empty() && !weekdays.is_empty() {
-        warn!(
-            %start,
-            %end,
-            weekdays = weekdays.len(),
-            "The calendar reports no trading day in this window; it may not span it"
-        );
+    if !calendar.covers(start, end) {
+        return Err(ArchiveError::Calendar { start, end });
     }
-    trading
+    Ok(weekdays
+        .into_iter()
+        .filter(|session| calendar.is_trading_day(*session))
+        .collect())
 }
 
 /// The sessions to request: those with no partition, plus the correction window.
@@ -474,7 +477,7 @@ pub async fn archive_missing_sessions(
     window_end: SessionDate,
     calendar: Option<&TradingCalendar>,
 ) -> Result<PassSummary, ArchiveError> {
-    let expected = sessions_in_window(window_start, window_end, calendar);
+    let expected = sessions_in_window(window_start, window_end, calendar)?;
     let present = present_sessions(
         s3_client,
         bucket,
@@ -833,7 +836,7 @@ pub async fn archive_intraday_sessions(
     scope: &Scope,
     calendar: Option<&TradingCalendar>,
 ) -> Result<PassSummary, ArchiveError> {
-    let expected = sessions_in_window(window_start, window_end, calendar);
+    let expected = sessions_in_window(window_start, window_end, calendar)?;
     let present = present_sessions(s3_client, bucket, interval, window_start, window_end).await?;
     let requested = sessions_for(scope.sessions, &expected, &present);
 
@@ -2273,7 +2276,11 @@ mod tests {
             sessions_without_data: 1,
             ..Default::default()
         };
-        let calendar = calendar_of(&[session(2026, 8, 17)]);
+        let calendar = calendar_of(
+            &[session(2026, 8, 17)],
+            session(2026, 8, 17),
+            session(2026, 8, 21),
+        );
 
         assert!(
             counts().into_bar_summary(None).is_complete(),
@@ -2296,7 +2303,7 @@ mod tests {
         let (start, end) = (session(2026, 7, 1), session(2026, 7, 6));
 
         assert_eq!(
-            sessions_in_window(start, end, None),
+            sessions_in_window(start, end, None).unwrap(),
             vec![
                 session(2026, 7, 1),
                 session(2026, 7, 2),
@@ -2306,13 +2313,17 @@ mod tests {
             "the weekday sweep keeps the holiday and drops only the weekend"
         );
 
-        let calendar = calendar_of(&[
-            session(2026, 7, 1),
-            session(2026, 7, 2),
-            session(2026, 7, 6),
-        ]);
+        let calendar = calendar_of(
+            &[
+                session(2026, 7, 1),
+                session(2026, 7, 2),
+                session(2026, 7, 6),
+            ],
+            start,
+            end,
+        );
         assert_eq!(
-            sessions_in_window(start, end, Some(&calendar)),
+            sessions_in_window(start, end, Some(&calendar)).unwrap(),
             vec![
                 session(2026, 7, 1),
                 session(2026, 7, 2),
@@ -2320,6 +2331,49 @@ mod tests {
             ],
             "the calendar drops 07-03, which would answer empty forever"
         );
+    }
+
+    /// The hole the first version of this only half-covered: it warned when the filter left nothing
+    /// at all, which misses the truncation that matters. A calendar short at either end drops real
+    /// sessions, shrinks `sessions_requested`, and leaves `is_complete()` reporting a clean run over
+    /// a window it never saw — the one failure the summary itself cannot show.
+    #[test]
+    fn test_a_calendar_that_does_not_span_the_window_is_refused() {
+        let (start, end) = (session(2026, 7, 1), session(2026, 7, 31));
+        let trading = [session(2026, 7, 1), session(2026, 7, 2)];
+
+        for (covered_start, covered_end, why) in [
+            (session(2026, 7, 6), end, "short at the start"),
+            (start, session(2026, 7, 20), "short at the end"),
+        ] {
+            let calendar = calendar_of(&trading, covered_start, covered_end);
+            assert!(
+                matches!(
+                    sessions_in_window(start, end, Some(&calendar)).unwrap_err(),
+                    ArchiveError::Calendar { start: refused_start, end: refused_end }
+                        if refused_start == start && refused_end == end
+                ),
+                "a calendar {why} must be refused, not silently narrow the request"
+            );
+        }
+
+        let spanning = calendar_of(&trading, start, end);
+        assert!(sessions_in_window(start, end, Some(&spanning)).is_ok());
+    }
+
+    /// A calendar built without recording its range cannot prove it covers anything, so it is
+    /// refused rather than trusted — the same conservatism `is_trading_day` already applies outside
+    /// its horizon, where it answers `false` rather than guessing.
+    #[test]
+    fn test_a_calendar_of_unknown_range_covers_nothing() {
+        let (start, end) = (session(2026, 7, 1), session(2026, 7, 2));
+        let unknown = TradingCalendar::from_days(vec![]);
+
+        assert!(!unknown.covers(start, end));
+        assert!(matches!(
+            sessions_in_window(start, end, Some(&unknown)).unwrap_err(),
+            ArchiveError::Calendar { .. }
+        ));
     }
 
     /// Every count has to survive the accumulator becoming a summary. Both finishers copy field by
@@ -2883,9 +2937,13 @@ mod tests {
         Scope::new(names, sessions).expect("a valid test scope")
     }
 
-    /// A calendar publishing exactly these sessions, at the usual bell.
-    fn calendar_of(sessions: &[SessionDate]) -> TradingCalendar {
-        TradingCalendar::from_days(
+    /// A calendar publishing exactly these sessions, at the usual bell, over `[start, end]`.
+    fn calendar_of(
+        sessions: &[SessionDate],
+        start: SessionDate,
+        end: SessionDate,
+    ) -> TradingCalendar {
+        TradingCalendar::covering(
             sessions
                 .iter()
                 .map(|at| {
@@ -2897,6 +2955,8 @@ mod tests {
                     .expect("a session with duration")
                 })
                 .collect(),
+            start,
+            end,
         )
     }
 

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -155,39 +155,188 @@ enum WriteOutcome {
     Failed(String),
 }
 
+/// What a pass produced, whose units differ where it matters.
+///
+/// `quotes_folded` counts ticks fetched and discarded, which is what decides whether a backfill is
+/// affordable: a session yields roughly 79 summaries per name and hundreds of thousands of quotes to
+/// produce them. Per variant rather than beside the shared counts, so a bar pass cannot report one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PassOutput {
+    /// Bars written across every partition the pass touched.
+    Bars { bars_written: usize },
+    /// Summary rows written across both cadences, and the ticks folded to produce them.
+    Quotes {
+        summaries_written: usize,
+        quotes_folded: usize,
+    },
+}
+
+impl PassOutput {
+    /// Rows this pass wrote to the archive, whichever kind it writes.
+    ///
+    /// For a caller that wants the one number rather than the variant — the trainer logs it, and a
+    /// bar pass and a quote pass both mean "rows that landed in a partition" by it.
+    pub fn rows_written(&self) -> usize {
+        match self {
+            PassOutput::Bars { bars_written } => *bars_written,
+            PassOutput::Quotes {
+                summaries_written, ..
+            } => *summaries_written,
+        }
+    }
+}
+
+/// How the sessions a pass requested were chosen, which decides whether an empty answer is a fault.
+///
+/// Not a label for which pass ran: [`expected_sessions`] excludes weekends but not holidays, because
+/// knowing them needs the calendar it deliberately does without. A holiday requested that way
+/// answers empty forever and is not a defect; one requested from a calendar-filtered list is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionSource {
+    /// Every weekday in the window, holidays included.
+    Weekdays,
+    /// Already filtered against the exchange calendar, so no holiday survives to answer empty.
+    TradingCalendar,
+}
+
+impl SessionSource {
+    /// Read off the calendar a pass actually held, so nothing can claim a filtering it never did.
+    fn of(calendar: Option<&TradingCalendar>) -> Self {
+        match calendar {
+            Some(_) => SessionSource::TradingCalendar,
+            None => SessionSource::Weekdays,
+        }
+    }
+}
+
 /// What one archiving pass accomplished.
 ///
-/// `sessions_without_data` is reported rather than swallowed because it is how a caller tells a
-/// healthy run from a broken one. A steady handful is the holidays this deliberately re-requests; a
-/// sudden window of them is Massive answering empty, which looks identical in the archive and
-/// nothing else would surface.
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct ArchiveSummary {
+/// Fields are private and read through accessors: every one is a result, except the session source,
+/// which is the policy that interprets them — a caller able to set that could call a broken pass
+/// clean, and the counts carry a partition invariant nothing outside should be able to break.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PassSummary {
+    sessions_requested: usize,
+    sessions_written: usize,
+    sessions_without_data: usize,
+    sessions_failed: Vec<SessionDate>,
+    symbols_failed: usize,
+    output: PassOutput,
+    sessions: SessionSource,
+}
+
+impl PassSummary {
     /// Sessions that were absent (or inside the correction window) and therefore requested.
-    pub sessions_requested: usize,
-    /// Sessions that came back with bars and were written.
-    pub sessions_written: usize,
-    /// Sessions that were requested and returned no bars — holidays, and anything Massive lacks.
-    pub sessions_without_data: usize,
+    pub fn sessions_requested(&self) -> usize {
+        self.sessions_requested
+    }
+
+    /// Sessions that came back with data and were written.
+    pub fn sessions_written(&self) -> usize {
+        self.sessions_written
+    }
+
+    /// Sessions that were requested and returned nothing.
+    ///
+    /// Reported rather than swallowed because it is how a caller tells a healthy run from a broken
+    /// one. Whether it is a fault depends on how the session list was built, which is what
+    /// [`PassSummary::is_complete`] settles.
+    pub fn sessions_without_data(&self) -> usize {
+        self.sessions_without_data
+    }
+
     /// Sessions whose fetch or write failed, carried rather than fatal.
     ///
-    /// Treat a non-empty list as an incomplete pass: `Ok` means the pass ran to the end, not that
-    /// every requested session was written.
-    pub sessions_failed: Vec<SessionDate>,
-    /// Bars written across every partition this pass touched.
-    pub bars_written: usize,
-    /// Symbols an intraday pass could not fetch after every attempt.
+    /// A non-empty list is an incomplete pass: `Ok` means the pass ran to the end, not that every
+    /// requested session was written.
+    pub fn sessions_failed(&self) -> &[SessionDate] {
+        &self.sessions_failed
+    }
+
+    /// Symbols the pass could not fetch after every attempt.
     ///
     /// Reported because nothing downstream can detect one: a session-level gap scan sees the
     /// partition and moves on, so a symbol missing from it stays missing until someone re-runs the
     /// window. Always zero on the daily path, which fetches the market in one call.
-    pub symbols_failed: usize,
+    pub fn symbols_failed(&self) -> usize {
+        self.symbols_failed
+    }
+
+    /// What landed in the archive, in the units of the pass that wrote it.
+    pub fn output(&self) -> &PassOutput {
+        &self.output
+    }
+
+    /// Whether every session this pass requested is now in the archive.
+    ///
+    /// The one rule every binary's exit code derives from. Deciding it per binary was wrong twice —
+    /// bars exiting 0 on failure, quotes counting holidays as failure — and it is silent when wrong,
+    /// because a partition an incomplete pass wrote reads as complete to everything downstream.
+    pub fn is_complete(&self) -> bool {
+        self.sessions_failed.is_empty()
+            && self.symbols_failed == 0
+            && match self.sessions {
+                // A pass given no calendar still requested holidays, and a holiday is
+                // indistinguishable from a session the vendor lacks, so this cannot be called a fault.
+                SessionSource::Weekdays => true,
+                SessionSource::TradingCalendar => self.sessions_without_data == 0,
+            }
+    }
+}
+
+/// What a pass accumulates while it runs, before it is finished into a [`PassSummary`].
+///
+/// Separate so the published type can carry [`PassOutput`] as an enum without any code matching on a
+/// variant it might not have: the variant is built once, by the finisher, where it is not in doubt.
+#[derive(Debug, Default)]
+struct PassProgress {
+    sessions_requested: usize,
+    sessions_written: usize,
+    sessions_without_data: usize,
+    sessions_failed: Vec<SessionDate>,
+    symbols_failed: usize,
+    /// Bars on a bar pass, summary rows on a quote pass — one quantity, named at the finish.
+    rows_written: usize,
+}
+
+impl PassProgress {
+    fn into_bar_summary(self, calendar: Option<&TradingCalendar>) -> PassSummary {
+        PassSummary {
+            sessions_requested: self.sessions_requested,
+            sessions_written: self.sessions_written,
+            sessions_without_data: self.sessions_without_data,
+            sessions_failed: self.sessions_failed,
+            symbols_failed: self.symbols_failed,
+            output: PassOutput::Bars {
+                bars_written: self.rows_written,
+            },
+            sessions: SessionSource::of(calendar),
+        }
+    }
+
+    /// `quotes_folded` arrives by return rather than through this accumulator, so no bar pass ever
+    /// holds a counter it cannot fill.
+    fn into_quote_summary(self, quotes_folded: usize) -> PassSummary {
+        PassSummary {
+            sessions_requested: self.sessions_requested,
+            sessions_written: self.sessions_written,
+            sessions_without_data: self.sessions_without_data,
+            sessions_failed: self.sessions_failed,
+            symbols_failed: self.symbols_failed,
+            output: PassOutput::Quotes {
+                summaries_written: self.rows_written,
+                quotes_folded,
+            },
+            sessions: SessionSource::TradingCalendar,
+        }
+    }
 }
 
 /// Every weekday in `[start, end]` that the archive should be able to answer for.
 ///
 /// Weekends are excluded because they are never sessions anywhere; holidays are not, because
-/// knowing them requires the calendar this deliberately does without.
+/// knowing them requires a calendar this deliberately does without — see [`sessions_in_window`],
+/// which applies one when the caller has it.
 fn expected_sessions(start: SessionDate, end: SessionDate) -> Vec<SessionDate> {
     let mut expected = Vec::new();
     let mut date = start;
@@ -198,6 +347,36 @@ fn expected_sessions(start: SessionDate, end: SessionDate) -> Vec<SessionDate> {
         date = date.plus_calendar_days(1);
     }
     expected
+}
+
+/// The sessions a pass should be able to answer for, filtered by `calendar` when it has one.
+///
+/// `calendar` must span the window: `is_trading_day` answers `false` outside its published horizon,
+/// so one fetched for a narrower range would quietly discard real sessions. That case is warned
+/// about rather than trusted, because a pass that requests nothing otherwise reports success.
+fn sessions_in_window(
+    start: SessionDate,
+    end: SessionDate,
+    calendar: Option<&TradingCalendar>,
+) -> Vec<SessionDate> {
+    let weekdays = expected_sessions(start, end);
+    let Some(calendar) = calendar else {
+        return weekdays;
+    };
+    let trading: Vec<SessionDate> = weekdays
+        .iter()
+        .copied()
+        .filter(|session| calendar.is_trading_day(*session))
+        .collect();
+    if trading.is_empty() && !weekdays.is_empty() {
+        warn!(
+            %start,
+            %end,
+            weekdays = weekdays.len(),
+            "The calendar reports no trading day in this window; it may not span it"
+        );
+    }
+    trading
 }
 
 /// The sessions to request: those with no partition, plus the correction window.
@@ -277,7 +456,7 @@ async fn present_partitions(
 /// are one case where a fixed lookback repairs only the first. Expected means "worth requesting"
 /// rather than "the market traded", since the trainer holds no broker credentials to consult a
 /// calendar with: a holiday is requested, answered with nothing, and requested again, at a cost of
-/// roughly ten empty requests a year that [`ArchiveSummary`] reports rather than hides.
+/// roughly ten empty requests a year that [`PassSummary`] reports rather than hides.
 ///
 /// Idempotent: a second pass over an unchanged window requests only the correction window and
 /// writes the same rows back. Safe to interrupt, because partitions are written as each chunk
@@ -293,8 +472,9 @@ pub async fn archive_missing_sessions(
     bucket: &str,
     window_start: SessionDate,
     window_end: SessionDate,
-) -> Result<ArchiveSummary, ArchiveError> {
-    let expected = expected_sessions(window_start, window_end);
+    calendar: Option<&TradingCalendar>,
+) -> Result<PassSummary, ArchiveError> {
+    let expected = sessions_in_window(window_start, window_end, calendar);
     let present = present_sessions(
         s3_client,
         bucket,
@@ -314,7 +494,7 @@ pub async fn archive_missing_sessions(
         "Scanned the bar archive for gaps"
     );
 
-    let mut summary = ArchiveSummary {
+    let mut progress = PassProgress {
         sessions_requested: requested.len(),
         ..Default::default()
     };
@@ -324,28 +504,28 @@ pub async fn archive_missing_sessions(
     // weekdays held every bar for all of them in memory before the first write. The same reasoning
     // and the same size as `seed_equity_bars_postgres`, whose chunking predates this.
     for chunk in requested.chunks(CHUNK_SESSIONS) {
-        archive_chunk(s3_client, massive, bucket, chunk, &mut summary).await?;
+        archive_chunk(s3_client, massive, bucket, chunk, &mut progress).await?;
     }
 
-    if !summary.sessions_failed.is_empty() {
+    if !progress.sessions_failed.is_empty() {
         // Logged rather than fatal: a failed session costs one partition, and the next pass finds
         // it missing again and retries it. That is the whole point of scanning rather than counting
         // back from today.
         warn!(
-            sessions_failed = ?summary.sessions_failed,
+            sessions_failed = ?progress.sessions_failed,
             "Some sessions could not be fetched; the next pass will retry them"
         );
     }
 
     info!(
-        sessions_requested = summary.sessions_requested,
-        sessions_written = summary.sessions_written,
-        sessions_without_data = summary.sessions_without_data,
-        sessions_failed = summary.sessions_failed.len(),
-        bars_written = summary.bars_written,
+        sessions_requested = progress.sessions_requested,
+        sessions_written = progress.sessions_written,
+        sessions_without_data = progress.sessions_without_data,
+        sessions_failed = progress.sessions_failed.len(),
+        bars_written = progress.rows_written,
         "Bar archive updated"
     );
-    Ok(summary)
+    Ok(progress.into_bar_summary(calendar))
 }
 
 /// Requested sessions that neither answered with bars nor failed outright.
@@ -353,7 +533,7 @@ pub async fn archive_missing_sessions(
 /// Counted over the requested sessions rather than by subtracting the number of answers. Responses
 /// are grouped by each bar's own timestamp, so a response can carry a session nobody asked for, and
 /// subtracting counts would let that extra one stand in for a session that genuinely came back
-/// empty — concealing exactly the signal [`ArchiveSummary::sessions_without_data`] exists to carry.
+/// empty — concealing exactly the signal [`PassSummary::sessions_without_data`] exists to carry.
 /// Taken together with the written and failed counts, this partitions the requested set.
 fn count_sessions_without_data(
     requested: &[SessionDate],
@@ -388,11 +568,11 @@ async fn archive_chunk(
     massive: &MassiveClient,
     bucket: &str,
     chunk: &[SessionDate],
-    summary: &mut ArchiveSummary,
+    progress: &mut PassProgress,
 ) -> Result<(), ArchiveError> {
     let fetched = bars::fetch_daily_bars(massive, chunk).await;
     let failed: BTreeSet<SessionDate> = fetched.dates_failed.iter().copied().collect();
-    summary.sessions_failed.extend(fetched.dates_failed);
+    progress.sessions_failed.extend(fetched.dates_failed);
 
     // One partition per session date, keyed by the bar's own timestamp rather than by the date that
     // was requested, so a response that answers for a neighbouring session cannot land under the
@@ -407,7 +587,7 @@ async fn archive_chunk(
     }
 
     let answered: BTreeSet<SessionDate> = by_date.keys().copied().collect();
-    summary.sessions_without_data += count_sessions_without_data(chunk, &answered, &failed);
+    progress.sessions_without_data += count_sessions_without_data(chunk, &answered, &failed);
 
     for (session, bars_for_session) in by_date {
         let fetched_frame = bars::bars_to_dataframe(&bars_for_session)?;
@@ -425,21 +605,21 @@ async fn archive_chunk(
             Ok(()) => {
                 // The rows this pass contributed, not the partition's height. Counting the merged
                 // total reported the archive's size as though every pass had just written it.
-                summary.sessions_written += 1;
-                summary.bars_written += fetched_rows;
+                progress.sessions_written += 1;
+                progress.rows_written += fetched_rows;
             }
             Err(ArchiveError::Contended { key, attempts }) => {
                 // Another pass kept winning the partition. Recorded as failed rather than retried
                 // forever: the next scan finds this session and repairs it, and the writer that did
                 // win wrote the same Massive response this one was holding.
                 warn!(key, attempts, %session, "Partition contended; the next pass will retry it");
-                summary.sessions_failed.push(session);
+                progress.sessions_failed.push(session);
             }
             // Carried like contention above, so one session's fault costs that session rather than
             // every session after it. The pass is only complete if `sessions_failed` is empty.
             Err(error) => {
                 warn!(%error, %session, "Partition write failed; this session was not archived");
-                summary.sessions_failed.push(session);
+                progress.sessions_failed.push(session);
             }
         }
     }
@@ -651,8 +831,9 @@ pub async fn archive_intraday_sessions(
     window_start: SessionDate,
     window_end: SessionDate,
     scope: &Scope,
-) -> Result<ArchiveSummary, ArchiveError> {
-    let expected = expected_sessions(window_start, window_end);
+    calendar: Option<&TradingCalendar>,
+) -> Result<PassSummary, ArchiveError> {
+    let expected = sessions_in_window(window_start, window_end, calendar);
     let present = present_sessions(s3_client, bucket, interval, window_start, window_end).await?;
     let requested = sessions_for(scope.sessions, &expected, &present);
 
@@ -667,7 +848,7 @@ pub async fn archive_intraday_sessions(
         "Planned an intraday pass"
     );
 
-    let mut summary = ArchiveSummary {
+    let mut progress = PassProgress {
         sessions_requested: requested.len(),
         ..Default::default()
     };
@@ -680,29 +861,29 @@ pub async fn archive_intraday_sessions(
             chunk,
             scope,
             &present,
-            &mut summary,
+            &mut progress,
         )
         .await?;
     }
 
-    if summary.symbols_failed > 0 {
+    if progress.symbols_failed > 0 {
         // Warned separately from the summary below, because this is the only outcome here that
         // needs a person: nothing re-requests a session that was written without one of its names.
         warn!(
-            symbols_failed = summary.symbols_failed,
+            symbols_failed = progress.symbols_failed,
             "Some symbols are absent from the partitions this pass wrote; re-run the window to repair them"
         );
     }
     info!(
-        sessions_requested = summary.sessions_requested,
-        sessions_written = summary.sessions_written,
-        sessions_without_data = summary.sessions_without_data,
-        sessions_failed = summary.sessions_failed.len(),
-        symbols_failed = summary.symbols_failed,
-        bars_written = summary.bars_written,
+        sessions_requested = progress.sessions_requested,
+        sessions_written = progress.sessions_written,
+        sessions_without_data = progress.sessions_without_data,
+        sessions_failed = progress.sessions_failed.len(),
+        symbols_failed = progress.symbols_failed,
+        bars_written = progress.rows_written,
         "Intraday archive updated"
     );
-    Ok(summary)
+    Ok(progress.into_bar_summary(calendar))
 }
 
 /// One chunk: derive the universe, fan out over it, then write a partition per session.
@@ -718,7 +899,7 @@ async fn archive_intraday_chunk(
     chunk: &[SessionDate],
     scope: &Scope,
     present: &BTreeSet<SessionDate>,
-    summary: &mut ArchiveSummary,
+    progress: &mut PassProgress,
 ) -> Result<(), ArchiveError> {
     let (Some(first), Some(last)) = (chunk.first(), chunk.last()) else {
         return Ok(());
@@ -736,7 +917,7 @@ async fn archive_intraday_chunk(
     }
     if universe.symbols.is_empty() {
         // Nothing to fetch, so nothing in the chunk gets written.
-        summary.sessions_without_data += chunk.len();
+        progress.sessions_without_data += chunk.len();
         return Ok(());
     }
     info!(
@@ -814,10 +995,10 @@ async fn archive_intraday_chunk(
     }
 
     let answered: BTreeSet<SessionDate> = by_session.keys().copied().collect();
-    summary.sessions_without_data +=
+    progress.sessions_without_data +=
         count_intraday_sessions_without_data(chunk, &universe.described, &answered);
     if symbols_failed > 0 {
-        summary.symbols_failed += symbols_failed;
+        progress.symbols_failed += symbols_failed;
         // Loud, because the partitions below are about to be written *without* these names and
         // nothing downstream can tell that from a complete one.
         warn!(
@@ -847,7 +1028,7 @@ async fn archive_intraday_chunk(
         );
     }
 
-    write_partitions(s3_client, bucket, interval, writable, summary).await
+    write_partitions(s3_client, bucket, interval, writable, progress).await
 }
 
 /// Whether this pass may write the partition for `session`.
@@ -881,7 +1062,7 @@ async fn write_partitions(
     bucket: &str,
     interval: BarInterval,
     partitions: Vec<(SessionDate, Vec<EquityBar>)>,
-    summary: &mut ArchiveSummary,
+    progress: &mut PassProgress,
 ) -> Result<(), ArchiveError> {
     let mut queued = partitions.into_iter();
     let mut writes = tokio::task::JoinSet::new();
@@ -905,19 +1086,19 @@ async fn write_partitions(
         };
         match finished {
             Ok((_, rows, Ok(()))) => {
-                summary.sessions_written += 1;
-                summary.bars_written += rows;
+                progress.sessions_written += 1;
+                progress.rows_written += rows;
             }
             Ok((session, _, Err(ArchiveError::Contended { key, attempts }))) => {
                 warn!(key, attempts, %session, "Partition contended; the next pass will retry it");
-                summary.sessions_failed.push(session);
+                progress.sessions_failed.push(session);
             }
             // Carried for the same reason contention is: one session's write says nothing about the
             // next one's. A fault that breaks writes but not reads is carried too and costs the rest
             // of the pass, which `sessions_failed` reports rather than hides.
             Ok((session, _, Err(error))) => {
                 warn!(%error, %session, "Partition write failed; this session was not archived");
-                summary.sessions_failed.push(session);
+                progress.sessions_failed.push(session);
             }
             Err(error) => {
                 return Err(ArchiveError::Write {
@@ -1334,33 +1515,6 @@ const QUOTE_CONCURRENCY: usize = 8;
 /// one of its names from a complete one.
 const QUOTE_SYMBOL_ATTEMPTS: usize = 3;
 
-/// What one quote-archiving pass accomplished.
-///
-/// Its own type rather than [`ArchiveSummary`], because the units differ where it matters:
-/// `quotes_folded` counts ticks that were fetched and discarded, and it is the number that decides
-/// whether a backfill is affordable. A session yields roughly 79 summaries per name and hundreds of
-/// thousands of quotes to produce them.
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct QuoteArchiveSummary {
-    /// Sessions with no summary yet, and therefore requested.
-    pub sessions_requested: usize,
-    /// Sessions whose summaries were written.
-    pub sessions_written: usize,
-    /// Sessions that could not be summarized: a holiday, or one the daily archive cannot describe.
-    pub sessions_without_data: usize,
-    /// Sessions whose write failed, carried rather than fatal.
-    ///
-    /// Treat a non-empty list as an incomplete pass: `Ok` means the pass ran to the end, not that
-    /// every requested session was summarized.
-    pub sessions_failed: Vec<SessionDate>,
-    /// Summary rows written across both cadences.
-    pub summaries_written: usize,
-    /// Symbols whose quotes could not be fetched after every attempt.
-    pub symbols_failed: usize,
-    /// Quotes folded and discarded, which is what the pass actually cost.
-    pub quotes_folded: usize,
-}
-
 /// Folds the quoted book across `sessions`, per `scope`.
 ///
 /// Session-major rather than ticker-major, unlike the intraday bar pass: a quote request is already
@@ -1370,6 +1524,9 @@ pub struct QuoteArchiveSummary {
 ///
 /// Regular hours only, taken from the calendar so an early close is 3.5 hours rather than 6.5. The
 /// overnight book is an order of magnitude wider and would swamp any session mean it entered.
+///
+/// `sessions` must already be calendar-filtered, which the returned summary assumes when it reports
+/// a session that answered with nothing as a fault rather than as a holiday.
 pub async fn archive_quote_sessions(
     s3_client: &S3Client,
     market_data: &MarketDataClient,
@@ -1377,9 +1534,9 @@ pub async fn archive_quote_sessions(
     bucket: &str,
     sessions: &[SessionDate],
     scope: &Scope,
-) -> Result<QuoteArchiveSummary, ArchiveError> {
+) -> Result<PassSummary, ArchiveError> {
     let (Some(first), Some(last)) = (sessions.first(), sessions.last()) else {
-        return Ok(QuoteArchiveSummary::default());
+        return Ok(PassProgress::default().into_quote_summary(0));
     };
     let present = present_partitions(
         s3_client,
@@ -1417,45 +1574,51 @@ pub async fn archive_quote_sessions(
         }
     }
 
-    let mut summary = QuoteArchiveSummary {
+    let mut progress = PassProgress {
         sessions_requested: requested.len(),
         ..Default::default()
     };
+    // Summed here rather than accumulated through `progress`, which is what lets the published
+    // summary carry it per variant without a bar pass holding a counter it can never fill.
+    let mut quotes_folded = 0usize;
     for session in requested {
-        archive_quote_session(
+        quotes_folded += archive_quote_session(
             s3_client,
             market_data,
             calendar,
             bucket,
             session,
             scope,
-            &mut summary,
+            &mut progress,
         )
         .await?;
     }
 
-    if summary.symbols_failed > 0 {
+    if progress.symbols_failed > 0 {
         // Warned separately, because this is the outcome nothing re-requests: the partition exists,
         // so the next pass reads the session as present and never looks inside it.
         warn!(
-            symbols_failed = summary.symbols_failed,
+            symbols_failed = progress.symbols_failed,
             "Some symbols are absent from the summaries this pass wrote; re-run those sessions to repair them"
         );
     }
     info!(
-        sessions_requested = summary.sessions_requested,
-        sessions_written = summary.sessions_written,
-        sessions_without_data = summary.sessions_without_data,
-        sessions_failed = summary.sessions_failed.len(),
-        summaries_written = summary.summaries_written,
-        symbols_failed = summary.symbols_failed,
-        quotes_folded = summary.quotes_folded,
+        sessions_requested = progress.sessions_requested,
+        sessions_written = progress.sessions_written,
+        sessions_without_data = progress.sessions_without_data,
+        sessions_failed = progress.sessions_failed.len(),
+        summaries_written = progress.rows_written,
+        symbols_failed = progress.symbols_failed,
+        quotes_folded,
         "Quote archive updated"
     );
-    Ok(summary)
+    Ok(progress.into_quote_summary(quotes_folded))
 }
 
 /// One session: derive the universe from the scope, fold every name's book, write both cadences.
+///
+/// Returns the quotes folded to produce them, which is the pass's real cost and the only figure that
+/// travels by return rather than through `progress`.
 #[allow(clippy::too_many_arguments)]
 async fn archive_quote_session(
     s3_client: &S3Client,
@@ -1464,13 +1627,13 @@ async fn archive_quote_session(
     bucket: &str,
     session: SessionDate,
     scope: &Scope,
-    summary: &mut QuoteArchiveSummary,
-) -> Result<(), ArchiveError> {
+    progress: &mut PassProgress,
+) -> Result<usize, ArchiveError> {
     let Some((open, close)) = quotes::trading_hours(calendar, session) else {
         // A date the calendar does not publish. Counted rather than fatal, so one unusable session
         // does not cost the rest of the window.
-        summary.sessions_without_data += 1;
-        return Ok(());
+        progress.sessions_without_data += 1;
+        return Ok(0);
     };
 
     let universe = match &scope.names {
@@ -1484,38 +1647,43 @@ async fn archive_quote_session(
                 // Left unwritten so a later pass retries, rather than summarized against a universe
                 // that never included whatever traded only on the session the daily archive lacks.
                 warn!(%session, "No daily partition to read a universe from; leaving the session unsummarized");
-                summary.sessions_without_data += 1;
-                return Ok(());
+                progress.sessions_without_data += 1;
+                return Ok(0);
             };
             names_from_partition(&scope.names, daily)?
         }
     };
     if universe.is_empty() {
-        summary.sessions_without_data += 1;
-        return Ok(());
+        progress.sessions_without_data += 1;
+        return Ok(0);
     }
 
     info!(%session, %open, %close, universe = universe.len(), "Folding a session's quoted book");
-    let folded = fold_universe(market_data, session, open, close, &universe, summary).await;
+    let (folded, quotes_folded) =
+        fold_universe(market_data, session, open, close, &universe, progress).await;
     if folded.is_empty() {
-        summary.sessions_without_data += 1;
-        return Ok(());
+        // The quotes still cost what they cost, so the count is returned even though nothing of
+        // this session reaches the archive.
+        progress.sessions_without_data += 1;
+        return Ok(quotes_folded);
     }
-    write_quote_partitions(s3_client, bucket, session, folded, summary).await
+    write_quote_partitions(s3_client, bucket, session, folded, progress).await?;
+    Ok(quotes_folded)
 }
 
-/// Fans out over the universe, folding each name's session and keeping only the summaries.
+/// Fans out over the universe, folding each name's session and keeping the summaries and the cost.
 async fn fold_universe(
     market_data: &MarketDataClient,
     session: SessionDate,
     open: DateTime<Utc>,
     close: DateTime<Utc>,
     universe: &BTreeSet<Ticker>,
-    summary: &mut QuoteArchiveSummary,
-) -> Vec<QuoteSummary> {
+    progress: &mut PassProgress,
+) -> (Vec<QuoteSummary>, usize) {
     let mut pending: Vec<Ticker> = universe.iter().cloned().collect();
     let mut tasks = tokio::task::JoinSet::new();
     let mut folded: Vec<QuoteSummary> = Vec::new();
+    let mut quotes_folded = 0usize;
 
     loop {
         while tasks.len() < QUOTE_CONCURRENCY {
@@ -1546,22 +1714,22 @@ async fn fold_universe(
         };
         match finished {
             Ok(Ok((summaries, fetch))) => {
-                summary.quotes_folded += fetch.received;
+                quotes_folded += fetch.received;
                 folded.extend(summaries);
             }
             // One symbol's failure costs that symbol, not the session — the other names are already
             // fetched, and discarding them would mean paying for them twice.
             Ok(Err((ticker, error))) => {
-                summary.symbols_failed += 1;
+                progress.symbols_failed += 1;
                 warn!(%ticker, %session, %error, "A symbol's quote fetch failed; continuing the session");
             }
             Err(error) => {
-                summary.symbols_failed += 1;
+                progress.symbols_failed += 1;
                 warn!(%error, %session, "A quote fold task did not complete");
             }
         }
     }
-    folded
+    (folded, quotes_folded)
 }
 
 /// Writes a session's summaries, one partition per cadence, five-minute first.
@@ -1574,7 +1742,7 @@ async fn write_quote_partitions(
     bucket: &str,
     session: SessionDate,
     folded: Vec<QuoteSummary>,
-    summary: &mut QuoteArchiveSummary,
+    progress: &mut PassProgress,
 ) -> Result<(), ArchiveError> {
     let mut intraday: Vec<QuoteSummary> = Vec::new();
     let mut daily: Vec<QuoteSummary> = Vec::new();
@@ -1611,19 +1779,19 @@ async fn write_quote_partitions(
             // already present will not return to it, so re-running is the operator's to decide.
             Err(ArchiveError::Contended { key, attempts }) => {
                 warn!(key, attempts, %session, "Quote partition contended; this session was not summarized");
-                summary.sessions_failed.push(session);
+                progress.sessions_failed.push(session);
                 return Ok(());
             }
             Err(error) => {
                 warn!(%error, %session, "Quote partition write failed; this session was not summarized");
-                summary.sessions_failed.push(session);
+                progress.sessions_failed.push(session);
                 return Ok(());
             }
         }
     }
 
-    summary.sessions_written += 1;
-    summary.summaries_written += written;
+    progress.sessions_written += 1;
+    progress.rows_written += written;
     Ok(())
 }
 
@@ -2006,21 +2174,21 @@ mod tests {
             .map(|at| (at, vec![one_bar("AAPL", at)]))
             .collect();
 
-        let mut summary = ArchiveSummary::default();
+        let mut progress = PassProgress::default();
         let outcome = write_partitions(
             &client,
             "test-bucket",
             BarInterval::FiveMinute,
             partitions,
-            &mut summary,
+            &mut progress,
         )
         .await;
 
         assert!(outcome.is_ok(), "one bad session must not end the pass");
-        assert_eq!(summary.sessions_written, 19);
+        assert_eq!(progress.sessions_written, 19);
         // The literal, not `doomed`: an expectation carried from the fixture moves with it, so
         // relocating the scripted failure would keep this passing without meaning to.
-        assert_eq!(summary.sessions_failed, vec![session(2026, 9, 3)]);
+        assert_eq!(progress.sessions_failed, vec![session(2026, 9, 3)]);
     }
 
     /// The stored layout, pinned to literals. Everything already written lives at these keys, and a
@@ -2067,6 +2235,142 @@ mod tests {
             );
             assert_eq!(date_from_partitioned_key(&quotes), Some(date));
         }
+    }
+
+    /// Each fault fails the pass on its own, and a clean pass passes. This is the rule all three
+    /// binaries' exit codes now derive from, and deciding it per binary was wrong twice.
+    #[test]
+    fn test_each_fault_alone_makes_a_pass_incomplete() {
+        let clean = PassProgress::default().into_bar_summary(None);
+        assert!(clean.is_complete());
+
+        let failed_session = PassProgress {
+            sessions_failed: vec![session(2026, 8, 19)],
+            ..Default::default()
+        }
+        .into_bar_summary(None);
+        assert!(!failed_session.is_complete(), "a failed session is a fault");
+
+        let failed_symbol = PassProgress {
+            symbols_failed: 1,
+            ..Default::default()
+        }
+        .into_bar_summary(None);
+        assert!(
+            !failed_symbol.is_complete(),
+            "a symbol missing from a written partition is a fault nothing downstream can see"
+        );
+    }
+
+    /// The bit that has been wrong twice, in both directions: bars exited 0 on failure and quotes
+    /// counted holidays as failure. The rule follows the calendar the pass actually held, so it
+    /// cannot claim a filtering it never did.
+    #[test]
+    fn test_an_empty_session_is_a_fault_only_when_a_calendar_filtered_the_window() {
+        let counts = || PassProgress {
+            sessions_requested: 5,
+            sessions_written: 4,
+            sessions_without_data: 1,
+            ..Default::default()
+        };
+        let calendar = calendar_of(&[session(2026, 8, 17)]);
+
+        assert!(
+            counts().into_bar_summary(None).is_complete(),
+            "with no calendar the list still holds holidays, which answer empty forever"
+        );
+        assert!(
+            !counts().into_bar_summary(Some(&calendar)).is_complete(),
+            "a calendar-filtered window has no holiday left to explain an empty answer"
+        );
+        assert!(
+            !counts().into_quote_summary(0).is_complete(),
+            "the quote pass is always calendar-filtered"
+        );
+    }
+
+    /// Holidays are what the weekday sweep cannot exclude on its own, and requesting them is what
+    /// made `sessions_without_data` ambiguous. 2026-07-03 is the observed Independence Day.
+    #[test]
+    fn test_a_calendar_drops_the_holidays_a_weekday_sweep_keeps() {
+        let (start, end) = (session(2026, 7, 1), session(2026, 7, 6));
+
+        assert_eq!(
+            sessions_in_window(start, end, None),
+            vec![
+                session(2026, 7, 1),
+                session(2026, 7, 2),
+                session(2026, 7, 3),
+                session(2026, 7, 6),
+            ],
+            "the weekday sweep keeps the holiday and drops only the weekend"
+        );
+
+        let calendar = calendar_of(&[
+            session(2026, 7, 1),
+            session(2026, 7, 2),
+            session(2026, 7, 6),
+        ]);
+        assert_eq!(
+            sessions_in_window(start, end, Some(&calendar)),
+            vec![
+                session(2026, 7, 1),
+                session(2026, 7, 2),
+                session(2026, 7, 6)
+            ],
+            "the calendar drops 07-03, which would answer empty forever"
+        );
+    }
+
+    /// Every count has to survive the accumulator becoming a summary. Both finishers copy field by
+    /// field, so a transposed pair would be silent — the counts would still be plausible, just
+    /// attached to the wrong name.
+    #[test]
+    fn test_the_finish_carries_every_count_through() {
+        let progress = || PassProgress {
+            sessions_requested: 11,
+            sessions_written: 7,
+            sessions_without_data: 3,
+            sessions_failed: vec![session(2026, 8, 19)],
+            symbols_failed: 5,
+            rows_written: 2_048,
+        };
+
+        for summary in [
+            progress().into_bar_summary(None),
+            progress().into_quote_summary(0),
+        ] {
+            assert_eq!(summary.sessions_requested(), 11);
+            assert_eq!(summary.sessions_written(), 7);
+            assert_eq!(summary.sessions_without_data(), 3);
+            assert_eq!(summary.sessions_failed(), [session(2026, 8, 19)]);
+            assert_eq!(summary.symbols_failed(), 5);
+            assert_eq!(summary.output().rows_written(), 2_048);
+        }
+    }
+
+    /// The one figure that travels by return rather than through the accumulator, which is what
+    /// lets a bar pass hold no counter it could never fill.
+    #[test]
+    fn test_a_quote_pass_carries_what_it_cost() {
+        let summary = PassProgress {
+            rows_written: 158,
+            ..Default::default()
+        }
+        .into_quote_summary(412_000);
+
+        assert_eq!(
+            summary.output,
+            PassOutput::Quotes {
+                summaries_written: 158,
+                quotes_folded: 412_000
+            }
+        );
+        assert_eq!(
+            summary.output.rows_written(),
+            158,
+            "the shared accessor reads the rows, not the ticks folded to get them"
+        );
     }
 
     /// The rule the product exists to enforce, and the reason "may it create" is not a third axis.
@@ -2577,6 +2881,23 @@ mod tests {
 
     fn scope(names: NameSelection, sessions: SessionSelection) -> Scope {
         Scope::new(names, sessions).expect("a valid test scope")
+    }
+
+    /// A calendar publishing exactly these sessions, at the usual bell.
+    fn calendar_of(sessions: &[SessionDate]) -> TradingCalendar {
+        TradingCalendar::from_days(
+            sessions
+                .iter()
+                .map(|at| {
+                    crate::common::alpaca::CalendarDay::new(
+                        at.date(),
+                        chrono::NaiveTime::from_hms_opt(9, 30, 0).expect("a valid open"),
+                        chrono::NaiveTime::from_hms_opt(16, 0, 0).expect("a valid close"),
+                    )
+                    .expect("a session with duration")
+                })
+                .collect(),
+        )
     }
 
     /// The whole point of the task: a partition that exists and is short two names reads as

--- a/src/data/calendar.rs
+++ b/src/data/calendar.rs
@@ -50,6 +50,7 @@ pub fn eastern_datetime(instant: DateTime<Utc>) -> chrono::NaiveDateTime {
 #[derive(Debug, Clone, Default)]
 pub struct TradingCalendar {
     days: BTreeMap<SessionDate, CalendarDay>,
+    covered: Option<(SessionDate, SessionDate)>,
 }
 
 impl TradingCalendar {
@@ -58,13 +59,43 @@ impl TradingCalendar {
     /// This is the boundary where a date Alpaca sent over the wire becomes a [`SessionDate`].
     /// [`CalendarDay`] stays on `NaiveDate` because it is what the transport parsed; everything
     /// above this line deals in sessions.
+    ///
+    /// The result answers `false` to [`TradingCalendar::covers`] for every range: what it was
+    /// fetched for cannot be recovered from what came back. Use [`TradingCalendar::covering`] where
+    /// a caller needs to prove the horizon spans a window.
     pub fn from_days(days: Vec<CalendarDay>) -> Self {
         Self {
-            days: days
-                .into_iter()
-                .map(|day| (SessionDate::from_date(day.session_date()), day))
-                .collect(),
+            days: Self::index(days),
+            covered: None,
         }
+    }
+
+    /// Builds a calendar from days published over `[start, end]`, recording that range.
+    ///
+    /// The range is carried rather than inferred, because the contents cannot answer it: a window
+    /// opening on a weekend or a holiday has no published day at its own start, so comparing the
+    /// first session against `start` would reject a perfectly good calendar.
+    pub fn covering(days: Vec<CalendarDay>, start: SessionDate, end: SessionDate) -> Self {
+        Self {
+            days: Self::index(days),
+            covered: Some((start, end)),
+        }
+    }
+
+    fn index(days: Vec<CalendarDay>) -> BTreeMap<SessionDate, CalendarDay> {
+        days.into_iter()
+            .map(|day| (SessionDate::from_date(day.session_date()), day))
+            .collect()
+    }
+
+    /// Whether this calendar was published over the whole of `[start, end]`.
+    ///
+    /// `false` when the covered range is unknown, for the same reason
+    /// [`TradingCalendar::is_trading_day`] answers `false` outside its horizon: not knowing what you
+    /// cover is not proof of covering it, and the caller cannot tell the two apart.
+    pub fn covers(&self, start: SessionDate, end: SessionDate) -> bool {
+        self.covered
+            .is_some_and(|(first, last)| first <= start && end <= last)
     }
 
     /// Whether the market trades on `date`.


### PR DESCRIPTION
# Overview

Third of four pull requests for the seed binary refactor (task 4). One summary type, one rule for
whether a pass finished, and a trading calendar so that rule can be the same everywhere.

## Changes

- Replace `ArchiveSummary` and `QuoteArchiveSummary` with one `PassSummary`, fields private behind accessors
- Add `is_complete()` as the single rule every binary's exit code derives from
- Carry the differing tail as `PassOutput::Bars` / `PassOutput::Quotes`, built once by a finisher rather than mutated through
- Give the bar passes `Option<&TradingCalendar>` so holidays are never requested
- Correct the two comments that documented the old design, in `devenv.nix` and the trainer's module doc

## Context

The two summary types shared five of seven fields and their docstrings drifted in parallel until one commit had to correct both. The half that matters more: **each binary decided its own exit semantics, and that has been wrong twice** — bars exiting 0 on failure, quotes counting holidays as failure. Wrong is silent, because a partition an incomplete pass wrote reads as complete to everything downstream and the exit code is the only signal automation sees.

### The enum's hole is removed, not tolerated

Carrying the tail per variant means invalid states are unrepresentable, but it implies variant-aware mutation — and the `quotes_folded` bar arm could then only be a silent no-op.

A private `PassProgress` accumulates the shared counts with plain `+=`, and two finishers build the variant once, at the end of each pass, where it is not in doubt. Nothing matches on a variant it might not have. `quotes_folded` never enters the accumulator at all: `fold_universe` returns it, `archive_quote_session` returns it, `archive_quote_sessions` sums it into the variant. That is what leaves `PassProgress` with no field meaningless on the path holding it.

### Why the calendar, and not a flag

The first draft carried a `SessionSource` the caller asserted. It was two fields for one bit — perfectly correlated with the output variant — and in the quote pass it was an assumption about a caller the function could not check.

Taking `Option<&TradingCalendar>` makes the policy and the mechanism the same value: nothing can claim a filtering it did not do, and `SessionSource` is read off the calendar the pass actually held. Same derive-rather-than-store move #1111 made for `may_create`.

### Verified against the live API before relying on it

`is_trading_day` answers `false` outside the published horizon, so a calendar fetched for a narrower range than the window would silently discard real sessions and the pass would request nothing while reporting success. That had to be measured, not assumed — `secretspec run -- curl` against `/v2/calendar`:

| request | sessions | notes |
|---|---|---|
| 5 years | **1,255** | one call, **123 ms**, 158 KiB |
| 10 years | 2,513 | one call |
| 1990–2030 | **10,067** | unpaginated, no cap |

Horizon is **1990-01-02 → 2029-12-24**, which brackets anything the archive will ask for. The 1,255 is an exact cross-check against the archive's 1,255 daily partitions. Half-days are marked with a 13:00 close, and observed holidays are absent (2021-12-24 for Christmas on a Saturday). An empty filtered window is warned about rather than trusted.

### Who requires it and who degrades

The seed binaries fetch the calendar and require it — they are run deliberately, and `secretspec run --` already supplies Alpaca in every profile. The trainer warns and passes `None`, keeping the degradation its own comment defends: *"a trainer that refused to run without a broker key would be a worse trade than one whose boundary table is a night stale."*

Both comments that documented the old design — `devenv.nix` and the trainer's module doc — asserted the bars need no Alpaca credentials. They are corrected here rather than left to read as a bug later.

### Private fields

Construction was already closed, but the counts carry a partition invariant nothing outside should be able to break, and a caller able to set the session source could call a broken pass clean.

### Verification

`devenv tasks run checks:all` passes. Coverage **81.26% → 81.17%** — the difference is the calendar helpers, which need a network.

Each new assertion was proved load-bearing by breaking the code under it and watching it fail: the `symbols_failed` clause dropped from `is_complete`, `SessionSource::of` always answering `Weekdays`, `sessions_in_window` ignoring its calendar, `quotes_folded` zeroed on the way into the variant, and two counts transposed in a finisher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9MuPyHx1o8E6X9cPZcCNZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archive repair and data seeding now use trading calendars to skip holidays and non-trading sessions.
  * Bar, intraday, and quote workflows provide consistent completion status and output reporting.
  * Intraday scan mode can run without broker credentials or calendar access.

* **Bug Fixes**
  * Prevented unnecessary requests for market holidays.
  * Missing calendar or series-boundary credentials now generate warnings and allow archive repair to continue.
  * Deliberate seed operations still require trading-calendar access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->