### PR TITLE
Fold the whole market on the quote archive path

### DIFF
--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -187,7 +187,8 @@ struct IntradayRepairArguments {
 
 #[derive(Debug, Subcommand)]
 enum QuoteAction {
-    /// Fold the screened universe into the sampled sessions that have no partition yet.
+    /// Fold every name the daily archive holds into the sampled sessions that have no partition
+    /// yet.
     Archive(QuoteArguments),
     /// Fold every name the daily archive holds into every sampled session, widening ones already
     /// summarized.
@@ -202,6 +203,25 @@ enum QuoteAction {
     /// a fold holds one name's ticks or every name's, and the throughput, which the published
     /// download estimate leaves out because it counts bandwidth only.
     Probe(ProbeArguments),
+}
+
+impl QuoteAction {
+    /// The scope an action that derives its universe from the archive folds under, and `None` for
+    /// the actions that name their own symbols or write nothing.
+    ///
+    /// Both universe actions fold the whole market and differ only in their session set. Returned
+    /// as one value so a test asserts the scope the pass will actually use rather than a
+    /// reconstruction of it beside it.
+    fn universe_scope(&self) -> Option<Result<Scope, SeedError>> {
+        let sessions = match self {
+            QuoteAction::Archive(_) => SessionSelection::Absent,
+            QuoteAction::Widen(_) => SessionSelection::Every,
+            QuoteAction::Measure(_) | QuoteAction::Repair(_) | QuoteAction::Probe(_) => {
+                return None;
+            }
+        };
+        Some(whole_market(sessions))
+    }
 }
 
 #[derive(Debug, Args)]
@@ -1015,48 +1035,34 @@ async fn seed_quotes(action: &QuoteAction) -> Result<Outcome, SeedError> {
             None => probe_flat_file(arguments.date).await,
             Some(named) => fold_named_from_flat_file(arguments.date, named).await,
         },
-        QuoteAction::Archive(arguments) => {
-            fold_sampled(
-                arguments,
-                NameSelection::Screened(LiquidityFloor::CURRENT),
-                SessionSelection::Absent,
-                QuoteProvider::WholeSession,
-            )
-            .await
-        }
-        QuoteAction::Widen(arguments) => {
-            fold_sampled(
-                arguments,
-                NameSelection::WholeMarket,
-                SessionSelection::Every,
-                QuoteProvider::WholeSession,
-            )
-            .await
+        // One arm, so the universe is written once and the two actions cannot disagree about it.
+        QuoteAction::Archive(arguments) | QuoteAction::Widen(arguments) => {
+            let scope = action
+                .universe_scope()
+                .expect("a universe action has a scope")?;
+            fold_sampled(arguments, scope, QuoteProvider::WholeSession).await
         }
         QuoteAction::Measure(symbols) => measure_sampled(symbols).await,
         QuoteAction::Repair(symbols) => {
             // Resolved before any credential is read, so a missing symbol set is refused in the
             // first millisecond rather than after a calendar fetch.
             let named = symbols.symbols.required_names()?;
-            fold_sampled(
-                &symbols.quotes,
-                NameSelection::Named(named),
-                SessionSelection::Present,
-                QuoteProvider::PerName,
-            )
-            .await
+            let scope = Scope::new(NameSelection::Named(named), SessionSelection::Present)
+                .map_err(|error| SeedError::Usage(error.to_string()))?;
+            fold_sampled(&symbols.quotes, scope, QuoteProvider::PerName).await
         }
     }
 }
 
 /// Folds the sampled sessions into the archive under the scope the action names.
+///
+/// Takes a built `Scope` rather than its two halves, so a caller cannot pair a universe with a
+/// session set here that the constructor would have refused.
 async fn fold_sampled(
     arguments: &QuoteArguments,
-    names: NameSelection,
-    sessions: SessionSelection,
+    scope: Scope,
     provider: QuoteProvider,
 ) -> Result<Outcome, SeedError> {
-    let scope = Scope::new(names, sessions).map_err(|error| SeedError::Usage(error.to_string()))?;
     let window = arguments.window.window()?;
     let (market_data, calendar) = quote_sources(&window).await?;
     let sampled = sample(&calendar, &window, arguments.stride);
@@ -1880,6 +1886,54 @@ mod tests {
                 .to_string(),
             "every name, every session"
         );
+    }
+
+    /// `archive` folded the screened universe, so a five-year pass wrote roughly 1,200 names a
+    /// session where the daily archive held 10,067. Nothing downstream reports it: the partition
+    /// exists, so the next pass reads the session as present and never looks inside, and widening
+    /// afterwards means re-reading vendor files a lapsed subscription no longer serves.
+    #[test]
+    fn test_both_universe_quote_actions_fold_the_whole_market() {
+        let window = ["--start", "2021-08-26", "--end", "2026-08-25"];
+        let parsed = |verb: &str| {
+            let arguments = parse(&[["equity-quotes", verb].as_slice(), &window].concat())
+                .expect("a quote window");
+            match arguments.command {
+                Command::EquityQuotes { action } => action,
+                other => panic!("expected a quote action, got {other:?}"),
+            }
+        };
+
+        let rendered = |verb: &str| {
+            parsed(verb)
+                .universe_scope()
+                .expect("a universe action has a scope")
+                .expect("the whole market may write a partition")
+                .to_string()
+        };
+
+        // Literals, not `whole_market(..).to_string()`: an expectation built from the call under
+        // test moves with it and can never fail.
+        assert_eq!(rendered("archive"), "every name, absent sessions only");
+        assert_eq!(rendered("widen"), "every name, every session");
+
+        // The actions that name their own symbols must not answer here at all, or the arm above
+        // would fold a universe over a repair.
+        let repair = parse(&[
+            "equity-quotes",
+            "repair",
+            "--symbols",
+            "AAPL",
+            "--start",
+            "2021-08-26",
+            "--end",
+            "2026-08-25",
+        ])
+        .expect("a repair");
+        match repair.command {
+            Command::EquityQuotes { action } => assert!(action.universe_scope().is_none()),
+            other => panic!("expected a quote action, got {other:?}"),
+        }
     }
 
     /// A scan that could not read a session found its names only in the ones it could, so both the

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -1037,9 +1037,12 @@ async fn seed_quotes(action: &QuoteAction) -> Result<Outcome, SeedError> {
         },
         // One arm, so the universe is written once and the two actions cannot disagree about it.
         QuoteAction::Archive(arguments) | QuoteAction::Widen(arguments) => {
+            // Unreachable: this arm names the two actions that answer. Returned rather than
+            // panicked so that adding a variant here without adding it to `universe_scope`
+            // degrades to a usage error instead of killing the process mid-pass.
             let scope = action
                 .universe_scope()
-                .expect("a universe action has a scope")?;
+                .ok_or_else(|| SeedError::Usage(format!("{action:?} folds no universe")))??;
             fold_sampled(arguments, scope, QuoteProvider::WholeSession).await
         }
         QuoteAction::Measure(symbols) => measure_sampled(symbols).await,


### PR DESCRIPTION
# Overview

`seed equity-quotes archive` folded the screened universe, so the five-year quote backfill wrote
roughly a tenth of the market for 254 sessions before it was caught.

## Changes

- `QuoteAction::Archive` and `QuoteAction::Widen` share one match arm in `seed_quotes`, so the
  universe is written once and the two actions cannot disagree about it
- `QuoteAction::universe_scope` returns the whole `Scope` for the two actions that derive a universe
  from the archive, and `None` for the three that name their own symbols or write nothing
- `fold_sampled` takes a built `Scope` rather than a `NameSelection` and a `SessionSelection`, so no
  call site can pair them itself
- `test_both_universe_quote_actions_fold_the_whole_market` pins both rendered scopes to literals and
  asserts a repair does not answer for a universe at all

## Context

`archive` hardcoded `NameSelection::Screened(LiquidityFloor::CURRENT)` — a $10 close and $50M dollar
volume floor — where the whole-market universe lived on the separate `widen` subcommand.

The disagreement is an order of magnitude, and both halves are measured rather than estimated:

| session | tickers in the quote summary | tickers with a daily bar |
|---|---|---|
| 2021-08-26, written by `archive` | 1,083 | 10,067 |
| 2026-08-21, written earlier through Alpaca | 12,153 | 12,166 |

It held near 1,200 through late 2022, so it is a screen rather than a lookback boundary effect.

**Nothing downstream reports this.** The partition exists, so the next pass reads the session as
present and never looks inside it, and `symbols_failed` counts what the vendor file lacked rather
than what the scope excluded. It surfaced only from a `count(DISTINCT ticker)` against the same
session's daily bars.

**The screen was a transport workaround, not a domain choice.** Whole-market quotes cost ~115 minutes
a session through Alpaca's per-name route against roughly 12 for the screened universe, which is why
the default was set that way. A flat-file pass reads the whole file regardless, so the screen now
saves nothing while costing the ~90% of names the cost model needs — the whole-market spread
distribution work rests on names far below a $50M floor. It also cannot be undone later, because
widening means re-reading vendor files that a lapsed subscription no longer serves.

`seed_intraday_bars` has always folded whole-market on both `fill` and `widen`; the quote path was
the outlier, and this brings it into line.

The test was proven load-bearing by restoring the screened scope and watching it fail with
`"the screened universe ($10 close on $50000000 traded), absent sessions only"`. An earlier version
of it passed against the bug, because it called `whole_market` itself instead of the path
`seed_quotes` uses — the assertion now runs through `universe_scope`, and its expectations are
literals rather than anything derived from the value under test.

The 251 screened partitions already written have been removed from the archive; the five
whole-market sessions from 2026-08 predate the run and were kept.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the **Archive** quote action to include the entire market, matching the behavior of **Widen**.
  * Preserved narrower scopes for named quote actions.
  * Added coverage to verify consistent behavior across quote actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->