### PR TITLE
Read the consolidated tape, not IEX, everywhere the application prices

### DIFF
--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -17,7 +17,7 @@ use burn::tensor::backend::Backend;
 use chrono::Utc;
 use tracing::{error, info, warn};
 
-use fund::common::alpaca::{AlpacaCredentials, MarketDataClient, TradingClient};
+use fund::common::alpaca::{AlpacaCredentials, DataFeed, MarketDataClient, TradingClient};
 use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
 use fund::common::types::SessionDate;
@@ -196,7 +196,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // one whose boundary table is a night stale.
     match AlpacaCredentials::from_env() {
         Ok(credentials) => {
-            let market_data = MarketDataClient::from_env(credentials);
+            let market_data = MarketDataClient::new(credentials, DataFeed::Sip);
             match archive::archive_boundaries(
                 &s3_client,
                 &market_data,

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -2362,26 +2362,6 @@ impl MarketDataClient {
         }
     }
 
-    /// Reads the data feed from `ALPACA_DATA_FEED`, defaulting to [`DataFeed::Iex`].
-    ///
-    /// Defaulting to `iex` keeps an unconfigured deployment working rather than failing on an
-    /// entitlement error. An unrecognized value warns and falls back rather than failing startup,
-    /// for the same reason -- but it warns, because silently serving a different feed than the
-    /// operator asked for changes every price the strategy sees.
-    pub fn from_env(credentials: AlpacaCredentials) -> Self {
-        let feed = match std::env::var("ALPACA_DATA_FEED") {
-            Ok(raw) => DataFeed::parse(&raw).unwrap_or_else(|| {
-                warn!(
-                    requested = %raw,
-                    "Unrecognized ALPACA_DATA_FEED, falling back to iex"
-                );
-                DataFeed::Iex
-            }),
-            Err(_) => DataFeed::Iex,
-        };
-        Self::new(credentials, feed)
-    }
-
     fn get(&self, url: &str) -> reqwest::RequestBuilder {
         self.http_client
             .get(url)
@@ -3880,6 +3860,31 @@ mod tests {
 
     fn client(base_url: String) -> MarketDataClient {
         MarketDataClient::with_base_url(credentials(), base_url, DataFeed::Iex)
+    }
+
+    /// The feed reaches the query string rather than being decoration on the client.
+    ///
+    /// Asserted against the literal `feed=sip`, because the application pins SIP and IEX's top of
+    /// book is not the national one — a client that quietly requested the wrong tape would return
+    /// prices that parse perfectly and describe a different market.
+    #[tokio::test]
+    async fn test_a_sip_client_requests_the_sip_feed() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/v2/stocks/snapshots?symbols=AAPL&feed=sip")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(FULL_SNAPSHOT)
+            .create_async()
+            .await;
+
+        let client = MarketDataClient::with_base_url(credentials(), server.url(), DataFeed::Sip);
+        client
+            .fetch_snapshots(&[Ticker::new("AAPL").unwrap()])
+            .await
+            .expect("the snapshot request should succeed");
+
+        mock.assert_async().await;
     }
 
     const FULL_SNAPSHOT: &str = r#"{

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -3862,11 +3862,10 @@ mod tests {
         MarketDataClient::with_base_url(credentials(), base_url, DataFeed::Iex)
     }
 
-    /// The feed reaches the query string rather than being decoration on the client.
+    /// The feed reaches the query string rather than decorating the client.
     ///
-    /// Asserted against the literal `feed=sip`, because the application pins SIP and IEX's top of
-    /// book is not the national one — a client that quietly requested the wrong tape would return
-    /// prices that parse perfectly and describe a different market.
+    /// Asserted against the literal `feed=sip`: a client requesting the wrong tape returns prices
+    /// that parse perfectly and describe a different market.
     #[tokio::test]
     async fn test_a_sip_client_requests_the_sip_feed() {
         let mut server = mockito::Server::new_async().await;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -11,7 +11,9 @@ use sqlx::PgPool;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-use crate::common::alpaca::{AlpacaCredentials, ClientError, MarketDataClient, TradingClient};
+use crate::common::alpaca::{
+    AlpacaCredentials, ClientError, DataFeed, MarketDataClient, TradingClient,
+};
 use crate::common::events::{self, Command, EventError};
 use crate::common::journal::{
     BarsIngested, CommandFinished, CommandOutcome, DatabaseExported, Journal, JournalError,
@@ -133,7 +135,10 @@ impl ServiceState {
         Ok(Self {
             pool,
             trading: TradingClient::from_env(credentials.clone()),
-            market_data: MarketDataClient::from_env(credentials),
+            // SIP, pinned rather than configurable: IEX carries a few percent of consolidated
+            // volume and its top of book is not the national one, so a feed set by environment
+            // would change every price the strategy sees without failing anything.
+            market_data: MarketDataClient::new(credentials, DataFeed::Sip),
             massive,
             s3_client: crate::common::aws::s3_client().await,
             bucket,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -135,9 +135,8 @@ impl ServiceState {
         Ok(Self {
             pool,
             trading: TradingClient::from_env(credentials.clone()),
-            // SIP, pinned rather than configurable: IEX carries a few percent of consolidated
-            // volume and its top of book is not the national one, so a feed set by environment
-            // would change every price the strategy sees without failing anything.
+            // SIP is pinned, not read from the environment: IEX's best bid and offer is not the
+            // national one, so a variable could put two incomparable series under one key.
             market_data: MarketDataClient::new(credentials, DataFeed::Sip),
             massive,
             s3_client: crate::common::aws::s3_client().await,


### PR DESCRIPTION
# Overview

The trading application has been pricing on IEX rather than the consolidated tape, and no
configuration existed that could have changed it. This pins SIP at every construction site and
deletes the environment knob that made the wrong feed the only reachable branch.

## Changes

- Delete `MarketDataClient::from_env`, which read `ALPACA_DATA_FEED` and returned `DataFeed::Iex`
  when the variable was unset. The variable is declared in no profile of `secretspec.toml`, so the
  default was the only branch that ever ran.
- Pin `DataFeed::Sip` at the three construction sites — `handlers.rs`, `tide_model_trainer.rs`, and
  `seed.rs`, which already did — so the feed is named where the client is built rather than
  resolved from the environment.
- Add `test_a_sip_client_requests_the_sip_feed`, asserting the literal `feed=sip` query string
  against a mock rather than reading the client's own field back.

## Context

**Why the defect was invisible.** IEX carries a few percent of consolidated volume and its top of
book is not the national one. The prices it returns parse cleanly and look plausible — they simply
describe a different market. `portfolio::evaluate` reads them through `fetch_snapshots`, which puts
the tape underneath every decision the service records, so the effect reaches the journal rather
than stopping at a display.

**Why pinning rather than setting the variable.** Declaring `ALPACA_DATA_FEED=sip` would fix today
and leave the identical hazard for the day the value goes missing, with the same silent failure
mode. `seed.rs` had already reached this conclusion for the quote archive and its comment states the
general form: a feed chosen by environment puts two incomparable series under one key.

**The entitlement was verified before the pin, not assumed.** A pin without entitlement turns every
market data request into a 403, so both accounts were probed first — `feed=sip` answers 200 on the
production credentials and on development.

**The test is proven load-bearing.** Building the client with `DataFeed::Iex` makes the request miss
the mock and fail with `Api { status: 501 }`; restored, it passes. Full `devenv tasks run
checks:rust` is clean.

**Known gap, recorded rather than fixed here.** The test covers the enum reaching the wire, not the
call sites — nothing catches an IEX default reintroduced in `handlers.rs`, because asserting that
needs `ServiceState` and therefore a database pool.

**One downstream note.** Decisions recorded before this change carry an IEX price basis. Nothing
reads them today, but task 8 of the laboratory expansion arc is replay from the journal, and a
replay spanning the cutover would reproduce decisions taken on the wrong tape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Market data requests now consistently use the SIP feed.
  * Eliminated inconsistent behavior caused by invalid or missing feed configuration.
  * Updated internal validation to confirm SIP feed requests are sent correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->