### PR TITLE
Fold the quoted book at a cadence rather than at a constant

### DIFF
--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -14,7 +14,9 @@ use fund::common::database::connect_pool;
 use fund::common::flatfiles;
 use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
-use fund::common::types::{BarInterval, LiquidityFloor, QuoteSummary, SessionDate, Ticker};
+use fund::common::types::{
+    BarInterval, IntradayCadence, LiquidityFloor, QuoteSummary, SessionDate, Ticker,
+};
 use fund::data::archive::{self, NameSelection, Scope, SessionSelection};
 use fund::data::calendar::TradingCalendar;
 use fund::data::{bars, details, quotes};
@@ -1200,7 +1202,7 @@ async fn fold_named_from_flat_file(
     };
 
     let started = tokio::time::Instant::now();
-    let fold = quotes::MarketFold::new(date, open, close, named);
+    let fold = quotes::MarketFold::new(date, QUOTE_CADENCE, open, close, named);
     let (file, fold) = client
         .fold_quotes(date.date(), fold)
         .await
@@ -1276,6 +1278,13 @@ async fn quote_sources(
     Ok((market_data, TradingCalendar::from_days(days)))
 }
 
+/// The cadence every quote action folds at.
+///
+/// One-minute is plumbed the whole way through [`IntradayCadence`] but deliberately unreachable from
+/// the command line: a one-minute pass re-derives the session row, and the check that compares it
+/// against the stored one rather than overwriting it does not exist yet.
+const QUOTE_CADENCE: IntradayCadence = IntradayCadence::FiveMinute;
+
 /// Which provider a fold reads from.
 ///
 /// A backfill takes whole sessions off Massive's flat files, because five years one name at a time
@@ -1296,10 +1305,16 @@ async fn fold_quotes(
 ) -> Result<archive::PassSummary, Box<dyn std::error::Error>> {
     let bucket = bucket_name()?;
     let s3_client = fund::common::aws::s3_client().await;
-    Ok(
-        archive::archive_quote_sessions(&s3_client, source, calendar, &bucket, sampled, scope)
-            .await?,
+    Ok(archive::archive_quote_sessions(
+        &s3_client,
+        source,
+        calendar,
+        &bucket,
+        sampled,
+        scope,
+        QUOTE_CADENCE,
     )
+    .await?)
 }
 
 /// Every `stride`-th published session in the window, anchored at the oldest.
@@ -1343,7 +1358,9 @@ async fn measure(
             continue;
         };
         for ticker in symbols {
-            match quotes::fold_session(market_data, ticker, *session, open, close).await {
+            match quotes::fold_session(market_data, ticker, *session, QUOTE_CADENCE, open, close)
+                .await
+            {
                 Ok((summaries, fetch)) => {
                     print_session_row(ticker, *session, &summaries, fetch.received)
                 }

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -719,6 +719,52 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for BarInterval {
     }
 }
 
+/// The grid a session is folded onto, which is the two [`BarInterval`] values that name a bucket.
+///
+/// Distinct from [`BarInterval`] so a fold cannot be opened at [`BarInterval::OneDay`], whose bucket
+/// is the session itself: the daily row is the merge of the intraday ones, never a grid of one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IntradayCadence {
+    OneMinute,
+    FiveMinute,
+}
+
+impl IntradayCadence {
+    /// Every variant, for exhaustive iteration in tests and validation.
+    pub const ALL: [IntradayCadence; 2] = [IntradayCadence::OneMinute, IntradayCadence::FiveMinute];
+
+    /// Seconds in one bucket.
+    pub fn seconds(self) -> i64 {
+        match self {
+            IntradayCadence::OneMinute => 60,
+            IntradayCadence::FiveMinute => 300,
+        }
+    }
+
+    /// The interval the rows folded at this cadence are stored under.
+    pub fn bar_interval(self) -> BarInterval {
+        match self {
+            IntradayCadence::OneMinute => BarInterval::OneMinute,
+            IntradayCadence::FiveMinute => BarInterval::FiveMinute,
+        }
+    }
+
+    /// The cadence an interval names, or `None` for [`BarInterval::OneDay`].
+    pub fn from_bar_interval(interval: BarInterval) -> Option<Self> {
+        match interval {
+            BarInterval::OneMinute => Some(IntradayCadence::OneMinute),
+            BarInterval::FiveMinute => Some(IntradayCadence::FiveMinute),
+            BarInterval::OneDay => None,
+        }
+    }
+}
+
+impl std::fmt::Display for IntradayCadence {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.bar_interval().as_str())
+    }
+}
+
 /// Why an open pair was closed.
 ///
 /// These four are the `close_reason` CHECK constraint in `schema.sql`, spelled as an enum so a
@@ -1935,6 +1981,23 @@ mod tests {
         assert!(BarInterval::parse("OneDay").is_none());
         assert!(BarInterval::parse("1day").is_none());
         assert!(BarInterval::parse("1_day").is_none());
+    }
+
+    /// Every cadence names a bucket, and every bucket-naming interval has a cadence.
+    ///
+    /// The `OneDay` arm is the point: a fold opened on the session would divide it into a grid of
+    /// one, and the daily row is the merge of the intraday rows rather than a bucket of its own.
+    #[test]
+    fn test_intraday_cadence_covers_the_bucket_naming_intervals_and_no_others() {
+        for cadence in IntradayCadence::ALL {
+            assert_eq!(
+                IntradayCadence::from_bar_interval(cadence.bar_interval()),
+                Some(cadence)
+            );
+        }
+        assert!(IntradayCadence::from_bar_interval(BarInterval::OneDay).is_none());
+        assert_eq!(IntradayCadence::OneMinute.seconds(), 60);
+        assert_eq!(IntradayCadence::FiveMinute.seconds(), 300);
     }
 
     #[test]

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -17,7 +17,7 @@ use crate::common::aws::{date_from_partitioned_key, date_partitioned_key};
 use crate::common::flatfiles::{FlatFileClient, FlatFileError};
 use crate::common::massive::MassiveClient;
 use crate::common::types::{
-    BarInterval, EquityBar, LiquidityFloor, QuoteSummary, SessionDate, Ticker,
+    BarInterval, EquityBar, IntradayCadence, LiquidityFloor, QuoteSummary, SessionDate, Ticker,
 };
 use crate::data::calendar::TradingCalendar;
 use crate::data::{bars, boundaries, quotes, splits};
@@ -1587,6 +1587,7 @@ pub async fn archive_quote_sessions(
     bucket: &str,
     sessions: &[SessionDate],
     scope: &Scope,
+    cadence: IntradayCadence,
 ) -> Result<PassSummary, ArchiveError> {
     let (Some(first), Some(last)) = (sessions.first(), sessions.last()) else {
         return Ok(PassProgress::default().into_quote_summary(0));
@@ -1642,6 +1643,7 @@ pub async fn archive_quote_sessions(
             bucket,
             session,
             scope,
+            cadence,
             &mut progress,
         )
         .await?;
@@ -1680,6 +1682,7 @@ async fn archive_quote_session(
     bucket: &str,
     session: SessionDate,
     scope: &Scope,
+    cadence: IntradayCadence,
     progress: &mut PassProgress,
 ) -> Result<usize, ArchiveError> {
     let Some((open, close)) = quotes::trading_hours(calendar, session) else {
@@ -1711,13 +1714,26 @@ async fn archive_quote_session(
         return Ok(0);
     }
 
-    info!(%session, %open, %close, %source, universe = universe.len(), "Folding a session's quoted book");
+    info!(%session, %open, %close, %source, %cadence, universe = universe.len(), "Folding a session's quoted book");
     let (folded, quotes_folded) = match source {
         QuoteSource::PerName(market_data) => {
-            fold_universe(market_data, session, open, close, &universe, progress).await
+            fold_universe(
+                market_data,
+                session,
+                cadence,
+                open,
+                close,
+                &universe,
+                progress,
+            )
+            .await
         }
         QuoteSource::WholeSession(flat_files) => {
-            match fold_whole_session(flat_files, session, open, close, universe, progress).await {
+            match fold_whole_session(
+                flat_files, session, cadence, open, close, universe, progress,
+            )
+            .await
+            {
                 Ok(folded) => folded,
                 Err(error) => {
                     // The file is the session: nothing partial survives it, so this is the session
@@ -1740,9 +1756,11 @@ async fn archive_quote_session(
 }
 
 /// Fans out over the universe, folding each name's session and keeping the summaries and the cost.
+#[allow(clippy::too_many_arguments)]
 async fn fold_universe(
     market_data: &MarketDataClient,
     session: SessionDate,
+    cadence: IntradayCadence,
     open: DateTime<Utc>,
     close: DateTime<Utc>,
     universe: &BTreeSet<Ticker>,
@@ -1760,7 +1778,9 @@ async fn fold_universe(
             tasks.spawn(async move {
                 let mut last_error = None;
                 for attempt in 0..QUOTE_SYMBOL_ATTEMPTS {
-                    match quotes::fold_session(&client, &ticker, session, open, close).await {
+                    match quotes::fold_session(&client, &ticker, session, cadence, open, close)
+                        .await
+                    {
                         Ok(folded) => return Ok(folded),
                         Err(error) => {
                             if !error.is_transient() {
@@ -1805,16 +1825,18 @@ async fn fold_universe(
 /// Every fold is held until the file ends rather than released at the ticker switch. Two names a
 /// session arrive in two runs, and a released fold cannot take the second: folding the runs apart
 /// extends each one's last quote to the close, so their weights overlap and sum past the session.
+#[allow(clippy::too_many_arguments)]
 async fn fold_whole_session(
     flat_files: &FlatFileClient,
     session: SessionDate,
+    cadence: IntradayCadence,
     open: DateTime<Utc>,
     close: DateTime<Utc>,
     universe: BTreeSet<Ticker>,
     progress: &mut PassProgress,
 ) -> Result<(Vec<QuoteSummary>, usize), FlatFileError> {
     let requested = universe.len();
-    let fold = quotes::MarketFold::new(session, open, close, universe);
+    let fold = quotes::MarketFold::new(session, cadence, open, close, universe);
     let (_, fold) = flat_files.fold_quotes(session.date(), fold).await?;
 
     let quotes_folded = fold.folded();
@@ -1830,11 +1852,11 @@ async fn fold_whole_session(
     Ok((folded.summaries, quotes_folded))
 }
 
-/// Writes a session's summaries, one partition per cadence, five-minute first.
+/// Writes a session's summaries, one partition per cadence, daily last.
 ///
 /// The order is the recovery rule, not a preference. Presence is read off the daily prefix, so a
-/// pass that dies between the two writes leaves the session looking absent and the next pass redoes
-/// both — where the reverse order would mark it done with its intraday half missing.
+/// pass that dies partway leaves the session looking absent and the next pass redoes every cadence —
+/// where writing the daily first would mark it done with its intraday half missing.
 async fn write_quote_partitions(
     s3_client: &S3Client,
     bucket: &str,
@@ -1842,24 +1864,21 @@ async fn write_quote_partitions(
     folded: Vec<QuoteSummary>,
     progress: &mut PassProgress,
 ) -> Result<(), ArchiveError> {
-    let mut intraday: Vec<QuoteSummary> = Vec::new();
+    let mut one_minute: Vec<QuoteSummary> = Vec::new();
+    let mut five_minute: Vec<QuoteSummary> = Vec::new();
     let mut daily: Vec<QuoteSummary> = Vec::new();
-    let mut unexpected = 0usize;
     for row in folded {
         match row.bar_interval() {
-            BarInterval::FiveMinute => intraday.push(row),
+            BarInterval::OneMinute => one_minute.push(row),
+            BarInterval::FiveMinute => five_minute.push(row),
             BarInterval::OneDay => daily.push(row),
-            // The fold emits exactly the two cadences above; a third is this module's own bug.
-            BarInterval::OneMinute => unexpected += 1,
         }
-    }
-    if unexpected > 0 {
-        warn!(unexpected, %session, "Discarded quote summaries at a cadence the archive has no prefix for");
     }
 
     let mut written = 0usize;
     for (interval, rows) in [
-        (BarInterval::FiveMinute, intraday),
+        (BarInterval::OneMinute, one_minute),
+        (BarInterval::FiveMinute, five_minute),
         (BarInterval::OneDay, daily),
     ] {
         if rows.is_empty() {

--- a/src/data/quotes.rs
+++ b/src/data/quotes.rs
@@ -11,11 +11,10 @@ use tracing::warn;
 
 use crate::common::alpaca::{ClientError, MarketDataClient, QuoteFetch, QuoteTick};
 use crate::common::flatfiles::QuoteSink;
-use crate::common::types::{BarInterval, BasisPoints, QuoteSummary, SessionDate, Ticker};
+use crate::common::types::{
+    BarInterval, BasisPoints, IntradayCadence, QuoteSummary, SessionDate, Ticker,
+};
 use crate::data::calendar::TradingCalendar;
-
-/// Seconds in one intraday bucket, matching the five-minute bar grid the archive is built on.
-const BUCKET_SECONDS: i64 = 300;
 
 /// The upper quantile every summary reports beside its median.
 const UPPER_QUANTILE: f64 = 0.9;
@@ -152,13 +151,14 @@ fn quantile(observations: &[(f64, f64)], weight: f64, quantile: f64) -> Option<f
     observations.last().map(|(spread, _)| *spread)
 }
 
-/// Accumulates one name's session into a five-minute grid and the session that grid sums to.
+/// Accumulates one name's session into an intraday grid and the session that grid sums to.
 ///
 /// Fed tick by tick and never holding them: the ticks a session's fetch delivers run to most of a
 /// million, and what survives is one summary per bucket.
 pub struct SessionFold {
     ticker: Ticker,
     session: SessionDate,
+    cadence: IntradayCadence,
     open: DateTime<Utc>,
     close: DateTime<Utc>,
     buckets: Vec<SpreadAccumulator>,
@@ -175,6 +175,7 @@ impl SessionFold {
     pub fn new(
         ticker: Ticker,
         session: SessionDate,
+        cadence: IntradayCadence,
         open: DateTime<Utc>,
         close: DateTime<Utc>,
     ) -> Option<Self> {
@@ -184,11 +185,12 @@ impl SessionFold {
         }
         // Rounded up, so a session whose close does not land on the grid keeps its short last
         // bucket rather than dropping the minutes past the final boundary.
-        let bucket_milliseconds = BUCKET_SECONDS * 1_000;
+        let bucket_milliseconds = cadence.seconds() * 1_000;
         let buckets = ((span + bucket_milliseconds - 1) / bucket_milliseconds) as usize;
         Some(Self {
             ticker,
             session,
+            cadence,
             open,
             close,
             buckets: (0..buckets).map(|_| SpreadAccumulator::default()).collect(),
@@ -215,7 +217,7 @@ impl SessionFold {
         self.previous = Some(tick);
     }
 
-    /// Closes the fold, returning the five-minute summaries followed by the session's.
+    /// Closes the fold, returning the intraday summaries followed by the session's.
     ///
     /// The session summary is the merge of the buckets rather than a separate accumulation, so the
     /// two cadences describe the same weight by construction.
@@ -236,8 +238,9 @@ impl SessionFold {
         let mut session = SpreadAccumulator::default();
         let mut summaries = Vec::with_capacity(self.buckets.len() + 1);
         for (index, mut bucket) in std::mem::take(&mut self.buckets).into_iter().enumerate() {
-            let opens_at = self.open + Duration::seconds(BUCKET_SECONDS * index as i64);
-            if let Some(summary) = bucket.summarize(&self.ticker, BarInterval::FiveMinute, opens_at)
+            let opens_at = self.open + Duration::seconds(self.cadence.seconds() * index as i64);
+            if let Some(summary) =
+                bucket.summarize(&self.ticker, self.cadence.bar_interval(), opens_at)
             {
                 summaries.push(summary);
             }
@@ -271,8 +274,9 @@ impl SessionFold {
             let Some(index) = self.bucket_index(cursor) else {
                 return;
             };
-            let boundary =
-                (self.open + Duration::seconds(BUCKET_SECONDS * (index as i64 + 1))).min(until);
+            let boundary = (self.open
+                + Duration::seconds(self.cadence.seconds() * (index as i64 + 1)))
+            .min(until);
             // Nanoseconds, not milliseconds: truncating loses a quarter of one per quote, which
             // cost AAPL 211 seconds of a 23,400-second session. One bucket cannot overflow it.
             let seconds = (boundary - cursor)
@@ -290,7 +294,7 @@ impl SessionFold {
         if instant < self.open || instant >= self.close {
             return None;
         }
-        let offset = (instant - self.open).num_milliseconds() / (BUCKET_SECONDS * 1_000);
+        let offset = (instant - self.open).num_milliseconds() / (self.cadence.seconds() * 1_000);
         let index = usize::try_from(offset).ok()?;
         (index < self.buckets.len()).then_some(index)
     }
@@ -339,10 +343,11 @@ pub async fn fold_session(
     market_data: &MarketDataClient,
     ticker: &Ticker,
     session: SessionDate,
+    cadence: IntradayCadence,
     open: DateTime<Utc>,
     close: DateTime<Utc>,
 ) -> Result<(Vec<QuoteSummary>, QuoteFetch), ClientError> {
-    let Some(mut fold) = SessionFold::new(ticker.clone(), session, open, close) else {
+    let Some(mut fold) = SessionFold::new(ticker.clone(), session, cadence, open, close) else {
         return Err(ClientError::Parse(format!(
             "{session} spans no time between {open} and {close}"
         )));
@@ -441,8 +446,14 @@ mod tests {
     /// Two quotes over two buckets: a ten-basis-point book standing from 13:30 to 13:36, then a
     /// two-basis-point book standing to the 13:40 close.
     fn folded() -> Vec<QuoteSummary> {
-        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(40, 0))
-            .expect("a positive session");
+        let mut fold = SessionFold::new(
+            ticker(),
+            session(),
+            IntradayCadence::FiveMinute,
+            at(30, 0),
+            at(40, 0),
+        )
+        .expect("a positive session");
         fold.push(tick(30, 99.95, 100.05, 100, 200));
         fold.push(tick(36, 99.99, 100.01, 300, 400));
         fold.finish()
@@ -487,6 +498,69 @@ mod tests {
         );
     }
 
+    /// The same ticks on the sixty-second grid, which is what the one-minute pass will fold.
+    fn folded_at_one_minute() -> Vec<QuoteSummary> {
+        let mut fold = SessionFold::new(
+            ticker(),
+            session(),
+            IntradayCadence::OneMinute,
+            at(30, 0),
+            at(40, 0),
+        )
+        .expect("a positive session");
+        fold.push(tick(30, 99.95, 100.05, 100, 200));
+        fold.push(tick(36, 99.99, 100.01, 300, 400));
+        fold.finish()
+    }
+
+    /// The cadence reaches the grid and the stored interval, rather than decorating the fold.
+    ///
+    /// Pinned to the literal 11 — ten one-minute buckets and the session — because a cadence that
+    /// were silently ignored would still produce a coherent frame, just the wrong one.
+    #[test]
+    fn test_a_one_minute_fold_buckets_by_the_minute_and_says_so() {
+        let summaries = folded_at_one_minute();
+        assert_eq!(
+            summaries.len(),
+            11,
+            "ten minutes of buckets and the session"
+        );
+
+        let buckets = &summaries[..summaries.len() - 1];
+        assert!(
+            buckets
+                .iter()
+                .all(|bucket| bucket.bar_interval() == BarInterval::OneMinute),
+            "every intraday row carries the cadence it was folded at"
+        );
+        assert!(
+            buckets
+                .iter()
+                .all(|bucket| bucket.covered_seconds() == 60.0),
+            "a sixty-second grid over a gapless session covers sixty seconds a bucket"
+        );
+    }
+
+    /// The premise of the cross-cadence check: two grids over the same ticks describe one session.
+    ///
+    /// Asserted against 600.0 and 6.8 rather than against the five-minute fold alone, so a bug that
+    /// moved both cadences the same way still fails.
+    #[test]
+    fn test_the_two_intraday_cadences_agree_on_the_session_they_describe() {
+        let one_minute = folded_at_one_minute().pop().expect("a session summary");
+        let five_minute = folded().pop().expect("a session summary");
+
+        assert_eq!(one_minute.bar_interval(), BarInterval::OneDay);
+        assert_eq!(one_minute.covered_seconds(), 600.0);
+        assert_eq!(one_minute.covered_seconds(), five_minute.covered_seconds());
+        assert_eq!(one_minute.quote_count(), five_minute.quote_count());
+        assert_close(one_minute.quoted_spread_basis_points_mean().value(), 6.8);
+        assert_close(
+            one_minute.quoted_spread_basis_points_mean().value(),
+            five_minute.quoted_spread_basis_points_mean().value(),
+        );
+    }
+
     /// Weighting by count instead would read 6.0 here. It reads 6.0 on AAPL's open too, against a
     /// time-weighted 3.44 — the count is a message rate, not a market.
     #[test]
@@ -526,8 +600,14 @@ mod tests {
     /// however long the final book stood — four minutes of the ten here.
     #[test]
     fn test_the_last_quote_prevails_to_the_close() {
-        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(40, 0))
-            .expect("a positive session");
+        let mut fold = SessionFold::new(
+            ticker(),
+            session(),
+            IntradayCadence::FiveMinute,
+            at(30, 0),
+            at(40, 0),
+        )
+        .expect("a positive session");
         fold.push(tick(30, 99.95, 100.05, 100, 200));
         let session_summary = fold.finish().pop().expect("a session summary");
         assert_eq!(session_summary.covered_seconds(), 600.0);
@@ -538,8 +618,14 @@ mod tests {
     /// time from the bucket it landed in.
     #[test]
     fn test_a_tick_older_than_the_one_before_it_is_dropped() {
-        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(40, 0))
-            .expect("a positive session");
+        let mut fold = SessionFold::new(
+            ticker(),
+            session(),
+            IntradayCadence::FiveMinute,
+            at(30, 0),
+            at(40, 0),
+        )
+        .expect("a positive session");
         fold.push(tick(30, 99.95, 100.05, 100, 200));
         fold.push(tick(36, 99.99, 100.01, 300, 400));
         fold.push(tick(33, 99.00, 101.00, 100, 100));
@@ -558,8 +644,14 @@ mod tests {
     /// zero spread into a cost model rather than an absence.
     #[test]
     fn test_a_bucket_no_quote_stood_across_produces_no_row() {
-        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(45, 0))
-            .expect("a positive session");
+        let mut fold = SessionFold::new(
+            ticker(),
+            session(),
+            IntradayCadence::FiveMinute,
+            at(30, 0),
+            at(45, 0),
+        )
+        .expect("a positive session");
         fold.push(tick(40, 99.95, 100.05, 100, 200));
         let summaries = fold.finish();
 
@@ -573,8 +665,14 @@ mod tests {
     /// session is weighed — otherwise a pre-open book would stretch the denominator.
     #[test]
     fn test_weight_outside_the_session_bounds_is_not_counted() {
-        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(40, 0))
-            .expect("a positive session");
+        let mut fold = SessionFold::new(
+            ticker(),
+            session(),
+            IntradayCadence::FiveMinute,
+            at(30, 0),
+            at(40, 0),
+        )
+        .expect("a positive session");
         fold.push(QuoteTick::new(at(20, 0), 99.95, 100.05, 100, 200).expect("a usable book"));
         let session_summary = fold.finish().pop().expect("a session summary");
         assert_eq!(session_summary.covered_seconds(), 600.0);
@@ -594,6 +692,7 @@ mod tests {
         let mut fold = SessionFold::new(
             ticker(),
             session(),
+            IntradayCadence::FiveMinute,
             opens,
             opens + Duration::milliseconds(1),
         )
@@ -623,8 +722,22 @@ mod tests {
 
     #[test]
     fn test_a_session_with_no_span_is_refused() {
-        assert!(SessionFold::new(ticker(), session(), at(40, 0), at(40, 0)).is_none());
-        assert!(SessionFold::new(ticker(), session(), at(40, 0), at(30, 0)).is_none());
+        assert!(SessionFold::new(
+            ticker(),
+            session(),
+            IntradayCadence::FiveMinute,
+            at(40, 0),
+            at(40, 0)
+        )
+        .is_none());
+        assert!(SessionFold::new(
+            ticker(),
+            session(),
+            IntradayCadence::FiveMinute,
+            at(40, 0),
+            at(30, 0)
+        )
+        .is_none());
     }
 
     /// Pinned to the stamp the daily bar archive actually carries, which 2025-11-28 shows is 16:00
@@ -669,6 +782,7 @@ mod tests {
     fn test_each_contiguous_name_folds_separately() {
         let mut fold = MarketFold::new(
             session(),
+            IntradayCadence::FiveMinute,
             at(30, 0),
             at(40, 0),
             universe(&["AAPL", "CBOE", "BCPC"]),
@@ -694,7 +808,13 @@ mod tests {
     /// must cost nothing — neither a summary nor a fold held open for it.
     #[test]
     fn test_a_name_outside_the_universe_is_not_folded() {
-        let mut fold = MarketFold::new(session(), at(30, 0), at(40, 0), universe(&["AAPL"]));
+        let mut fold = MarketFold::new(
+            session(),
+            IntradayCadence::FiveMinute,
+            at(30, 0),
+            at(40, 0),
+            universe(&["AAPL"]),
+        );
         fold.push(named("AAPL"), quote(30, 99.95, 100.05));
         fold.push(named("CBOE"), quote(30, 199.80, 200.20));
         fold.push(named("ZZZ"), quote(30, 9.95, 10.05));
@@ -716,6 +836,7 @@ mod tests {
     fn test_a_name_that_quoted_only_outside_regular_hours_still_counts_as_seen() {
         let mut fold = MarketFold::new(
             session(),
+            IntradayCadence::FiveMinute,
             at(30, 0),
             at(40, 0),
             universe(&["AAPL", "CBOE", "ZZZ"]),
@@ -749,6 +870,7 @@ mod tests {
     fn test_a_split_name_resumes_its_own_fold_rather_than_opening_a_second() {
         let mut fold = MarketFold::new(
             session(),
+            IntradayCadence::FiveMinute,
             at(30, 0),
             at(40, 0),
             universe(&["AAPL", "CBOE", "BCPC"]),
@@ -799,6 +921,7 @@ mod tests {
 /// session itself.
 pub struct MarketFold {
     session: SessionDate,
+    cadence: IntradayCadence,
     open: DateTime<Utc>,
     close: DateTime<Utc>,
     /// The run in progress, kept out of the map so the common row costs no lookup.
@@ -816,12 +939,14 @@ impl MarketFold {
     /// Opens a fold over one session's regular hours.
     pub fn new(
         session: SessionDate,
+        cadence: IntradayCadence,
         open: DateTime<Utc>,
         close: DateTime<Utc>,
         universe: BTreeSet<Ticker>,
     ) -> Self {
         Self {
             session,
+            cadence,
             open,
             close,
             current: None,
@@ -862,7 +987,13 @@ impl MarketFold {
                 self.resumed.insert(ticker.clone());
                 Some(fold)
             }
-            None => SessionFold::new(ticker.clone(), self.session, self.open, self.close),
+            None => SessionFold::new(
+                ticker.clone(),
+                self.session,
+                self.cadence,
+                self.open,
+                self.close,
+            ),
         };
         self.current = fold.map(|fold| (ticker, fold));
     }


### PR DESCRIPTION
# Overview

Makes the intraday grid a parameter of the quote fold instead of a module constant, so the trade pass can fold one-minute quote summaries on the read it already has to make.

## Changes

- Adds `IntradayCadence` to `common/types.rs` — the two `BarInterval` values that name a *bucket*. Carries `seconds()`, `bar_interval()`, and `from_bar_interval()`.
- Threads it through `SessionFold`, `MarketFold`, `fold_session`, `fold_universe`, `fold_whole_session`, and `archive_quote_sessions`. `BUCKET_SECONDS` is gone.
- `finish` tags intraday rows with the cadence they were folded at rather than a hardcoded `FiveMinute`.
- `write_quote_partitions` gains a real `OneMinute` arm and writes daily last.
- `seed.rs` pins `QUOTE_CADENCE = FiveMinute`. No behaviour change to anything that runs today.

## Context

**Why a new type rather than a `None` arm on `BarInterval`.** `BarInterval` names three things a stored row can be; only two name a bucket. `OneDay`'s bucket is the session itself, and the daily row is already the merge of the intraday accumulators — a fold opened at `OneDay` would divide the session into a grid of one and derive the daily figure twice, by two routes free to disagree. Making that unconstructible costs less than checking for it, and it lets `bar_interval()` be total.

**Why the guard at `archive.rs` could go.** It emitted "Discarded quote summaries at a cadence the archive has no prefix for", which was true and is now false — `quote_archive_prefix` has always taken a `BarInterval`, so the third prefix costs nothing. The write order generalises from "five-minute first" to "daily last", preserving rather than replacing the recovery rule: presence is read off the daily prefix, so a pass that dies partway must leave the session looking absent.

**Why the one-minute pass is not reachable from the command line.** It re-derives the session row, and the cross-cadence check that compares it against the stored one rather than overwriting it does not exist yet. Shipping the flag first would let a re-fold replace 1,254 sessions of daily figures with its own and call the agreement a verification. The flag lands with the check.

**Verification.** `devenv tasks run checks:rust` green; coverage 81.22%; clippy's warning set is byte-identical to `254fa318`. Both new tests were confirmed load-bearing by mutation — hardcoding `FiveMinute` back into `finish`, and making `OneMinute::seconds()` return 300, each failed them, and each was reverted. No real-data route was exercised, and none applies: nothing writes `one_minute` yet, and the five-minute path is unchanged by construction.

Groundwork for the trade fold, which follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KQiJumjK2WhBCNmhNV9sq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for one-minute and five-minute intraday quote intervals.
  * Quote archiving now preserves summaries across one-minute, five-minute, and daily timeframes.
  * Added cadence-aware time buckets and interval conversions for more flexible market data aggregation.

* **Bug Fixes**
  * Improved quote folding across different intraday intervals, including consistent session boundary handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->