### PR TITLE
Fold the printed tape, counting only what the policy admits

### DIFF
--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -2099,6 +2099,74 @@ impl QuoteTick {
     }
 }
 
+/// One printed trade, carrying the marks that decide whether it counts.
+///
+/// `size` is `f64` and not the `i32` a quote's size is: 16.5% of a session's prints are fractional
+/// shares, some as small as 0.0008. `conditions` travels with the tick because eligibility is
+/// decided at fold time and cannot be recovered from the aggregate afterwards.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TradeTick {
+    timestamp: DateTime<Utc>,
+    price: f64,
+    size: f64,
+    conditions: Vec<u32>,
+    corrected: bool,
+}
+
+impl TradeTick {
+    /// Constructs a `TradeTick`, refusing a print that can carry no weight.
+    ///
+    /// `None` rather than an error, matching [`QuoteTick::new`]: these are refused in bulk and
+    /// counted. A zero size is refused here rather than downstream because it would divide.
+    pub fn new(
+        timestamp: DateTime<Utc>,
+        price: f64,
+        size: f64,
+        conditions: Vec<u32>,
+        corrected: bool,
+    ) -> Option<Self> {
+        if !price.is_finite() || price <= 0.0 {
+            return None;
+        }
+        if !size.is_finite() || size <= 0.0 {
+            return None;
+        }
+        Some(Self {
+            timestamp,
+            price,
+            size,
+            conditions,
+            corrected,
+        })
+    }
+
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
+    }
+
+    pub fn price(&self) -> f64 {
+        self.price
+    }
+
+    pub fn size(&self) -> f64 {
+        self.size
+    }
+
+    pub fn conditions(&self) -> &[u32] {
+        &self.conditions
+    }
+
+    /// Whether the provider marked the print corrected or busted.
+    pub fn corrected(&self) -> bool {
+        self.corrected
+    }
+
+    /// What the print was worth, which is the weight every trade aggregate is taken against.
+    pub fn notional(&self) -> f64 {
+        self.price * self.size
+    }
+}
+
 /// Attempts per quote page before the fetch gives up on the whole symbol.
 ///
 /// Four, because the page is the unit that fails: one session of AAPL is 118 pages and a single

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use flate2::read::GzDecoder;
 use tracing::{info, warn};
 
-use crate::common::alpaca::QuoteTick;
+use crate::common::alpaca::{QuoteTick, TradeTick};
 use crate::common::types::Ticker;
 
 /// The bucket every dataset lives under, which Massive support named on 2026-08-24.
@@ -62,6 +62,10 @@ const BID_PRICE_COLUMN: &str = "bid_price";
 const BID_SIZE_COLUMN: &str = "bid_size";
 const ASK_PRICE_COLUMN: &str = "ask_price";
 const ASK_SIZE_COLUMN: &str = "ask_size";
+const PRICE_COLUMN: &str = "price";
+const SIZE_COLUMN: &str = "size";
+const CONDITIONS_COLUMN: &str = "conditions";
+const CORRECTION_COLUMN: &str = "correction";
 
 /// Why a flat-file read failed.
 #[derive(Debug, thiserror::Error)]
@@ -171,6 +175,11 @@ pub trait QuoteSink {
     fn push(&mut self, ticker: Ticker, tick: QuoteTick);
 }
 
+/// Somewhere for a file's trades to go, on the same reasoning as [`QuoteSink`].
+pub trait TradeSink {
+    fn push(&mut self, ticker: Ticker, tick: TradeTick);
+}
+
 /// Adapts a plain closure, for a caller that keeps nothing — counting a file, or a test.
 pub struct ForEach<F>(pub F);
 
@@ -183,6 +192,18 @@ where
     }
 }
 
+/// The trade half of [`ForEach`], distinct because one closure cannot implement both traits.
+pub struct ForEachTrade<F>(pub F);
+
+impl<F> TradeSink for ForEachTrade<F>
+where
+    F: FnMut(Ticker, TradeTick),
+{
+    fn push(&mut self, ticker: Ticker, tick: TradeTick) {
+        (self.0)(ticker, tick)
+    }
+}
+
 /// The S3 key holding one day of consolidated quotes.
 ///
 /// The `us_stocks_sip` prefix is Massive's own and corroborates the SIP sourcing behind their NBBO
@@ -191,6 +212,20 @@ pub fn quote_key(date: NaiveDate) -> String {
     use chrono::Datelike;
     format!(
         "us_stocks_sip/quotes_v1/{}/{:02}/{}.csv.gz",
+        date.year(),
+        date.month(),
+        date.format("%Y-%m-%d")
+    )
+}
+
+/// The S3 key holding one day of consolidated trades.
+///
+/// The same layout as [`quote_key`] under a sibling dataset, which is what lets one pass read both
+/// halves of a session without a second convention.
+pub fn trade_key(date: NaiveDate) -> String {
+    use chrono::Datelike;
+    format!(
+        "us_stocks_sip/trades_v1/{}/{:02}/{}.csv.gz",
         date.year(),
         date.month(),
         date.format("%Y-%m-%d")
@@ -395,6 +430,45 @@ impl FlatFileClient {
                 .map_or("unmeasured", |layout| layout.as_str()),
             compressed_bytes,
             "Folded a flat file of quotes"
+        );
+        Ok((summary, fold))
+    }
+
+    /// Streams one day of trades, handing every usable print to `fold`.
+    ///
+    /// The same shape as [`FlatFileClient::fold_quotes`] over the sibling dataset — the ranges, the
+    /// blocking parse and the ordering guarantee are shared, and only the row schema differs.
+    pub async fn fold_trades<S: TradeSink + Send + 'static>(
+        &self,
+        date: NaiveDate,
+        fold: S,
+    ) -> Result<(QuoteFileFold, S), FlatFileError> {
+        let key = trade_key(date);
+        info!(bucket = FLAT_FILE_BUCKET, key, %date, "Reading a flat file of trades");
+
+        let compressed_bytes = self.object_length(&key).await?;
+        let reader = self.ranged_reader(&key, compressed_bytes);
+        let scoped = key.clone();
+        let (mut summary, fold) =
+            tokio::task::spawn_blocking(move || fold_gzipped_trades(reader, &scoped, fold))
+                .await
+                .map_err(|error| FlatFileError::Read {
+                    key: key.clone(),
+                    source: std::io::Error::other(error),
+                })??;
+
+        summary.compressed_bytes = compressed_bytes;
+        info!(
+            key,
+            rows_read = summary.rows_read,
+            ticks_folded = summary.ticks_folded,
+            unusable = summary.unusable,
+            tickers = summary.tickers,
+            layout = summary
+                .layout()
+                .map_or("unmeasured", |layout| layout.as_str()),
+            compressed_bytes,
+            "Folded a flat file of trades"
         );
         Ok((summary, fold))
     }
@@ -649,6 +723,70 @@ impl QuoteColumns {
     }
 }
 
+/// Where each field the trade fold needs sits in this particular file.
+///
+/// Resolved from the header on the same reasoning as [`QuoteColumns`]: a renamed column fails on the
+/// first row rather than folding zeros.
+struct TradeColumns {
+    ticker: usize,
+    timestamp: usize,
+    price: usize,
+    size: usize,
+    conditions: usize,
+    correction: usize,
+}
+
+impl TradeColumns {
+    fn resolve(header: &csv::StringRecord, key: &str) -> Result<Self, FlatFileError> {
+        let index = |column: &'static str| {
+            header
+                .iter()
+                .position(|found| found.trim() == column)
+                .ok_or_else(|| FlatFileError::Column {
+                    key: key.to_string(),
+                    column,
+                    header: header.iter().collect::<Vec<_>>().join(","),
+                })
+        };
+        Ok(Self {
+            ticker: index(TICKER_COLUMN)?,
+            // `sip_timestamp`, never `participant_timestamp`: the quote file is stamped in SIP time
+            // and an effective spread pairs the two, so the venue's clock would compare two clocks.
+            timestamp: index(TIMESTAMP_COLUMN)?,
+            price: index(PRICE_COLUMN)?,
+            size: index(SIZE_COLUMN)?,
+            conditions: index(CONDITIONS_COLUMN)?,
+            correction: index(CORRECTION_COLUMN)?,
+        })
+    }
+
+    /// Reads one row, or `None` if it is not a print that can carry weight.
+    fn tick(&self, row: &csv::StringRecord) -> Option<(Ticker, TradeTick)> {
+        let field = |index: usize| row.get(index).map(str::trim);
+        let ticker = Ticker::new(field(self.ticker)?)?;
+        let timestamp = nanoseconds_to_instant(field(self.timestamp)?.parse::<i64>().ok()?)?;
+        let tick = TradeTick::new(
+            timestamp,
+            field(self.price)?.parse::<f64>().ok()?,
+            field(self.size)?.parse::<f64>().ok()?,
+            parse_conditions(field(self.conditions)?),
+            field(self.correction)?.parse::<u32>().ok()? != 0,
+        )?;
+        Some((ticker, tick))
+    }
+}
+
+/// Splits the comma-separated condition set, dropping codes that are not numbers.
+///
+/// Parsed to integers rather than matched as text, because the field holds a *set*: `"14,12,37,41"`
+/// contains 41, and a substring test for `"4"` would find it inside that and inside 14.
+fn parse_conditions(field: &str) -> Vec<u32> {
+    field
+        .split(',')
+        .filter_map(|code| code.trim().parse::<u32>().ok())
+        .collect()
+}
+
 /// Massive stamps a SIP quote in nanoseconds since the epoch, and `None` rejects any other unit.
 ///
 /// A stamp in seconds, millis or micros converts without complaint and lands in January 1970, where
@@ -660,6 +798,47 @@ fn nanoseconds_to_instant(nanoseconds: i64) -> Option<DateTime<Utc>> {
         return None;
     }
     Some(Utc.timestamp_nanos(nanoseconds))
+}
+
+/// The per-name bookkeeping every ticker-major flat file needs, whatever its rows hold.
+///
+/// Extracted rather than written twice: quotes and trades share a layout, and the split-ticker and
+/// backwards counts are what a fold trusts to decide whether it saw a whole session. Two copies that
+/// drifted would give the two datasets different integrity guarantees without saying so.
+#[derive(Default)]
+struct TickerRuns {
+    latest: HashMap<Ticker, DateTime<Utc>>,
+    previous: Option<Ticker>,
+}
+
+impl TickerRuns {
+    /// Records that `ticker` appeared stamped `timestamp`, updating `summary` in place.
+    fn observe(&mut self, ticker: &Ticker, timestamp: DateTime<Utc>, summary: &mut QuoteFileFold) {
+        // An owned key is needed only the first time a name appears, and a day is hundreds of
+        // millions of rows.
+        let seen_before = match self.latest.get_mut(ticker) {
+            Some(previous) => {
+                if timestamp < *previous {
+                    summary.backwards += 1;
+                }
+                *previous = timestamp;
+                true
+            }
+            None => {
+                self.latest.insert(ticker.clone(), timestamp);
+                summary.tickers += 1;
+                false
+            }
+        };
+        if self.previous.as_ref() != Some(ticker) {
+            summary.ticker_runs += 1;
+            // Already seen, and yet starting a run: its rows are split across the file.
+            if seen_before {
+                summary.split_tickers.0.insert(ticker.clone());
+            }
+            self.previous = Some(ticker.clone());
+        }
+    }
 }
 
 /// Decompresses, parses and folds, on whichever thread the caller put this on.
@@ -679,8 +858,7 @@ where
     let columns = QuoteColumns::resolve(header, key)?;
 
     let mut summary = QuoteFileFold::default();
-    let mut latest: HashMap<Ticker, DateTime<Utc>> = HashMap::new();
-    let mut previous_ticker: Option<Ticker> = None;
+    let mut runs = TickerRuns::default();
     let mut row = csv::StringRecord::new();
     while records
         .read_record(&mut row)
@@ -691,30 +869,7 @@ where
             summary.unusable += 1;
             continue;
         };
-        // An owned key is needed only the first time a name appears, and a day is hundreds of
-        // millions of rows.
-        let seen_before = match latest.get_mut(&ticker) {
-            Some(previous) => {
-                if tick.timestamp() < *previous {
-                    summary.backwards += 1;
-                }
-                *previous = tick.timestamp();
-                true
-            }
-            None => {
-                latest.insert(ticker.clone(), tick.timestamp());
-                summary.tickers += 1;
-                false
-            }
-        };
-        if previous_ticker.as_ref() != Some(&ticker) {
-            summary.ticker_runs += 1;
-            // Already seen, and yet starting a run: its rows are split across the file.
-            if seen_before {
-                summary.split_tickers.0.insert(ticker.clone());
-            }
-            previous_ticker = Some(ticker.clone());
-        }
+        runs.observe(&ticker, tick.timestamp(), &mut summary);
         summary.ticks_folded += 1;
         fold.push(ticker, tick);
     }
@@ -731,6 +886,52 @@ where
             unusable = summary.unusable,
             rows_read = summary.rows_read,
             "Skipped rows no spread can be read off"
+        );
+    }
+    Ok((summary, fold))
+}
+
+/// The trade half of [`fold_gzipped_quotes`], sharing its bookkeeping and its ordering guarantee.
+fn fold_gzipped_trades<R, S>(
+    reader: R,
+    key: &str,
+    mut fold: S,
+) -> Result<(QuoteFileFold, S), FlatFileError>
+where
+    R: std::io::Read,
+    S: TradeSink,
+{
+    let mut records = csv::Reader::from_reader(GzDecoder::new(reader));
+    let header = records.headers().map_err(|error| read_error(key, error))?;
+    let columns = TradeColumns::resolve(header, key)?;
+
+    let mut summary = QuoteFileFold::default();
+    let mut runs = TickerRuns::default();
+    let mut row = csv::StringRecord::new();
+    while records
+        .read_record(&mut row)
+        .map_err(|error| read_error(key, error))?
+    {
+        summary.rows_read += 1;
+        let Some((ticker, tick)) = columns.tick(&row) else {
+            summary.unusable += 1;
+            continue;
+        };
+        runs.observe(&ticker, tick.timestamp(), &mut summary);
+        summary.ticks_folded += 1;
+        fold.push(ticker, tick);
+    }
+
+    summary.require_ascending(key)?;
+
+    if summary.unusable > 0 {
+        // A zero-size or zero-price print, which is rare but real — 51 of 871,159 rows on
+        // 2026-08-21. A file suddenly half unusable is a vendor change nobody announced.
+        warn!(
+            key,
+            unusable = summary.unusable,
+            rows_read = summary.rows_read,
+            "Skipped trades that can carry no weight"
         );
     }
     Ok((summary, fold))
@@ -807,6 +1008,139 @@ mod tests {
         assert_eq!(
             quote_key(date),
             "us_stocks_sip/quotes_v1/2026/03/2026-03-09.csv.gz"
+        );
+        assert_eq!(
+            trade_key(date),
+            "us_stocks_sip/trades_v1/2026/03/2026-03-09.csv.gz"
+        );
+    }
+
+    /// The real trade header, in the provider's own column order, read 2026-08-31.
+    const TRADE_HEADER: &str = "ticker,conditions,correction,exchange,id,participant_timestamp,\
+         price,sequence_number,sip_timestamp,size,tape,trf_id,trf_timestamp";
+
+    fn trade_row(
+        ticker: &str,
+        conditions: &str,
+        correction: &str,
+        price: &str,
+        size: &str,
+        nanos: i64,
+    ) -> String {
+        // `participant_timestamp` is deliberately a different instant from `sip_timestamp`: the fold
+        // must read the SIP clock, and a fixture where both agree could not tell the two apart.
+        format!(
+            "{ticker},\"{conditions}\",{correction},4,71675223161163,{},{price},3519,{nanos},{size},1,202,{}\n",
+            nanos - 10_000_000_000,
+            nanos - 500
+        )
+    }
+
+    fn fold_trades_body(
+        body: &str,
+    ) -> (
+        Result<QuoteFileFold, FlatFileError>,
+        Vec<(String, TradeTick)>,
+    ) {
+        let seen = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let collector = std::rc::Rc::clone(&seen);
+        let summary = fold_gzipped_trades(
+            std::io::Cursor::new(gzipped(body)),
+            "trades.csv.gz",
+            ForEachTrade(move |ticker: Ticker, tick: TradeTick| {
+                collector
+                    .borrow_mut()
+                    .push((ticker.as_str().to_string(), tick));
+            }),
+        );
+        let observed = seen.borrow().clone();
+        (summary.map(|(summary, _)| summary), observed)
+    }
+
+    /// The trade fold reads the SIP clock, the fractional size, and the condition set.
+    ///
+    /// The size is asserted at 0.0008 because 16.5% of a real session's prints are fractional; an
+    /// `i32` here would truncate them to zero and silently drop a sixth of the tape.
+    #[test]
+    fn test_a_trade_row_is_read_off_the_sip_clock_with_its_marks() {
+        let body = format!(
+            "{TRADE_HEADER}\n{}",
+            trade_row("AAPL", "14,12,37,41", "0", "156.30", "0.000800", stamp(0))
+        );
+        let (summary, seen) = fold_trades_body(&body);
+        let summary = summary.expect("a usable file");
+        assert_eq!(summary.rows_read, 1);
+        assert_eq!(summary.ticks_folded, 1);
+
+        let (ticker, tick) = seen.first().expect("one print");
+        assert_eq!(ticker, "AAPL");
+        assert_eq!(tick.timestamp().timestamp_nanos_opt(), Some(stamp(0)));
+        assert_eq!(tick.price(), 156.30);
+        assert_eq!(tick.size(), 0.000_8);
+        assert_eq!(tick.conditions(), &[14, 12, 37, 41]);
+        assert!(!tick.corrected());
+    }
+
+    /// The condition field is a set of integers, not a string to search.
+    ///
+    /// `"14,12,37,41"` contains the digit 4 inside both 14 and 41, so a substring test would report
+    /// condition 4 — Derivatively Priced is 10, but 4 is Bunched Trade — on a print carrying neither.
+    #[test]
+    fn test_conditions_are_parsed_as_a_set_rather_than_matched_as_text() {
+        assert_eq!(parse_conditions("14,12,37,41"), vec![14, 12, 37, 41]);
+        assert_eq!(parse_conditions(""), Vec::<u32>::new());
+        assert_eq!(parse_conditions("37"), vec![37]);
+        // Whitespace and unparsable codes are dropped rather than poisoning the set.
+        assert_eq!(parse_conditions(" 14 , 37 "), vec![14, 37]);
+        assert_eq!(parse_conditions("14,,37"), vec![14, 37]);
+    }
+
+    /// A print that can carry no weight is counted and dropped, never folded at zero.
+    ///
+    /// Zero sizes are rare and real — 51 of 871,159 rows on 2026-08-21 — and one reaching a VWAP
+    /// divisor would take the whole bar with it.
+    #[test]
+    fn test_a_trade_with_no_size_or_no_price_is_unusable() {
+        let body = format!(
+            "{TRADE_HEADER}\n{}{}{}",
+            trade_row("AAPL", "37", "0", "156.30", "0.000000", stamp(0)),
+            trade_row("AAPL", "37", "0", "0.000000", "100", stamp(1)),
+            trade_row("AAPL", "37", "0", "156.30", "100", stamp(2)),
+        );
+        let (summary, seen) = fold_trades_body(&body);
+        let summary = summary.expect("a usable file");
+        assert_eq!(summary.rows_read, 3);
+        assert_eq!(summary.unusable, 2, "the zero size and the zero price");
+        assert_eq!(summary.ticks_folded, 1);
+        assert_eq!(seen.len(), 1);
+    }
+
+    /// The correction marker survives into the tick, because the fold is what has to drop it.
+    ///
+    /// 30 corrected prints of 871,159 carried 4.5% of the session's dollar volume on 2026-08-21, so
+    /// this is a rare flag on enormous trades rather than noise.
+    #[test]
+    fn test_a_corrected_print_is_marked_rather_than_discarded_by_the_reader() {
+        let body = format!(
+            "{TRADE_HEADER}\n{}{}",
+            trade_row("AAPL", "37", "8", "156.30", "100", stamp(0)),
+            trade_row("AAPL", "37", "0", "156.31", "100", stamp(1)),
+        );
+        let (_, seen) = fold_trades_body(&body);
+        assert_eq!(seen.len(), 2, "both reach the fold");
+        assert!(seen[0].1.corrected(), "correction 8 is a correction");
+        assert!(!seen[1].1.corrected(), "correction 0 is not");
+    }
+
+    /// A renamed column fails on the header rather than folding zeros, as it does for quotes.
+    #[test]
+    fn test_a_trade_file_missing_a_column_fails_on_the_header() {
+        let renamed = TRADE_HEADER.replace("conditions", "sale_conditions");
+        let body = format!("{renamed}\n");
+        let error = fold_trades_body(&body).0.expect_err("a renamed column");
+        assert!(
+            matches!(error, FlatFileError::Column { column, .. } if column == "conditions"),
+            "got {error:?}"
         );
     }
 

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -88,10 +88,10 @@ pub enum FlatFileError {
         column: &'static str,
         header: String,
     },
-    /// More quotes stepped backwards in time than stepped forwards, which is what a file sorted the
-    /// wrong way looks like. See [`QuoteFileFold::require_ascending`].
+    /// More rows stepped backwards in time than stepped forwards, which is what a file sorted the
+    /// wrong way looks like. See [`FlatFileFold::require_ascending`].
     #[error(
-        "{key} is not in ascending time within a ticker: {backwards} quotes stepped back against \
+        "{key} is not in ascending time within a ticker: {backwards} rows stepped back against \
          {forwards} forwards, so the fold would weigh almost every one at zero"
     )]
     Descending {
@@ -238,14 +238,14 @@ pub fn trade_key(date: NaiveDate) -> String {
 /// which is ordinary around the open rather than a defect. Reported because it is the only trace a
 /// discarded row leaves, and a file that is suddenly half unusable is a vendor change.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct QuoteFileFold {
+pub struct FlatFileFold {
     /// Names whose rows are not contiguous, which is what a fold releasing at the switch must know.
     pub split_tickers: SplitTickers,
     pub rows_read: usize,
     pub ticks_folded: usize,
     pub unusable: usize,
     pub tickers: usize,
-    /// Rows whose ticker differs from the row before, which is what [`QuoteFileFold::layout`] reads.
+    /// Rows whose ticker differs from the row before, which is what [`FlatFileFold::layout`] reads.
     pub ticker_runs: usize,
     /// The object's own size, which cannot be obtained before paying — an unauthenticated `HEAD`
     /// returns 403 — and is what turns a download estimate from arithmetic into a measurement.
@@ -305,7 +305,7 @@ impl std::fmt::Display for RowLayout {
     }
 }
 
-impl QuoteFileFold {
+impl FlatFileFold {
     /// Which way the file is grouped, or `None` when it folded nothing to judge.
     ///
     /// Ticker-major puts each name in one contiguous run, so runs equal names; time-major
@@ -325,9 +325,9 @@ impl QuoteFileFold {
         }
     }
 
-    /// Refuses a file whose quotes descend in time within a ticker.
+    /// Refuses a file whose rows descend in time within a ticker.
     ///
-    /// The fold weighs each quote by the interval to the next, so a descending run weighs every one
+    /// The quote fold weighs each tick by the interval to the next, so a descending run weighs every one
     /// at zero and still produces a summary — a silent wrong answer rather than a failure. Massive
     /// does not document the row order and it cannot be inspected before paying, so it is asserted.
     ///
@@ -403,7 +403,7 @@ impl FlatFileClient {
         &self,
         date: NaiveDate,
         fold: S,
-    ) -> Result<(QuoteFileFold, S), FlatFileError> {
+    ) -> Result<(FlatFileFold, S), FlatFileError> {
         let key = quote_key(date);
         info!(bucket = FLAT_FILE_BUCKET, key, %date, "Reading a flat file of quotes");
 
@@ -442,7 +442,7 @@ impl FlatFileClient {
         &self,
         date: NaiveDate,
         fold: S,
-    ) -> Result<(QuoteFileFold, S), FlatFileError> {
+    ) -> Result<(FlatFileFold, S), FlatFileError> {
         let key = trade_key(date);
         info!(bucket = FLAT_FILE_BUCKET, key, %date, "Reading a flat file of trades");
 
@@ -672,6 +672,24 @@ impl std::io::Read for ChunkReader {
     }
 }
 
+/// Where `column` sits in `header`, or the error naming what the file called its columns instead.
+///
+/// Shared by both resolvers so a renamed column fails identically whichever dataset met it first.
+fn column_index(
+    header: &csv::StringRecord,
+    key: &str,
+    column: &'static str,
+) -> Result<usize, FlatFileError> {
+    header
+        .iter()
+        .position(|found| found.trim() == column)
+        .ok_or_else(|| FlatFileError::Column {
+            key: key.to_string(),
+            column,
+            header: header.iter().collect::<Vec<_>>().join(","),
+        })
+}
+
 /// Where each field the fold needs sits in this particular file.
 ///
 /// Resolved from the header rather than fixed, so a column inserted or reordered upstream costs
@@ -687,16 +705,7 @@ struct QuoteColumns {
 
 impl QuoteColumns {
     fn resolve(header: &csv::StringRecord, key: &str) -> Result<Self, FlatFileError> {
-        let index = |column: &'static str| {
-            header
-                .iter()
-                .position(|found| found.trim() == column)
-                .ok_or_else(|| FlatFileError::Column {
-                    key: key.to_string(),
-                    column,
-                    header: header.iter().collect::<Vec<_>>().join(","),
-                })
-        };
+        let index = |column: &'static str| column_index(header, key, column);
         Ok(Self {
             ticker: index(TICKER_COLUMN)?,
             timestamp: index(TIMESTAMP_COLUMN)?,
@@ -738,16 +747,7 @@ struct TradeColumns {
 
 impl TradeColumns {
     fn resolve(header: &csv::StringRecord, key: &str) -> Result<Self, FlatFileError> {
-        let index = |column: &'static str| {
-            header
-                .iter()
-                .position(|found| found.trim() == column)
-                .ok_or_else(|| FlatFileError::Column {
-                    key: key.to_string(),
-                    column,
-                    header: header.iter().collect::<Vec<_>>().join(","),
-                })
-        };
+        let index = |column: &'static str| column_index(header, key, column);
         Ok(Self {
             ticker: index(TICKER_COLUMN)?,
             // `sip_timestamp`, never `participant_timestamp`: the quote file is stamped in SIP time
@@ -770,7 +770,13 @@ impl TradeColumns {
             field(self.price)?.parse::<f64>().ok()?,
             field(self.size)?.parse::<f64>().ok()?,
             parse_conditions(field(self.conditions)?),
-            field(self.correction)?.parse::<u32>().ok()? != 0,
+            // A blank cell is "no correction", not an unreadable row. The provider has never
+            // emitted one in the data measured, and a row rejected for it would disappear into the
+            // `unusable` count with nothing naming the cause.
+            match field(self.correction)? {
+                "" => false,
+                marker => marker.parse::<u32>().ok()? != 0,
+            },
         )?;
         Some((ticker, tick))
     }
@@ -813,7 +819,7 @@ struct TickerRuns {
 
 impl TickerRuns {
     /// Records that `ticker` appeared stamped `timestamp`, updating `summary` in place.
-    fn observe(&mut self, ticker: &Ticker, timestamp: DateTime<Utc>, summary: &mut QuoteFileFold) {
+    fn observe(&mut self, ticker: &Ticker, timestamp: DateTime<Utc>, summary: &mut FlatFileFold) {
         // An owned key is needed only the first time a name appears, and a day is hundreds of
         // millions of rows.
         let seen_before = match self.latest.get_mut(ticker) {
@@ -848,7 +854,7 @@ fn fold_gzipped_quotes<R, S>(
     reader: R,
     key: &str,
     mut fold: S,
-) -> Result<(QuoteFileFold, S), FlatFileError>
+) -> Result<(FlatFileFold, S), FlatFileError>
 where
     R: std::io::Read,
     S: QuoteSink,
@@ -857,7 +863,7 @@ where
     let header = records.headers().map_err(|error| read_error(key, error))?;
     let columns = QuoteColumns::resolve(header, key)?;
 
-    let mut summary = QuoteFileFold::default();
+    let mut summary = FlatFileFold::default();
     let mut runs = TickerRuns::default();
     let mut row = csv::StringRecord::new();
     while records
@@ -896,7 +902,7 @@ fn fold_gzipped_trades<R, S>(
     reader: R,
     key: &str,
     mut fold: S,
-) -> Result<(QuoteFileFold, S), FlatFileError>
+) -> Result<(FlatFileFold, S), FlatFileError>
 where
     R: std::io::Read,
     S: TradeSink,
@@ -905,7 +911,7 @@ where
     let header = records.headers().map_err(|error| read_error(key, error))?;
     let columns = TradeColumns::resolve(header, key)?;
 
-    let mut summary = QuoteFileFold::default();
+    let mut summary = FlatFileFold::default();
     let mut runs = TickerRuns::default();
     let mut row = csv::StringRecord::new();
     while records
@@ -985,7 +991,7 @@ mod tests {
     }
 
     /// Folds a body and returns what the fold saw alongside the summary.
-    fn fold(body: &str) -> (Result<QuoteFileFold, FlatFileError>, Vec<(String, i64)>) {
+    fn fold(body: &str) -> (Result<FlatFileFold, FlatFileError>, Vec<(String, i64)>) {
         let seen = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
         let collector = std::rc::Rc::clone(&seen);
         let summary = fold_gzipped_quotes(
@@ -1039,7 +1045,7 @@ mod tests {
     fn fold_trades_body(
         body: &str,
     ) -> (
-        Result<QuoteFileFold, FlatFileError>,
+        Result<FlatFileFold, FlatFileError>,
         Vec<(String, TradeTick)>,
     ) {
         let seen = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -1308,14 +1308,26 @@ pub struct TradeExclusions {
 
 impl TradeExclusions {
     /// Takes everything `other` recorded, so a coarser bar is the merge of its finer ones.
+    ///
+    /// Destructured rather than field-by-field: a field added later stops compiling here instead of
+    /// being silently omitted, which would make a daily row understate what its minutes reported.
     pub(crate) fn absorb(&mut self, other: Self) {
-        self.volume_ineligible_trades += other.volume_ineligible_trades;
-        self.volume_ineligible_dollar_volume += other.volume_ineligible_dollar_volume;
-        self.corrected_trades += other.corrected_trades;
-        self.corrected_dollar_volume += other.corrected_dollar_volume;
-        self.non_market_price_trades += other.non_market_price_trades;
-        self.non_market_price_dollar_volume += other.non_market_price_dollar_volume;
-        self.unresolved_condition_trades += other.unresolved_condition_trades;
+        let Self {
+            volume_ineligible_trades,
+            volume_ineligible_dollar_volume,
+            corrected_trades,
+            corrected_dollar_volume,
+            non_market_price_trades,
+            non_market_price_dollar_volume,
+            unresolved_condition_trades,
+        } = other;
+        self.volume_ineligible_trades += volume_ineligible_trades;
+        self.volume_ineligible_dollar_volume += volume_ineligible_dollar_volume;
+        self.corrected_trades += corrected_trades;
+        self.corrected_dollar_volume += corrected_dollar_volume;
+        self.non_market_price_trades += non_market_price_trades;
+        self.non_market_price_dollar_volume += non_market_price_dollar_volume;
+        self.unresolved_condition_trades += unresolved_condition_trades;
     }
 }
 
@@ -1334,7 +1346,8 @@ pub struct TradeSummary {
     /// Shares, fractional: 16.5% of a session's prints are not whole shares.
     volume: f64,
     dollar_volume: f64,
-    volume_weighted_average_price: f64,
+    /// `None` when no eligible share traded, which an exclusion-only bar is.
+    volume_weighted_average_price: Option<f64>,
     median_trade_size: f64,
     ninetieth_percentile_trade_size: f64,
     /// Buys minus sells in shares, signed by the tick rule — a trade above the previous price is a
@@ -1362,9 +1375,21 @@ impl TradeSummary {
         signed_volume: f64,
         exclusions: TradeExclusions,
     ) -> Result<Self, InconsistentRecordError> {
+        // A bar that admitted nothing is still a row when it *excluded* something: an auction-only
+        // bar is exactly where the exclusion matters, and dropping it would lose the only record
+        // that the tape had anything in it at all. Zeroes are permitted on that condition alone, so
+        // a fold that produced nothing for no reason is still refused.
+        let excluded_something = exclusions != TradeExclusions::default();
         for (name, value) in [("volume", volume), ("dollar volume", dollar_volume)] {
-            if !value.is_finite() || value <= 0.0 {
-                return Err(reject(format!("{name} {value} is not a positive number")));
+            if !value.is_finite() || value < 0.0 {
+                return Err(reject(format!(
+                    "{name} {value} is not a non-negative number"
+                )));
+            }
+            if value == 0.0 && !excluded_something {
+                return Err(reject(format!(
+                    "{name} is zero on a bar that excluded nothing, so it describes no trades"
+                )));
             }
         }
         for (name, value) in [
@@ -1385,10 +1410,13 @@ impl TradeSummary {
                 "median trade size {median_trade_size} exceeds the ninetieth percentile {ninetieth_percentile_trade_size}"
             )));
         }
-        if trade_count <= 0 {
-            return Err(reject(format!(
-                "trade count {trade_count} is not a positive number"
-            )));
+        if trade_count < 0 {
+            return Err(reject(format!("trade count {trade_count} is negative")));
+        }
+        if trade_count == 0 && !excluded_something {
+            return Err(reject(
+                "a bar with no trades and no exclusions describes nothing".to_string(),
+            ));
         }
         // Signed volume is buys minus sells drawn from the same shares, so it cannot exceed them.
         // A violation means the tick rule and the volume accumulator saw different trades.
@@ -1405,7 +1433,9 @@ impl TradeSummary {
             volume,
             dollar_volume,
             // Divided here rather than passed in, so the identity cannot be violated by a caller.
-            volume_weighted_average_price: dollar_volume / volume,
+            // `None` on an exclusion-only bar: no eligible share traded, so there is no price it
+            // traded at, and a zero would read as one.
+            volume_weighted_average_price: (volume > 0.0).then(|| dollar_volume / volume),
             median_trade_size,
             ninetieth_percentile_trade_size,
             signed_volume,
@@ -1437,7 +1467,7 @@ impl TradeSummary {
         self.dollar_volume
     }
 
-    pub fn volume_weighted_average_price(&self) -> f64 {
+    pub fn volume_weighted_average_price(&self) -> Option<f64> {
         self.volume_weighted_average_price
     }
 

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -1289,24 +1289,78 @@ impl QuoteSummary {
 /// recover how much of the tape it declined to count. Both counts and dollar volumes, because the
 /// two disagree wildly — 246 auction prints were 0.03% of one session's trades and 14.1% of its
 /// money.
+/// Every field is private and every count moves with its dollars, which is the point: a rule
+/// recorded in two statements can be half-recorded, and these columns are the audit trail.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct TradeExclusions {
     /// Refused by the provider's own `updates_volume`, chiefly the official open and close.
-    pub volume_ineligible_trades: i64,
-    pub volume_ineligible_dollar_volume: f64,
+    volume_ineligible_trades: i64,
+    volume_ineligible_dollar_volume: f64,
     /// Marked corrected or busted by the provider.
-    pub corrected_trades: i64,
-    pub corrected_dollar_volume: f64,
+    corrected_trades: i64,
+    corrected_dollar_volume: f64,
     /// Priced away from the market — an average or derivatively priced print. Counted rather than
     /// applied: no aggregate here differences against a quote yet, and this is what it would cost.
-    pub non_market_price_trades: i64,
-    pub non_market_price_dollar_volume: f64,
+    non_market_price_trades: i64,
+    non_market_price_dollar_volume: f64,
     /// Carried a condition the baked table does not name, so its eligibility was assumed rather than
     /// read. Never disqualifying; a rising count is how a provider's new code becomes visible.
-    pub unresolved_condition_trades: i64,
+    unresolved_condition_trades: i64,
 }
 
 impl TradeExclusions {
+    /// Records a print the provider's volume rule refused.
+    pub fn record_volume_ineligible(&mut self, notional: f64) {
+        self.volume_ineligible_trades += 1;
+        self.volume_ineligible_dollar_volume += notional;
+    }
+
+    /// Records a print the provider marked corrected or busted.
+    pub fn record_correction(&mut self, notional: f64) {
+        self.corrected_trades += 1;
+        self.corrected_dollar_volume += notional;
+    }
+
+    /// Records a print whose price is not a market price, which still counts as volume.
+    pub fn record_non_market_price(&mut self, notional: f64) {
+        self.non_market_price_trades += 1;
+        self.non_market_price_dollar_volume += notional;
+    }
+
+    /// Records a print carrying a condition this table does not name. No dollars: the print is
+    /// folded like any other, and this counts only that its eligibility was assumed.
+    pub fn record_unresolved_condition(&mut self) {
+        self.unresolved_condition_trades += 1;
+    }
+
+    pub fn volume_ineligible_trades(&self) -> i64 {
+        self.volume_ineligible_trades
+    }
+
+    pub fn volume_ineligible_dollar_volume(&self) -> f64 {
+        self.volume_ineligible_dollar_volume
+    }
+
+    pub fn corrected_trades(&self) -> i64 {
+        self.corrected_trades
+    }
+
+    pub fn corrected_dollar_volume(&self) -> f64 {
+        self.corrected_dollar_volume
+    }
+
+    pub fn non_market_price_trades(&self) -> i64 {
+        self.non_market_price_trades
+    }
+
+    pub fn non_market_price_dollar_volume(&self) -> f64 {
+        self.non_market_price_dollar_volume
+    }
+
+    pub fn unresolved_condition_trades(&self) -> i64 {
+        self.unresolved_condition_trades
+    }
+
     /// Takes everything `other` recorded, so a coarser bar is the merge of its finer ones.
     ///
     /// Destructured rather than field-by-field: a field added later stops compiling here instead of
@@ -1328,6 +1382,55 @@ impl TradeExclusions {
         self.non_market_price_trades += non_market_price_trades;
         self.non_market_price_dollar_volume += non_market_price_dollar_volume;
         self.unresolved_condition_trades += unresolved_condition_trades;
+    }
+}
+
+#[cfg(test)]
+mod trade_exclusion_tests {
+    use super::TradeExclusions;
+
+    /// Every recorded exclusion moves its count and its dollars together.
+    ///
+    /// The reason the fields are private. Recording a rule used to be two statements at each of
+    /// three call sites, so a fourth rule added later could increment a count and forget its
+    /// dollars — and these columns are the archive's audit trail, so the audit would be the thing
+    /// that was wrong. Pinned to literals rather than to a sum of the inputs.
+    #[test]
+    fn test_a_recorded_exclusion_moves_its_count_and_its_dollars_together() {
+        let mut exclusions = TradeExclusions::default();
+        exclusions.record_volume_ineligible(100_000.0);
+        exclusions.record_volume_ineligible(50_000.0);
+        exclusions.record_correction(7_500.0);
+        exclusions.record_non_market_price(250.0);
+        exclusions.record_unresolved_condition();
+
+        assert_eq!(exclusions.volume_ineligible_trades(), 2);
+        assert_eq!(exclusions.volume_ineligible_dollar_volume(), 150_000.0);
+        assert_eq!(exclusions.corrected_trades(), 1);
+        assert_eq!(exclusions.corrected_dollar_volume(), 7_500.0);
+        assert_eq!(exclusions.non_market_price_trades(), 1);
+        assert_eq!(exclusions.non_market_price_dollar_volume(), 250.0);
+        // No dollars: the print is folded like any other, and this counts only that its
+        // eligibility was assumed rather than read.
+        assert_eq!(exclusions.unresolved_condition_trades(), 1);
+    }
+
+    /// A coarser bar is the merge of its finer ones, on every field at once.
+    #[test]
+    fn test_absorb_carries_every_rule_upward() {
+        let mut minute = TradeExclusions::default();
+        minute.record_correction(1_000.0);
+        minute.record_unresolved_condition();
+
+        let mut session = TradeExclusions::default();
+        session.record_volume_ineligible(9_000.0);
+        session.absorb(minute);
+
+        assert_eq!(session.corrected_trades(), 1);
+        assert_eq!(session.corrected_dollar_volume(), 1_000.0);
+        assert_eq!(session.volume_ineligible_trades(), 1);
+        assert_eq!(session.volume_ineligible_dollar_volume(), 9_000.0);
+        assert_eq!(session.unresolved_condition_trades(), 1);
     }
 }
 

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -1283,6 +1283,181 @@ impl QuoteSummary {
     }
 }
 
+/// What a bar dropped, and under whose rule.
+///
+/// Carried beside every aggregate because the fold is lossy: once a bar is written, no reader can
+/// recover how much of the tape it declined to count. Both counts and dollar volumes, because the
+/// two disagree wildly — 246 auction prints were 0.03% of one session's trades and 14.1% of its
+/// money.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct TradeExclusions {
+    /// Refused by the provider's own `updates_volume`, chiefly the official open and close.
+    pub volume_ineligible_trades: i64,
+    pub volume_ineligible_dollar_volume: f64,
+    /// Marked corrected or busted by the provider.
+    pub corrected_trades: i64,
+    pub corrected_dollar_volume: f64,
+    /// Priced away from the market — an average or derivatively priced print. Counted rather than
+    /// applied: no aggregate here differences against a quote yet, and this is what it would cost.
+    pub non_market_price_trades: i64,
+    pub non_market_price_dollar_volume: f64,
+    /// Carried a condition the baked table does not name, so its eligibility was assumed rather than
+    /// read. Never disqualifying; a rising count is how a provider's new code becomes visible.
+    pub unresolved_condition_trades: i64,
+}
+
+impl TradeExclusions {
+    /// Takes everything `other` recorded, so a coarser bar is the merge of its finer ones.
+    pub(crate) fn absorb(&mut self, other: Self) {
+        self.volume_ineligible_trades += other.volume_ineligible_trades;
+        self.volume_ineligible_dollar_volume += other.volume_ineligible_dollar_volume;
+        self.corrected_trades += other.corrected_trades;
+        self.corrected_dollar_volume += other.corrected_dollar_volume;
+        self.non_market_price_trades += other.non_market_price_trades;
+        self.non_market_price_dollar_volume += other.non_market_price_dollar_volume;
+        self.unresolved_condition_trades += other.unresolved_condition_trades;
+    }
+}
+
+/// One bar's worth of printed trades, counting only what the eligibility policy admits.
+///
+/// `volume` and `dollar_volume` are the eligible tape, not the whole of it; [`TradeSummary::
+/// exclusions`] says what was left out. A reader that wants the raw total must add them back
+/// deliberately rather than by default.
+#[derive(Debug, Clone)]
+pub struct TradeSummary {
+    ticker: Ticker,
+    bar_interval: BarInterval,
+    /// UTC timestamp of the period this summary opens, matching the bar it describes.
+    timestamp: DateTime<Utc>,
+    trade_count: i64,
+    /// Shares, fractional: 16.5% of a session's prints are not whole shares.
+    volume: f64,
+    dollar_volume: f64,
+    volume_weighted_average_price: f64,
+    median_trade_size: f64,
+    ninetieth_percentile_trade_size: f64,
+    /// Buys minus sells in shares, signed by the tick rule — a trade above the previous price is a
+    /// buy, below is a sell, equal inherits the last non-zero direction.
+    signed_volume: f64,
+    exclusions: TradeExclusions,
+}
+
+impl TradeSummary {
+    /// Constructs a `TradeSummary`, rejecting a bar that cannot have come from real prints.
+    ///
+    /// A bar nothing eligible traded in has no summary rather than a zero-volume one, so `volume`
+    /// must be positive. The exclusions may still be non-zero on such a bar, which is why a bar of
+    /// nothing but auction prints is absent here and visible in the daily row that absorbs it.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        ticker: Ticker,
+        bar_interval: BarInterval,
+        timestamp: DateTime<Utc>,
+        trade_count: i64,
+        volume: f64,
+        dollar_volume: f64,
+        median_trade_size: f64,
+        ninetieth_percentile_trade_size: f64,
+        signed_volume: f64,
+        exclusions: TradeExclusions,
+    ) -> Result<Self, InconsistentRecordError> {
+        for (name, value) in [("volume", volume), ("dollar volume", dollar_volume)] {
+            if !value.is_finite() || value <= 0.0 {
+                return Err(reject(format!("{name} {value} is not a positive number")));
+            }
+        }
+        for (name, value) in [
+            ("median trade size", median_trade_size),
+            (
+                "ninetieth percentile trade size",
+                ninetieth_percentile_trade_size,
+            ),
+        ] {
+            if !value.is_finite() || value < 0.0 {
+                return Err(reject(format!(
+                    "{name} {value} is not a non-negative number"
+                )));
+            }
+        }
+        if median_trade_size > ninetieth_percentile_trade_size {
+            return Err(reject(format!(
+                "median trade size {median_trade_size} exceeds the ninetieth percentile {ninetieth_percentile_trade_size}"
+            )));
+        }
+        if trade_count <= 0 {
+            return Err(reject(format!(
+                "trade count {trade_count} is not a positive number"
+            )));
+        }
+        // Signed volume is buys minus sells drawn from the same shares, so it cannot exceed them.
+        // A violation means the tick rule and the volume accumulator saw different trades.
+        if !signed_volume.is_finite() || signed_volume.abs() > volume {
+            return Err(reject(format!(
+                "signed volume {signed_volume} exceeds the {volume} shares it is drawn from"
+            )));
+        }
+        Ok(Self {
+            ticker,
+            bar_interval,
+            timestamp,
+            trade_count,
+            volume,
+            dollar_volume,
+            // Divided here rather than passed in, so the identity cannot be violated by a caller.
+            volume_weighted_average_price: dollar_volume / volume,
+            median_trade_size,
+            ninetieth_percentile_trade_size,
+            signed_volume,
+            exclusions,
+        })
+    }
+
+    pub fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    pub fn bar_interval(&self) -> BarInterval {
+        self.bar_interval
+    }
+
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
+    }
+
+    pub fn trade_count(&self) -> i64 {
+        self.trade_count
+    }
+
+    pub fn volume(&self) -> f64 {
+        self.volume
+    }
+
+    pub fn dollar_volume(&self) -> f64 {
+        self.dollar_volume
+    }
+
+    pub fn volume_weighted_average_price(&self) -> f64 {
+        self.volume_weighted_average_price
+    }
+
+    pub fn median_trade_size(&self) -> f64 {
+        self.median_trade_size
+    }
+
+    pub fn ninetieth_percentile_trade_size(&self) -> f64 {
+        self.ninetieth_percentile_trade_size
+    }
+
+    pub fn signed_volume(&self) -> f64 {
+        self.signed_volume
+    }
+
+    pub fn exclusions(&self) -> TradeExclusions {
+        self.exclusions
+    }
+}
+
 /// The most recent trade in a symbol, as one snapshot reported it.
 ///
 /// The timestamp is not optional because the last trade is what the pass prices on whenever the

--- a/src/data.rs
+++ b/src/data.rs
@@ -15,6 +15,7 @@ pub mod export;
 pub mod purge;
 pub mod quotes;
 pub mod splits;
+pub mod trades;
 pub mod truncate;
 pub mod universe;
 

--- a/src/data/conditions.rs
+++ b/src/data/conditions.rs
@@ -43,25 +43,6 @@ pub enum Eligibility {
     Ambiguous,
 }
 
-/// The rule a trade was excluded under, which the archive carries per bar.
-///
-/// Split by *whose* rule it is. The provider publishes no spread-eligibility flag, so
-/// [`Exclusion::HouseSpreadRule`] is our judgment and is labelled as ours — a reader who disagrees
-/// with it should be able to see they are disagreeing with us rather than with the SIP.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Exclusion {
-    /// The provider's own `updates_volume` said no.
-    ProviderVolumeRule,
-    /// The provider corrected or busted the print.
-    ProviderCorrection,
-    /// Priced away from the market at the moment it printed, so no spread can be read off it.
-    HouseSpreadRule,
-    /// No size, so it can weigh nothing and would divide by zero.
-    HouseZeroSize,
-    /// A code this table does not carry. Counted rather than dropped, and never disqualifying.
-    UnresolvedCode,
-}
-
 /// Conditions whose price is not a market price at the instant they printed.
 ///
 /// Ours, not the provider's — both are volume-eligible and belong in VWAP. An average-price trade

--- a/src/data/trades.rs
+++ b/src/data/trades.rs
@@ -81,8 +81,10 @@ impl TradeAccumulator {
         self.exclusions.absorb(other.exclusions);
     }
 
-    /// Reduces the bar to a summary, or `None` when nothing eligible traded in it.
+    /// Reduces the bar to a summary, or `None` when the tape held nothing here at all.
     ///
+    /// A bar that admitted no eligible print but excluded one is still a row: that is the case the
+    /// exclusion columns exist for, and an auction-only bar would otherwise leave no trace anywhere.
     /// Sorts in place, so the sizes are left ordered for whoever absorbs them.
     fn summarize(
         &mut self,
@@ -90,7 +92,8 @@ impl TradeAccumulator {
         bar_interval: BarInterval,
         timestamp: DateTime<Utc>,
     ) -> Option<TradeSummary> {
-        if self.trade_count == 0 || self.volume <= 0.0 {
+        let excluded_something = self.exclusions != TradeExclusions::default();
+        if self.trade_count == 0 && !excluded_something {
             return None;
         }
         self.sizes.sort_unstable_by(f64::total_cmp);
@@ -102,8 +105,9 @@ impl TradeAccumulator {
             self.trade_count,
             self.volume,
             self.dollar_volume,
-            quantile(&self.sizes, 0.5)?,
-            quantile(&self.sizes, UPPER_QUANTILE)?,
+            // Zero on an exclusion-only bar, where no eligible print has a size to report.
+            quantile(&self.sizes, 0.5).unwrap_or(0.0),
+            quantile(&self.sizes, UPPER_QUANTILE).unwrap_or(0.0),
             self.signed_volume,
             self.exclusions,
         );
@@ -143,6 +147,8 @@ pub struct SessionFold {
     previous_price: Option<f64>,
     /// The direction an unchanged price inherits, per the tick rule's zero-tick convention.
     previous_direction: f64,
+    /// The last stamp accepted, which is what an inverted print is judged against.
+    previous_timestamp: Option<DateTime<Utc>>,
     out_of_order: usize,
 }
 
@@ -168,6 +174,7 @@ impl SessionFold {
             buckets: (0..buckets).map(|_| TradeAccumulator::default()).collect(),
             previous_price: None,
             previous_direction: 1.0,
+            previous_timestamp: None,
             out_of_order: 0,
         })
     }
@@ -175,8 +182,20 @@ impl SessionFold {
     /// Accepts the next print, applying the eligibility policy before it can weigh anything.
     ///
     /// Exclusions are recorded against the bucket the print fell in, so a bar says what it dropped
-    /// even when it admits nothing — a session whose only prints were the auction is visible.
+    /// even when it admits nothing — a bar whose only prints were the auction is still a row.
     pub fn push(&mut self, tick: TradeTick) {
+        // A print older than the one before it is dropped rather than signed. The file is only
+        // *mostly* ascending — `require_ascending` tolerates a minority of SIP reorderings — and an
+        // inverted print would still set `previous_price`, making the tick rule read a sequence the
+        // tape never printed. Only the sign is affected, which is why it needs counting to be seen.
+        if let Some(previous) = self.previous_timestamp {
+            if tick.timestamp() < previous {
+                self.out_of_order += 1;
+                return;
+            }
+        }
+        self.previous_timestamp = Some(tick.timestamp());
+
         let Some(index) = self.bucket_index(tick.timestamp()) else {
             return;
         };
@@ -340,14 +359,21 @@ pub struct MarketFold {
 }
 
 impl MarketFold {
-    /// Opens a fold over one session's regular hours.
+    /// Opens a fold over one session's regular hours, or `None` if that span is not positive.
+    ///
+    /// Refused here rather than left to the per-name folds. Each of those would return `None`
+    /// separately, `push` would count every print as folded, and `finish` would return no rows and
+    /// no warning — a session that reports its whole cost and produces nothing, silently.
     pub fn new(
         session: SessionDate,
         open: DateTime<Utc>,
         close: DateTime<Utc>,
         universe: BTreeSet<Ticker>,
-    ) -> Self {
-        Self {
+    ) -> Option<Self> {
+        if (close - open).num_milliseconds() <= 0 {
+            return None;
+        }
+        Some(Self {
             session,
             open,
             close,
@@ -356,7 +382,7 @@ impl MarketFold {
             resumed: BTreeSet::new(),
             universe,
             folded: 0,
-        }
+        })
     }
 
     /// Prints folded, which is this pass's cost.
@@ -416,6 +442,7 @@ impl MarketFold {
         let summaries = parked.into_values().flat_map(SessionFold::finish).collect();
         SessionFolded {
             summaries,
+            folded: self.folded,
             resumed: self.resumed,
             seen,
         }
@@ -425,6 +452,8 @@ impl MarketFold {
 /// What one session's trade file yielded.
 pub struct SessionFolded {
     pub summaries: Vec<TradeSummary>,
+    /// Prints belonging to the universe, which is what the pass reports as its cost.
+    pub folded: usize,
     pub resumed: BTreeSet<Ticker>,
     pub seen: usize,
 }
@@ -474,12 +503,14 @@ pub fn summaries_to_dataframe(summaries: &[TradeSummary]) -> Result<DataFrame, P
             "dollar_volume",
             summaries.iter().map(TradeSummary::dollar_volume).collect(),
         ),
-        column(
-            "volume_weighted_average_price",
+        // Null rather than zero on an exclusion-only bar: no eligible share traded, so there is no
+        // price it traded at, and a zero would average into a reader's own aggregate as if real.
+        Column::new(
+            "volume_weighted_average_price".into(),
             summaries
                 .iter()
                 .map(TradeSummary::volume_weighted_average_price)
-                .collect(),
+                .collect::<Vec<Option<f64>>>(),
         ),
         column(
             "median_trade_size",
@@ -643,7 +674,7 @@ mod tests {
         let summaries = fold_of(vec![trade(30, 100.0, 100.0), trade(31, 200.0, 300.0)]);
         let daily = rows(&summaries, BarInterval::OneDay);
         // 100*100 + 200*300 = 70,000 over 400 shares. A size-blind mean would read 150.
-        assert_eq!(daily[0].volume_weighted_average_price(), 175.0);
+        assert_eq!(daily[0].volume_weighted_average_price(), Some(175.0));
     }
 
     /// The auction prints are counted and excluded, and the bar says so.
@@ -751,6 +782,29 @@ mod tests {
     /// The frame is pinned to its declared column set and order.
     #[test]
     fn test_the_frame_column_set_and_order_is_fixed() {
+        // Written out rather than read off `TRADE_FRAME_COLUMNS`, which is half of what this
+        // protects: an edit that moved the constant and the builder together would otherwise change
+        // the archive's wire schema against a green test.
+        let expected: [(&str, DataType); 17] = [
+            ("ticker", DataType::String),
+            ("bar_interval", DataType::String),
+            ("timestamp", DataType::Int64),
+            ("trade_count", DataType::Int64),
+            ("volume", DataType::Float64),
+            ("dollar_volume", DataType::Float64),
+            ("volume_weighted_average_price", DataType::Float64),
+            ("median_trade_size", DataType::Float64),
+            ("ninetieth_percentile_trade_size", DataType::Float64),
+            ("signed_volume", DataType::Float64),
+            ("volume_ineligible_trades", DataType::Int64),
+            ("volume_ineligible_dollar_volume", DataType::Float64),
+            ("corrected_trades", DataType::Int64),
+            ("corrected_dollar_volume", DataType::Float64),
+            ("non_market_price_trades", DataType::Int64),
+            ("non_market_price_dollar_volume", DataType::Float64),
+            ("unresolved_condition_trades", DataType::Int64),
+        ];
+
         let summaries = fold_of(vec![trade(30, 100.0, 100.0)]);
         let frame = summaries_to_dataframe(&summaries).expect("a frame");
         let observed: Vec<(String, DataType)> = frame
@@ -758,11 +812,168 @@ mod tests {
             .iter()
             .map(|column| (column.name().to_string(), column.dtype().clone()))
             .collect();
-        let expected: Vec<(String, DataType)> = TRADE_FRAME_COLUMNS
+
+        let literal: Vec<(String, DataType)> = expected
             .iter()
             .map(|(name, dtype)| (name.to_string(), dtype.clone()))
             .collect();
-        assert_eq!(observed, expected);
+        assert_eq!(observed, literal, "the builder matches the literal schema");
+        // And the declared constant matches it too, so the two cannot drift apart in step.
+        let declared: Vec<(String, DataType)> = TRADE_FRAME_COLUMNS
+            .iter()
+            .map(|(name, dtype)| (name.to_string(), dtype.clone()))
+            .collect();
+        assert_eq!(declared, literal, "the constant matches the literal schema");
+    }
+
+    /// An exclusion-only bar is a row, because that is the case the columns exist for.
+    ///
+    /// A name whose whole session was the closing auction would otherwise vanish from the archive
+    /// entirely, taking with it the only record that 14% of a session's dollar volume was dropped.
+    #[test]
+    fn test_a_bar_with_only_excluded_prints_is_still_a_row() {
+        let summaries = fold_of(vec![marked(30, 100.0, 1_000.0, vec![16], false)]);
+        let daily = rows(&summaries, BarInterval::OneDay);
+        assert_eq!(daily.len(), 1, "the session is recorded, not dropped");
+        assert_eq!(daily[0].trade_count(), 0);
+        assert_eq!(daily[0].volume(), 0.0);
+        assert_eq!(
+            daily[0].volume_weighted_average_price(),
+            None,
+            "no eligible share traded, so there is no price it traded at"
+        );
+        assert_eq!(daily[0].exclusions().volume_ineligible_trades, 1);
+        assert_eq!(
+            daily[0].exclusions().volume_ineligible_dollar_volume,
+            100_000.0
+        );
+        assert_eq!(rows(&summaries, BarInterval::OneMinute).len(), 1);
+    }
+
+    /// A print older than the one before it is dropped rather than signed against a later price.
+    ///
+    /// The flat file is only mostly ascending — `require_ascending` tolerates a minority of SIP
+    /// reorderings — so an inversion reaches this fold and must not corrupt the tick rule.
+    #[test]
+    fn test_a_print_older_than_the_one_before_it_is_dropped() {
+        let summaries = fold_of(vec![
+            trade(30, 100.0, 100.0),
+            trade(32, 105.0, 100.0),
+            // Older than its predecessor: dropped, and must not become the reference price.
+            trade(31, 90.0, 100.0),
+            trade(33, 106.0, 100.0),
+        ]);
+        let daily = rows(&summaries, BarInterval::OneDay);
+        assert_eq!(
+            daily[0].trade_count(),
+            3,
+            "the inverted print is not folded"
+        );
+        assert_eq!(daily[0].volume(), 300.0);
+        // 106 is an uptick against 105, not against the dropped 90. All three are buys.
+        assert_eq!(daily[0].signed_volume(), 300.0);
+    }
+
+    /// The short trailing bar an early close leaves is emitted rather than dropped.
+    ///
+    /// Seven minutes, so the last five-minute bar holds only two: the branch every other test in
+    /// this module misses, because a ten-minute window divides evenly.
+    #[test]
+    fn test_a_window_that_does_not_divide_evenly_keeps_its_short_last_bar() {
+        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(37, 0))
+            .expect("a positive session");
+        fold.push(trade(30, 100.0, 100.0));
+        fold.push(trade(36, 100.0, 200.0));
+        let summaries = fold.finish();
+
+        let fives = rows(&summaries, BarInterval::FiveMinute);
+        assert_eq!(fives.len(), 2, "13:30-13:35 and the short 13:35-13:37");
+        assert_eq!(fives[0].volume(), 100.0);
+        assert_eq!(fives[1].volume(), 200.0, "the tail is not lost");
+        assert_eq!(rows(&summaries, BarInterval::OneDay)[0].volume(), 300.0);
+    }
+
+    /// The daily row is stamped at 16:00 Eastern, crossing the timezone boundary properly.
+    ///
+    /// Pinned to 20:00 UTC because 2026-08-20 is daylight saving; the winter stamp is 21:00, and a
+    /// fold that used a fixed offset would put the row an hour from the bar it must join.
+    #[test]
+    fn test_the_session_row_is_stamped_where_the_daily_bar_is() {
+        let summaries = fold_of(vec![trade(30, 100.0, 100.0)]);
+        let daily = rows(&summaries, BarInterval::OneDay);
+        assert_eq!(
+            daily[0].timestamp().to_rfc3339(),
+            "2026-08-20T20:00:00+00:00"
+        );
+
+        let winter =
+            SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 1, 15).expect("a real date"));
+        assert_eq!(
+            daily_stamp(winter).to_rfc3339(),
+            "2026-01-15T21:00:00+00:00",
+            "outside daylight saving the same 16:00 Eastern is an hour later in UTC"
+        );
+    }
+
+    /// A name whose rows arrive in two runs resumes its own fold rather than opening a second.
+    ///
+    /// The case the whole `MarketFold` shape exists for: two names a session arrive split, and
+    /// folding the runs apart would report the name twice with half its tape each.
+    #[test]
+    fn test_a_split_name_resumes_its_own_fold() {
+        let universe: BTreeSet<Ticker> = ["AAPL", "CBOE"]
+            .iter()
+            .map(|name| Ticker::new(name).expect("a valid ticker"))
+            .collect();
+        let mut fold =
+            MarketFold::new(session(), at(30, 0), at(40, 0), universe).expect("a positive session");
+        let named = |name: &str| Ticker::new(name).expect("a valid ticker");
+
+        fold.push(named("AAPL"), trade(30, 100.0, 100.0));
+        fold.push(named("CBOE"), trade(31, 200.0, 50.0));
+        // AAPL comes back after CBOE's run, which is the split this holds folds open for.
+        fold.push(named("AAPL"), trade(32, 101.0, 300.0));
+        // Outside the universe, so never folded at all.
+        fold.push(named("AAPL"), trade(33, 101.0, 1.0));
+
+        let folded = fold.finish();
+        assert!(folded.resumed.contains(&named("AAPL")), "AAPL was resumed");
+        assert_eq!(folded.seen, 2, "two names carried rows");
+
+        let apple: Vec<&TradeSummary> = folded
+            .summaries
+            .iter()
+            .filter(|row| {
+                row.ticker().as_str() == "AAPL" && row.bar_interval() == BarInterval::OneDay
+            })
+            .collect();
+        assert_eq!(apple.len(), 1, "one daily row, not one per run");
+        assert_eq!(apple[0].volume(), 401.0, "both runs in a single fold");
+    }
+
+    /// A name outside the universe is not folded, however many rows the file carries for it.
+    #[test]
+    fn test_a_name_outside_the_universe_is_not_folded() {
+        let universe: BTreeSet<Ticker> = std::iter::once(ticker()).collect();
+        let mut fold =
+            MarketFold::new(session(), at(30, 0), at(40, 0), universe).expect("a positive session");
+        fold.push(
+            Ticker::new("CBOE").expect("a valid ticker"),
+            trade(30, 200.0, 50.0),
+        );
+        let folded = fold.finish();
+        assert_eq!(folded.folded, 0, "nothing in the universe was pushed");
+        assert!(folded.summaries.is_empty());
+    }
+
+    /// A market fold refuses a span its per-name folds would each refuse separately.
+    ///
+    /// Without this it would report every print as folded and return no rows, with nothing logged.
+    #[test]
+    fn test_a_market_fold_refuses_a_session_with_no_span() {
+        let universe: BTreeSet<Ticker> = std::iter::once(ticker()).collect();
+        assert!(MarketFold::new(session(), at(40, 0), at(40, 0), universe.clone()).is_none());
+        assert!(MarketFold::new(session(), at(40, 0), at(30, 0), universe).is_none());
     }
 
     /// A session with no span is refused rather than folded into zero buckets.

--- a/src/data/trades.rs
+++ b/src/data/trades.rs
@@ -1,0 +1,774 @@
+//! The printed tape folded on ingest: trades in, one row per bar out.
+//!
+//! Eligibility is decided here, by [`crate::data::conditions`], because the fold cannot be undone.
+
+use std::collections::{BTreeSet, HashMap};
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use chrono_tz::America::New_York;
+use polars::prelude::*;
+use tracing::warn;
+
+use crate::common::alpaca::TradeTick;
+use crate::common::flatfiles::TradeSink;
+use crate::common::types::{
+    BarInterval, IntradayCadence, SessionDate, Ticker, TradeExclusions, TradeSummary,
+};
+use crate::data::conditions::{carries_a_market_price, volume_eligibility, Eligibility};
+
+/// The upper quantile every summary reports beside its median.
+const UPPER_QUANTILE: f64 = 0.9;
+
+/// The finest grid the fold accumulates on; the coarser cadences are merges of it.
+///
+/// Accumulating once and merging upward is what makes the three cadences agree by construction
+/// rather than by a second pass that could disagree.
+const BASE_CADENCE: IntradayCadence = IntradayCadence::OneMinute;
+
+/// The column set and order every trade partition is written in.
+pub const TRADE_FRAME_COLUMNS: [(&str, DataType); 17] = [
+    ("ticker", DataType::String),
+    ("bar_interval", DataType::String),
+    ("timestamp", DataType::Int64),
+    ("trade_count", DataType::Int64),
+    ("volume", DataType::Float64),
+    ("dollar_volume", DataType::Float64),
+    ("volume_weighted_average_price", DataType::Float64),
+    ("median_trade_size", DataType::Float64),
+    ("ninetieth_percentile_trade_size", DataType::Float64),
+    ("signed_volume", DataType::Float64),
+    ("volume_ineligible_trades", DataType::Int64),
+    ("volume_ineligible_dollar_volume", DataType::Float64),
+    ("corrected_trades", DataType::Int64),
+    ("corrected_dollar_volume", DataType::Float64),
+    ("non_market_price_trades", DataType::Int64),
+    ("non_market_price_dollar_volume", DataType::Float64),
+    ("unresolved_condition_trades", DataType::Int64),
+];
+
+/// One bar's worth of printed tape, counting only what the policy admits.
+#[derive(Debug, Default)]
+struct TradeAccumulator {
+    trade_count: i64,
+    volume: f64,
+    dollar_volume: f64,
+    signed_volume: f64,
+    /// Every eligible print's size, which the quantiles are read off. Held rather than summarised
+    /// because a five-minute median is not derivable from five one-minute medians.
+    sizes: Vec<f64>,
+    exclusions: TradeExclusions,
+}
+
+impl TradeAccumulator {
+    /// Records an eligible print, signed by `direction`.
+    fn add(&mut self, tick: &TradeTick, direction: f64) {
+        self.trade_count += 1;
+        self.volume += tick.size();
+        self.dollar_volume += tick.notional();
+        self.signed_volume += direction * tick.size();
+        self.sizes.push(tick.size());
+    }
+
+    /// Takes everything `other` accumulated, consuming it.
+    ///
+    /// By value rather than by `&mut`, so a bar cannot be absorbed twice and double-count itself.
+    fn absorb(&mut self, mut other: Self) {
+        self.trade_count += other.trade_count;
+        self.volume += other.volume;
+        self.dollar_volume += other.dollar_volume;
+        self.signed_volume += other.signed_volume;
+        self.sizes.append(&mut other.sizes);
+        self.exclusions.absorb(other.exclusions);
+    }
+
+    /// Reduces the bar to a summary, or `None` when nothing eligible traded in it.
+    ///
+    /// Sorts in place, so the sizes are left ordered for whoever absorbs them.
+    fn summarize(
+        &mut self,
+        ticker: &Ticker,
+        bar_interval: BarInterval,
+        timestamp: DateTime<Utc>,
+    ) -> Option<TradeSummary> {
+        if self.trade_count == 0 || self.volume <= 0.0 {
+            return None;
+        }
+        self.sizes.sort_unstable_by(f64::total_cmp);
+
+        let summary = TradeSummary::new(
+            ticker.clone(),
+            bar_interval,
+            timestamp,
+            self.trade_count,
+            self.volume,
+            self.dollar_volume,
+            quantile(&self.sizes, 0.5)?,
+            quantile(&self.sizes, UPPER_QUANTILE)?,
+            self.signed_volume,
+            self.exclusions,
+        );
+        match summary {
+            Ok(summary) => Some(summary),
+            // A fold that cannot make a coherent summary is this module's bug, not the tape's, and
+            // dropping the bar keeps one arithmetic slip from poisoning a whole session's archive.
+            Err(error) => {
+                warn!(%ticker, %bar_interval, %timestamp, %error, "Discarded an incoherent trade fold");
+                None
+            }
+        }
+    }
+}
+
+/// The size at or below which `quantile` of the bar's prints fell.
+///
+/// No interpolation: the reported figure is a size that actually printed. `sizes` must be sorted.
+fn quantile(sizes: &[f64], quantile: f64) -> Option<f64> {
+    if sizes.is_empty() {
+        return None;
+    }
+    let index = ((sizes.len() as f64 - 1.0) * quantile).round() as usize;
+    sizes.get(index).copied()
+}
+
+/// Accumulates one name's session onto a one-minute grid and the coarser bars it merges into.
+///
+/// Fed print by print and never holding them beyond their size, which the quantiles need.
+pub struct SessionFold {
+    ticker: Ticker,
+    session: SessionDate,
+    open: DateTime<Utc>,
+    close: DateTime<Utc>,
+    buckets: Vec<TradeAccumulator>,
+    /// The last price that moved, which the tick rule signs against.
+    previous_price: Option<f64>,
+    /// The direction an unchanged price inherits, per the tick rule's zero-tick convention.
+    previous_direction: f64,
+    out_of_order: usize,
+}
+
+impl SessionFold {
+    /// Opens a fold over `[open, close)`, which must be a positive interval.
+    pub fn new(
+        ticker: Ticker,
+        session: SessionDate,
+        open: DateTime<Utc>,
+        close: DateTime<Utc>,
+    ) -> Option<Self> {
+        let span = (close - open).num_milliseconds();
+        if span <= 0 {
+            return None;
+        }
+        let bucket_milliseconds = BASE_CADENCE.seconds() * 1_000;
+        let buckets = ((span + bucket_milliseconds - 1) / bucket_milliseconds) as usize;
+        Some(Self {
+            ticker,
+            session,
+            open,
+            close,
+            buckets: (0..buckets).map(|_| TradeAccumulator::default()).collect(),
+            previous_price: None,
+            previous_direction: 1.0,
+            out_of_order: 0,
+        })
+    }
+
+    /// Accepts the next print, applying the eligibility policy before it can weigh anything.
+    ///
+    /// Exclusions are recorded against the bucket the print fell in, so a bar says what it dropped
+    /// even when it admits nothing — a session whose only prints were the auction is visible.
+    pub fn push(&mut self, tick: TradeTick) {
+        let Some(index) = self.bucket_index(tick.timestamp()) else {
+            return;
+        };
+        // Signed before any exclusion test: the tick rule reads the tape as printed, and skipping
+        // an ineligible print would make the next one's direction depend on the policy.
+        let direction = self.direction_of(&tick);
+
+        let bucket = &mut self.buckets[index];
+        if tick.corrected() {
+            bucket.exclusions.corrected_trades += 1;
+            bucket.exclusions.corrected_dollar_volume += tick.notional();
+            return;
+        }
+        match volume_eligibility(tick.conditions()) {
+            Eligibility::Ineligible => {
+                bucket.exclusions.volume_ineligible_trades += 1;
+                bucket.exclusions.volume_ineligible_dollar_volume += tick.notional();
+                return;
+            }
+            // Counted and still folded: an unknown code is likelier to be a namespace this table
+            // does not cover than a volume rule the provider forgot to publish.
+            Eligibility::Ambiguous => bucket.exclusions.unresolved_condition_trades += 1,
+            Eligibility::Eligible => {}
+        }
+        if !carries_a_market_price(tick.conditions()) {
+            bucket.exclusions.non_market_price_trades += 1;
+            bucket.exclusions.non_market_price_dollar_volume += tick.notional();
+        }
+        bucket.add(&tick, direction);
+    }
+
+    /// The tick rule's verdict on this print, updating the state it carries forward.
+    ///
+    /// An unchanged price inherits the last direction rather than counting as neither, which is what
+    /// makes signed volume sum to something other than noise on a name that prints flat.
+    fn direction_of(&mut self, tick: &TradeTick) -> f64 {
+        let direction = match self.previous_price {
+            Some(previous) if tick.price() > previous => 1.0,
+            Some(previous) if tick.price() < previous => -1.0,
+            Some(_) => self.previous_direction,
+            // The session's first print has nothing to compare against; treated as a buy by
+            // convention, and one print cannot move a bar of any size.
+            None => 1.0,
+        };
+        self.previous_price = Some(tick.price());
+        self.previous_direction = direction;
+        direction
+    }
+
+    /// Closes the fold, returning one-minute, five-minute and session rows in that order.
+    ///
+    /// The coarser bars are merges of the finer ones rather than separate accumulations, so all
+    /// three describe the same tape by construction.
+    pub fn finish(mut self) -> Vec<TradeSummary> {
+        if self.out_of_order > 0 {
+            warn!(
+                ticker = %self.ticker,
+                session = %self.session,
+                out_of_order = self.out_of_order,
+                "Dropped trades that arrived older than the one before them"
+            );
+        }
+
+        let minutes = std::mem::take(&mut self.buckets);
+        let per_five_minutes =
+            (IntradayCadence::FiveMinute.seconds() / BASE_CADENCE.seconds()).max(1) as usize;
+
+        let mut summaries =
+            Vec::with_capacity(minutes.len() + minutes.len() / per_five_minutes + 1);
+        let mut session = TradeAccumulator::default();
+        let mut five_minute = TradeAccumulator::default();
+        let mut five_minute_index = 0usize;
+
+        for (index, mut minute) in minutes.into_iter().enumerate() {
+            let opens_at = self.open + Duration::seconds(BASE_CADENCE.seconds() * index as i64);
+            if let Some(summary) = minute.summarize(&self.ticker, BarInterval::OneMinute, opens_at)
+            {
+                summaries.push(summary);
+            }
+            five_minute.absorb(minute);
+
+            let closes_the_five = (index + 1) % per_five_minutes == 0;
+            if closes_the_five {
+                let opens_at = self.open
+                    + Duration::seconds(
+                        IntradayCadence::FiveMinute.seconds() * five_minute_index as i64,
+                    );
+                let mut bar = std::mem::take(&mut five_minute);
+                if let Some(summary) =
+                    bar.summarize(&self.ticker, BarInterval::FiveMinute, opens_at)
+                {
+                    summaries.push(summary);
+                }
+                session.absorb(bar);
+                five_minute_index += 1;
+            }
+        }
+        // A session whose length is not a multiple of five minutes leaves a short last bar, which is
+        // emitted rather than dropped — an early close is 3.5 hours and would otherwise lose its tail.
+        if five_minute.trade_count > 0 || five_minute.exclusions != TradeExclusions::default() {
+            let opens_at = self.open
+                + Duration::seconds(
+                    IntradayCadence::FiveMinute.seconds() * five_minute_index as i64,
+                );
+            if let Some(summary) =
+                five_minute.summarize(&self.ticker, BarInterval::FiveMinute, opens_at)
+            {
+                summaries.push(summary);
+            }
+            session.absorb(five_minute);
+        }
+
+        summaries.extend(session.summarize(
+            &self.ticker,
+            BarInterval::OneDay,
+            daily_stamp(self.session),
+        ));
+        summaries
+    }
+
+    /// Which bucket an instant falls in, or `None` outside the session.
+    fn bucket_index(&self, instant: DateTime<Utc>) -> Option<usize> {
+        if instant < self.open || instant >= self.close {
+            return None;
+        }
+        let offset = (instant - self.open).num_milliseconds() / (BASE_CADENCE.seconds() * 1_000);
+        let index = usize::try_from(offset).ok()?;
+        (index < self.buckets.len()).then_some(index)
+    }
+}
+
+/// The instant the archive stamps a session's daily row at, which is 16:00 Eastern.
+///
+/// Matches [`crate::data::quotes`] deliberately: a trade row and a quote row for the same session
+/// must join, and an early close still carries a 16:00 stamp in the daily bar archive.
+fn daily_stamp(session: SessionDate) -> DateTime<Utc> {
+    let local_close = session
+        .date()
+        .and_hms_opt(16, 0, 0)
+        .expect("16:00 is a valid wall-clock time");
+    New_York
+        .from_local_datetime(&local_close)
+        .earliest()
+        .map(|zoned| zoned.with_timezone(&Utc))
+        .unwrap_or_else(|| local_close.and_utc())
+}
+
+/// Folds a whole session out of one ticker-major flat file, resuming a name that comes back.
+///
+/// The same shape as [`crate::data::quotes::MarketFold`] and for the same reason: two names a
+/// session arrive in more than one run, and a released fold cannot take the second.
+pub struct MarketFold {
+    session: SessionDate,
+    open: DateTime<Utc>,
+    close: DateTime<Utc>,
+    current: Option<(Ticker, SessionFold)>,
+    parked: HashMap<Ticker, SessionFold>,
+    resumed: BTreeSet<Ticker>,
+    universe: BTreeSet<Ticker>,
+    folded: usize,
+}
+
+impl MarketFold {
+    /// Opens a fold over one session's regular hours.
+    pub fn new(
+        session: SessionDate,
+        open: DateTime<Utc>,
+        close: DateTime<Utc>,
+        universe: BTreeSet<Ticker>,
+    ) -> Self {
+        Self {
+            session,
+            open,
+            close,
+            current: None,
+            parked: HashMap::new(),
+            resumed: BTreeSet::new(),
+            universe,
+            folded: 0,
+        }
+    }
+
+    /// Prints folded, which is this pass's cost.
+    pub fn folded(&self) -> usize {
+        self.folded
+    }
+
+    /// Accepts the next row of the file, which carries its own ticker.
+    pub fn push(&mut self, ticker: Ticker, tick: TradeTick) {
+        if !self.universe.contains(&ticker) {
+            return;
+        }
+        self.folded += 1;
+        let same = matches!(&self.current, Some((open, _)) if *open == ticker);
+        if !same {
+            self.rotate(ticker);
+        }
+        if let Some((_, fold)) = self.current.as_mut() {
+            fold.push(tick);
+        }
+    }
+
+    /// Parks the run in progress and takes up `ticker`, resuming its fold if it already has one.
+    fn rotate(&mut self, ticker: Ticker) {
+        if let Some((held, fold)) = self.current.take() {
+            self.parked.insert(held, fold);
+        }
+        let fold = match self.parked.remove(&ticker) {
+            Some(fold) => {
+                self.resumed.insert(ticker.clone());
+                Some(fold)
+            }
+            None => SessionFold::new(ticker.clone(), self.session, self.open, self.close),
+        };
+        self.current = fold.map(|fold| (ticker, fold));
+    }
+
+    /// Closes every fold and reports what the session yielded.
+    pub fn finish(mut self) -> SessionFolded {
+        if let Some((held, fold)) = self.current.take() {
+            self.parked.insert(held, fold);
+        }
+        if !self.resumed.is_empty() {
+            warn!(
+                session = %self.session,
+                names = %self
+                    .resumed
+                    .iter()
+                    .map(|ticker| ticker.as_str())
+                    .collect::<Vec<_>>()
+                    .join(","),
+                "Resumed names whose trades arrived in more than one run"
+            );
+        }
+        let parked = std::mem::take(&mut self.parked);
+        let seen = parked.len();
+        let summaries = parked.into_values().flat_map(SessionFold::finish).collect();
+        SessionFolded {
+            summaries,
+            resumed: self.resumed,
+            seen,
+        }
+    }
+}
+
+/// What one session's trade file yielded.
+pub struct SessionFolded {
+    pub summaries: Vec<TradeSummary>,
+    pub resumed: BTreeSet<Ticker>,
+    pub seen: usize,
+}
+
+impl TradeSink for MarketFold {
+    fn push(&mut self, ticker: Ticker, tick: TradeTick) {
+        MarketFold::push(self, ticker, tick)
+    }
+}
+
+/// Builds the canonical trade frame, in [`TRADE_FRAME_COLUMNS`] order.
+pub fn summaries_to_dataframe(summaries: &[TradeSummary]) -> Result<DataFrame, PolarsError> {
+    let column = |name: &str, values: Vec<f64>| Column::new(name.into(), values);
+    let counted = |name: &str, values: Vec<i64>| Column::new(name.into(), values);
+
+    DataFrame::new(vec![
+        Column::new(
+            "ticker".into(),
+            summaries
+                .iter()
+                .map(|row| row.ticker().to_string())
+                .collect::<Vec<_>>(),
+        ),
+        Column::new(
+            "bar_interval".into(),
+            summaries
+                .iter()
+                .map(|row| row.bar_interval().as_str().to_string())
+                .collect::<Vec<_>>(),
+        ),
+        counted(
+            "timestamp",
+            summaries
+                .iter()
+                .map(|row| row.timestamp().timestamp_millis())
+                .collect(),
+        ),
+        counted(
+            "trade_count",
+            summaries.iter().map(TradeSummary::trade_count).collect(),
+        ),
+        column(
+            "volume",
+            summaries.iter().map(TradeSummary::volume).collect(),
+        ),
+        column(
+            "dollar_volume",
+            summaries.iter().map(TradeSummary::dollar_volume).collect(),
+        ),
+        column(
+            "volume_weighted_average_price",
+            summaries
+                .iter()
+                .map(TradeSummary::volume_weighted_average_price)
+                .collect(),
+        ),
+        column(
+            "median_trade_size",
+            summaries
+                .iter()
+                .map(TradeSummary::median_trade_size)
+                .collect(),
+        ),
+        column(
+            "ninetieth_percentile_trade_size",
+            summaries
+                .iter()
+                .map(TradeSummary::ninetieth_percentile_trade_size)
+                .collect(),
+        ),
+        column(
+            "signed_volume",
+            summaries.iter().map(TradeSummary::signed_volume).collect(),
+        ),
+        counted(
+            "volume_ineligible_trades",
+            summaries
+                .iter()
+                .map(|row| row.exclusions().volume_ineligible_trades)
+                .collect(),
+        ),
+        column(
+            "volume_ineligible_dollar_volume",
+            summaries
+                .iter()
+                .map(|row| row.exclusions().volume_ineligible_dollar_volume)
+                .collect(),
+        ),
+        counted(
+            "corrected_trades",
+            summaries
+                .iter()
+                .map(|row| row.exclusions().corrected_trades)
+                .collect(),
+        ),
+        column(
+            "corrected_dollar_volume",
+            summaries
+                .iter()
+                .map(|row| row.exclusions().corrected_dollar_volume)
+                .collect(),
+        ),
+        counted(
+            "non_market_price_trades",
+            summaries
+                .iter()
+                .map(|row| row.exclusions().non_market_price_trades)
+                .collect(),
+        ),
+        column(
+            "non_market_price_dollar_volume",
+            summaries
+                .iter()
+                .map(|row| row.exclusions().non_market_price_dollar_volume)
+                .collect(),
+        ),
+        counted(
+            "unresolved_condition_trades",
+            summaries
+                .iter()
+                .map(|row| row.exclusions().unresolved_condition_trades)
+                .collect(),
+        ),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    fn ticker() -> Ticker {
+        Ticker::new("AAPL").expect("AAPL is a valid ticker")
+    }
+
+    fn session() -> SessionDate {
+        SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 8, 20).expect("a real date"))
+    }
+
+    /// 13:30 UTC through 13:40, ten minutes: two five-minute bars over ten one-minute ones.
+    fn at(minute: u32, second: u32) -> DateTime<Utc> {
+        session()
+            .date()
+            .and_hms_opt(13, minute, second)
+            .expect("a valid wall clock")
+            .and_utc()
+    }
+
+    fn trade(minute: u32, price: f64, size: f64) -> TradeTick {
+        TradeTick::new(at(minute, 0), price, size, Vec::new(), false).expect("a usable print")
+    }
+
+    fn marked(
+        minute: u32,
+        price: f64,
+        size: f64,
+        conditions: Vec<u32>,
+        corrected: bool,
+    ) -> TradeTick {
+        TradeTick::new(at(minute, 0), price, size, conditions, corrected).expect("a usable print")
+    }
+
+    fn fold_of(ticks: Vec<TradeTick>) -> Vec<TradeSummary> {
+        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(40, 0))
+            .expect("a positive session");
+        for tick in ticks {
+            fold.push(tick);
+        }
+        fold.finish()
+    }
+
+    fn rows(summaries: &[TradeSummary], interval: BarInterval) -> Vec<&TradeSummary> {
+        summaries
+            .iter()
+            .filter(|row| row.bar_interval() == interval)
+            .collect()
+    }
+
+    /// The property that makes three cadences safe to publish side by side.
+    ///
+    /// Pinned to literals — 600 shares, $60,150 — rather than to the finer rows' own sum, because an
+    /// assertion derived from the thing under test moves with it and can never fail.
+    #[test]
+    fn test_the_finer_bars_sum_back_to_the_coarser_ones() {
+        let summaries = fold_of(vec![
+            trade(30, 100.0, 100.0),
+            trade(32, 100.5, 200.0),
+            trade(36, 100.25, 300.0),
+        ]);
+
+        let daily = rows(&summaries, BarInterval::OneDay);
+        assert_eq!(daily.len(), 1);
+        assert_eq!(daily[0].volume(), 600.0);
+        assert_eq!(daily[0].trade_count(), 3);
+        assert_eq!(
+            daily[0].dollar_volume(),
+            100.0 * 100.0 + 100.5 * 200.0 + 100.25 * 300.0
+        );
+
+        let minutes = rows(&summaries, BarInterval::OneMinute);
+        assert_eq!(minutes.len(), 3, "one bar per minute that printed");
+        let minute_volume: f64 = minutes.iter().map(|row| row.volume()).sum();
+        assert_eq!(minute_volume, 600.0);
+
+        let fives = rows(&summaries, BarInterval::FiveMinute);
+        assert_eq!(fives.len(), 2, "13:30-13:35 and 13:35-13:40");
+        let five_volume: f64 = fives.iter().map(|row| row.volume()).sum();
+        assert_eq!(five_volume, 600.0);
+        assert_eq!(fives[0].volume(), 300.0, "the 13:30 and 13:32 prints");
+        assert_eq!(fives[1].volume(), 300.0, "the 13:36 print");
+    }
+
+    /// VWAP is the identity it claims, not a separately accumulated mean.
+    #[test]
+    fn test_the_average_price_is_dollar_volume_over_volume() {
+        let summaries = fold_of(vec![trade(30, 100.0, 100.0), trade(31, 200.0, 300.0)]);
+        let daily = rows(&summaries, BarInterval::OneDay);
+        // 100*100 + 200*300 = 70,000 over 400 shares. A size-blind mean would read 150.
+        assert_eq!(daily[0].volume_weighted_average_price(), 175.0);
+    }
+
+    /// The auction prints are counted and excluded, and the bar says so.
+    ///
+    /// Condition 16 is Market Center Official Open, which the provider marks volume-ineligible.
+    #[test]
+    fn test_a_volume_ineligible_print_is_excluded_and_recorded() {
+        let summaries = fold_of(vec![
+            marked(30, 100.0, 1_000_000.0, vec![16], false),
+            trade(31, 100.0, 100.0),
+        ]);
+        let daily = rows(&summaries, BarInterval::OneDay);
+        assert_eq!(daily[0].volume(), 100.0, "the auction is not in volume");
+        assert_eq!(daily[0].trade_count(), 1);
+        assert_eq!(daily[0].exclusions().volume_ineligible_trades, 1);
+        assert_eq!(
+            daily[0].exclusions().volume_ineligible_dollar_volume,
+            100_000_000.0
+        );
+    }
+
+    /// A corrected print is excluded before its conditions are even consulted.
+    #[test]
+    fn test_a_corrected_print_is_excluded_and_recorded() {
+        let summaries = fold_of(vec![
+            marked(30, 100.0, 5_000.0, vec![37], true),
+            trade(31, 100.0, 100.0),
+        ]);
+        let daily = rows(&summaries, BarInterval::OneDay);
+        assert_eq!(daily[0].volume(), 100.0);
+        assert_eq!(daily[0].exclusions().corrected_trades, 1);
+        assert_eq!(daily[0].exclusions().corrected_dollar_volume, 500_000.0);
+        assert_eq!(daily[0].exclusions().volume_ineligible_trades, 0);
+    }
+
+    /// An average-price print counts as volume and is flagged as not a market price.
+    ///
+    /// Both at once: the provider says it is volume, and the house rule says its price cannot be
+    /// differenced against a quote. Recording only one of those would lose the other.
+    #[test]
+    fn test_a_non_market_price_print_counts_as_volume_and_is_flagged() {
+        let summaries = fold_of(vec![marked(30, 100.0, 500.0, vec![2], false)]);
+        let daily = rows(&summaries, BarInterval::OneDay);
+        assert_eq!(daily[0].volume(), 500.0, "still real volume");
+        assert_eq!(daily[0].exclusions().non_market_price_trades, 1);
+        assert_eq!(
+            daily[0].exclusions().non_market_price_dollar_volume,
+            50_000.0
+        );
+        assert_eq!(daily[0].exclusions().volume_ineligible_trades, 0);
+    }
+
+    /// An unknown code is folded and counted, never treated as ordinary in silence.
+    #[test]
+    fn test_an_unresolved_condition_is_folded_and_counted() {
+        let summaries = fold_of(vec![marked(30, 100.0, 200.0, vec![41], false)]);
+        let daily = rows(&summaries, BarInterval::OneDay);
+        assert_eq!(daily[0].volume(), 200.0, "41 is not a sale condition");
+        assert_eq!(daily[0].exclusions().unresolved_condition_trades, 1);
+    }
+
+    /// The tick rule signs on price direction, and a flat print inherits the last one.
+    #[test]
+    fn test_signed_volume_follows_the_tick_rule() {
+        // 100 up (first, by convention), 100 up, 100 down, 100 flat inheriting the down.
+        let summaries = fold_of(vec![
+            trade(30, 100.0, 100.0),
+            trade(31, 101.0, 100.0),
+            trade(32, 100.0, 100.0),
+            trade(33, 100.0, 100.0),
+        ]);
+        let daily = rows(&summaries, BarInterval::OneDay);
+        assert_eq!(daily[0].volume(), 400.0);
+        // +100 +100 -100 -100
+        assert_eq!(daily[0].signed_volume(), 0.0);
+    }
+
+    /// The tick rule reads the tape as printed, not as filtered.
+    ///
+    /// An excluded print still moves the reference price. Skipping it would make a later trade's
+    /// direction depend on the eligibility policy, which is a different measurement.
+    #[test]
+    fn test_an_excluded_print_still_moves_the_tick_rule() {
+        let summaries = fold_of(vec![
+            trade(30, 100.0, 100.0),
+            marked(31, 200.0, 100.0, vec![16], false),
+            trade(32, 150.0, 100.0),
+        ]);
+        let daily = rows(&summaries, BarInterval::OneDay);
+        // The 150 print is a downtick against the excluded 200, not an uptick against the 100.
+        assert_eq!(daily[0].signed_volume(), 0.0, "+100 then -100");
+        assert_eq!(daily[0].volume(), 200.0);
+    }
+
+    /// A print outside regular hours is not folded at all.
+    #[test]
+    fn test_a_print_outside_the_session_is_not_folded() {
+        let mut fold = SessionFold::new(ticker(), session(), at(30, 0), at(40, 0))
+            .expect("a positive session");
+        fold.push(trade(29, 100.0, 100.0));
+        fold.push(trade(45, 100.0, 100.0));
+        assert!(fold.finish().is_empty(), "nothing inside the session");
+    }
+
+    /// The frame is pinned to its declared column set and order.
+    #[test]
+    fn test_the_frame_column_set_and_order_is_fixed() {
+        let summaries = fold_of(vec![trade(30, 100.0, 100.0)]);
+        let frame = summaries_to_dataframe(&summaries).expect("a frame");
+        let observed: Vec<(String, DataType)> = frame
+            .get_columns()
+            .iter()
+            .map(|column| (column.name().to_string(), column.dtype().clone()))
+            .collect();
+        let expected: Vec<(String, DataType)> = TRADE_FRAME_COLUMNS
+            .iter()
+            .map(|(name, dtype)| (name.to_string(), dtype.clone()))
+            .collect();
+        assert_eq!(observed, expected);
+    }
+
+    /// A session with no span is refused rather than folded into zero buckets.
+    #[test]
+    fn test_a_session_with_no_span_is_refused() {
+        assert!(SessionFold::new(ticker(), session(), at(40, 0), at(40, 0)).is_none());
+        assert!(SessionFold::new(ticker(), session(), at(40, 0), at(30, 0)).is_none());
+    }
+}

--- a/src/data/trades.rs
+++ b/src/data/trades.rs
@@ -205,24 +205,21 @@ impl SessionFold {
 
         let bucket = &mut self.buckets[index];
         if tick.corrected() {
-            bucket.exclusions.corrected_trades += 1;
-            bucket.exclusions.corrected_dollar_volume += tick.notional();
+            bucket.exclusions.record_correction(tick.notional());
             return;
         }
         match volume_eligibility(tick.conditions()) {
             Eligibility::Ineligible => {
-                bucket.exclusions.volume_ineligible_trades += 1;
-                bucket.exclusions.volume_ineligible_dollar_volume += tick.notional();
+                bucket.exclusions.record_volume_ineligible(tick.notional());
                 return;
             }
             // Counted and still folded: an unknown code is likelier to be a namespace this table
             // does not cover than a volume rule the provider forgot to publish.
-            Eligibility::Ambiguous => bucket.exclusions.unresolved_condition_trades += 1,
+            Eligibility::Ambiguous => bucket.exclusions.record_unresolved_condition(),
             Eligibility::Eligible => {}
         }
         if !carries_a_market_price(tick.conditions()) {
-            bucket.exclusions.non_market_price_trades += 1;
-            bucket.exclusions.non_market_price_dollar_volume += tick.notional();
+            bucket.exclusions.record_non_market_price(tick.notional());
         }
         bucket.add(&tick, direction);
     }
@@ -534,49 +531,49 @@ pub fn summaries_to_dataframe(summaries: &[TradeSummary]) -> Result<DataFrame, P
             "volume_ineligible_trades",
             summaries
                 .iter()
-                .map(|row| row.exclusions().volume_ineligible_trades)
+                .map(|row| row.exclusions().volume_ineligible_trades())
                 .collect(),
         ),
         column(
             "volume_ineligible_dollar_volume",
             summaries
                 .iter()
-                .map(|row| row.exclusions().volume_ineligible_dollar_volume)
+                .map(|row| row.exclusions().volume_ineligible_dollar_volume())
                 .collect(),
         ),
         counted(
             "corrected_trades",
             summaries
                 .iter()
-                .map(|row| row.exclusions().corrected_trades)
+                .map(|row| row.exclusions().corrected_trades())
                 .collect(),
         ),
         column(
             "corrected_dollar_volume",
             summaries
                 .iter()
-                .map(|row| row.exclusions().corrected_dollar_volume)
+                .map(|row| row.exclusions().corrected_dollar_volume())
                 .collect(),
         ),
         counted(
             "non_market_price_trades",
             summaries
                 .iter()
-                .map(|row| row.exclusions().non_market_price_trades)
+                .map(|row| row.exclusions().non_market_price_trades())
                 .collect(),
         ),
         column(
             "non_market_price_dollar_volume",
             summaries
                 .iter()
-                .map(|row| row.exclusions().non_market_price_dollar_volume)
+                .map(|row| row.exclusions().non_market_price_dollar_volume())
                 .collect(),
         ),
         counted(
             "unresolved_condition_trades",
             summaries
                 .iter()
-                .map(|row| row.exclusions().unresolved_condition_trades)
+                .map(|row| row.exclusions().unresolved_condition_trades())
                 .collect(),
         ),
     ])
@@ -689,9 +686,9 @@ mod tests {
         let daily = rows(&summaries, BarInterval::OneDay);
         assert_eq!(daily[0].volume(), 100.0, "the auction is not in volume");
         assert_eq!(daily[0].trade_count(), 1);
-        assert_eq!(daily[0].exclusions().volume_ineligible_trades, 1);
+        assert_eq!(daily[0].exclusions().volume_ineligible_trades(), 1);
         assert_eq!(
-            daily[0].exclusions().volume_ineligible_dollar_volume,
+            daily[0].exclusions().volume_ineligible_dollar_volume(),
             100_000_000.0
         );
     }
@@ -705,9 +702,9 @@ mod tests {
         ]);
         let daily = rows(&summaries, BarInterval::OneDay);
         assert_eq!(daily[0].volume(), 100.0);
-        assert_eq!(daily[0].exclusions().corrected_trades, 1);
-        assert_eq!(daily[0].exclusions().corrected_dollar_volume, 500_000.0);
-        assert_eq!(daily[0].exclusions().volume_ineligible_trades, 0);
+        assert_eq!(daily[0].exclusions().corrected_trades(), 1);
+        assert_eq!(daily[0].exclusions().corrected_dollar_volume(), 500_000.0);
+        assert_eq!(daily[0].exclusions().volume_ineligible_trades(), 0);
     }
 
     /// An average-price print counts as volume and is flagged as not a market price.
@@ -719,12 +716,12 @@ mod tests {
         let summaries = fold_of(vec![marked(30, 100.0, 500.0, vec![2], false)]);
         let daily = rows(&summaries, BarInterval::OneDay);
         assert_eq!(daily[0].volume(), 500.0, "still real volume");
-        assert_eq!(daily[0].exclusions().non_market_price_trades, 1);
+        assert_eq!(daily[0].exclusions().non_market_price_trades(), 1);
         assert_eq!(
-            daily[0].exclusions().non_market_price_dollar_volume,
+            daily[0].exclusions().non_market_price_dollar_volume(),
             50_000.0
         );
-        assert_eq!(daily[0].exclusions().volume_ineligible_trades, 0);
+        assert_eq!(daily[0].exclusions().volume_ineligible_trades(), 0);
     }
 
     /// An unknown code is folded and counted, never treated as ordinary in silence.
@@ -733,7 +730,7 @@ mod tests {
         let summaries = fold_of(vec![marked(30, 100.0, 200.0, vec![41], false)]);
         let daily = rows(&summaries, BarInterval::OneDay);
         assert_eq!(daily[0].volume(), 200.0, "41 is not a sale condition");
-        assert_eq!(daily[0].exclusions().unresolved_condition_trades, 1);
+        assert_eq!(daily[0].exclusions().unresolved_condition_trades(), 1);
     }
 
     /// The tick rule signs on price direction, and a flat print inherits the last one.
@@ -842,9 +839,9 @@ mod tests {
             None,
             "no eligible share traded, so there is no price it traded at"
         );
-        assert_eq!(daily[0].exclusions().volume_ineligible_trades, 1);
+        assert_eq!(daily[0].exclusions().volume_ineligible_trades(), 1);
         assert_eq!(
-            daily[0].exclusions().volume_ineligible_dollar_volume,
+            daily[0].exclusions().volume_ineligible_dollar_volume(),
             100_000.0
         );
         assert_eq!(rows(&summaries, BarInterval::OneMinute).len(), 1);


### PR DESCRIPTION
# Overview

Reads Massive's trade flat files and folds them into one-minute, five-minute and daily bars, applying the eligibility policy from #1120 at fold time and recording per bar what it dropped and why. **Nothing writes these partitions yet** — the archive path follows.

## Changes

- `TradeTick` in `common/alpaca.rs` — price, **fractional `f64`** size, condition set, correction flag.
- `TradeColumns`, `trade_key`, `TradeSink`, `fold_trades` in `common/flatfiles.rs` — the sibling dataset on the existing range machinery.
- `TickerRuns` — **extracted** from `fold_gzipped_quotes` so both datasets share one implementation of the per-name bookkeeping.
- `TradeExclusions` and `TradeSummary` in `common/types.rs` — validated constructor; VWAP is divided internally so the identity cannot be violated by a caller.
- `data/trades.rs` — the fold, `TRADE_FRAME_COLUMNS`, and `summaries_to_dataframe`.

## Context

**Why eligibility is applied here.** The fold is lossy: VWAP, dollar volume and signed volume collapse trades into numbers, and no reader can recover a different policy afterwards. Fixing it later means restoring from Deep Archive and re-folding. Every bar therefore carries its own exclusions — counts *and* dollar volumes, because the two disagree wildly: 246 auction prints were 0.03% of a session's trades and 14.1% of its money.

**Three cadences that agree by construction.** One minute is the only grid accumulated; five-minute and daily are merges of it. That is the strong form of the sum-back invariant — unlike the quote archive, where the two cadences were folded in separate passes and agreement must be *checked* rather than built in.

**The tick rule signs before the eligibility test.** An excluded print still moves the reference price. Skipping it would make a later trade's direction depend on the policy, which measures something else. There is a test for exactly this.

**Sizes are retained per bucket, not summarised**, because a five-minute median is not derivable from five one-minute medians. Same shape as `SpreadAccumulator`'s observations, comparable memory: trades run ~80M a session against quotes' ~50M, at 8 bytes each against 16.

**Verification against real data, not fixtures.** 871,159 actual vendor rows through the production parser and fold, against an independently computed baseline:

| metric | baseline | fold |
|---|---|---|
| eligible trades | 870,883 | 870,883 |
| dollar volume | $10,358,460,862.50 | $10,358,460,862.50 |
| VWAP | 75.040219 | 75.040219 |
| volume-ineligible | 186 / $1,799,610,733.68 | 186 / $1,799,610,733.68 |
| corrected | 30 / $574,434,881.11 | 30 / $574,434,881.11 |
| non-market-price | 33,908 / $505,731,022.41 | 33,908 / $505,731,022.41 |
| unresolved | 247,857 | 247,857 |

An initial 195-vs-186 gap on volume-ineligible reconciled exactly: 18 rows fall outside the probe's midnight-to-midnight UTC window (the file spans 08:00 on 08-21 to 00:00:00.39 on 08-22), 9 of which the reader had already refused as unusable. `195 − 9 = 186` and `$1,799,761,645.90 − $150,912.22 = $1,799,610,733.68`, to the cent. Production bounds to `trading_hours()`, so it does not arise. Volume differs at the twelfth significant figure — summation order, baseline in file order against per-bucket then merged.

**Deliberately absent: effective spread.** It is specified for this pass and is not here. It needs each trade matched to the prevailing NBBO, which means merging two ticker-major streams of 7.15 GB and 2.95 GB — a distinct architectural problem that would make this unreviewable. The house rule it depends on is applied and recorded now as `non_market_price_*`, so the policy is live and its footprint measured; the spread will consume that flag rather than re-derive it.

`devenv tasks run checks:rust` green, 867 tests, coverage 81.36%, clippy warning set identical to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KQiJumjK2WhBCNmhNV9sq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trade-tape processing for building one-minute, five-minute, and session-level market bars.
  * Added trade summaries with volume, dollar volume, VWAP, trade-size percentiles, signed volume, and exclusion counts.
  * Added support for exporting trade summaries in a standardized 17-column data table.
  * Added validation to exclude invalid, corrected, unresolved, or non-market-price trades while preserving reporting details.
* **Tests**
  * Added coverage for reading, parsing, folding, and summarizing trade data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->