### PR TITLE
Read a whole session out of Massive's flat files, and fold it into the archive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tokio = { version = "1.51.1", features = ["full"] }
 # `CancellationToken`, for the shutdown signal shared between the listener and the recovery scan.
 # `io-util` brings `SyncIoBridge`, which is what lets a flat file's async `ByteStream` be read by the
 # synchronous gzip decoder and CSV reader on a blocking thread, where that CPU work belongs anyway.
-tokio-util = { version = "0.7", features = ["io", "io-util"] }
+tokio-util = "0.7"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.23", features = [
   "env-filter",

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -1116,6 +1116,20 @@ async fn probe_flat_file(date: SessionDate) -> Result<Outcome, SeedError> {
         ),
         None => println!("  no usable rows, so the layout is unmeasured"),
     }
+    if summary.split_tickers.is_empty() {
+        println!("  every name's rows are contiguous");
+    } else {
+        println!(
+            "  {} names are split across the file: {}",
+            summary.split_tickers.len(),
+            summary
+                .split_tickers
+                .names()
+                .map(|ticker| ticker.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
     println!(
         "  {:.2} GiB compressed, read in {elapsed:.0}s at {:.1} MiB/s and {:.0} rows/s",
         summary.compressed_bytes as f64 / (1024.0 * 1024.0 * 1024.0),

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -1197,25 +1197,27 @@ async fn fold_named_from_flat_file(
         .await
         .map_err(box_error)?;
     let elapsed = started.elapsed().as_secs_f64();
-    let folded = fold.folded();
-    let (summaries, resumed) = fold.finish();
+    let folded_ticks = fold.folded();
+    let folded = fold.finish();
 
     println!("{}", flatfiles::quote_key(date.date()));
     println!(
-        "  {} rows scanned in {elapsed:.0}s, {folded} folded for the names asked for",
+        "  {} rows scanned in {elapsed:.0}s, {folded_ticks} folded for the names asked for",
         file.rows_read
     );
-    if !resumed.is_empty() {
+    if !folded.resumed.is_empty() {
         println!(
             "  resumed across runs: {}",
-            resumed
+            folded
+                .resumed
                 .iter()
                 .map(Ticker::as_str)
                 .collect::<Vec<_>>()
                 .join(", ")
         );
     }
-    let mut session_rows: Vec<_> = summaries
+    let mut session_rows: Vec<_> = folded
+        .summaries
         .iter()
         .filter(|summary| summary.bar_interval() == BarInterval::OneDay)
         .collect();

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -209,6 +209,10 @@ struct ProbeArguments {
     /// The session to read, as an Eastern calendar date: YYYY-MM-DD.
     #[arg(long, value_parser = session_date)]
     date: SessionDate,
+    /// Fold only these names and print their session summaries, rather than counting the file.
+    /// This is how a flat-file fold is checked against the same session through Alpaca.
+    #[command(flatten)]
+    symbols: SymbolArguments,
 }
 
 #[derive(Debug, Args)]
@@ -1007,12 +1011,16 @@ fn report(scan: &archive::SymbolScan) {
 /// be reachable only after one has been demanded.
 async fn seed_quotes(action: &QuoteAction) -> Result<Outcome, SeedError> {
     match action {
-        QuoteAction::Probe(arguments) => probe_flat_file(arguments.date).await,
+        QuoteAction::Probe(arguments) => match arguments.symbols.names()? {
+            None => probe_flat_file(arguments.date).await,
+            Some(named) => fold_named_from_flat_file(arguments.date, named).await,
+        },
         QuoteAction::Archive(arguments) => {
             fold_sampled(
                 arguments,
                 NameSelection::Screened(LiquidityFloor::CURRENT),
                 SessionSelection::Absent,
+                QuoteProvider::WholeSession,
             )
             .await
         }
@@ -1021,6 +1029,7 @@ async fn seed_quotes(action: &QuoteAction) -> Result<Outcome, SeedError> {
                 arguments,
                 NameSelection::WholeMarket,
                 SessionSelection::Every,
+                QuoteProvider::WholeSession,
             )
             .await
         }
@@ -1033,6 +1042,7 @@ async fn seed_quotes(action: &QuoteAction) -> Result<Outcome, SeedError> {
                 &symbols.quotes,
                 NameSelection::Named(named),
                 SessionSelection::Present,
+                QuoteProvider::PerName,
             )
             .await
         }
@@ -1044,6 +1054,7 @@ async fn fold_sampled(
     arguments: &QuoteArguments,
     names: NameSelection,
     sessions: SessionSelection,
+    provider: QuoteProvider,
 ) -> Result<Outcome, SeedError> {
     let scope = Scope::new(names, sessions).map_err(|error| SeedError::Usage(error.to_string()))?;
     let window = arguments.window.window()?;
@@ -1051,8 +1062,19 @@ async fn fold_sampled(
     let sampled = sample(&calendar, &window, arguments.stride);
     report_sample(&window, arguments.stride, &calendar, &sampled);
 
+    // Bound before the source so it outlives the borrow, and built only where it is used: a
+    // repair must not demand flat-file credentials to reach two names through Alpaca.
+    let flat_files;
+    let source = match provider {
+        QuoteProvider::WholeSession => {
+            flat_files = flatfiles::FlatFileClient::from_env().map_err(box_error)?;
+            archive::QuoteSource::WholeSession(&flat_files)
+        }
+        QuoteProvider::PerName => archive::QuoteSource::PerName(&market_data),
+    };
+
     Ok(Outcome::Pass(
-        fold_quotes(&market_data, &calendar, &sampled, &scope).await?,
+        fold_quotes(&source, &calendar, &sampled, &scope).await?,
     ))
 }
 
@@ -1094,8 +1116,8 @@ fn report_sample(
 async fn probe_flat_file(date: SessionDate) -> Result<Outcome, SeedError> {
     let client = flatfiles::FlatFileClient::from_env().map_err(box_error)?;
     let started = tokio::time::Instant::now();
-    let summary = client
-        .fold_quotes(date.date(), |_ticker, _tick| {})
+    let (summary, _) = client
+        .fold_quotes(date.date(), flatfiles::ForEach(|_ticker, _tick| {}))
         .await
         .map_err(box_error)?;
     let elapsed = started.elapsed().as_secs_f64();
@@ -1146,6 +1168,74 @@ async fn probe_flat_file(date: SessionDate) -> Result<Outcome, SeedError> {
     Ok(Outcome::Complete)
 }
 
+/// Folds named symbols out of a session's flat file and prints what they read, writing nothing.
+///
+/// The counterpart of `equity-quotes measure`, which asks Alpaca the same question. Running both on
+/// one session is how the two providers are checked against each other, and it costs one file rather
+/// than the whole universe held in memory.
+async fn fold_named_from_flat_file(
+    date: SessionDate,
+    named: BTreeSet<Ticker>,
+) -> Result<Outcome, SeedError> {
+    let client = flatfiles::FlatFileClient::from_env().map_err(box_error)?;
+    let credentials = AlpacaCredentials::from_env().map_err(box_error)?;
+    let days = TradingClient::from_env(credentials)
+        .fetch_calendar(date.date(), date.date())
+        .await
+        .map_err(box_error)?;
+    let calendar = TradingCalendar::from_days(days);
+    let Some((open, close)) = quotes::trading_hours(&calendar, date) else {
+        return Err(SeedError::Usage(format!(
+            "{date} is not a published session"
+        )));
+    };
+
+    let started = tokio::time::Instant::now();
+    let fold = quotes::MarketFold::new(date, open, close, named);
+    let (file, fold) = client
+        .fold_quotes(date.date(), fold)
+        .await
+        .map_err(box_error)?;
+    let elapsed = started.elapsed().as_secs_f64();
+    let folded = fold.folded();
+    let (summaries, resumed) = fold.finish();
+
+    println!("{}", flatfiles::quote_key(date.date()));
+    println!(
+        "  {} rows scanned in {elapsed:.0}s, {folded} folded for the names asked for",
+        file.rows_read
+    );
+    if !resumed.is_empty() {
+        println!(
+            "  resumed across runs: {}",
+            resumed
+                .iter()
+                .map(Ticker::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    let mut session_rows: Vec<_> = summaries
+        .iter()
+        .filter(|summary| summary.bar_interval() == BarInterval::OneDay)
+        .collect();
+    session_rows.sort_by_key(|summary| summary.ticker().as_str().to_string());
+    for summary in session_rows {
+        println!(
+            "  {:<6} mean {:>8.3}bp  median {:>8.3}bp  p90 {:>9.3}bp  bid {:>10.1}  ask {:>10.1}  quotes {:>9}  covered {:>8.1}s",
+            summary.ticker().as_str(),
+            summary.quoted_spread_basis_points_mean().value(),
+            summary.quoted_spread_basis_points_median().value(),
+            summary.quoted_spread_basis_points_ninetieth_percentile().value(),
+            summary.bid_size_mean(),
+            summary.ask_size_mean(),
+            summary.quote_count(),
+            summary.covered_seconds(),
+        );
+    }
+    Ok(Outcome::Complete)
+}
+
 /// Guards the division, because an empty file is a real answer rather than a panic.
 fn percentage(part: usize, whole: usize) -> f64 {
     if whole == 0 {
@@ -1175,9 +1265,20 @@ async fn quote_sources(
     Ok((market_data, TradingCalendar::from_days(days)))
 }
 
+/// Which provider a fold reads from.
+///
+/// A backfill takes whole sessions off Massive's flat files, because five years one name at a time
+/// is a hundred days of API calls. A repair takes named symbols from Alpaca, because it already
+/// knows which names it wants and a whole file to reach two of them is seven gigabytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuoteProvider {
+    WholeSession,
+    PerName,
+}
+
 /// Folds the sampled sessions into the archive, which is the half a measurement skips.
 async fn fold_quotes(
-    market_data: &MarketDataClient,
+    source: &archive::QuoteSource<'_>,
     calendar: &TradingCalendar,
     sampled: &[SessionDate],
     scope: &Scope,
@@ -1185,7 +1286,7 @@ async fn fold_quotes(
     let bucket = bucket_name()?;
     let s3_client = fund::common::aws::s3_client().await;
     Ok(
-        archive::archive_quote_sessions(&s3_client, market_data, calendar, &bucket, sampled, scope)
+        archive::archive_quote_sessions(&s3_client, source, calendar, &bucket, sampled, scope)
             .await?,
     )
 }
@@ -1671,10 +1772,10 @@ mod tests {
         }
     }
 
-    /// A probe reads one vendor file rather than the archive, so it takes a date and nothing else:
-    /// no window to sample over, no stride, no symbol set.
+    /// A probe reads one vendor file rather than the archive, so it takes a date and at most a set
+    /// of names to fold out of it — never a window or a stride, which only a sampled pass has.
     #[test]
-    fn test_a_probe_takes_one_date_and_nothing_else() {
+    fn test_a_probe_takes_one_date_and_optionally_names() {
         let QuoteAction::Probe(arguments) =
             quotes(&["equity-quotes", "probe", "--date", "2026-03-09"])
         else {
@@ -1682,11 +1783,29 @@ mod tests {
         };
         assert_eq!(arguments.date, session("2026-03-09"));
 
-        for extra in [
-            vec!["--stride", "21"],
-            vec!["--symbols", "AAPL"],
-            vec!["--start", "2026-03-09"],
-        ] {
+        // Named, it folds those names and prints their summaries against the same session read
+        // through Alpaca; unnamed, it counts the file.
+        let QuoteAction::Probe(arguments) = quotes(&[
+            "equity-quotes",
+            "probe",
+            "--date",
+            "2026-03-09",
+            "--symbols",
+            "AAPL,MSFT",
+        ]) else {
+            panic!("expected the probe action");
+        };
+        assert_eq!(
+            arguments
+                .symbols
+                .names()
+                .expect("a valid symbol list")
+                .expect("names were given")
+                .len(),
+            2
+        );
+
+        for extra in [vec!["--stride", "21"], vec!["--start", "2026-03-09"]] {
             let mut arguments = vec!["equity-quotes", "probe", "--date", "2026-03-09"];
             arguments.extend_from_slice(&extra);
             assert!(

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -38,7 +38,10 @@ const RANGE_ATTEMPTS: usize = 5;
 /// The first wait after a failed range, doubling per attempt.
 const RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(250);
 
-/// Chunks allowed to sit finished ahead of the parser, bounding what the reorder costs in memory.
+/// Chunks allowed to sit finished in the channel ahead of the parser.
+///
+/// This is not the whole reorder cost: a completed request keeps its own chunk until the ones before
+/// it have been sent, so the peak is `(RANGES_IN_FLIGHT + READY_CHUNKS) * CHUNK_BYTES`, 272 MiB.
 const READY_CHUNKS: usize = 8;
 
 /// How long a range may read nothing before it is abandoned.
@@ -91,6 +94,14 @@ pub enum FlatFileError {
         key: String,
         backwards: usize,
         forwards: usize,
+    },
+    /// A range answered with a different number of bytes than it asked for.
+    #[error("{key} {range} returned {received} bytes rather than {expected}")]
+    ShortRange {
+        key: String,
+        range: String,
+        expected: usize,
+        received: usize,
     },
 }
 
@@ -439,9 +450,10 @@ async fn fetch_ranges(
     loop {
         while in_flight.len() < RANGES_IN_FLIGHT && next_offset < length {
             let (range, after) = chunk_range(next_offset, length);
+            let expected = (after - next_offset) as usize;
             let (client, key) = (client.clone(), key.clone());
             in_flight.push_back(tokio::spawn(async move {
-                fetch_one_range(client, key, range).await
+                fetch_one_range(client, key, range, expected).await
             }));
             next_offset = after;
         }
@@ -457,7 +469,12 @@ async fn fetch_ranges(
             }),
         };
         // A closed receiver means the parse stopped early, which is its answer rather than an error.
+        // Dropping a handle does not cancel its request, so the rest are stopped rather than left
+        // downloading megabytes nothing will read.
         if sender.send(chunk).await.is_err() {
+            for pending in in_flight {
+                pending.abort();
+            }
             return;
         }
     }
@@ -492,10 +509,11 @@ async fn fetch_one_range(
     client: S3Client,
     key: String,
     range: String,
+    expected: usize,
 ) -> Result<Vec<u8>, FlatFileError> {
     let mut attempt = 1;
     loop {
-        match try_fetch_one_range(&client, &key, &range).await {
+        match try_fetch_one_range(&client, &key, &range, expected).await {
             Ok(bytes) => return Ok(bytes),
             Err(error) if attempt < RANGE_ATTEMPTS => {
                 warn!(key, range, attempt, chain = %error_chain(&error), "Retrying a range");
@@ -511,6 +529,7 @@ async fn try_fetch_one_range(
     client: &S3Client,
     key: &str,
     range: &str,
+    expected: usize,
 ) -> Result<Vec<u8>, FlatFileError> {
     let object = client
         .get_object()
@@ -531,7 +550,18 @@ async fn try_fetch_one_range(
             key: format!("{key} {range}"),
             source: Box::new(error),
         })?;
-    Ok(body.to_vec())
+    let bytes = body.to_vec();
+    // A short body puts a hole in the gzip stream, and an endpoint that ignores Range altogether
+    // answers with the whole object, which decodes to its first member and reads as a clean success.
+    if bytes.len() != expected {
+        return Err(FlatFileError::ShortRange {
+            key: key.to_string(),
+            range: range.to_string(),
+            expected,
+            received: bytes.len(),
+        });
+    }
+    Ok(bytes)
 }
 
 /// Presents the ordered chunks as something the gzip decoder can read.
@@ -912,6 +942,58 @@ mod tests {
         Some((first.parse().ok()?, last.parse().ok()?))
     }
 
+    /// Serves `missing` bytes fewer than each range asked for, which is what a truncating endpoint
+    /// looks like from the client's side.
+    fn client_serving_short(
+        body: Vec<u8>,
+        missing: usize,
+    ) -> (
+        FlatFileClient,
+        std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    ) {
+        let requested = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let http_client = infallible_client_fn(move |request| {
+            match (
+                request.method().clone(),
+                parse_range(
+                    request
+                        .headers()
+                        .get("range")
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or_default(),
+                ),
+            ) {
+                (http::Method::HEAD, _) => http::Response::builder()
+                    .status(200)
+                    .header("content-length", body.len().to_string())
+                    .body(SdkBody::empty())
+                    .expect("a valid response"),
+                (http::Method::GET, Some((first, last))) => {
+                    let last = last.min(body.len() - 1).saturating_sub(missing);
+                    let slice = body[first..=last.max(first)].to_vec();
+                    http::Response::builder()
+                        .status(206)
+                        .body(SdkBody::from(slice))
+                        .expect("a valid response")
+                }
+                _ => http::Response::builder()
+                    .status(405)
+                    .body(SdkBody::empty())
+                    .expect("a valid response"),
+            }
+        });
+        let credentials = FlatFileCredentials::new(
+            "https://files.massive.com".to_string(),
+            "key".to_string(),
+            "secret".to_string(),
+        )
+        .expect("usable credentials");
+        let configuration = FlatFileClient::configuration(credentials)
+            .http_client(http_client)
+            .build();
+        (FlatFileClient::from_configuration(configuration), requested)
+    }
+
     /// An object store, near enough: `HEAD` reports the length and `GET` serves only what its
     /// `Range` asks for. A `GET` without one is refused, so a regression to whole-object reads —
     /// which is what could not survive a file this size — fails rather than quietly passing.
@@ -1020,6 +1102,39 @@ mod tests {
         assert_eq!(seen.len(), 2, "{seen:?}");
         assert_eq!(seen[0], format!("HEAD {path}"));
         assert_eq!(seen[1], format!("GET {path} bytes=0-{}", body_length - 1));
+    }
+
+    /// A short body puts a hole in the gzip stream, and an endpoint that ignores Range altogether
+    /// answers with the whole object — which decodes to its first member and reads as a clean
+    /// success. Both are refused by comparing what came back against what was asked for.
+    #[tokio::test]
+    async fn test_a_range_answered_with_the_wrong_number_of_bytes_is_refused() {
+        let body = format!(
+            "{HEADER}\n{}",
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(0)),
+        );
+        let compressed = gzipped(&body);
+        // Reports the real length but serves one byte fewer than every range asks for.
+        let (client, _) = client_serving_short(compressed.clone(), 1);
+        let error = client
+            .fold_quotes(
+                NaiveDate::from_ymd_opt(2026, 3, 9).expect("a real date"),
+                ForEach(|_ticker: Ticker, _tick: QuoteTick| {}),
+            )
+            .await
+            .map(|(summary, _)| summary)
+            .expect_err("a truncated range");
+        // Wrapped by the reader boundary on its way out, so the refusal is read off the message
+        // rather than the variant — what matters is that the byte count is named and the file fails.
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains(&format!(
+                "returned {} bytes rather than {}",
+                compressed.len() - 1,
+                compressed.len()
+            )),
+            "{rendered}"
+        );
     }
 
     /// Both ends inclusive, and the last chunk of a file stops where the file does rather than on a

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -152,6 +152,26 @@ impl FlatFileCredentials {
     }
 }
 
+/// Somewhere for a file's ticks to go.
+///
+/// A trait rather than a closure because the caller needs its accumulator back, and a closure's
+/// captures cannot be reached once it has been moved onto the blocking thread.
+pub trait QuoteSink {
+    fn push(&mut self, ticker: Ticker, tick: QuoteTick);
+}
+
+/// Adapts a plain closure, for a caller that keeps nothing — counting a file, or a test.
+pub struct ForEach<F>(pub F);
+
+impl<F> QuoteSink for ForEach<F>
+where
+    F: FnMut(Ticker, QuoteTick),
+{
+    fn push(&mut self, ticker: Ticker, tick: QuoteTick) {
+        (self.0)(ticker, tick)
+    }
+}
+
 /// The S3 key holding one day of consolidated quotes.
 ///
 /// The `us_stocks_sip` prefix is Massive's own and corroborates the SIP sourcing behind their NBBO
@@ -333,21 +353,18 @@ impl FlatFileClient {
     /// Nothing is collected and nothing touches disk: the object arrives as concurrent byte ranges
     /// which are decompressed, parsed and folded in order as they land. The parse runs on a blocking
     /// thread because decompression and CSV parsing are the CPU cost of the download, not a wait.
-    pub async fn fold_quotes<F>(
+    pub async fn fold_quotes<S: QuoteSink + Send + 'static>(
         &self,
         date: NaiveDate,
-        fold: F,
-    ) -> Result<QuoteFileFold, FlatFileError>
-    where
-        F: FnMut(Ticker, QuoteTick) + Send + 'static,
-    {
+        fold: S,
+    ) -> Result<(QuoteFileFold, S), FlatFileError> {
         let key = quote_key(date);
         info!(bucket = FLAT_FILE_BUCKET, key, %date, "Reading a flat file of quotes");
 
         let compressed_bytes = self.object_length(&key).await?;
         let reader = self.ranged_reader(&key, compressed_bytes);
         let scoped = key.clone();
-        let mut summary =
+        let (mut summary, fold) =
             tokio::task::spawn_blocking(move || fold_gzipped_quotes(reader, &scoped, fold))
                 .await
                 .map_err(|error| FlatFileError::Read {
@@ -368,7 +385,7 @@ impl FlatFileClient {
             compressed_bytes,
             "Folded a flat file of quotes"
         );
-        Ok(summary)
+        Ok((summary, fold))
     }
 
     /// The object's size, which the range requests need before any of them can be addressed.
@@ -618,14 +635,14 @@ fn nanoseconds_to_instant(nanoseconds: i64) -> Option<DateTime<Utc>> {
 /// Decompresses, parses and folds, on whichever thread the caller put this on.
 ///
 /// Separate from the request so it can be tested against a file that never went over a network.
-fn fold_gzipped_quotes<R, F>(
+fn fold_gzipped_quotes<R, S>(
     reader: R,
     key: &str,
-    mut fold: F,
-) -> Result<QuoteFileFold, FlatFileError>
+    mut fold: S,
+) -> Result<(QuoteFileFold, S), FlatFileError>
 where
     R: std::io::Read,
-    F: FnMut(Ticker, QuoteTick),
+    S: QuoteSink,
 {
     let mut records = csv::Reader::from_reader(GzDecoder::new(reader));
     let header = records.headers().map_err(|error| read_error(key, error))?;
@@ -669,7 +686,7 @@ where
             previous_ticker = Some(ticker.clone());
         }
         summary.ticks_folded += 1;
-        fold(ticker, tick);
+        fold.push(ticker, tick);
     }
 
     // Asserted here because this is what read the file. An error means the fold must be discarded:
@@ -686,7 +703,7 @@ where
             "Skipped rows no spread can be read off"
         );
     }
-    Ok(summary)
+    Ok((summary, fold))
 }
 
 fn read_error(key: &str, error: csv::Error) -> FlatFileError {
@@ -743,15 +760,15 @@ mod tests {
         let summary = fold_gzipped_quotes(
             std::io::Cursor::new(gzipped(body)),
             "test.csv.gz",
-            move |ticker, tick| {
+            ForEach(move |ticker: Ticker, tick: QuoteTick| {
                 collector.borrow_mut().push((
                     ticker.as_str().to_string(),
                     tick.timestamp().timestamp_nanos_opt().unwrap_or_default(),
                 ));
-            },
+            }),
         );
         let observed = seen.borrow().clone();
-        (summary, observed)
+        (summary.map(|(summary, _)| summary), observed)
     }
 
     #[test]
@@ -977,15 +994,16 @@ mod tests {
         let summary = client
             .fold_quotes(
                 NaiveDate::from_ymd_opt(2026, 3, 9).expect("a real date"),
-                move |ticker, _tick| {
+                ForEach(move |ticker: Ticker, _tick: QuoteTick| {
                     collector
                         .lock()
                         .expect("no fold thread panics holding this")
                         .push(ticker.as_str().to_string());
-                },
+                }),
             )
             .await
-            .expect("a usable file");
+            .expect("a usable file")
+            .0;
 
         assert_eq!(summary.ticks_folded, 2);
         assert_eq!(summary.tickers, 2);

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use aws_sdk_s3::Client as S3Client;
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use flate2::read::GzDecoder;
-use tokio_util::io::SyncIoBridge;
 use tracing::{info, warn};
 
 use crate::common::alpaca::QuoteTick;
@@ -19,6 +18,35 @@ const FLAT_FILE_BUCKET: &str = "flatfiles";
 /// The region the signer needs. Massive is not AWS, so nothing resolves this from an instance or a
 /// profile — it is a constant the signature requires rather than a place anything is stored.
 const FLAT_FILE_REGION: &str = "us-east-1";
+
+/// How much of the object one range request asks for.
+///
+/// Small enough that a failure costs little and the reorder buffer stays bounded, large enough that
+/// per-request overhead does not dominate.
+const CHUNK_BYTES: i64 = 2 * 1024 * 1024;
+
+/// How many ranges are outstanding at once, which is what buys the throughput.
+///
+/// Measured against one session: 1 connection reads 1.15 MB/s, 64 read 14.1, 128 read 26.8 — the
+/// throttle is per connection, so concurrency is the only lever. Massive resets connections when
+/// pushed, which [`RANGE_ATTEMPTS`] absorbs rather than this number avoiding.
+const RANGES_IN_FLIGHT: usize = 128;
+
+/// How many times one range is asked for before the file gives up.
+const RANGE_ATTEMPTS: usize = 5;
+
+/// The first wait after a failed range, doubling per attempt.
+const RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Chunks allowed to sit finished ahead of the parser, bounding what the reorder costs in memory.
+const READY_CHUNKS: usize = 8;
+
+/// How long a range may read nothing before it is abandoned.
+///
+/// The default is five seconds, which a request waiting its turn behind [`RANGES_IN_FLIGHT`] others
+/// exceeds routinely — that default is what killed the first whole-file read, mid-download and with
+/// no explanation. Long enough that only a genuinely dead connection trips it.
+const STALL_GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// The columns [`QuoteColumns`] resolves out of a quote file's header.
 ///
@@ -251,6 +279,11 @@ impl FlatFileClient {
             .region(aws_sdk_s3::config::Region::new(FLAT_FILE_REGION))
             .endpoint_url(credentials.endpoint_url)
             .force_path_style(true)
+            .stalled_stream_protection(
+                aws_sdk_s3::config::StalledStreamProtectionConfig::enabled()
+                    .grace_period(STALL_GRACE_PERIOD)
+                    .build(),
+            )
             .credentials_provider(aws_sdk_s3::config::Credentials::new(
                 credentials.access_key_id,
                 credentials.secret_access_key,
@@ -273,9 +306,9 @@ impl FlatFileClient {
 
     /// Streams one day of quotes, handing every usable tick to `fold`.
     ///
-    /// Nothing is collected and nothing touches disk: `GetObject` gives a byte stream, which is
-    /// decompressed, parsed and folded as it arrives. The whole pipeline runs on a blocking thread
-    /// because decompression and CSV parsing are the CPU cost of the download, not a wait.
+    /// Nothing is collected and nothing touches disk: the object arrives as concurrent byte ranges
+    /// which are decompressed, parsed and folded in order as they land. The parse runs on a blocking
+    /// thread because decompression and CSV parsing are the CPU cost of the download, not a wait.
     pub async fn fold_quotes<F>(
         &self,
         date: NaiveDate,
@@ -287,29 +320,16 @@ impl FlatFileClient {
         let key = quote_key(date);
         info!(bucket = FLAT_FILE_BUCKET, key, %date, "Reading a flat file of quotes");
 
-        let object = self
-            .s3_client
-            .get_object()
-            .bucket(FLAT_FILE_BUCKET)
-            .key(&key)
-            .send()
-            .await
-            .map_err(|error| FlatFileError::Fetch {
-                key: key.clone(),
-                source: Box::new(error),
-            })?;
-
-        let compressed_bytes = object.content_length().unwrap_or_default();
-        let reader = object.body.into_async_read();
+        let compressed_bytes = self.object_length(&key).await?;
+        let reader = self.ranged_reader(&key, compressed_bytes);
         let scoped = key.clone();
-        let mut summary = tokio::task::spawn_blocking(move || {
-            fold_gzipped_quotes(SyncIoBridge::new(reader), &scoped, fold)
-        })
-        .await
-        .map_err(|error| FlatFileError::Read {
-            key: key.clone(),
-            source: std::io::Error::other(error),
-        })??;
+        let mut summary =
+            tokio::task::spawn_blocking(move || fold_gzipped_quotes(reader, &scoped, fold))
+                .await
+                .map_err(|error| FlatFileError::Read {
+                    key: key.clone(),
+                    source: std::io::Error::other(error),
+                })??;
 
         summary.compressed_bytes = compressed_bytes;
         info!(
@@ -325,6 +345,185 @@ impl FlatFileClient {
             "Folded a flat file of quotes"
         );
         Ok(summary)
+    }
+
+    /// The object's size, which the range requests need before any of them can be addressed.
+    async fn object_length(&self, key: &str) -> Result<i64, FlatFileError> {
+        let head = self
+            .s3_client
+            .head_object()
+            .bucket(FLAT_FILE_BUCKET)
+            .key(key)
+            .send()
+            .await
+            .map_err(|error| FlatFileError::Fetch {
+                key: key.to_string(),
+                source: Box::new(error),
+            })?;
+        match head.content_length() {
+            Some(length) if length > 0 => Ok(length),
+            _ => Err(FlatFileError::Empty { field: "object" }),
+        }
+    }
+
+    /// A reader over the whole object, fetched as concurrent ranges and delivered in order.
+    ///
+    /// One connection is both too slow and too fragile for a file this size: Massive throttles per
+    /// connection, and a stream held open for the length of a whole file does not reliably survive.
+    fn ranged_reader(&self, key: &str, length: i64) -> ChunkReader {
+        let (sender, receiver) = tokio::sync::mpsc::channel(READY_CHUNKS);
+        let client = self.s3_client.clone();
+        let key = key.to_string();
+        tokio::spawn(async move { fetch_ranges(client, key, length, sender).await });
+        ChunkReader::new(receiver)
+    }
+}
+
+/// Fetches every range of `key` with [`RANGES_IN_FLIGHT`] outstanding, sending them in file order.
+///
+/// Order is what makes this usable: gzip decodes only forwards, so a chunk that arrives early waits
+/// for its predecessors. Awaiting the oldest request while newer ones are still running is what
+/// keeps the pipe full without buffering the file.
+async fn fetch_ranges(
+    client: S3Client,
+    key: String,
+    length: i64,
+    sender: tokio::sync::mpsc::Sender<Result<Vec<u8>, FlatFileError>>,
+) {
+    let mut in_flight: std::collections::VecDeque<
+        tokio::task::JoinHandle<Result<Vec<u8>, FlatFileError>>,
+    > = std::collections::VecDeque::with_capacity(RANGES_IN_FLIGHT);
+    let mut next_offset = 0i64;
+
+    loop {
+        while in_flight.len() < RANGES_IN_FLIGHT && next_offset < length {
+            let (range, after) = chunk_range(next_offset, length);
+            let (client, key) = (client.clone(), key.clone());
+            in_flight.push_back(tokio::spawn(async move {
+                fetch_one_range(client, key, range).await
+            }));
+            next_offset = after;
+        }
+
+        let Some(oldest) = in_flight.pop_front() else {
+            return;
+        };
+        let chunk = match oldest.await {
+            Ok(chunk) => chunk,
+            Err(error) => Err(FlatFileError::Read {
+                key: key.clone(),
+                source: std::io::Error::other(error),
+            }),
+        };
+        // A closed receiver means the parse stopped early, which is its answer rather than an error.
+        if sender.send(chunk).await.is_err() {
+            return;
+        }
+    }
+}
+
+/// Every layer of an error, because the outermost one is routinely the least informative.
+fn error_chain(error: &dyn std::error::Error) -> String {
+    let mut rendered = error.to_string();
+    let mut source = error.source();
+    while let Some(inner) = source {
+        rendered.push_str(&format!(" <- {inner}"));
+        source = inner.source();
+    }
+    rendered
+}
+
+/// The `Range` header covering the chunk at `offset`, and the offset the next one starts at.
+///
+/// Inclusive on both ends, which is what the header means and where the off-by-one lives: the last
+/// chunk of a file stops at `length - 1` rather than a chunk boundary.
+fn chunk_range(offset: i64, length: i64) -> (String, i64) {
+    let last = (offset + CHUNK_BYTES - 1).min(length - 1);
+    (format!("bytes={offset}-{last}"), last + 1)
+}
+
+/// Fetches one range, retrying it on its own.
+///
+/// The point of addressing bytes by offset: a reset range is simply asked for again, where a reset
+/// whole-file stream had nothing to resume from. Massive resets connections under load, so this is
+/// the ordinary case rather than the exceptional one.
+async fn fetch_one_range(
+    client: S3Client,
+    key: String,
+    range: String,
+) -> Result<Vec<u8>, FlatFileError> {
+    let mut attempt = 1;
+    loop {
+        match try_fetch_one_range(&client, &key, &range).await {
+            Ok(bytes) => return Ok(bytes),
+            Err(error) if attempt < RANGE_ATTEMPTS => {
+                warn!(key, range, attempt, chain = %error_chain(&error), "Retrying a range");
+                tokio::time::sleep(RETRY_BACKOFF * 2u32.pow(attempt as u32 - 1)).await;
+                attempt += 1;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+async fn try_fetch_one_range(
+    client: &S3Client,
+    key: &str,
+    range: &str,
+) -> Result<Vec<u8>, FlatFileError> {
+    let object = client
+        .get_object()
+        .bucket(FLAT_FILE_BUCKET)
+        .key(key)
+        .range(range)
+        .send()
+        .await
+        .map_err(|error| FlatFileError::Fetch {
+            key: format!("{key} {range}"),
+            source: Box::new(error),
+        })?;
+    let body = object
+        .body
+        .collect()
+        .await
+        .map_err(|error| FlatFileError::Fetch {
+            key: format!("{key} {range}"),
+            source: Box::new(error),
+        })?;
+    Ok(body.to_vec())
+}
+
+/// Presents the ordered chunks as something the gzip decoder can read.
+///
+/// Blocking by construction: it is handed to `spawn_blocking` alongside the decoder and the parser,
+/// so waiting for the next chunk is the same wait the old single stream did.
+struct ChunkReader {
+    receiver: tokio::sync::mpsc::Receiver<Result<Vec<u8>, FlatFileError>>,
+    current: std::io::Cursor<Vec<u8>>,
+}
+
+impl ChunkReader {
+    fn new(receiver: tokio::sync::mpsc::Receiver<Result<Vec<u8>, FlatFileError>>) -> Self {
+        Self {
+            receiver,
+            current: std::io::Cursor::new(Vec::new()),
+        }
+    }
+}
+
+impl std::io::Read for ChunkReader {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        loop {
+            let read = std::io::Read::read(&mut self.current, buffer)?;
+            if read > 0 {
+                return Ok(read);
+            }
+            match self.receiver.blocking_recv() {
+                None => return Ok(0),
+                Some(Ok(chunk)) => self.current = std::io::Cursor::new(chunk),
+                Some(Err(error)) => return Err(std::io::Error::other(error)),
+            }
+        }
     }
 }
 
@@ -660,7 +859,15 @@ mod tests {
         assert_eq!(summary.tickers, 2);
     }
 
-    /// Serves `body` for any `GET`, and refuses anything else so a change of verb is visible.
+    /// `bytes=first-last`, or `None` for anything else.
+    fn parse_range(header: &str) -> Option<(usize, usize)> {
+        let (first, last) = header.strip_prefix("bytes=")?.split_once('-')?;
+        Some((first.parse().ok()?, last.parse().ok()?))
+    }
+
+    /// An object store, near enough: `HEAD` reports the length and `GET` serves only what its
+    /// `Range` asks for. A `GET` without one is refused, so a regression to whole-object reads —
+    /// which is what could not survive a file this size — fails rather than quietly passing.
     fn client_serving(
         body: Vec<u8>,
     ) -> (
@@ -670,15 +877,40 @@ mod tests {
         let requested = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let recorder = std::sync::Arc::clone(&requested);
         let http_client = infallible_client_fn(move |request| {
+            let range = request
+                .headers()
+                .get("range")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_string();
             recorder
                 .lock()
                 .expect("no test thread panics holding this")
-                .push(request.uri().path().to_string());
-            match *request.method() {
-                http::Method::GET => http::Response::builder()
+                .push(format!(
+                    "{} {}{}",
+                    request.method(),
+                    request.uri().path(),
+                    {
+                        if range.is_empty() {
+                            String::new()
+                        } else {
+                            format!(" {range}")
+                        }
+                    }
+                ));
+            match (request.method().clone(), parse_range(&range)) {
+                (http::Method::HEAD, _) => http::Response::builder()
                     .status(200)
-                    .body(SdkBody::from(body.clone()))
+                    .header("content-length", body.len().to_string())
+                    .body(SdkBody::empty())
                     .expect("a valid response"),
+                (http::Method::GET, Some((first, last))) => {
+                    let slice = body[first..=last.min(body.len() - 1)].to_vec();
+                    http::Response::builder()
+                        .status(206)
+                        .body(SdkBody::from(slice))
+                        .expect("a valid response")
+                }
                 _ => http::Response::builder()
                     .status(405)
                     .body(SdkBody::empty())
@@ -706,7 +938,9 @@ mod tests {
             row("AAPL", "100.05", "200", "99.95", "100", stamp(0)),
             row("CBOE", "200.20", "50", "199.80", "40", stamp(1)),
         );
-        let (client, requested) = client_serving(gzipped(&body));
+        let compressed = gzipped(&body);
+        let body_length = compressed.len();
+        let (client, requested) = client_serving(compressed);
         let folded = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let collector = std::sync::Arc::clone(&folded);
 
@@ -731,11 +965,74 @@ mod tests {
         );
 
         // Path-style, because the endpoint is not AWS: a virtual-host bucket would resolve
-        // `flatfiles.files.massive.com`, which does not exist.
+        // `flatfiles.files.massive.com`, which does not exist. The length is asked for first, then
+        // the bytes are asked for by range rather than as a whole object.
+        let path = "/flatfiles/us_stocks_sip/quotes_v1/2026/03/2026-03-09.csv.gz";
+        let seen = requested.lock().expect("the request was recorded").clone();
+        assert_eq!(seen.len(), 2, "{seen:?}");
+        assert_eq!(seen[0], format!("HEAD {path}"));
+        assert_eq!(seen[1], format!("GET {path} bytes=0-{}", body_length - 1));
+    }
+
+    /// Both ends inclusive, and the last chunk of a file stops where the file does rather than on a
+    /// chunk boundary — which is where an off-by-one would drop or duplicate bytes.
+    #[test]
+    fn test_ranges_are_contiguous_and_stop_at_the_final_byte() {
+        let length = CHUNK_BYTES * 2 + 5;
+        let mut offset = 0;
+        let mut headers = Vec::new();
+        while offset < length {
+            let (header, after) = chunk_range(offset, length);
+            headers.push(header);
+            offset = after;
+        }
+
         assert_eq!(
-            *requested.lock().expect("the request was recorded"),
-            vec!["/flatfiles/us_stocks_sip/quotes_v1/2026/03/2026-03-09.csv.gz".to_string()]
+            headers,
+            vec![
+                "bytes=0-2097151".to_string(),
+                "bytes=2097152-4194303".to_string(),
+                "bytes=4194304-4194308".to_string(),
+            ]
         );
+        assert_eq!(offset, length, "the walk ends exactly at the length");
+    }
+
+    /// The chunks arrive as separate reads and have to read back as one stream, because gzip decodes
+    /// only forwards and a boundary landing mid-token would corrupt the parse rather than fail it.
+    #[test]
+    fn test_ordered_chunks_read_back_as_one_stream() {
+        let (sender, receiver) = tokio::sync::mpsc::channel(4);
+        for chunk in ["ticker,sip", "_timestamp\nAAPL", ",1773066600000000000\n"] {
+            sender
+                .blocking_send(Ok(chunk.as_bytes().to_vec()))
+                .expect("the receiver is alive");
+        }
+        drop(sender);
+
+        let mut read = String::new();
+        std::io::Read::read_to_string(&mut ChunkReader::new(receiver), &mut read)
+            .expect("the chunks concatenate");
+        assert_eq!(read, "ticker,sip_timestamp\nAAPL,1773066600000000000\n");
+    }
+
+    /// A failed range must reach the parser as an error rather than as a short read, which would
+    /// look like a truncated file and produce a summary of whatever arrived before it.
+    #[test]
+    fn test_a_failed_range_surfaces_rather_than_truncating() {
+        let (sender, receiver) = tokio::sync::mpsc::channel(4);
+        sender
+            .blocking_send(Ok(b"ticker,sip_timestamp\n".to_vec()))
+            .expect("the receiver is alive");
+        sender
+            .blocking_send(Err(FlatFileError::Empty { field: "object" }))
+            .expect("the receiver is alive");
+        drop(sender);
+
+        let mut read = String::new();
+        let error = std::io::Read::read_to_string(&mut ChunkReader::new(receiver), &mut read)
+            .expect_err("the failed range");
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
     }
 
     /// The measurement the probe exists to take, because it decides whether the backfill holds one

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -171,8 +171,10 @@ pub fn quote_key(date: NaiveDate) -> String {
 /// `unusable` counts rows whose book no spread can be read off — a crossed or zero-priced quote,
 /// which is ordinary around the open rather than a defect. Reported because it is the only trace a
 /// discarded row leaves, and a file that is suddenly half unusable is a vendor change.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct QuoteFileFold {
+    /// Names whose rows are not contiguous, which is what a fold releasing at the switch must know.
+    pub split_tickers: SplitTickers,
     pub rows_read: usize,
     pub ticks_folded: usize,
     pub unusable: usize,
@@ -183,6 +185,28 @@ pub struct QuoteFileFold {
     /// returns 403 — and is what turns a download estimate from arithmetic into a measurement.
     pub compressed_bytes: i64,
     backwards: usize,
+}
+
+/// Names that start a second run after their first has ended, which a ticker-major file should have
+/// none of and every measured session has two of.
+///
+/// Kept separately from the counts because a fold that releases at the ticker switch is correct only
+/// for names absent from this set — for the rest it would write two partial summaries.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SplitTickers(std::collections::BTreeSet<Ticker>);
+
+impl SplitTickers {
+    pub fn names(&self) -> impl Iterator<Item = &Ticker> {
+        self.0.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 /// How a file's rows are grouped, which is what decides how many folds must be held at once.
@@ -622,20 +646,26 @@ where
         };
         // An owned key is needed only the first time a name appears, and a day is hundreds of
         // millions of rows.
-        match latest.get_mut(&ticker) {
+        let seen_before = match latest.get_mut(&ticker) {
             Some(previous) => {
                 if tick.timestamp() < *previous {
                     summary.backwards += 1;
                 }
                 *previous = tick.timestamp();
+                true
             }
             None => {
                 latest.insert(ticker.clone(), tick.timestamp());
                 summary.tickers += 1;
+                false
             }
-        }
+        };
         if previous_ticker.as_ref() != Some(&ticker) {
             summary.ticker_runs += 1;
+            // Already seen, and yet starting a run: its rows are split across the file.
+            if seen_before {
+                summary.split_tickers.0.insert(ticker.clone());
+            }
             previous_ticker = Some(ticker.clone());
         }
         summary.ticks_folded += 1;
@@ -1060,6 +1090,41 @@ mod tests {
         let summary = fold(&time_major).0.expect("interleaved and ascending");
         assert_eq!(summary.ticker_runs, 4, "every row starts a run");
         assert_eq!(summary.layout(), Some(RowLayout::TimeMajor));
+    }
+
+    /// A ticker-major file still puts two real names in two runs each — BCPC and TPC, on every
+    /// session measured. A fold that releases at the switch is wrong for exactly those, so the names
+    /// are reported rather than the count alone: two out of thirteen thousand is invisible in a
+    /// total and actionable as a list.
+    #[test]
+    fn test_a_name_returning_after_its_run_is_named_not_just_counted() {
+        let body = format!(
+            "{HEADER}\n{}{}{}",
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(0)),
+            row("CBOE", "200.20", "50", "199.80", "40", stamp(1)),
+            row("AAPL", "100.02", "300", "99.98", "150", stamp(2)),
+        );
+        let summary = fold(&body).0.expect("a usable file");
+
+        assert_eq!(summary.tickers, 2);
+        assert_eq!(summary.ticker_runs, 3, "AAPL opens two of them");
+        assert_eq!(summary.split_tickers.len(), 1);
+        assert_eq!(
+            summary
+                .split_tickers
+                .names()
+                .map(|ticker| ticker.as_str())
+                .collect::<Vec<_>>(),
+            vec!["AAPL"]
+        );
+
+        let contiguous = format!(
+            "{HEADER}\n{}{}",
+            row("AAPL", "100.05", "200", "99.95", "100", stamp(0)),
+            row("CBOE", "200.20", "50", "199.80", "40", stamp(1)),
+        );
+        let summary = fold(&contiguous).0.expect("a usable file");
+        assert!(summary.split_tickers.is_empty());
     }
 
     /// The layout decides whether the backfill holds one name's ticks or every name's, so a file

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -1078,6 +1078,9 @@ pub struct QuoteSummary {
     quoted_spread_basis_points_mean: BasisPoints,
     quoted_spread_basis_points_median: BasisPoints,
     quoted_spread_basis_points_ninetieth_percentile: BasisPoints,
+    /// Time-weighted top-of-book size, in the unit the session's feed used: **round lots before
+    /// 2025-11-03, shares on or after**. A series crossing that date steps by about a hundred and
+    /// the step is the unit rather than the liquidity, so convert on read, keyed on the session.
     bid_size_mean: f64,
     ask_size_mean: f64,
     quote_count: i64,

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -1547,17 +1547,6 @@ const QUOTE_CONCURRENCY: usize = 8;
 /// one of its names from a complete one.
 const QUOTE_SYMBOL_ATTEMPTS: usize = 3;
 
-/// Folds the quoted book across `sessions`, per `scope`.
-///
-/// Session-major rather than ticker-major, unlike the intraday bar pass: a quote request is already
-/// bounded to one session's hours, so there is nothing to gain by holding a chunk of them. That is
-/// also why the never-create rule costs nothing here: a session-major pass never fetches outside the
-/// sessions it selected, while a bar chunk spans a range and needs [`writable_session`] at the write.
-///
-/// Regular hours only, taken from the calendar so an early close is 3.5 hours rather than 6.5. The
-/// overnight book is an order of magnitude wider and would swamp any session mean it entered.
-///
-/// `sessions` must already be calendar-filtered, which the returned summary assumes when it reports
 /// Where a quote pass gets its ticks.
 ///
 /// Two providers with opposite shapes: Alpaca answers one name at a time and is what a repair wants,
@@ -1579,6 +1568,17 @@ impl std::fmt::Display for QuoteSource<'_> {
     }
 }
 
+/// Folds the quoted book across `sessions`, per `scope`, taking its ticks from `source`.
+///
+/// Session-major rather than ticker-major, unlike the intraday bar pass: a quote request is already
+/// bounded to one session's hours, so there is nothing to gain by holding a chunk of them. That is
+/// also why the never-create rule costs nothing here: a session-major pass never fetches outside the
+/// sessions it selected, while a bar chunk spans a range and needs [`writable_session`] at the write.
+///
+/// Regular hours only, taken from the calendar so an early close is 3.5 hours rather than 6.5. The
+/// overnight book is an order of magnitude wider and would swamp any session mean it entered.
+///
+/// `sessions` must already be calendar-filtered, which the returned summary assumes when it reports
 /// a session that answered with nothing as a fault rather than as a holiday.
 pub async fn archive_quote_sessions(
     s3_client: &S3Client,
@@ -1818,14 +1818,16 @@ async fn fold_whole_session(
     let (_, fold) = flat_files.fold_quotes(session.date(), fold).await?;
 
     let quotes_folded = fold.folded();
-    let (summaries, resumed) = fold.finish();
-    let summarized: BTreeSet<&Ticker> = summaries.iter().map(QuoteSummary::ticker).collect();
-    // A name the file never carried, which the per-name path would have recorded as a failed fetch.
-    progress.symbols_failed += requested.saturating_sub(summarized.len());
-    if !resumed.is_empty() {
-        info!(%session, resumed = resumed.len(), "Names whose rows arrived in more than one run");
+    let folded = fold.finish();
+    // Counted against what the file carried rather than against what produced a summary: a name that
+    // was there and stayed quiet through regular hours is not a failure, and the per-name path counts
+    // only a failed fetch. Counting it would make almost every session of a whole-market pass exit
+    // non-zero and invite a re-run that cannot change the result.
+    progress.symbols_failed += requested.saturating_sub(folded.seen);
+    if !folded.resumed.is_empty() {
+        info!(%session, resumed = folded.resumed.len(), "Names whose rows arrived in more than one run");
     }
-    Ok((summaries, quotes_folded))
+    Ok((folded.summaries, quotes_folded))
 }
 
 /// Writes a session's summaries, one partition per cadence, five-minute first.

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -14,6 +14,7 @@ use tracing::{info, warn};
 
 use crate::common::alpaca::MarketDataClient;
 use crate::common::aws::{date_from_partitioned_key, date_partitioned_key};
+use crate::common::flatfiles::{FlatFileClient, FlatFileError};
 use crate::common::massive::MassiveClient;
 use crate::common::types::{
     BarInterval, EquityBar, LiquidityFloor, QuoteSummary, SessionDate, Ticker,
@@ -1557,10 +1558,31 @@ const QUOTE_SYMBOL_ATTEMPTS: usize = 3;
 /// overnight book is an order of magnitude wider and would swamp any session mean it entered.
 ///
 /// `sessions` must already be calendar-filtered, which the returned summary assumes when it reports
+/// Where a quote pass gets its ticks.
+///
+/// Two providers with opposite shapes: Alpaca answers one name at a time and is what a repair wants,
+/// while a Massive flat file is whole-market by construction and is the only affordable way to reach
+/// five years. The scope decides the universe either way; only the fetching differs.
+pub enum QuoteSource<'a> {
+    /// One request per name, retried per name.
+    PerName(&'a MarketDataClient),
+    /// One file per session, folded whole.
+    WholeSession(&'a FlatFileClient),
+}
+
+impl std::fmt::Display for QuoteSource<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            QuoteSource::PerName(_) => "per-name",
+            QuoteSource::WholeSession(_) => "whole-session",
+        })
+    }
+}
+
 /// a session that answered with nothing as a fault rather than as a holiday.
 pub async fn archive_quote_sessions(
     s3_client: &S3Client,
-    market_data: &MarketDataClient,
+    source: &QuoteSource<'_>,
     calendar: &TradingCalendar,
     bucket: &str,
     sessions: &[SessionDate],
@@ -1615,7 +1637,7 @@ pub async fn archive_quote_sessions(
     for session in requested {
         quotes_folded += archive_quote_session(
             s3_client,
-            market_data,
+            source,
             calendar,
             bucket,
             session,
@@ -1653,7 +1675,7 @@ pub async fn archive_quote_sessions(
 #[allow(clippy::too_many_arguments)]
 async fn archive_quote_session(
     s3_client: &S3Client,
-    market_data: &MarketDataClient,
+    source: &QuoteSource<'_>,
     calendar: &TradingCalendar,
     bucket: &str,
     session: SessionDate,
@@ -1689,9 +1711,24 @@ async fn archive_quote_session(
         return Ok(0);
     }
 
-    info!(%session, %open, %close, universe = universe.len(), "Folding a session's quoted book");
-    let (folded, quotes_folded) =
-        fold_universe(market_data, session, open, close, &universe, progress).await;
+    info!(%session, %open, %close, %source, universe = universe.len(), "Folding a session's quoted book");
+    let (folded, quotes_folded) = match source {
+        QuoteSource::PerName(market_data) => {
+            fold_universe(market_data, session, open, close, &universe, progress).await
+        }
+        QuoteSource::WholeSession(flat_files) => {
+            match fold_whole_session(flat_files, session, open, close, universe, progress).await {
+                Ok(folded) => folded,
+                Err(error) => {
+                    // The file is the session: nothing partial survives it, so this is the session
+                    // failing rather than a name within it.
+                    warn!(%session, %error, "A session's flat file could not be folded");
+                    progress.sessions_failed.push(session);
+                    return Ok(0);
+                }
+            }
+        }
+    };
     if folded.is_empty() {
         // The quotes still cost what they cost, so the count is returned even though nothing of
         // this session reaches the archive.
@@ -1761,6 +1798,34 @@ async fn fold_universe(
         }
     }
     (folded, quotes_folded)
+}
+
+/// Folds a whole session out of one flat file, keeping only the names the scope asked for.
+///
+/// Every fold is held until the file ends rather than released at the ticker switch. Two names a
+/// session arrive in two runs, and a released fold cannot take the second: folding the runs apart
+/// extends each one's last quote to the close, so their weights overlap and sum past the session.
+async fn fold_whole_session(
+    flat_files: &FlatFileClient,
+    session: SessionDate,
+    open: DateTime<Utc>,
+    close: DateTime<Utc>,
+    universe: BTreeSet<Ticker>,
+    progress: &mut PassProgress,
+) -> Result<(Vec<QuoteSummary>, usize), FlatFileError> {
+    let requested = universe.len();
+    let fold = quotes::MarketFold::new(session, open, close, universe);
+    let (_, fold) = flat_files.fold_quotes(session.date(), fold).await?;
+
+    let quotes_folded = fold.folded();
+    let (summaries, resumed) = fold.finish();
+    let summarized: BTreeSet<&Ticker> = summaries.iter().map(QuoteSummary::ticker).collect();
+    // A name the file never carried, which the per-name path would have recorded as a failed fetch.
+    progress.symbols_failed += requested.saturating_sub(summarized.len());
+    if !resumed.is_empty() {
+        info!(%session, resumed = resumed.len(), "Names whose rows arrived in more than one run");
+    }
+    Ok((summaries, quotes_folded))
 }
 
 /// Writes a session's summaries, one partition per cadence, five-minute first.

--- a/src/data/quotes.rs
+++ b/src/data/quotes.rs
@@ -2,12 +2,15 @@
 //!
 //! Quotes come from Alpaca rather than Massive; see [`crate::common::alpaca`] for that split.
 
+use std::collections::{BTreeSet, HashMap};
+
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use chrono_tz::America::New_York;
 use polars::prelude::*;
 use tracing::warn;
 
 use crate::common::alpaca::{ClientError, MarketDataClient, QuoteFetch, QuoteTick};
+use crate::common::flatfiles::QuoteSink;
 use crate::common::types::{BarInterval, BasisPoints, QuoteSummary, SessionDate, Ticker};
 use crate::data::calendar::TradingCalendar;
 
@@ -643,5 +646,210 @@ mod tests {
         let expected: Vec<&str> = QUOTE_FRAME_COLUMNS.iter().map(|(name, _)| *name).collect();
         assert_eq!(names, expected);
         assert_eq!(frame.height(), 3);
+    }
+
+    fn universe(names: &[&str]) -> BTreeSet<Ticker> {
+        names.iter().map(|raw| named(raw)).collect()
+    }
+
+    fn named(raw: &str) -> Ticker {
+        Ticker::new(raw).expect("a valid ticker")
+    }
+
+    fn quote(minute: u32, bid: f64, ask: f64) -> QuoteTick {
+        QuoteTick::new(at(minute, 0), bid, ask, 100, 200).expect("a usable book")
+    }
+
+    /// The ordinary shape of a ticker-major file: each name contiguous, each folded on its own.
+    #[test]
+    fn test_each_contiguous_name_folds_separately() {
+        let mut fold = MarketFold::new(
+            session(),
+            at(30, 0),
+            at(40, 0),
+            universe(&["AAPL", "CBOE", "BCPC"]),
+        );
+        fold.push(named("AAPL"), quote(30, 99.95, 100.05));
+        fold.push(named("AAPL"), quote(36, 99.99, 100.01));
+        fold.push(named("CBOE"), quote(30, 199.80, 200.20));
+        let (summaries, merged) = fold.finish();
+
+        assert!(merged.is_empty(), "nothing was split");
+        let names: BTreeSet<_> = summaries
+            .iter()
+            .map(|summary| summary.ticker().as_str().to_string())
+            .collect();
+        assert_eq!(
+            names,
+            BTreeSet::from(["AAPL".to_string(), "CBOE".to_string()])
+        );
+    }
+
+    /// A flat file is whole-market whatever the scope asked for, so a name outside the universe
+    /// must cost nothing — neither a summary nor a fold held open for it.
+    #[test]
+    fn test_a_name_outside_the_universe_is_not_folded() {
+        let mut fold = MarketFold::new(session(), at(30, 0), at(40, 0), universe(&["AAPL"]));
+        fold.push(named("AAPL"), quote(30, 99.95, 100.05));
+        fold.push(named("CBOE"), quote(30, 199.80, 200.20));
+        fold.push(named("ZZZ"), quote(30, 9.95, 10.05));
+        assert_eq!(fold.folded(), 1, "only the name asked for");
+
+        let (summaries, _) = fold.finish();
+        let names: BTreeSet<_> = summaries
+            .iter()
+            .map(|summary| summary.ticker().as_str().to_string())
+            .collect();
+        assert_eq!(names, BTreeSet::from(["AAPL".to_string()]));
+    }
+
+    /// BCPC and TPC arrive in two runs on every session measured. The second run resumes the first
+    /// one's fold rather than starting a second session for the name — folded separately, each run's
+    /// last quote would prevail to the close and the two would together claim 840 seconds of a
+    /// 600-second session.
+    #[test]
+    fn test_a_split_name_resumes_its_own_fold_rather_than_opening_a_second() {
+        let mut fold = MarketFold::new(
+            session(),
+            at(30, 0),
+            at(40, 0),
+            universe(&["AAPL", "CBOE", "BCPC"]),
+        );
+        fold.push(named("BCPC"), quote(30, 99.95, 100.05));
+        fold.push(named("CBOE"), quote(30, 199.80, 200.20));
+        fold.push(named("BCPC"), quote(36, 99.99, 100.01));
+        let (summaries, merged) = fold.finish();
+
+        assert_eq!(
+            merged.iter().map(Ticker::as_str).collect::<Vec<_>>(),
+            vec!["BCPC"],
+            "the split name is reported rather than silently handled"
+        );
+
+        let session_bar = summaries
+            .iter()
+            .find(|summary| {
+                summary.ticker().as_str() == "BCPC" && summary.bar_interval() == BarInterval::OneDay
+            })
+            .expect("BCPC has one session bar rather than two");
+        assert_eq!(
+            summaries
+                .iter()
+                .filter(|summary| summary.ticker().as_str() == "BCPC"
+                    && summary.bar_interval() == BarInterval::OneDay)
+                .count(),
+            1
+        );
+        assert_eq!(session_bar.quote_count(), 2, "both runs counted");
+        // Ten minutes of session, covered end to end between the two runs.
+        assert_close(session_bar.covered_seconds(), 600.0);
+    }
+}
+
+/// Folds a whole session out of one ticker-major flat file, resuming a name that comes back.
+///
+/// Every name's fold is held until the file ends. Releasing at the ticker switch would be cheaper —
+/// thirteen megabytes against seven gigabytes — but two names a session arrive in two runs, and a
+/// released fold cannot take the second one: its observations are gone, and folding the runs
+/// separately extends each one's last quote to the close, so their weights overlap and sum past the
+/// session itself.
+pub struct MarketFold {
+    session: SessionDate,
+    open: DateTime<Utc>,
+    close: DateTime<Utc>,
+    /// The run in progress, kept out of the map so the common row costs no lookup.
+    current: Option<(Ticker, SessionFold)>,
+    parked: HashMap<Ticker, SessionFold>,
+    resumed: BTreeSet<Ticker>,
+    /// The names worth folding. A flat file is whole-market whatever the scope asked for, so the
+    /// scope is applied here rather than by the transport.
+    universe: BTreeSet<Ticker>,
+    /// Ticks belonging to the universe, which is what the pass reports as its cost.
+    folded: usize,
+}
+
+impl MarketFold {
+    /// Opens a fold over one session's regular hours.
+    pub fn new(
+        session: SessionDate,
+        open: DateTime<Utc>,
+        close: DateTime<Utc>,
+        universe: BTreeSet<Ticker>,
+    ) -> Self {
+        Self {
+            session,
+            open,
+            close,
+            current: None,
+            parked: HashMap::new(),
+            resumed: BTreeSet::new(),
+            universe,
+            folded: 0,
+        }
+    }
+
+    /// Ticks folded, which is this pass's cost and the only trace a discarded row leaves.
+    pub fn folded(&self) -> usize {
+        self.folded
+    }
+
+    /// Accepts the next row of the file, which carries its own ticker.
+    pub fn push(&mut self, ticker: Ticker, tick: QuoteTick) {
+        if !self.universe.contains(&ticker) {
+            return;
+        }
+        self.folded += 1;
+        let same = matches!(&self.current, Some((open, _)) if *open == ticker);
+        if !same {
+            self.rotate(ticker);
+        }
+        if let Some((_, fold)) = self.current.as_mut() {
+            fold.push(tick);
+        }
+    }
+
+    /// Parks the run in progress and takes up `ticker`, resuming its fold if it already has one.
+    fn rotate(&mut self, ticker: Ticker) {
+        if let Some((held, fold)) = self.current.take() {
+            self.parked.insert(held, fold);
+        }
+        let fold = match self.parked.remove(&ticker) {
+            Some(fold) => {
+                self.resumed.insert(ticker.clone());
+                Some(fold)
+            }
+            None => SessionFold::new(ticker.clone(), self.session, self.open, self.close),
+        };
+        self.current = fold.map(|fold| (ticker, fold));
+    }
+
+    /// Closes every fold, returning the summaries and the names that came back for a second run.
+    pub fn finish(mut self) -> (Vec<QuoteSummary>, BTreeSet<Ticker>) {
+        if let Some((held, fold)) = self.current.take() {
+            self.parked.insert(held, fold);
+        }
+        if !self.resumed.is_empty() {
+            warn!(
+                session = %self.session,
+                names = %self
+                    .resumed
+                    .iter()
+                    .map(|ticker| ticker.as_str())
+                    .collect::<Vec<_>>()
+                    .join(","),
+                "Resumed names whose rows arrived in more than one run"
+            );
+        }
+        let summaries = std::mem::take(&mut self.parked)
+            .into_values()
+            .flat_map(SessionFold::finish)
+            .collect();
+        (summaries, self.resumed)
+    }
+}
+
+impl QuoteSink for MarketFold {
+    fn push(&mut self, ticker: Ticker, tick: QuoteTick) {
+        MarketFold::push(self, ticker, tick)
     }
 }

--- a/src/data/quotes.rs
+++ b/src/data/quotes.rs
@@ -676,10 +676,11 @@ mod tests {
         fold.push(named("AAPL"), quote(30, 99.95, 100.05));
         fold.push(named("AAPL"), quote(36, 99.99, 100.01));
         fold.push(named("CBOE"), quote(30, 199.80, 200.20));
-        let (summaries, merged) = fold.finish();
+        let folded = fold.finish();
 
-        assert!(merged.is_empty(), "nothing was split");
-        let names: BTreeSet<_> = summaries
+        assert!(folded.resumed.is_empty(), "nothing was split");
+        let names: BTreeSet<_> = folded
+            .summaries
             .iter()
             .map(|summary| summary.ticker().as_str().to_string())
             .collect();
@@ -699,12 +700,45 @@ mod tests {
         fold.push(named("ZZZ"), quote(30, 9.95, 10.05));
         assert_eq!(fold.folded(), 1, "only the name asked for");
 
-        let (summaries, _) = fold.finish();
-        let names: BTreeSet<_> = summaries
+        let folded = fold.finish();
+        let names: BTreeSet<_> = folded
+            .summaries
             .iter()
             .map(|summary| summary.ticker().as_str().to_string())
             .collect();
         assert_eq!(names, BTreeSet::from(["AAPL".to_string()]));
+    }
+
+    /// `seen` is what separates a name the file never carried from one that was there and simply
+    /// never quoted inside regular hours. Only the first is a failed symbol, and counting the second
+    /// would make almost every session of a whole-market pass exit non-zero.
+    #[test]
+    fn test_a_name_that_quoted_only_outside_regular_hours_still_counts_as_seen() {
+        let mut fold = MarketFold::new(
+            session(),
+            at(30, 0),
+            at(40, 0),
+            universe(&["AAPL", "CBOE", "ZZZ"]),
+        );
+        fold.push(named("AAPL"), quote(30, 99.95, 100.05));
+        // In the universe and in the file, but its only quote lands after the close. A quote posted
+        // *before* the open would not do: standing and unrevised, it is the book at the open and is
+        // weighed as such.
+        fold.push(named("CBOE"), quote(50, 199.80, 200.20));
+
+        let folded = fold.finish();
+        assert_eq!(folded.seen, 2, "AAPL and CBOE were both in the file");
+        assert_eq!(
+            folded
+                .summaries
+                .iter()
+                .map(|summary| summary.ticker().as_str().to_string())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from(["AAPL".to_string()]),
+            "CBOE quoted nothing the session could weigh"
+        );
+        // ZZZ never appeared at all: three asked for, two carried, one genuinely missing.
+        assert_eq!(3usize.saturating_sub(folded.seen), 1);
     }
 
     /// BCPC and TPC arrive in two runs on every session measured. The second run resumes the first
@@ -722,22 +756,28 @@ mod tests {
         fold.push(named("BCPC"), quote(30, 99.95, 100.05));
         fold.push(named("CBOE"), quote(30, 199.80, 200.20));
         fold.push(named("BCPC"), quote(36, 99.99, 100.01));
-        let (summaries, merged) = fold.finish();
+        let folded = fold.finish();
 
         assert_eq!(
-            merged.iter().map(Ticker::as_str).collect::<Vec<_>>(),
+            folded
+                .resumed
+                .iter()
+                .map(Ticker::as_str)
+                .collect::<Vec<_>>(),
             vec!["BCPC"],
             "the split name is reported rather than silently handled"
         );
 
-        let session_bar = summaries
+        let session_bar = folded
+            .summaries
             .iter()
             .find(|summary| {
                 summary.ticker().as_str() == "BCPC" && summary.bar_interval() == BarInterval::OneDay
             })
             .expect("BCPC has one session bar rather than two");
         assert_eq!(
-            summaries
+            folded
+                .summaries
                 .iter()
                 .filter(|summary| summary.ticker().as_str() == "BCPC"
                     && summary.bar_interval() == BarInterval::OneDay)
@@ -827,8 +867,8 @@ impl MarketFold {
         self.current = fold.map(|fold| (ticker, fold));
     }
 
-    /// Closes every fold, returning the summaries and the names that came back for a second run.
-    pub fn finish(mut self) -> (Vec<QuoteSummary>, BTreeSet<Ticker>) {
+    /// Closes every fold and reports what the session yielded.
+    pub fn finish(mut self) -> SessionFolded {
         if let Some((held, fold)) = self.current.take() {
             self.parked.insert(held, fold);
         }
@@ -844,12 +884,25 @@ impl MarketFold {
                 "Resumed names whose rows arrived in more than one run"
             );
         }
-        let summaries = std::mem::take(&mut self.parked)
-            .into_values()
-            .flat_map(SessionFold::finish)
-            .collect();
-        (summaries, self.resumed)
+        let parked = std::mem::take(&mut self.parked);
+        let seen = parked.len();
+        let summaries = parked.into_values().flat_map(SessionFold::finish).collect();
+        SessionFolded {
+            summaries,
+            resumed: self.resumed,
+            seen,
+        }
     }
+}
+
+/// What one session's file yielded.
+pub struct SessionFolded {
+    pub summaries: Vec<QuoteSummary>,
+    /// Names that came back for a second run.
+    pub resumed: BTreeSet<Ticker>,
+    /// Names the file carried at all, which is what separates a name absent from the file from one
+    /// that was there and simply never quoted inside regular hours. Only the first is a failure.
+    pub seen: usize,
 }
 
 impl QuoteSink for MarketFold {

--- a/src/data/quotes.rs
+++ b/src/data/quotes.rs
@@ -36,6 +36,7 @@ pub const QUOTE_FRAME_COLUMNS: [(&str, DataType); 11] = [
         "quoted_spread_basis_points_ninetieth_percentile",
         DataType::Float64,
     ),
+    // Round lots before 2025-11-03 and shares on or after; see `QuoteSummary::bid_size_mean`.
     ("bid_size_mean", DataType::Float64),
     ("ask_size_mean", DataType::Float64),
     ("quote_count", DataType::Int64),
@@ -52,6 +53,9 @@ struct SpreadAccumulator {
     covered_seconds: f64,
     spread_weighted: f64,
     spread_basis_points_weighted: f64,
+    /// Time-weighted top-of-book size **in whatever unit the session's feed used**: round lots
+    /// before 2025-11-03 and shares on or after, per the SEC MDI rules. Not normalised here, because
+    /// the divisor is a per-ticker `round_lot` and today's value is not the one a 2021 session had.
     bid_size_weighted: f64,
     ask_size_weighted: f64,
     quote_count: i64,


### PR DESCRIPTION
# Overview

The Advanced subscription is bought, the files are real, and this is what it took to read one and
turn it into the archive. Four commits, each a separate concern; the middle two are the ones worth
reading closely.

**Validated against real data on both providers.** For 2026-08-21 the flat-file fold and the Alpaca
API agree to the displayed precision — AAPL 0.964bp against 0.96, CBOE 15.452 against 15.45, MSFT
2.090 against 2.09, all covering 23,400 seconds exactly.

## Changes

- Fetch a flat file as 128 concurrent byte ranges, retried individually, rather than one stream
- Report the names a ticker-major file splits, rather than only how many
- Fold a whole session out of one file: `QuoteSource`, `MarketFold`, `QuoteSink`
- `equity-quotes probe --symbols` folds named symbols so the two providers can be compared
- Document that a quote size is round lots before 2025-11-03 and shares after
- No new dependencies; `tokio-util`'s `io` features are given back

## Context

### One stream could not carry it, for three separate reasons

The transport built against synthetic fixtures met its first 7.5 GB object and failed three times.

The first read died after 32 minutes reporting only `streaming error`. The obvious reading — a
long-lived connection the vendor drops — was **wrong**, and building for it would have been wasted
work. Walking `source()` gave `minimum throughput was specified at 1 B/s, but throughput of 0 B/s was
observed`: the SDK's own stalled-stream guard, default grace five seconds. Now 60 seconds rather than
disabled, so a genuinely dead connection still fails. `error_chain` exists because two of the three
failures were this guard and the outer layer named a symptom while pointing at the wrong subsystem.

The second is throughput. Massive throttles **per connection**, and the local line is not the limit:

| connections | aggregate | 1,255 sessions |
|---|---|---|
| 1 | 1.15 MB/s | ~50 days |
| 64 | 14.1 MB/s | 7.7 days |
| **128** | **26.8 MB/s** | **~4.5 days** |

The same machine does 88 MB/s aggregate to a fast CDN, so concurrency is the only lever and it is the
difference between feasible and not.

The third is that Massive resets connections when pushed — about **4.4% of ranges** per session at 128
in flight. Absorbed by retrying the range, which is the payoff of addressing bytes by offset: a reset
range is asked for again, where a reset whole-file stream has nothing to resume from. The SDK's own
retries do not cover it, because the reset happens while collecting the body after `send()` returned.

### The measurement the probe existed for

The file is **ticker-major** — 13,029 tickers in 13,031 runs, whole-file. That is the cheap layout,
and it is why a fold can hold one name rather than all of them.

Except the run count is **two above** the ticker count, on both sessions measured. Named, they are
**BCPC and TPC** — Balchem and Tutor Perini, both real and liquid, so not a junk-symbol artifact that
could be screened away. Two in thirteen thousand is invisible in a total and actionable as a list.

### Why every fold is held, which reverses the original plan

Releasing at the ticker switch is far cheaper — thirteen megabytes against seven gigabytes — and was
the plan. It is wrong for a split name: the released fold's observations are gone, and folding the
two runs apart is worse than lossy, because `SessionFold::finish` extends the last quote to the
session close. **Each run then claims the time the other covers**: 840 seconds of a 600-second
session. A test written to pin the merge's arithmetic is what found it, and the merge is gone.
Resuming the parked fold costs one hash lookup per switch and is exactly right.

Holding everything is affordable, and the number is measured rather than estimated: **7.2 GiB of
observations** for a whole-market session, ~11 GB with allocator overhead. That does not fit the
16 GB laptop this was written on, so the backfill wants **32 GB, or 64 GB for two sessions at once** —
and two is the useful ceiling anyway, since the pipe saturates near 27 MB/s.

### Sizes change units mid-window

`bid_size` and `ask_size` are **round lots before 2025-11-03 and shares on or after**, per the SEC MDI
rules, so a five-year series steps by about a hundred in its own middle. Left unconverted on purpose:
the divisor is a per-ticker `round_lot` whose only source is today's reference data, and applying that
to a 2021 session repeats the mistake of resolving a historical symbol through today's ticker table.
A wrong conversion at ingestion would cost re-downloading ~7.8 TB, while the unit is a pure function
of the session date the archive already partitions on — and is measurable from our own data once the
backfill spans the cutover. Spreads are unaffected, since prices did not change units.

### Known, visible, not fixed

BCPC and TPC drop 175 and 1,173 quotes as out-of-order, because their second run covers time the
first already passed. `SessionFold` has always counted and logged such quotes on both paths, so the
loss is named per session rather than silent — but it is **not visible from the stored data**, since
the dropped quotes are simply absent from `quote_count`. `equity-quotes repair --symbols BCPC,TPC`
patches those names from Alpaca, which pins `sort=asc`; at one or two requests per name-session it is
well under an hour for the whole window.

### Verification

`devenv tasks run checks:all` passes. Coverage **81.22% → 81.00%** — the difference is the new
provider path, which needs a vendor.

Every new assertion proved load-bearing by breaking the code under it and watching it fail:
contiguous ranges ending exactly at the length, ordered chunks reading back as one stream, a failed
range surfacing rather than truncating, a returning name being named, a split name resuming its own
fold rather than opening a second, and a name outside the universe costing nothing.

Beyond the tests, exercised against the real vendor: two full sessions read end to end, and the
provider comparison above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9MuPyHx1o8E6X9cPZcCNZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added symbol-specific quote probing with daily summaries and trading-date validation.
  * Added support for archiving complete quote sessions from flat-file data.
  * Added detection and handling for symbols split across multiple data segments.

* **Bug Fixes**
  * Improved large quote-file downloads with ranged requests, retries, ordered processing, and stalled-transfer protection.
  * Improved quote folding across repeated symbol segments and reporting of missing symbols.

* **Documentation**
  * Clarified how bid and ask size measurements are represented across data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->