### PR TITLE
Read Massive's flat files, and measure one before trusting any estimate of them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,6 +2966,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "csv",
  "flate2",
  "http 1.5.0",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ chrono = { version = "0.4.44", features = ["serde"] }
 # what the six binaries it replaced kept getting wrong: each hand-wrote a `USAGE` constant that the
 # parser beneath it was free to drift from, and every new option arrived as another positional slot.
 clap = { version = "4.6.6", features = ["derive"] }
+# Massive's flat files are gzipped CSV, one per day, and a day of quotes is hundreds of millions of
+# rows. The hand-rolled `split_csv_line` in `data::details` is right for a four-column file read once
+# and wrong for this, so the parsing happens in a crate built for the hot loop.
+csv = "1.4.0"
 polars = { version = "0.51.0", features = [
   "lazy",
   "parquet",
@@ -44,7 +48,9 @@ sqlx = { version = "0.8", default-features = false, features = [
 ] }
 tokio = { version = "1.51.1", features = ["full"] }
 # `CancellationToken`, for the shutdown signal shared between the listener and the recovery scan.
-tokio-util = "0.7"
+# `io-util` brings `SyncIoBridge`, which is what lets a flat file's async `ByteStream` be read by the
+# synchronous gzip decoder and CSV reader on a blocking thread, where that CPU work belongs anyway.
+tokio-util = { version = "0.7", features = ["io", "io-util"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.23", features = [
   "env-filter",

--- a/secretspec.toml
+++ b/secretspec.toml
@@ -1,3 +1,8 @@
+# The MASSIVE_S3_* triple is deliberately optional in every profile, unlike the rest.
+# Massive's flat files need their own endpoint and their own S3 credentials, separate from
+# MASSIVE_API_KEY, and they exist only while the Advanced subscription does -- one month, for the
+# quote backfill. Requiring them would make every binary that has nothing to do with flat files
+# refuse to start for the other eleven.
 [project]
 name = "fund"
 revision = "1.0"
@@ -5,6 +10,9 @@ revision = "1.0"
 [profiles.production]
 MASSIVE_BASE_URL = { description = "Massive API base URL", required = true }
 MASSIVE_API_KEY = { description = "Massive API key for data", required = true }
+MASSIVE_S3_ENDPOINT = { description = "Massive object-store endpoint; S3-compatible, not AWS", required = false }
+MASSIVE_S3_ACCESS_KEY_ID = { description = "Massive object-store access key ID", required = false }
+MASSIVE_S3_SECRET_ACCESS_KEY = { description = "Massive object-store secret access key", required = false }
 ALPACA_API_KEY_ID = { description = "Alpaca API key for trading and data", required = true }
 ALPACA_API_SECRET = { description = "Alpaca API secret for trading and data", required = true }
 ALPACA_IS_PAPER = { description = "Alpaca paper trading flag", required = false, default = "false" }
@@ -12,6 +20,9 @@ ALPACA_IS_PAPER = { description = "Alpaca paper trading flag", required = false,
 [profiles."development/john.forstmeier"]
 MASSIVE_BASE_URL = { description = "Massive API base URL", required = true }
 MASSIVE_API_KEY = { description = "Massive API key for data", required = true }
+MASSIVE_S3_ENDPOINT = { description = "Massive object-store endpoint; S3-compatible, not AWS", required = false }
+MASSIVE_S3_ACCESS_KEY_ID = { description = "Massive object-store access key ID", required = false }
+MASSIVE_S3_SECRET_ACCESS_KEY = { description = "Massive object-store secret access key", required = false }
 ALPACA_API_KEY_ID = { description = "Alpaca API key for trading and data", required = true }
 ALPACA_API_SECRET = { description = "Alpaca API secret for trading and data", required = true }
 ALPACA_IS_PAPER = { description = "Alpaca paper trading flag", required = false, default = "true" }
@@ -19,6 +30,9 @@ ALPACA_IS_PAPER = { description = "Alpaca paper trading flag", required = false,
 [profiles."development/chris.addy"]
 MASSIVE_BASE_URL = { description = "Massive API base URL", required = true }
 MASSIVE_API_KEY = { description = "Massive API key for data", required = true }
+MASSIVE_S3_ENDPOINT = { description = "Massive object-store endpoint; S3-compatible, not AWS", required = false }
+MASSIVE_S3_ACCESS_KEY_ID = { description = "Massive object-store access key ID", required = false }
+MASSIVE_S3_SECRET_ACCESS_KEY = { description = "Massive object-store secret access key", required = false }
 ALPACA_API_KEY_ID = { description = "Alpaca API key for trading and data", required = true }
 ALPACA_API_SECRET = { description = "Alpaca API secret for trading and data", required = true }
 ALPACA_IS_PAPER = { description = "Alpaca paper trading flag", required = false, default = "true" }
@@ -26,6 +40,9 @@ ALPACA_IS_PAPER = { description = "Alpaca paper trading flag", required = false,
 [profiles.development]
 MASSIVE_BASE_URL = { description = "Massive API base URL", required = false, default = "" }
 MASSIVE_API_KEY = { description = "Massive API key", required = false, default = "" }
+MASSIVE_S3_ENDPOINT = { description = "Massive object-store endpoint; S3-compatible, not AWS", required = false }
+MASSIVE_S3_ACCESS_KEY_ID = { description = "Massive object-store access key ID", required = false }
+MASSIVE_S3_SECRET_ACCESS_KEY = { description = "Massive object-store secret access key", required = false }
 ALPACA_API_KEY_ID = { description = "Alpaca API key ID", required = false, default = "" }
 ALPACA_API_SECRET = { description = "Alpaca API secret", required = false, default = "" }
 ALPACA_IS_PAPER = { description = "Alpaca paper flag", required = false, default = "true" }

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -1109,11 +1109,13 @@ async fn probe_flat_file(date: SessionDate) -> Result<Outcome, SeedError> {
         percentage(summary.unusable, summary.rows_read),
         summary.tickers
     );
-    println!(
-        "  {} ticker runs, so the file is {}",
-        summary.ticker_runs,
-        summary.layout()
-    );
+    match summary.layout() {
+        Some(layout) => println!(
+            "  {} ticker runs, so the file is {layout}",
+            summary.ticker_runs
+        ),
+        None => println!("  no usable rows, so the layout is unmeasured"),
+    }
     println!(
         "  {:.2} GiB compressed, read in {elapsed:.0}s at {:.1} MiB/s and {:.0} rows/s",
         summary.compressed_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
@@ -1122,9 +1124,10 @@ async fn probe_flat_file(date: SessionDate) -> Result<Outcome, SeedError> {
     );
     // The number that decides whether a fold can hold every name at once. Regular hours only, and
     // the observations are what a time-weighted quantile cannot be computed without.
+    const OBSERVATION_BYTES: f64 = 16.0;
     println!(
         "  holding every fold at once would keep {:.1} GiB of observations",
-        summary.ticks_folded as f64 * 16.0 / (1024.0 * 1024.0 * 1024.0)
+        summary.ticks_folded as f64 * OBSERVATION_BYTES / (1024.0 * 1024.0 * 1024.0)
     );
     Ok(Outcome::Complete)
 }

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -11,6 +11,7 @@ use tracing::{error, info, warn};
 
 use fund::common::alpaca::{AlpacaCredentials, DataFeed, MarketDataClient, TradingClient};
 use fund::common::database::connect_pool;
+use fund::common::flatfiles;
 use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
 use fund::common::types::{BarInterval, LiquidityFloor, QuoteSummary, SessionDate, Ticker};
@@ -195,6 +196,19 @@ enum QuoteAction {
     Measure(QuoteSymbolArguments),
     /// Fold named symbols into the sampled sessions that already have a partition.
     Repair(QuoteSymbolArguments),
+    /// Read one day of Massive's flat files and report what is in it, writing nothing.
+    ///
+    /// What the backfill needs measured before it is written: the row order, which decides whether
+    /// a fold holds one name's ticks or every name's, and the throughput, which the published
+    /// download estimate leaves out because it counts bandwidth only.
+    Probe(ProbeArguments),
+}
+
+#[derive(Debug, Args)]
+struct ProbeArguments {
+    /// The session to read, as an Eastern calendar date: YYYY-MM-DD.
+    #[arg(long, value_parser = session_date)]
+    date: SessionDate,
 }
 
 #[derive(Debug, Args)]
@@ -986,52 +1000,148 @@ fn report(scan: &archive::SymbolScan) {
 
 // --- Quotes ---------------------------------------------------------------------------------
 
-/// Folds the sampled sessions, or measures the named symbols across them.
+/// Folds the sampled sessions, measures named symbols across them, or probes a vendor file.
+///
+/// One function per action, as on the intraday path and for the same reason: a probe reads a
+/// different vendor over a different transport and needs no Alpaca credential at all, so it must not
+/// be reachable only after one has been demanded.
 async fn seed_quotes(action: &QuoteAction) -> Result<Outcome, SeedError> {
-    // Resolved before any credential is read, so a missing symbol set is refused in the first
-    // millisecond rather than after a calendar fetch. Empty exactly when the action names none,
-    // because `required_names` refuses an empty set for the two that do.
-    let (arguments, named) = match action {
-        QuoteAction::Archive(arguments) | QuoteAction::Widen(arguments) => {
-            (arguments, BTreeSet::new())
+    match action {
+        QuoteAction::Probe(arguments) => probe_flat_file(arguments.date).await,
+        QuoteAction::Archive(arguments) => {
+            fold_sampled(
+                arguments,
+                NameSelection::Screened(LiquidityFloor::CURRENT),
+                SessionSelection::Absent,
+            )
+            .await
         }
-        QuoteAction::Measure(symbols) | QuoteAction::Repair(symbols) => {
-            (&symbols.quotes, symbols.symbols.required_names()?)
+        QuoteAction::Widen(arguments) => {
+            fold_sampled(
+                arguments,
+                NameSelection::WholeMarket,
+                SessionSelection::Every,
+            )
+            .await
         }
-    };
-    let window = arguments.window.window()?;
-
-    let (market_data, calendar) = quote_sources(&window).await?;
-    let sampled = sample(&calendar, &window, arguments.stride);
-
-    info!(
-        start = %window.start,
-        end = %window.end,
-        stride = arguments.stride,
-        published = calendar.len(),
-        sampled = sampled.len(),
-        "Sampled the sessions to fold"
-    );
-
-    let scope = match action {
-        QuoteAction::Archive(_) => Scope::new(
-            NameSelection::Screened(LiquidityFloor::CURRENT),
-            SessionSelection::Absent,
-        ),
-        QuoteAction::Widen(_) => Scope::new(NameSelection::WholeMarket, SessionSelection::Every),
-        QuoteAction::Measure(_) => {
-            measure(&market_data, &calendar, &sampled, &named).await;
-            return Ok(Outcome::Complete);
-        }
-        QuoteAction::Repair(_) => {
-            Scope::new(NameSelection::Named(named), SessionSelection::Present)
+        QuoteAction::Measure(symbols) => measure_sampled(symbols).await,
+        QuoteAction::Repair(symbols) => {
+            // Resolved before any credential is read, so a missing symbol set is refused in the
+            // first millisecond rather than after a calendar fetch.
+            let named = symbols.symbols.required_names()?;
+            fold_sampled(
+                &symbols.quotes,
+                NameSelection::Named(named),
+                SessionSelection::Present,
+            )
+            .await
         }
     }
-    .map_err(|error| SeedError::Usage(error.to_string()))?;
+}
+
+/// Folds the sampled sessions into the archive under the scope the action names.
+async fn fold_sampled(
+    arguments: &QuoteArguments,
+    names: NameSelection,
+    sessions: SessionSelection,
+) -> Result<Outcome, SeedError> {
+    let scope = Scope::new(names, sessions).map_err(|error| SeedError::Usage(error.to_string()))?;
+    let window = arguments.window.window()?;
+    let (market_data, calendar) = quote_sources(&window).await?;
+    let sampled = sample(&calendar, &window, arguments.stride);
+    report_sample(&window, arguments.stride, &calendar, &sampled);
 
     Ok(Outcome::Pass(
         fold_quotes(&market_data, &calendar, &sampled, &scope).await?,
     ))
+}
+
+/// Folds named symbols across the sampled sessions and prints what they read, writing nothing.
+async fn measure_sampled(symbols: &QuoteSymbolArguments) -> Result<Outcome, SeedError> {
+    let named = symbols.symbols.required_names()?;
+    let arguments = &symbols.quotes;
+    let window = arguments.window.window()?;
+    let (market_data, calendar) = quote_sources(&window).await?;
+    let sampled = sample(&calendar, &window, arguments.stride);
+    report_sample(&window, arguments.stride, &calendar, &sampled);
+
+    measure(&market_data, &calendar, &sampled, &named).await;
+    Ok(Outcome::Complete)
+}
+
+fn report_sample(
+    window: &Window,
+    stride: usize,
+    calendar: &TradingCalendar,
+    sampled: &[SessionDate],
+) {
+    info!(
+        start = %window.start,
+        end = %window.end,
+        stride,
+        published = calendar.len(),
+        sampled = sampled.len(),
+        "Sampled the sessions to fold"
+    );
+}
+
+/// Reads one day of Massive's flat files and reports what is in it, folding nothing.
+///
+/// Four things cannot be known before the subscription exists and all four decide how the backfill
+/// is written: the row order, the file's size, the throughput of decompressing and parsing it, and
+/// how much of it is a book no spread reads off. Counting rather than folding, so the measurement
+/// costs one download and almost no memory.
+async fn probe_flat_file(date: SessionDate) -> Result<Outcome, SeedError> {
+    let client = flatfiles::FlatFileClient::from_env().map_err(box_error)?;
+    let started = tokio::time::Instant::now();
+    let summary = client
+        .fold_quotes(date.date(), |_ticker, _tick| {})
+        .await
+        .map_err(box_error)?;
+    let elapsed = started.elapsed().as_secs_f64();
+
+    println!("{}", flatfiles::quote_key(date.date()));
+    println!(
+        "  {} rows, {} usable, {} unusable ({:.2}%), {} tickers",
+        summary.rows_read,
+        summary.ticks_folded,
+        summary.unusable,
+        percentage(summary.unusable, summary.rows_read),
+        summary.tickers
+    );
+    println!(
+        "  {} ticker runs, so the file is {}",
+        summary.ticker_runs,
+        summary.layout()
+    );
+    println!(
+        "  {:.2} GiB compressed, read in {elapsed:.0}s at {:.1} MiB/s and {:.0} rows/s",
+        summary.compressed_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+        rate(summary.compressed_bytes as f64 / (1024.0 * 1024.0), elapsed),
+        rate(summary.rows_read as f64, elapsed)
+    );
+    // The number that decides whether a fold can hold every name at once. Regular hours only, and
+    // the observations are what a time-weighted quantile cannot be computed without.
+    println!(
+        "  holding every fold at once would keep {:.1} GiB of observations",
+        summary.ticks_folded as f64 * 16.0 / (1024.0 * 1024.0 * 1024.0)
+    );
+    Ok(Outcome::Complete)
+}
+
+/// Guards the division, because an empty file is a real answer rather than a panic.
+fn percentage(part: usize, whole: usize) -> f64 {
+    if whole == 0 {
+        return 0.0;
+    }
+    part as f64 * 100.0 / whole as f64
+}
+
+fn rate(quantity: f64, seconds: f64) -> f64 {
+    if seconds <= 0.0 {
+        return 0.0;
+    }
+    quantity / seconds
 }
 
 /// The Alpaca client and the calendar every quote action needs, measuring or writing.
@@ -1542,6 +1652,35 @@ mod tests {
                 "{value} must not parse"
             );
         }
+    }
+
+    /// A probe reads one vendor file rather than the archive, so it takes a date and nothing else:
+    /// no window to sample over, no stride, no symbol set.
+    #[test]
+    fn test_a_probe_takes_one_date_and_nothing_else() {
+        let QuoteAction::Probe(arguments) =
+            quotes(&["equity-quotes", "probe", "--date", "2026-03-09"])
+        else {
+            panic!("expected the probe action");
+        };
+        assert_eq!(arguments.date, session("2026-03-09"));
+
+        for extra in [
+            vec!["--stride", "21"],
+            vec!["--symbols", "AAPL"],
+            vec!["--start", "2026-03-09"],
+        ] {
+            let mut arguments = vec!["equity-quotes", "probe", "--date", "2026-03-09"];
+            arguments.extend_from_slice(&extra);
+            assert!(
+                parse(&arguments).is_err(),
+                "{extra:?} is not a probe argument"
+            );
+        }
+        assert!(
+            parse(&["equity-quotes", "probe"]).is_err(),
+            "the date is required"
+        );
     }
 
     /// Writing is the irreversible half and measuring reads a handful of numbers, so neither can

--- a/src/common.rs
+++ b/src/common.rs
@@ -5,6 +5,7 @@ pub mod aws;
 pub mod crypto;
 pub mod database;
 pub mod events;
+pub mod flatfiles;
 pub mod journal;
 pub mod log;
 pub mod massive;

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -1,9 +1,8 @@
 //! Massive's flat files: one gzipped CSV per day, streamed and handed to a fold row by row.
 //!
-//! A separate endpoint and separate credentials from [`crate::common::massive`]'s REST API, and not
-//! AWS despite speaking S3. Nothing reaches local disk; nothing holds the file.
+//! Separate endpoint and credentials from [`crate::common::massive`]; nothing holds the file.
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 use aws_sdk_s3::Client as S3Client;
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
@@ -171,29 +170,40 @@ pub enum RowLayout {
     TimeMajor,
 }
 
-impl std::fmt::Display for RowLayout {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(match self {
+impl RowLayout {
+    /// The name to print, separate from [`std::fmt::Display`] so a caller holding an
+    /// `Option<RowLayout>` can render the absent case without one.
+    pub fn as_str(&self) -> &'static str {
+        match self {
             RowLayout::TickerMajor => "ticker-major",
             RowLayout::TimeMajor => "time-major",
-        })
+        }
+    }
+}
+
+impl std::fmt::Display for RowLayout {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
     }
 }
 
 impl QuoteFileFold {
-    /// Which way the file is grouped.
+    /// Which way the file is grouped, or `None` when it folded nothing to judge.
     ///
     /// Ticker-major puts each name in one contiguous run, so runs equal names; time-major
     /// interleaves, so nearly every row starts one. On a real day those are twelve thousand against
     /// four hundred million, so what separates them is which end the count sits nearer — there is no
     /// threshold for anyone to choose, and nothing real lands in between.
-    pub fn layout(&self) -> RowLayout {
+    pub fn layout(&self) -> Option<RowLayout> {
+        if self.ticks_folded == 0 {
+            return None;
+        }
         let above_tickers = self.ticker_runs.saturating_sub(self.tickers);
         let below_rows = self.rows_read.saturating_sub(self.ticker_runs);
         if above_tickers < below_rows {
-            RowLayout::TickerMajor
+            Some(RowLayout::TickerMajor)
         } else {
-            RowLayout::TimeMajor
+            Some(RowLayout::TimeMajor)
         }
     }
 
@@ -308,7 +318,9 @@ impl FlatFileClient {
             ticks_folded = summary.ticks_folded,
             unusable = summary.unusable,
             tickers = summary.tickers,
-            layout = %summary.layout(),
+            layout = summary
+                .layout()
+                .map_or("unmeasured", |layout| layout.as_str()),
             compressed_bytes,
             "Folded a flat file of quotes"
         );
@@ -367,12 +379,17 @@ impl QuoteColumns {
     }
 }
 
-/// Massive stamps a SIP quote in nanoseconds since the epoch.
+/// Massive stamps a SIP quote in nanoseconds since the epoch, and `None` rejects any other unit.
 ///
-/// Nanoseconds rather than millis, which is the same distinction that cost AAPL 211 seconds of a
-/// session on the Alpaca path when an interval was truncated to whole milliseconds.
+/// A stamp in seconds, millis or micros converts without complaint and lands in January 1970, where
+/// it would count as usable and weigh a whole session at one interval.
 fn nanoseconds_to_instant(nanoseconds: i64) -> Option<DateTime<Utc>> {
-    Utc.timestamp_nanos(nanoseconds).into()
+    // Below any real quote file, and far above a recent date stamped in seconds, millis or micros.
+    const YEAR_2000_NANOSECONDS: i64 = 946_684_800_000_000_000;
+    if nanoseconds < YEAR_2000_NANOSECONDS {
+        return None;
+    }
+    Some(Utc.timestamp_nanos(nanoseconds))
 }
 
 /// Decompresses, parses and folds, on whichever thread the caller put this on.
@@ -392,7 +409,7 @@ where
     let columns = QuoteColumns::resolve(header, key)?;
 
     let mut summary = QuoteFileFold::default();
-    let mut latest: BTreeMap<Ticker, DateTime<Utc>> = BTreeMap::new();
+    let mut latest: HashMap<Ticker, DateTime<Utc>> = HashMap::new();
     let mut previous_ticker: Option<Ticker> = None;
     let mut row = csv::StringRecord::new();
     while records
@@ -404,10 +421,19 @@ where
             summary.unusable += 1;
             continue;
         };
-        match latest.insert(ticker.clone(), tick.timestamp()) {
-            Some(previous) if tick.timestamp() < previous => summary.backwards += 1,
-            Some(_) => {}
-            None => summary.tickers += 1,
+        // An owned key is needed only the first time a name appears, and a day is hundreds of
+        // millions of rows.
+        match latest.get_mut(&ticker) {
+            Some(previous) => {
+                if tick.timestamp() < *previous {
+                    summary.backwards += 1;
+                }
+                *previous = tick.timestamp();
+            }
+            None => {
+                latest.insert(ticker.clone(), tick.timestamp());
+                summary.tickers += 1;
+            }
         }
         if previous_ticker.as_ref() != Some(&ticker) {
             summary.ticker_runs += 1;
@@ -417,9 +443,8 @@ where
         fold(ticker, tick);
     }
 
-    // Asserted here rather than by the caller, because this is what read the file and so this is
-    // what can answer for it. A caller that gets an error must discard whatever the fold accumulated:
-    // the rows were handed over before the order was known, which is the nature of a single pass.
+    // Asserted here because this is what read the file. An error means the fold must be discarded:
+    // the rows were handed over before the order was known.
     summary.require_ascending(key)?;
 
     if summary.unusable > 0 {
@@ -453,6 +478,13 @@ mod tests {
 
     const HEADER: &str =
         "ticker,ask_exchange,ask_price,ask_size,bid_exchange,bid_price,bid_size,sip_timestamp";
+
+    /// A stamp `offset` nanoseconds into 2026-03-09T14:30:00Z, the session the fixtures pretend to
+    /// be. A stamp near the epoch is a unit mistake rather than a quote, so these sit where real
+    /// ones would.
+    fn stamp(offset: i64) -> i64 {
+        1_773_066_600_000_000_000 + offset
+    }
 
     /// A row in the column order the header above declares, which is deliberately not the order the
     /// fold reads them in — that is the whole point of resolving against the header.
@@ -508,9 +540,9 @@ mod tests {
     fn test_every_row_is_folded_with_its_own_ticker() {
         let body = format!(
             "{HEADER}\n{}{}{}",
-            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_000),
-            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_001),
-            row("AAPL", "100.02", "300", "99.98", "150", 1_000_000_002),
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(0)),
+            row("CBOE", "200.20", "50", "199.80", "40", stamp(1)),
+            row("AAPL", "100.02", "300", "99.98", "150", stamp(2)),
         );
         let (summary, seen) = fold(&body);
         let summary = summary.expect("a usable file");
@@ -522,9 +554,9 @@ mod tests {
         assert_eq!(
             seen,
             vec![
-                ("AAPL".to_string(), 1_000_000_000),
-                ("CBOE".to_string(), 1_000_000_001),
-                ("AAPL".to_string(), 1_000_000_002),
+                ("AAPL".to_string(), stamp(0)),
+                ("CBOE".to_string(), stamp(1)),
+                ("AAPL".to_string(), stamp(2)),
             ]
         );
     }
@@ -534,11 +566,11 @@ mod tests {
     #[test]
     fn test_the_columns_are_read_off_the_header_rather_than_by_position() {
         let reordered = "sip_timestamp,bid_size,bid_price,ask_size,ask_price,ticker";
-        let body = format!("{reordered}\n1000000000,100,99.95,200,100.05,AAPL\n");
+        let body = format!("{reordered}\n1773066600000000000,100,99.95,200,100.05,AAPL\n");
         let (summary, seen) = fold(&body);
 
         assert_eq!(summary.expect("a usable file").ticks_folded, 1);
-        assert_eq!(seen, vec![("AAPL".to_string(), 1_000_000_000)]);
+        assert_eq!(seen, vec![("AAPL".to_string(), stamp(0))]);
     }
 
     /// A renamed column would otherwise fold whatever sat in that position, so it fails on the
@@ -560,10 +592,10 @@ mod tests {
     fn test_a_book_no_spread_reads_off_is_counted_and_skipped() {
         let body = format!(
             "{HEADER}\n{}{}{}{}",
-            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_000),
-            row("AAPL", "99.90", "200", "100.10", "100", 1_000_000_001),
-            row("AAPL", "0", "200", "0", "100", 1_000_000_002),
-            row("AAPL", "100.05", "200", "not-a-price", "100", 1_000_000_003),
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(0)),
+            row("AAPL", "99.90", "200", "100.10", "100", stamp(1)),
+            row("AAPL", "0", "200", "0", "100", stamp(2)),
+            row("AAPL", "100.05", "200", "not-a-price", "100", stamp(3)),
         );
         let (summary, seen) = fold(&body);
         let summary = summary.expect("a usable file");
@@ -579,16 +611,7 @@ mod tests {
     #[test]
     fn test_a_descending_file_is_refused_rather_than_folded_to_zero() {
         let descending: String = (0..10)
-            .map(|index| {
-                row(
-                    "AAPL",
-                    "100.05",
-                    "200",
-                    "99.95",
-                    "100",
-                    1_000_000_000 - index,
-                )
-            })
+            .map(|index| row("AAPL", "100.05", "200", "99.95", "100", stamp(-index)))
             .collect();
         let error = fold(&format!("{HEADER}\n{descending}"))
             .0
@@ -609,25 +632,11 @@ mod tests {
         let mut body = String::from(HEADER);
         body.push('\n');
         for index in 0..20 {
-            body.push_str(&row(
-                "AAPL",
-                "100.05",
-                "200",
-                "99.95",
-                "100",
-                1_000_000_000 + index,
-            ));
+            body.push_str(&row("AAPL", "100.05", "200", "99.95", "100", stamp(index)));
         }
         // Three quotes the SIP reordered, which is ordinary rather than a wrongly sorted file.
         for index in [5, 9, 14] {
-            body.push_str(&row(
-                "AAPL",
-                "100.05",
-                "200",
-                "99.95",
-                "100",
-                1_000_000_000 + index,
-            ));
+            body.push_str(&row("AAPL", "100.05", "200", "99.95", "100", stamp(index)));
         }
         let summary = fold(&body).0.expect("an ascending file with ties");
         assert_eq!(summary.ticks_folded, 23);
@@ -641,10 +650,10 @@ mod tests {
     fn test_ordering_is_judged_within_a_ticker_not_across_the_file() {
         let body = format!(
             "{HEADER}\n{}{}{}{}",
-            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_100),
-            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_200),
-            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_001),
-            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_002),
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(100)),
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(200)),
+            row("CBOE", "200.20", "50", "199.80", "40", stamp(1)),
+            row("CBOE", "200.20", "50", "199.80", "40", stamp(2)),
         );
         let summary = fold(&body).0.expect("each ticker ascends");
         assert_eq!(summary.ticks_folded, 4);
@@ -694,8 +703,8 @@ mod tests {
     async fn test_a_day_is_streamed_from_the_endpoint_and_folded() {
         let body = format!(
             "{HEADER}\n{}{}",
-            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_000),
-            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_001),
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(0)),
+            row("CBOE", "200.20", "50", "199.80", "40", stamp(1)),
         );
         let (client, requested) = client_serving(gzipped(&body));
         let folded = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
@@ -735,25 +744,67 @@ mod tests {
     fn test_the_layout_is_read_off_where_the_ticker_changes() {
         let ticker_major = format!(
             "{HEADER}\n{}{}{}{}",
-            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_100),
-            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_200),
-            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_001),
-            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_002),
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(100)),
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(200)),
+            row("CBOE", "200.20", "50", "199.80", "40", stamp(1)),
+            row("CBOE", "200.20", "50", "199.80", "40", stamp(2)),
         );
         let summary = fold(&ticker_major).0.expect("each ticker ascends");
         assert_eq!(summary.ticker_runs, 2, "one run per name");
-        assert_eq!(summary.layout(), RowLayout::TickerMajor);
+        assert_eq!(summary.layout(), Some(RowLayout::TickerMajor));
 
         let time_major = format!(
             "{HEADER}\n{}{}{}{}",
-            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_000),
-            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_001),
-            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_002),
-            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_003),
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(0)),
+            row("CBOE", "200.20", "50", "199.80", "40", stamp(1)),
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(2)),
+            row("CBOE", "200.20", "50", "199.80", "40", stamp(3)),
         );
         let summary = fold(&time_major).0.expect("interleaved and ascending");
         assert_eq!(summary.ticker_runs, 4, "every row starts a run");
-        assert_eq!(summary.layout(), RowLayout::TimeMajor);
+        assert_eq!(summary.layout(), Some(RowLayout::TimeMajor));
+    }
+
+    /// The layout decides whether the backfill holds one name's ticks or every name's, so a file
+    /// that folded nothing must report no layout rather than the expensive one by arithmetic.
+    #[test]
+    fn test_a_file_that_folded_nothing_reports_no_layout() {
+        let header_only = fold(&format!("{HEADER}\n")).0.expect("an empty file");
+        assert_eq!(header_only.rows_read, 0);
+        assert_eq!(header_only.ticks_folded, 0);
+        assert_eq!(header_only.layout(), None);
+
+        // Rows that parse but carry no readable book: the guard is on what was folded, not on what
+        // was read.
+        let all_unusable = format!(
+            "{HEADER}\n{}{}",
+            row("AAPL", "0", "200", "0", "100", stamp(0)),
+            row("CBOE", "0", "50", "0", "40", stamp(1)),
+        );
+        let summary = fold(&all_unusable).0.expect("a file of unusable rows");
+        assert_eq!(summary.rows_read, 2);
+        assert_eq!(summary.ticks_folded, 0);
+        assert_eq!(summary.unusable, 2);
+        assert_eq!(summary.layout(), None);
+    }
+
+    /// The column names are a guess and so are the units. A stamp in the wrong one converts without
+    /// complaint and lands in 1970, where it would fold as a usable tick and weigh a whole session.
+    #[test]
+    fn test_a_stamp_in_the_wrong_unit_is_unusable_rather_than_a_1970_tick() {
+        let milliseconds = stamp(0) / 1_000_000;
+        let body = format!(
+            "{HEADER}\n{}{}",
+            row("AAPL", "100.05", "200", "99.95", "100", milliseconds),
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(0)),
+        );
+        let (summary, seen) = fold(&body);
+        let summary = summary.expect("one usable row");
+
+        assert_eq!(summary.rows_read, 2);
+        assert_eq!(summary.ticks_folded, 1);
+        assert_eq!(summary.unusable, 1, "the millisecond stamp");
+        assert_eq!(seen, vec![("AAPL".to_string(), 1_773_066_600_000_000_000)]);
     }
 
     #[test]

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -1,0 +1,784 @@
+//! Massive's flat files: one gzipped CSV per day, streamed and handed to a fold row by row.
+//!
+//! A separate endpoint and separate credentials from [`crate::common::massive`]'s REST API, and not
+//! AWS despite speaking S3. Nothing reaches local disk; nothing holds the file.
+
+use std::collections::BTreeMap;
+
+use aws_sdk_s3::Client as S3Client;
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+use flate2::read::GzDecoder;
+use tokio_util::io::SyncIoBridge;
+use tracing::{info, warn};
+
+use crate::common::alpaca::QuoteTick;
+use crate::common::types::Ticker;
+
+/// The bucket every dataset lives under, which Massive support named on 2026-08-24.
+const FLAT_FILE_BUCKET: &str = "flatfiles";
+
+/// The region the signer needs. Massive is not AWS, so nothing resolves this from an instance or a
+/// profile — it is a constant the signature requires rather than a place anything is stored.
+const FLAT_FILE_REGION: &str = "us-east-1";
+
+/// The columns [`QuoteColumns`] resolves out of a quote file's header.
+///
+/// Declared here rather than as positions because the column *order* is undocumented and could not
+/// be checked before the subscription was bought. A file that renames one of these fails loudly on
+/// the header rather than silently folding the wrong field.
+const TICKER_COLUMN: &str = "ticker";
+const TIMESTAMP_COLUMN: &str = "sip_timestamp";
+const BID_PRICE_COLUMN: &str = "bid_price";
+const BID_SIZE_COLUMN: &str = "bid_size";
+const ASK_PRICE_COLUMN: &str = "ask_price";
+const ASK_SIZE_COLUMN: &str = "ask_size";
+
+/// Why a flat-file read failed.
+#[derive(Debug, thiserror::Error)]
+pub enum FlatFileError {
+    #[error("{variable} environment variable is not set")]
+    Missing { variable: &'static str },
+    #[error("{field} must not be empty")]
+    Empty { field: &'static str },
+    #[error("could not fetch {key}: {source}")]
+    Fetch {
+        key: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[error("could not read {key}: {source}")]
+    Read { key: String, source: std::io::Error },
+    /// The header named none of the columns the fold needs, or renamed one of them.
+    #[error("{key} has no {column} column; its header is {header}")]
+    Column {
+        key: String,
+        column: &'static str,
+        header: String,
+    },
+    /// More quotes stepped backwards in time than stepped forwards, which is what a file sorted the
+    /// wrong way looks like. See [`QuoteFileFold::require_ascending`].
+    #[error(
+        "{key} is not in ascending time within a ticker: {backwards} quotes stepped back against \
+         {forwards} forwards, so the fold would weigh almost every one at zero"
+    )]
+    Descending {
+        key: String,
+        backwards: usize,
+        forwards: usize,
+    },
+}
+
+/// Credentials for `files.massive.com`: issued by Massive, spoken in S3's dialect, not AWS's.
+///
+/// Named `MASSIVE_S3_*` rather than anything containing `AWS` on purpose. This process also holds
+/// real AWS credentials and writes the archive with them, and `aws_config::load_defaults` reads
+/// `AWS_ACCESS_KEY_ID` from the environment — so a name in that family would hand Massive's key to
+/// every genuine AWS call in the same binary.
+///
+/// Deliberately does not derive `Debug`: it holds a secret key, and a derived `Debug` puts that key
+/// into any log line or panic message that formats a struct containing one.
+#[derive(Clone)]
+pub struct FlatFileCredentials {
+    endpoint_url: String,
+    access_key_id: String,
+    secret_access_key: String,
+}
+
+impl FlatFileCredentials {
+    /// Constructs from explicit values, rejecting empties.
+    pub fn new(
+        endpoint_url: String,
+        access_key_id: String,
+        secret_access_key: String,
+    ) -> Result<Self, FlatFileError> {
+        if endpoint_url.is_empty() {
+            return Err(FlatFileError::Empty {
+                field: "endpoint_url",
+            });
+        }
+        if access_key_id.is_empty() {
+            return Err(FlatFileError::Empty {
+                field: "access_key_id",
+            });
+        }
+        if secret_access_key.is_empty() {
+            return Err(FlatFileError::Empty {
+                field: "secret_access_key",
+            });
+        }
+        Ok(Self {
+            endpoint_url,
+            access_key_id,
+            secret_access_key,
+        })
+    }
+
+    /// Reads the three `MASSIVE_S3_*` variables from the environment.
+    pub fn from_env() -> Result<Self, FlatFileError> {
+        let read = |variable: &'static str| {
+            std::env::var(variable).map_err(|_| FlatFileError::Missing { variable })
+        };
+        Self::new(
+            read("MASSIVE_S3_ENDPOINT")?,
+            read("MASSIVE_S3_ACCESS_KEY_ID")?,
+            read("MASSIVE_S3_SECRET_ACCESS_KEY")?,
+        )
+    }
+}
+
+/// The S3 key holding one day of consolidated quotes.
+///
+/// The `us_stocks_sip` prefix is Massive's own and corroborates the SIP sourcing behind their NBBO
+/// answer — a file under it is the consolidated book rather than one venue's.
+pub fn quote_key(date: NaiveDate) -> String {
+    use chrono::Datelike;
+    format!(
+        "us_stocks_sip/quotes_v1/{}/{:02}/{}.csv.gz",
+        date.year(),
+        date.month(),
+        date.format("%Y-%m-%d")
+    )
+}
+
+/// What one file cost and what it yielded.
+///
+/// `unusable` counts rows whose book no spread can be read off — a crossed or zero-priced quote,
+/// which is ordinary around the open rather than a defect. Reported because it is the only trace a
+/// discarded row leaves, and a file that is suddenly half unusable is a vendor change.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct QuoteFileFold {
+    pub rows_read: usize,
+    pub ticks_folded: usize,
+    pub unusable: usize,
+    pub tickers: usize,
+    /// Rows whose ticker differs from the row before, which is what [`QuoteFileFold::layout`] reads.
+    pub ticker_runs: usize,
+    /// The object's own size, which cannot be obtained before paying — an unauthenticated `HEAD`
+    /// returns 403 — and is what turns a download estimate from arithmetic into a measurement.
+    pub compressed_bytes: i64,
+    backwards: usize,
+}
+
+/// How a file's rows are grouped, which is what decides how many folds must be held at once.
+///
+/// Massive documents no row order and it cannot be inspected before paying, so this is measured on
+/// the first file rather than assumed. It is the difference between holding one name's ticks and
+/// holding every name's.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowLayout {
+    /// Each ticker's rows are contiguous, so a fold can be finished and dropped at the switch.
+    TickerMajor,
+    /// Tickers interleave, so every fold stays open until the file ends.
+    TimeMajor,
+}
+
+impl std::fmt::Display for RowLayout {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            RowLayout::TickerMajor => "ticker-major",
+            RowLayout::TimeMajor => "time-major",
+        })
+    }
+}
+
+impl QuoteFileFold {
+    /// Which way the file is grouped.
+    ///
+    /// Ticker-major puts each name in one contiguous run, so runs equal names; time-major
+    /// interleaves, so nearly every row starts one. On a real day those are twelve thousand against
+    /// four hundred million, so what separates them is which end the count sits nearer — there is no
+    /// threshold for anyone to choose, and nothing real lands in between.
+    pub fn layout(&self) -> RowLayout {
+        let above_tickers = self.ticker_runs.saturating_sub(self.tickers);
+        let below_rows = self.rows_read.saturating_sub(self.ticker_runs);
+        if above_tickers < below_rows {
+            RowLayout::TickerMajor
+        } else {
+            RowLayout::TimeMajor
+        }
+    }
+
+    /// Refuses a file whose quotes descend in time within a ticker.
+    ///
+    /// The fold weighs each quote by the interval to the next, so a descending run weighs every one
+    /// at zero and still produces a summary — a silent wrong answer rather than a failure. Massive
+    /// does not document the row order and it cannot be inspected before paying, so it is asserted.
+    ///
+    /// The threshold is not a tuning knob: an ascending file inverts only where the SIP itself ties
+    /// or reorders, a handful of rows per name, while a descending file inverts every row after the
+    /// first. Nothing real sits between them.
+    fn require_ascending(&self, key: &str) -> Result<(), FlatFileError> {
+        let forwards = self.ticks_folded.saturating_sub(self.backwards);
+        if self.backwards <= forwards {
+            return Ok(());
+        }
+        Err(FlatFileError::Descending {
+            key: key.to_string(),
+            backwards: self.backwards,
+            forwards,
+        })
+    }
+}
+
+/// Reads one day of flat files from Massive's object store.
+pub struct FlatFileClient {
+    s3_client: S3Client,
+}
+
+impl FlatFileClient {
+    /// Builds a client against Massive's endpoint rather than AWS's.
+    ///
+    /// Path-style addressing, because the endpoint is not AWS and a virtual-host bucket would
+    /// resolve `flatfiles.files.massive.com`, which does not exist.
+    pub fn new(credentials: FlatFileCredentials) -> Self {
+        Self::from_configuration(Self::configuration(credentials).build())
+    }
+
+    /// The signed, path-style configuration, separated so a test can attach its own transport to
+    /// exactly the configuration production uses rather than to an approximation of it.
+    fn configuration(credentials: FlatFileCredentials) -> aws_sdk_s3::config::Builder {
+        aws_sdk_s3::Config::builder()
+            .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
+            .region(aws_sdk_s3::config::Region::new(FLAT_FILE_REGION))
+            .endpoint_url(credentials.endpoint_url)
+            .force_path_style(true)
+            .credentials_provider(aws_sdk_s3::config::Credentials::new(
+                credentials.access_key_id,
+                credentials.secret_access_key,
+                None,
+                None,
+                "massive-flat-files",
+            ))
+    }
+
+    fn from_configuration(configuration: aws_sdk_s3::Config) -> Self {
+        Self {
+            s3_client: S3Client::from_conf(configuration),
+        }
+    }
+
+    /// Constructs from the environment.
+    pub fn from_env() -> Result<Self, FlatFileError> {
+        Ok(Self::new(FlatFileCredentials::from_env()?))
+    }
+
+    /// Streams one day of quotes, handing every usable tick to `fold`.
+    ///
+    /// Nothing is collected and nothing touches disk: `GetObject` gives a byte stream, which is
+    /// decompressed, parsed and folded as it arrives. The whole pipeline runs on a blocking thread
+    /// because decompression and CSV parsing are the CPU cost of the download, not a wait.
+    pub async fn fold_quotes<F>(
+        &self,
+        date: NaiveDate,
+        fold: F,
+    ) -> Result<QuoteFileFold, FlatFileError>
+    where
+        F: FnMut(Ticker, QuoteTick) + Send + 'static,
+    {
+        let key = quote_key(date);
+        info!(bucket = FLAT_FILE_BUCKET, key, %date, "Reading a flat file of quotes");
+
+        let object = self
+            .s3_client
+            .get_object()
+            .bucket(FLAT_FILE_BUCKET)
+            .key(&key)
+            .send()
+            .await
+            .map_err(|error| FlatFileError::Fetch {
+                key: key.clone(),
+                source: Box::new(error),
+            })?;
+
+        let compressed_bytes = object.content_length().unwrap_or_default();
+        let reader = object.body.into_async_read();
+        let scoped = key.clone();
+        let mut summary = tokio::task::spawn_blocking(move || {
+            fold_gzipped_quotes(SyncIoBridge::new(reader), &scoped, fold)
+        })
+        .await
+        .map_err(|error| FlatFileError::Read {
+            key: key.clone(),
+            source: std::io::Error::other(error),
+        })??;
+
+        summary.compressed_bytes = compressed_bytes;
+        info!(
+            key,
+            rows_read = summary.rows_read,
+            ticks_folded = summary.ticks_folded,
+            unusable = summary.unusable,
+            tickers = summary.tickers,
+            layout = %summary.layout(),
+            compressed_bytes,
+            "Folded a flat file of quotes"
+        );
+        Ok(summary)
+    }
+}
+
+/// Where each field the fold needs sits in this particular file.
+///
+/// Resolved from the header rather than fixed, so a column inserted or reordered upstream costs
+/// nothing and a column *renamed* fails on the first row rather than folding zeros.
+struct QuoteColumns {
+    ticker: usize,
+    timestamp: usize,
+    bid_price: usize,
+    bid_size: usize,
+    ask_price: usize,
+    ask_size: usize,
+}
+
+impl QuoteColumns {
+    fn resolve(header: &csv::StringRecord, key: &str) -> Result<Self, FlatFileError> {
+        let index = |column: &'static str| {
+            header
+                .iter()
+                .position(|found| found.trim() == column)
+                .ok_or_else(|| FlatFileError::Column {
+                    key: key.to_string(),
+                    column,
+                    header: header.iter().collect::<Vec<_>>().join(","),
+                })
+        };
+        Ok(Self {
+            ticker: index(TICKER_COLUMN)?,
+            timestamp: index(TIMESTAMP_COLUMN)?,
+            bid_price: index(BID_PRICE_COLUMN)?,
+            bid_size: index(BID_SIZE_COLUMN)?,
+            ask_price: index(ASK_PRICE_COLUMN)?,
+            ask_size: index(ASK_SIZE_COLUMN)?,
+        })
+    }
+
+    /// Reads one row, or `None` if it is not a book a spread can be read off.
+    fn tick(&self, row: &csv::StringRecord) -> Option<(Ticker, QuoteTick)> {
+        let field = |index: usize| row.get(index).map(str::trim);
+        let ticker = Ticker::new(field(self.ticker)?)?;
+        let timestamp = nanoseconds_to_instant(field(self.timestamp)?.parse::<i64>().ok()?)?;
+        let tick = QuoteTick::new(
+            timestamp,
+            field(self.bid_price)?.parse::<f64>().ok()?,
+            field(self.ask_price)?.parse::<f64>().ok()?,
+            field(self.bid_size)?.parse::<i32>().ok()?,
+            field(self.ask_size)?.parse::<i32>().ok()?,
+        )?;
+        Some((ticker, tick))
+    }
+}
+
+/// Massive stamps a SIP quote in nanoseconds since the epoch.
+///
+/// Nanoseconds rather than millis, which is the same distinction that cost AAPL 211 seconds of a
+/// session on the Alpaca path when an interval was truncated to whole milliseconds.
+fn nanoseconds_to_instant(nanoseconds: i64) -> Option<DateTime<Utc>> {
+    Utc.timestamp_nanos(nanoseconds).into()
+}
+
+/// Decompresses, parses and folds, on whichever thread the caller put this on.
+///
+/// Separate from the request so it can be tested against a file that never went over a network.
+fn fold_gzipped_quotes<R, F>(
+    reader: R,
+    key: &str,
+    mut fold: F,
+) -> Result<QuoteFileFold, FlatFileError>
+where
+    R: std::io::Read,
+    F: FnMut(Ticker, QuoteTick),
+{
+    let mut records = csv::Reader::from_reader(GzDecoder::new(reader));
+    let header = records.headers().map_err(|error| read_error(key, error))?;
+    let columns = QuoteColumns::resolve(header, key)?;
+
+    let mut summary = QuoteFileFold::default();
+    let mut latest: BTreeMap<Ticker, DateTime<Utc>> = BTreeMap::new();
+    let mut previous_ticker: Option<Ticker> = None;
+    let mut row = csv::StringRecord::new();
+    while records
+        .read_record(&mut row)
+        .map_err(|error| read_error(key, error))?
+    {
+        summary.rows_read += 1;
+        let Some((ticker, tick)) = columns.tick(&row) else {
+            summary.unusable += 1;
+            continue;
+        };
+        match latest.insert(ticker.clone(), tick.timestamp()) {
+            Some(previous) if tick.timestamp() < previous => summary.backwards += 1,
+            Some(_) => {}
+            None => summary.tickers += 1,
+        }
+        if previous_ticker.as_ref() != Some(&ticker) {
+            summary.ticker_runs += 1;
+            previous_ticker = Some(ticker.clone());
+        }
+        summary.ticks_folded += 1;
+        fold(ticker, tick);
+    }
+
+    // Asserted here rather than by the caller, because this is what read the file and so this is
+    // what can answer for it. A caller that gets an error must discard whatever the fold accumulated:
+    // the rows were handed over before the order was known, which is the nature of a single pass.
+    summary.require_ascending(key)?;
+
+    if summary.unusable > 0 {
+        // Ordinary rather than alarming — a crossed consolidated book is common around the open —
+        // but a file that is suddenly half unusable is a vendor change nobody announced.
+        warn!(
+            key,
+            unusable = summary.unusable,
+            rows_read = summary.rows_read,
+            "Skipped rows no spread can be read off"
+        );
+    }
+    Ok(summary)
+}
+
+fn read_error(key: &str, error: csv::Error) -> FlatFileError {
+    FlatFileError::Read {
+        key: key.to_string(),
+        source: std::io::Error::other(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Write;
+
+    use aws_smithy_http_client::test_util::infallible_client_fn;
+    use aws_smithy_types::body::SdkBody;
+
+    const HEADER: &str =
+        "ticker,ask_exchange,ask_price,ask_size,bid_exchange,bid_price,bid_size,sip_timestamp";
+
+    /// A row in the column order the header above declares, which is deliberately not the order the
+    /// fold reads them in — that is the whole point of resolving against the header.
+    fn row(
+        ticker: &str,
+        ask: &str,
+        ask_size: &str,
+        bid: &str,
+        bid_size: &str,
+        nanos: i64,
+    ) -> String {
+        format!("{ticker},12,{ask},{ask_size},11,{bid},{bid_size},{nanos}\n")
+    }
+
+    fn gzipped(body: &str) -> Vec<u8> {
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder
+            .write_all(body.as_bytes())
+            .expect("writing to a vector cannot fail");
+        encoder.finish().expect("the encoder flushes")
+    }
+
+    /// Folds a body and returns what the fold saw alongside the summary.
+    fn fold(body: &str) -> (Result<QuoteFileFold, FlatFileError>, Vec<(String, i64)>) {
+        let seen = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let collector = std::rc::Rc::clone(&seen);
+        let summary = fold_gzipped_quotes(
+            std::io::Cursor::new(gzipped(body)),
+            "test.csv.gz",
+            move |ticker, tick| {
+                collector.borrow_mut().push((
+                    ticker.as_str().to_string(),
+                    tick.timestamp().timestamp_nanos_opt().unwrap_or_default(),
+                ));
+            },
+        );
+        let observed = seen.borrow().clone();
+        (summary, observed)
+    }
+
+    #[test]
+    fn test_the_key_is_the_layout_massive_named() {
+        let date = NaiveDate::from_ymd_opt(2026, 3, 9).expect("a real date");
+        assert_eq!(
+            quote_key(date),
+            "us_stocks_sip/quotes_v1/2026/03/2026-03-09.csv.gz"
+        );
+    }
+
+    /// A file interleaves every ticker, so the fold is handed the ticker with each tick rather than
+    /// being told once whose quotes these are.
+    #[test]
+    fn test_every_row_is_folded_with_its_own_ticker() {
+        let body = format!(
+            "{HEADER}\n{}{}{}",
+            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_000),
+            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_001),
+            row("AAPL", "100.02", "300", "99.98", "150", 1_000_000_002),
+        );
+        let (summary, seen) = fold(&body);
+        let summary = summary.expect("a usable file");
+
+        assert_eq!(summary.rows_read, 3);
+        assert_eq!(summary.ticks_folded, 3);
+        assert_eq!(summary.unusable, 0);
+        assert_eq!(summary.tickers, 2, "AAPL is one ticker across two rows");
+        assert_eq!(
+            seen,
+            vec![
+                ("AAPL".to_string(), 1_000_000_000),
+                ("CBOE".to_string(), 1_000_000_001),
+                ("AAPL".to_string(), 1_000_000_002),
+            ]
+        );
+    }
+
+    /// The column order is undocumented and could not be checked before the subscription was
+    /// bought, so the header is what says where each field is. Reordering it must change nothing.
+    #[test]
+    fn test_the_columns_are_read_off_the_header_rather_than_by_position() {
+        let reordered = "sip_timestamp,bid_size,bid_price,ask_size,ask_price,ticker";
+        let body = format!("{reordered}\n1000000000,100,99.95,200,100.05,AAPL\n");
+        let (summary, seen) = fold(&body);
+
+        assert_eq!(summary.expect("a usable file").ticks_folded, 1);
+        assert_eq!(seen, vec![("AAPL".to_string(), 1_000_000_000)]);
+    }
+
+    /// A renamed column would otherwise fold whatever sat in that position, so it fails on the
+    /// header rather than on the data.
+    #[test]
+    fn test_a_missing_column_is_refused_by_name() {
+        let body = "ticker,bid_price,bid_size,ask_price,ask_size\nAAPL,99.95,100,100.05,200\n";
+        let error = fold(body).0.expect_err("no sip_timestamp column");
+        assert!(
+            matches!(&error, FlatFileError::Column { column, .. } if *column == "sip_timestamp"),
+            "{error}"
+        );
+        assert!(error.to_string().contains("ticker,bid_price"), "{error}");
+    }
+
+    /// A crossed or zero-priced book is ordinary around the open, so those rows are counted and
+    /// skipped rather than failing the file.
+    #[test]
+    fn test_a_book_no_spread_reads_off_is_counted_and_skipped() {
+        let body = format!(
+            "{HEADER}\n{}{}{}{}",
+            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_000),
+            row("AAPL", "99.90", "200", "100.10", "100", 1_000_000_001),
+            row("AAPL", "0", "200", "0", "100", 1_000_000_002),
+            row("AAPL", "100.05", "200", "not-a-price", "100", 1_000_000_003),
+        );
+        let (summary, seen) = fold(&body);
+        let summary = summary.expect("a usable file");
+
+        assert_eq!(summary.rows_read, 4);
+        assert_eq!(summary.ticks_folded, 1);
+        assert_eq!(summary.unusable, 3, "crossed, zero-priced and unparseable");
+        assert_eq!(seen.len(), 1);
+    }
+
+    /// The fold weighs each quote by the interval to the next, so a descending file weighs every one
+    /// at zero and still produces a summary. Massive documents no row order, so it is asserted.
+    #[test]
+    fn test_a_descending_file_is_refused_rather_than_folded_to_zero() {
+        let descending: String = (0..10)
+            .map(|index| {
+                row(
+                    "AAPL",
+                    "100.05",
+                    "200",
+                    "99.95",
+                    "100",
+                    1_000_000_000 - index,
+                )
+            })
+            .collect();
+        let error = fold(&format!("{HEADER}\n{descending}"))
+            .0
+            .expect_err("a descending file");
+        assert!(
+            matches!(
+                &error,
+                FlatFileError::Descending { backwards, forwards, .. } if *backwards == 9 && *forwards == 1
+            ),
+            "{error}"
+        );
+    }
+
+    /// An ascending file inverts only where the SIP itself ties or reorders, so the assertion must
+    /// not fire on one — a handful of steps back among many forwards is the real shape.
+    #[test]
+    fn test_a_few_inversions_in_an_ascending_file_are_tolerated() {
+        let mut body = String::from(HEADER);
+        body.push('\n');
+        for index in 0..20 {
+            body.push_str(&row(
+                "AAPL",
+                "100.05",
+                "200",
+                "99.95",
+                "100",
+                1_000_000_000 + index,
+            ));
+        }
+        // Three quotes the SIP reordered, which is ordinary rather than a wrongly sorted file.
+        for index in [5, 9, 14] {
+            body.push_str(&row(
+                "AAPL",
+                "100.05",
+                "200",
+                "99.95",
+                "100",
+                1_000_000_000 + index,
+            ));
+        }
+        let summary = fold(&body).0.expect("an ascending file with ties");
+        assert_eq!(summary.ticks_folded, 23);
+    }
+
+    /// Ordering is asserted per ticker rather than across the file, and the ordering that proves it
+    /// is the one a **ticker-major** file has: each name ascends while the file as a whole zig-zags
+    /// back every time it switches names. Judged across the file, this would read as descending and
+    /// be refused — and a ticker-major file is one of the two layouts Massive might hand over.
+    #[test]
+    fn test_ordering_is_judged_within_a_ticker_not_across_the_file() {
+        let body = format!(
+            "{HEADER}\n{}{}{}{}",
+            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_100),
+            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_200),
+            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_001),
+            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_002),
+        );
+        let summary = fold(&body).0.expect("each ticker ascends");
+        assert_eq!(summary.ticks_folded, 4);
+        assert_eq!(summary.tickers, 2);
+    }
+
+    /// Serves `body` for any `GET`, and refuses anything else so a change of verb is visible.
+    fn client_serving(
+        body: Vec<u8>,
+    ) -> (
+        FlatFileClient,
+        std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    ) {
+        let requested = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = std::sync::Arc::clone(&requested);
+        let http_client = infallible_client_fn(move |request| {
+            recorder
+                .lock()
+                .expect("no test thread panics holding this")
+                .push(request.uri().path().to_string());
+            match *request.method() {
+                http::Method::GET => http::Response::builder()
+                    .status(200)
+                    .body(SdkBody::from(body.clone()))
+                    .expect("a valid response"),
+                _ => http::Response::builder()
+                    .status(405)
+                    .body(SdkBody::empty())
+                    .expect("a valid response"),
+            }
+        });
+        let credentials = FlatFileCredentials::new(
+            "https://files.massive.com".to_string(),
+            "key".to_string(),
+            "secret".to_string(),
+        )
+        .expect("usable credentials");
+        let configuration = FlatFileClient::configuration(credentials)
+            .http_client(http_client)
+            .build();
+        (FlatFileClient::from_configuration(configuration), requested)
+    }
+
+    /// The whole path a real run takes: a signed request against Massive's endpoint, a gzip stream
+    /// off the response body, and a fold that never sees the file. Only the network is scripted.
+    #[tokio::test]
+    async fn test_a_day_is_streamed_from_the_endpoint_and_folded() {
+        let body = format!(
+            "{HEADER}\n{}{}",
+            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_000),
+            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_001),
+        );
+        let (client, requested) = client_serving(gzipped(&body));
+        let folded = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let collector = std::sync::Arc::clone(&folded);
+
+        let summary = client
+            .fold_quotes(
+                NaiveDate::from_ymd_opt(2026, 3, 9).expect("a real date"),
+                move |ticker, _tick| {
+                    collector
+                        .lock()
+                        .expect("no fold thread panics holding this")
+                        .push(ticker.as_str().to_string());
+                },
+            )
+            .await
+            .expect("a usable file");
+
+        assert_eq!(summary.ticks_folded, 2);
+        assert_eq!(summary.tickers, 2);
+        assert_eq!(
+            *folded.lock().expect("the fold finished"),
+            vec!["AAPL".to_string(), "CBOE".to_string()]
+        );
+
+        // Path-style, because the endpoint is not AWS: a virtual-host bucket would resolve
+        // `flatfiles.files.massive.com`, which does not exist.
+        assert_eq!(
+            *requested.lock().expect("the request was recorded"),
+            vec!["/flatfiles/us_stocks_sip/quotes_v1/2026/03/2026-03-09.csv.gz".to_string()]
+        );
+    }
+
+    /// The measurement the probe exists to take, because it decides whether the backfill holds one
+    /// name's ticks or every name's — thirteen megabytes against several gigabytes.
+    #[test]
+    fn test_the_layout_is_read_off_where_the_ticker_changes() {
+        let ticker_major = format!(
+            "{HEADER}\n{}{}{}{}",
+            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_100),
+            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_200),
+            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_001),
+            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_002),
+        );
+        let summary = fold(&ticker_major).0.expect("each ticker ascends");
+        assert_eq!(summary.ticker_runs, 2, "one run per name");
+        assert_eq!(summary.layout(), RowLayout::TickerMajor);
+
+        let time_major = format!(
+            "{HEADER}\n{}{}{}{}",
+            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_000),
+            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_001),
+            row("AAPL", "100.05", "200", "99.95", "100", 1_000_000_002),
+            row("CBOE", "200.20", "50", "199.80", "40", 1_000_000_003),
+        );
+        let summary = fold(&time_major).0.expect("interleaved and ascending");
+        assert_eq!(summary.ticker_runs, 4, "every row starts a run");
+        assert_eq!(summary.layout(), RowLayout::TimeMajor);
+    }
+
+    #[test]
+    fn test_credentials_reject_an_empty_field() {
+        assert!(
+            FlatFileCredentials::new(String::new(), "key".to_string(), "secret".to_string())
+                .is_err()
+        );
+        assert!(FlatFileCredentials::new(
+            "https://files.massive.com".to_string(),
+            String::new(),
+            "secret".to_string()
+        )
+        .is_err());
+        assert!(FlatFileCredentials::new(
+            "https://files.massive.com".to_string(),
+            "key".to_string(),
+            String::new()
+        )
+        .is_err());
+        assert!(FlatFileCredentials::new(
+            "https://files.massive.com".to_string(),
+            "key".to_string(),
+            "secret".to_string()
+        )
+        .is_ok());
+    }
+}


### PR DESCRIPTION
# Overview

The transport for Massive's flat files, and the probe that has to run before the fold is written.
First of the task 3 quote-depth work. **Nothing here spends money** — the subscription is the step
after this one, and both halves are exercised against synthetic files and a scripted S3 transport.

## Changes

- Add `common::flatfiles`: a streaming reader for `files.massive.com`, one gzipped CSV per day
- Add `seed equity-quotes probe --date D`, which reads a day with a counting fold and reports it
- Split `seed_quotes` one function per verb, so a probe never passes through an Alpaca credential
- Add the `MASSIVE_S3_*` credentials to `secretspec.toml`, optional in every profile
- Add `csv`; enable `io` and `io-util` on the existing `tokio-util`

## Context

The quote archive is **five sessions deep against 1,255 for bars**. Stride-1 over five years through
the Alpaca API is ~100 days, so the depth question was already answered by changing instrument
rather than effort: bulk download, 40–80 hours.

### The transport holds nothing

`GetObject` gives a byte stream, which is decompressed, parsed and folded as it arrives — the only
resident state is the caller's fold. It runs on a blocking thread because decompression and CSV
parsing are the CPU cost of the download rather than a wait, which is also what makes `flate2` —
already in the tree for the model artifact — sufficient. `tokio-util`'s `SyncIoBridge` turns the
async stream into the synchronous reader those two want. **So the only new crate is `csv`.**

### Columns resolve from the header

Massive documented the key layout and nothing else, so the column order is unknown and unknowable
before paying. A column inserted or reordered upstream costs nothing; a column **renamed** fails on
the header, with the header printed, rather than folding whatever sat in that slot.

### Ascending time is asserted, and per ticker

The fold weighs each quote by the interval to the next, so a descending file weighs every one at zero
and **still produces a summary** — a silent wrong answer. The `sort=asc` pin that prevents this on the
Alpaca path protects nothing on a file someone else sorted.

The rule is that backwards steps must not outnumber forwards, which is not a tuning knob: an ascending
file inverts a handful of rows per name where the SIP itself ties, a descending one inverts every row
after the first, and nothing real lands between. Per *ticker*, because a ticker-major file zig-zags
across the file while ascending within each name — and that is one of the two layouts on offer.

### Why the credentials are `MASSIVE_S3_*`

They are issued by Massive and authenticate to `files.massive.com`. S3 is the dialect, not the owner.

The naming is load-bearing rather than cosmetic: this process **also holds real AWS credentials** and
writes the archive with them, and `aws_config::load_defaults` reads `AWS_ACCESS_KEY_ID` from the
environment. A name in that family would hand Massive's key to every genuine AWS call in the same
binary.

Optional in every profile, because they exist only while the one-month Advanced subscription does and
requiring them would stop the other eleven binaries from starting. Verified that `secretspec run`
still resolves with all three absent.

### The probe answers what cannot be reasoned to

Four things decide how the backfill is written and none can be known before the subscription exists:
the row order, the file's size, the throughput of decompressing and parsing it, and how much of it is
a book no spread reads off. `seed equity-quotes probe --date D` reads a day with a counting fold, so
the measurement costs one download and almost no memory.

**The row order matters most, and the standing estimate for it is wrong.** The plan puts ~12,000
concurrent folds at 60–100 MB resident. That counts the accumulator state but not
`SpreadAccumulator::observations` — one `(f64, f64)` per tick, and the thing a time-weighted quantile
cannot be computed without. At the measured ~400M quotes a session that is **~6.4 GB, about sixty
times the estimate**.

| layout | folds held at once | resident |
|---|---|---|
| ticker-major | 1 — finish and drop at the switch | ~13 MB |
| time-major | ~12,000 — every one until the file ends | ~6.4 GB |

So the probe counts **ticker runs**, and `layout()` asks which end that count sits nearer — twelve
thousand or four hundred million. A measurement, not a threshold anyone had to choose.

**Deliberately not solved here.** Both remedies are small and each is valid under exactly one layout,
so building both means building dead code and picking one blind is a coin flip. One download settles
it — and measuring one day before committing to five years of any dataset was already the standing
rule, the sixty-fold error above being the latest reason for it.

### A defect caught while building

Adding `Probe` to `QuoteAction` left a dead arm in the scope match, which is the defect the #1113
review round removed from the intraday path. `seed_quotes` is split one function per verb on the same
terms: exhaustive, no dead arm, and a probe now reaches its own transport without passing through
anything that reads an Alpaca credential. Verified with `ALPACA_API_KEY_ID`, `ALPACA_API_SECRET` and
`AWS_S3_BUCKET_NAME` all unset — it fails on `MASSIVE_S3_ENDPOINT` and nothing else.

### The one guess left

`sip_timestamp`, `bid_price`, `bid_size`, `ask_price`, `ask_size` and `ticker` are the expected column
names. Header resolution means a wrong guess fails loudly on day one with the real header printed
rather than folding the wrong field, so this is **safe to be wrong about** — and it will need a
one-line fix once a file exists.

### Verification

`devenv tasks run checks:all` passes. Coverage **81.38% → 81.19%** — the difference is the probe body
and the four quote functions, which need a vendor.

Eleven transport tests, including one that goes through the real S3 client with a scripted transport
and asserts the exact request path. Each new assertion was proved load-bearing by breaking the code
under it and watching it fail: the descending refusal, header resolution against a reordered header,
path-style addressing against a non-AWS endpoint, per-ticker ordering under a ticker-major file, the
layout comparison, the run boundary, and the probe's required date.

### What happens next

This is the "ready to buy" state. Then: buy Advanced, run the probe on one day, pick the fold's
release policy from what it says, write the fold, validate against the Alpaca week already held,
backfill, revert to Starter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9MuPyHx1o8E6X9cPZcCNZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for streaming and processing compressed daily quote files from compatible cloud storage.
  * Added an `equity-quotes probe --date` command to inspect file layout, data quality, ticker ordering, throughput, and estimated memory usage without archiving data.
  * Added optional cloud storage configuration for supported advanced data subscriptions.
* **Bug Fixes**
  * Improved validation and reporting for missing credentials, unavailable files, malformed rows, missing columns, and descending quote data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->