### PR TITLE
Write the folded tape to the archive, and split the bucket variables

### DIFF
--- a/.sqlfluffignore
+++ b/.sqlfluffignore
@@ -2,4 +2,5 @@
 target/
 .venv/
 models/tide/.devenv/
+.scratchpad/
 tools/duckdb_initialization.sql

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ start-trainer
 devenv tasks run data:seed:s3
 
 # Launch DuckDB for a local query interface against S3 with all data lake views
-# pre-loaded. Once in the DuckDB shell, run .help for commands and SHOW TABLES
-# to list loaded views.
-start-duckdb oscm-fund-production
+# pre-loaded. The argument names the shared archive the data/** views read; the
+# exports/** views read this profile's own bucket. Once in the DuckDB shell, run
+# .help for commands and SHOW TABLES to list loaded views.
+start-duckdb oscm-fund-archive
 ```
 
 > For development VMs, run the equivalent `development` scripts.

--- a/devenv.nix
+++ b/devenv.nix
@@ -704,11 +704,13 @@ in {
 
   scripts.start-duckdb.exec = ''
     set -euo pipefail
+    ${runtimeEnv}
 
     if [ -z "''${1:-}" ]; then
       echo "Usage: start-duckdb <archive-bucket-name>" >&2
       echo "" >&2
-      echo "Every view reads data/**, so this names the shared archive." >&2
+      echo "Names the shared archive the data/** views read. The exports/** views" >&2
+      echo "read this profile's own records bucket, which comes from FUND_PROFILE." >&2
       echo "" >&2
       echo "Example:" >&2
       echo "  start-duckdb ${archiveBucket}" >&2
@@ -716,7 +718,7 @@ in {
     fi
 
     export AWS_S3_ARCHIVE_BUCKET_NAME="$1"
-    echo "Opening DuckDB lab (archive: $AWS_S3_ARCHIVE_BUCKET_NAME)"
+    echo "Opening DuckDB lab (archive: $AWS_S3_ARCHIVE_BUCKET_NAME, records: $AWS_S3_BUCKET_NAME)"
 
     exec duckdb ~/lab.duckdb -init "$DEVENV_ROOT/tools/duckdb_initialization.sql"
   '';

--- a/devenv.nix
+++ b/devenv.nix
@@ -7,8 +7,17 @@
   # artifacts live in the same per-profile bucket under models/tide/: the Rust
   # tide trainer (tide_model_trainer) writes there and the inference service
   # reads there, so training and serving agree in both dev and production.
+  #
+  # Two buckets, split by whether the bytes are a provider-derived fact or a
+  # record of what one instance did. The archive holds data/** and is shared:
+  # production writes it, every instance reads it, and it is not per-profile
+  # because the corpus is expensive and irreproducible once a subscription
+  # lapses. Everything else -- exports, models, database backups -- stays in the
+  # per-profile bucket, so a stray key is a bug rather than a judgement call.
+  archiveBucket = "oscm-fund-archive";
   runtimeEnv = ''
     export AWS_S3_BUCKET_NAME="oscm-fund-$(echo ''${FUND_PROFILE} | tr '/.' '--')"
+    export AWS_S3_ARCHIVE_BUCKET_NAME="${archiveBucket}"
     export SECRETSPEC_PROFILE="''${FUND_PROFILE}"
     export AWS_S3_MODEL_ARTIFACT_PATH="models/tide/"
     if [[ ! -w "''${FUND_LOG_DIRECTORY:-/var/log/fund}" ]]; then
@@ -300,7 +309,8 @@ in {
     ${runtimeEnv}
     unset AWS_ENDPOINT_URL
     echo "=== Fund S3 Buckets (profile: $FUND_PROFILE) ==="
-    echo "  Bucket: $AWS_S3_BUCKET_NAME"
+    echo "  Records: $AWS_S3_BUCKET_NAME"
+    echo "  Archive: $AWS_S3_ARCHIVE_BUCKET_NAME (shared, holds data/**)"
     echo ""
     buckets=$(aws s3 ls)
     printf '%s\n' "$buckets" | grep fund || echo "No fund buckets found"
@@ -696,16 +706,17 @@ in {
     set -euo pipefail
 
     if [ -z "''${1:-}" ]; then
-      echo "Usage: start-duckdb <bucket-name>" >&2
+      echo "Usage: start-duckdb <archive-bucket-name>" >&2
       echo "" >&2
-      echo "Examples:" >&2
-      echo "  start-duckdb oscm-fund-production" >&2
-      echo "  start-duckdb oscm-fund-development-john-forstmeier" >&2
+      echo "Every view reads data/**, so this names the shared archive." >&2
+      echo "" >&2
+      echo "Example:" >&2
+      echo "  start-duckdb ${archiveBucket}" >&2
       exit 1
     fi
 
-    export AWS_S3_BUCKET_NAME="$1"
-    echo "Opening DuckDB lab (bucket: $AWS_S3_BUCKET_NAME)"
+    export AWS_S3_ARCHIVE_BUCKET_NAME="$1"
+    echo "Opening DuckDB lab (archive: $AWS_S3_ARCHIVE_BUCKET_NAME)"
 
     exec duckdb ~/lab.duckdb -init "$DEVENV_ROOT/tools/duckdb_initialization.sql"
   '';
@@ -1058,7 +1069,7 @@ in {
       export AWS_S3_MODEL_ARTIFACT_PATH="models/tide-smoke/"
       export FUND_EPOCHS="''${FUND_EPOCHS:-1}"
       echo "Rehearsing against PRODUCTION ($FUND_EPOCHS epoch(s), lookback ''${FUND_LOOKBACK_DAYS:-trainer default})"
-      echo "  Reading and repairing s3://$AWS_S3_BUCKET_NAME/data/equity/bars/interval=one_day/"
+      echo "  Reading and repairing s3://$AWS_S3_ARCHIVE_BUCKET_NAME/data/equity/bars/interval=one_day/"
       echo "  Publishing to s3://$AWS_S3_BUCKET_NAME/$AWS_S3_MODEL_ARTIFACT_PATH, which nothing serves from."
       secretspec run -- cargo run --release --bin tide_model_trainer
     '';
@@ -1115,8 +1126,8 @@ in {
       exec = ''
         set -euo pipefail
 
-        if [ -z "''${AWS_S3_BUCKET_NAME:-}" ]; then
-          echo "AWS_S3_BUCKET_NAME is not set."
+        if [ -z "''${AWS_S3_ARCHIVE_BUCKET_NAME:-}" ]; then
+          echo "AWS_S3_ARCHIVE_BUCKET_NAME is not set."
           echo "  This half of the seed writes what the trainer trains from and needs AWS and"
           echo "  Massive credentials. If you only wanted the database, run"
           echo "  'devenv tasks run data:seed:postgres' instead."
@@ -1314,7 +1325,8 @@ in {
     {
       echo "Fund development environment (profile: $FUND_PROFILE)"
       echo ""
-      echo "  Bucket: $AWS_S3_BUCKET_NAME"
+      echo "  Records: $AWS_S3_BUCKET_NAME"
+      echo "  Archive: $AWS_S3_ARCHIVE_BUCKET_NAME (shared, holds data/**)"
       echo ""
       echo "  Profiles:"
       echo "    devenv --profile application up      Start application processes"

--- a/src/bin/laboratory_baselines.rs
+++ b/src/bin/laboratory_baselines.rs
@@ -116,13 +116,13 @@ async fn main() {
 
 /// Reads the window, lays out the panel, and scores every baseline against it.
 ///
-/// Reads `AWS_S3_BUCKET_NAME` and writes to the laboratory journal. Nothing is fetched and nothing
+/// Reads `AWS_S3_ARCHIVE_BUCKET_NAME` and writes to the laboratory journal. Nothing is fetched and nothing
 /// is published: this measures what the archive already holds.
 async fn run(
     parameters: &Parameters,
 ) -> Result<Vec<laboratory::ForecastScored>, Box<dyn std::error::Error>> {
-    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
-        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
     let s3_client = fund::common::aws::s3_client().await;
 
     // One instant for the run, resolved once to its Eastern session, as the trainer does: the window

--- a/src/bin/laboratory_convergence.rs
+++ b/src/bin/laboratory_convergence.rs
@@ -105,8 +105,8 @@ async fn main() {
 async fn run(
     parameters: &Parameters,
 ) -> Result<Vec<laboratory::ConvergenceMeasured>, Box<dyn std::error::Error>> {
-    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
-        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
     let s3_client = fund::common::aws::s3_client().await;
 
     let session = SessionDate::at(Utc::now());

--- a/src/bin/laboratory_information.rs
+++ b/src/bin/laboratory_information.rs
@@ -137,8 +137,8 @@ async fn main() {
 async fn run(
     parameters: &Parameters,
 ) -> Result<Vec<laboratory::FeatureTriaged>, Box<dyn std::error::Error>> {
-    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
-        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
     let s3_client = fund::common::aws::s3_client().await;
 
     let now = Utc::now();

--- a/src/bin/laboratory_intraday_baselines.rs
+++ b/src/bin/laboratory_intraday_baselines.rs
@@ -106,8 +106,8 @@ async fn main() {
 }
 
 async fn run(parameters: &Parameters) -> Result<(), Box<dyn std::error::Error>> {
-    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
-        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
     let s3_client = fund::common::aws::s3_client().await;
 
     info!(

--- a/src/bin/laboratory_intraday_convergence.rs
+++ b/src/bin/laboratory_intraday_convergence.rs
@@ -116,8 +116,8 @@ async fn main() {
 }
 
 async fn run(parameters: &Parameters) -> Result<(), Box<dyn std::error::Error>> {
-    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
-        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
     let s3_client = fund::common::aws::s3_client().await;
 
     // The models are fitted on daily closes, as production fits them, so the daily window must

--- a/src/bin/laboratory_regime.rs
+++ b/src/bin/laboratory_regime.rs
@@ -110,8 +110,8 @@ async fn main() {
 async fn run(
     parameters: &Parameters,
 ) -> Result<Vec<laboratory::RegimeMeasured>, Box<dyn std::error::Error>> {
-    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
-        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
     let s3_client = fund::common::aws::s3_client().await;
 
     let now = Utc::now();

--- a/src/bin/laboratory_stability.rs
+++ b/src/bin/laboratory_stability.rs
@@ -111,8 +111,8 @@ async fn main() {
 async fn run(
     parameters: &Parameters,
 ) -> Result<Vec<laboratory::StabilityMeasured>, Box<dyn std::error::Error>> {
-    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
-        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
     let s3_client = fund::common::aws::s3_client().await;
 
     let now = Utc::now();

--- a/src/bin/laboratory_tide.rs
+++ b/src/bin/laboratory_tide.rs
@@ -149,8 +149,8 @@ async fn main() {
 async fn run(
     parameters: &Parameters,
 ) -> Result<Vec<laboratory::ForecastScored>, Box<dyn std::error::Error>> {
-    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
-        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+    let bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
     let s3_client = fund::common::aws::s3_client().await;
 
     let now = Utc::now();

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -1493,8 +1493,8 @@ fn print_session_row(
 
 /// The bucket every S3 subcommand writes into.
 fn bucket_name() -> Result<String, Box<dyn std::error::Error>> {
-    std::env::var("AWS_S3_BUCKET_NAME")
-        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)".into())
+    std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)".into())
 }
 
 /// Boxes a concrete error, which `?` cannot reach [`SeedError`] through in one conversion.

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -82,6 +82,12 @@ enum Command {
         #[command(subcommand)]
         action: QuoteAction,
     },
+    /// The printed tape from Massive's flat files, into the S3 archive. Every session is written at
+    /// all three cadences, so there is no interval to choose.
+    EquityTrades {
+        #[command(subcommand)]
+        action: TradeAction,
+    },
 }
 
 impl Command {
@@ -97,6 +103,7 @@ impl Command {
             },
             Command::EquityDetails { .. } => "seed-equity-details",
             Command::EquityQuotes { .. } => "seed-equity-quotes",
+            Command::EquityTrades { .. } => "seed-equity-trades",
         }
     }
 }
@@ -223,6 +230,36 @@ impl QuoteAction {
             }
         };
         Some(whole_market(sessions))
+    }
+}
+
+/// What a trade pass does with the sessions it is given.
+///
+/// Two actions where quotes have five: there is no per-name repair, because a trade file *is* the
+/// session and a name missing from it is missing from the tape rather than from a retryable fetch.
+#[derive(Debug, Subcommand)]
+enum TradeAction {
+    /// Fold every name the daily archive holds into the sampled sessions that have no partition yet.
+    Archive(QuoteArguments),
+    /// Fold every name the daily archive holds into every sampled session, widening ones already
+    /// summarized.
+    Widen(QuoteArguments),
+}
+
+impl TradeAction {
+    /// The scope this action folds under. Both fold the whole market and differ only in sessions.
+    fn universe_scope(&self) -> Result<Scope, SeedError> {
+        whole_market(match self {
+            TradeAction::Archive(_) => SessionSelection::Absent,
+            TradeAction::Widen(_) => SessionSelection::Every,
+        })
+    }
+
+    /// The window and stride this action runs over.
+    fn arguments(&self) -> &QuoteArguments {
+        match self {
+            TradeAction::Archive(arguments) | TradeAction::Widen(arguments) => arguments,
+        }
     }
 }
 
@@ -639,6 +676,7 @@ async fn run(command: &Command, today: SessionDate) -> Result<Outcome, SeedError
             Ok(Outcome::Complete)
         }
         Command::EquityQuotes { action } => seed_quotes(action).await,
+        Command::EquityTrades { action } => seed_trades(action).await,
     }
 }
 
@@ -1086,6 +1124,41 @@ async fn fold_sampled(
 
     Ok(Outcome::Pass(
         fold_quotes(&source, &calendar, &sampled, &scope).await?,
+    ))
+}
+
+/// Folds the sampled sessions' printed tape into the archive under the scope the action names.
+///
+/// The calendar comes from Alpaca and the tape from Massive, which is the same split the quote
+/// pass uses: only the exchange publishes its own hours, and only the flat files hold every print.
+async fn seed_trades(action: &TradeAction) -> Result<Outcome, SeedError> {
+    let arguments = action.arguments();
+    let scope = action.universe_scope()?;
+    let window = arguments.window.window()?;
+
+    let credentials = AlpacaCredentials::from_env().map_err(box_error)?;
+    let days = TradingClient::from_env(credentials)
+        .fetch_calendar(window.start.date(), window.end.date())
+        .await
+        .map_err(box_error)?;
+    let calendar = TradingCalendar::from_days(days);
+    let sampled = sample(&calendar, &window, arguments.stride);
+    report_sample(&window, arguments.stride, &calendar, &sampled);
+
+    let flat_files = flatfiles::FlatFileClient::from_env().map_err(box_error)?;
+    let bucket = bucket_name()?;
+    let s3_client = fund::common::aws::s3_client().await;
+    Ok(Outcome::Pass(
+        archive::archive_trade_sessions(
+            &s3_client,
+            &flat_files,
+            &calendar,
+            &bucket,
+            &sampled,
+            &scope,
+        )
+        .await
+        .map_err(box_error)?,
     ))
 }
 
@@ -1954,6 +2027,33 @@ mod tests {
             Command::EquityQuotes { action } => assert!(action.universe_scope().is_none()),
             other => panic!("expected a quote action, got {other:?}"),
         }
+    }
+
+    /// The trade pass folds the whole market, asserted before it runs for four days.
+    ///
+    /// The quote backfill folded the *screened* universe for fifteen hours and 254 sessions before a
+    /// count caught it, because nothing pinned the scope the pass would actually use. This is that
+    /// assertion for trades, and it is worth more here: the trade pass is the last Advanced-only
+    /// item, so a wrong universe cannot be re-read after the subscription lapses.
+    #[test]
+    fn test_both_universe_trade_actions_fold_the_whole_market() {
+        let window = ["--start", "2021-08-26", "--end", "2026-08-25"];
+        let rendered = |verb: &str| {
+            let arguments = parse(&[["equity-trades", verb].as_slice(), &window].concat())
+                .expect("a trade window");
+            match arguments.command {
+                Command::EquityTrades { action } => action
+                    .universe_scope()
+                    .expect("the whole market may write a partition")
+                    .to_string(),
+                other => panic!("expected a trade action, got {other:?}"),
+            }
+        };
+
+        // Literals, not `whole_market(..).to_string()`: an expectation built from the call under
+        // test moves with it and can never fail.
+        assert_eq!(rendered("archive"), "every name, absent sessions only");
+        assert_eq!(rendered("widen"), "every name, every session");
     }
 
     /// A scan that could not read a session found its names only in the ones it could, so both the

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -72,8 +72,14 @@ async fn main() {
 }
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    // Two buckets, because this binary does two things. It repairs and reads `data/**`, which every
+    // instance shares, and it publishes a model artifact, which belongs to the instance that trained
+    // it. One variable for both would either put one trainer's artifacts in the shared archive or
+    // give each instance its own copy of a corpus that is expensive and irreproducible.
+    let archive_bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
     let bucket = std::env::var("AWS_S3_BUCKET_NAME")
-        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (the equity-bar data bucket)")?;
+        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (this instance's records)")?;
     let artifact_prefix =
         std::env::var("AWS_S3_MODEL_ARTIFACT_PATH").unwrap_or_else(|_| "models/tide/".to_string());
     let lookback_days = read_positive_env("FUND_LOOKBACK_DAYS", DEFAULT_LOOKBACK_DAYS)?;
@@ -148,7 +154,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             match archive::archive_missing_sessions(
                 &s3_client,
                 &massive,
-                &bucket,
+                &archive_bucket,
                 window_start,
                 session,
                 calendar.as_ref(),
@@ -169,7 +175,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
             // Refreshed whole rather than topped up, and stepped over on failure like the bars
             // above. Stage two reads it, and refuses to train if it is absent entirely.
-            match archive::archive_splits(&s3_client, &massive, &bucket, now).await {
+            match archive::archive_splits(&s3_client, &massive, &archive_bucket, now).await {
                 Ok(splits) => info!(splits, "Splits table refreshed"),
                 Err(error) => warn!(%error, "Splits refresh failed; the archive keeps its copy"),
             }
@@ -181,7 +187,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // reaching S3 with it needs no Massive credential. Gating it on one meant a bad key left
     // DuckDB's `training_details` view resolving a stale copy for a reason that had nothing to do
     // with it.
-    if let Err(error) = archive::archive_details(&s3_client, &bucket, details::embedded_csv()).await
+    if let Err(error) =
+        archive::archive_details(&s3_client, &archive_bucket, details::embedded_csv()).await
     {
         warn!(%error, "Ticker metadata upload failed; the archive keeps the previous copy");
     }
@@ -200,7 +207,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             match archive::archive_boundaries(
                 &s3_client,
                 &market_data,
-                &bucket,
+                &archive_bucket,
                 window_start,
                 session,
                 now,
@@ -223,7 +230,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let prepared = dataset::build(
         &s3_client,
-        &bucket,
+        &archive_bucket,
         lookback_days,
         session,
         training_fraction,

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -72,10 +72,8 @@ async fn main() {
 }
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    // Two buckets, because this binary does two things. It repairs and reads `data/**`, which every
-    // instance shares, and it publishes a model artifact, which belongs to the instance that trained
-    // it. One variable for both would either put one trainer's artifacts in the shared archive or
-    // give each instance its own copy of a corpus that is expensive and irreproducible.
+    // Two buckets: `data/**` is the shared corpus this reads and repairs, and the model artifact
+    // below belongs to the one instance that trained it.
     let archive_bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
         .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
     let bucket = std::env::var("AWS_S3_BUCKET_NAME")

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -18,9 +18,10 @@ use crate::common::flatfiles::{FlatFileClient, FlatFileError};
 use crate::common::massive::MassiveClient;
 use crate::common::types::{
     BarInterval, EquityBar, IntradayCadence, LiquidityFloor, QuoteSummary, SessionDate, Ticker,
+    TradeSummary,
 };
 use crate::data::calendar::TradingCalendar;
-use crate::data::{bars, boundaries, quotes, splits};
+use crate::data::{bars, boundaries, quotes, splits, trades};
 
 /// Root of the bar archive, never a partition prefix on its own — [`bar_archive_prefix`] adds the
 /// cadence, and a key built without one collides with every other cadence of the same session.
@@ -1522,14 +1523,22 @@ fn merge_or_replace(
 
 /// Root of the quote-summary archive, beside the bars rather than under them.
 ///
-/// `data/equity/bars` is Massive's and this is Alpaca's. One prefix for both would put two vendors'
-/// opinions of the same session under one key, and make whichever job ran second the one that
-/// mattered.
+/// Keyed by what the rows describe, not by who supplied them: the five-year backfill folded these
+/// from Massive's flat files and a repair folds the same names from Alpaca, so one session's
+/// partition routinely holds both. Splitting by vendor would put one session under two keys.
 pub const QUOTE_ARCHIVE_PREFIX: &str = "data/equity/quotes";
 
 /// The archive prefix for one summary cadence, hive-partitioned like the bars.
 pub fn quote_archive_prefix(interval: BarInterval) -> String {
     format!("{QUOTE_ARCHIVE_PREFIX}/interval={interval}")
+}
+
+/// Root of the trade-summary archive, beside the quotes it will eventually be differenced against.
+pub const TRADE_ARCHIVE_PREFIX: &str = "data/equity/trades";
+
+/// The archive prefix for one trade cadence, hive-partitioned like the quotes.
+pub fn trade_archive_prefix(interval: BarInterval) -> String {
+    format!("{TRADE_ARCHIVE_PREFIX}/interval={interval}")
 }
 
 /// Names folded at once.
@@ -1912,6 +1921,206 @@ async fn write_quote_partitions(
     Ok(())
 }
 
+/// Folds the printed tape across `sessions`, per `scope`, out of Massive's flat files.
+///
+/// Session-major and flat-file only. There is no per-name variant because there is no repair path
+/// yet: a trade file is the session, so a name missing from it is missing from the tape rather than
+/// from a fetch that can be retried.
+///
+/// `sessions` must already be calendar-filtered, on the same terms as the quote pass.
+pub async fn archive_trade_sessions(
+    s3_client: &S3Client,
+    flat_files: &FlatFileClient,
+    calendar: &TradingCalendar,
+    bucket: &str,
+    sessions: &[SessionDate],
+    scope: &Scope,
+) -> Result<PassSummary, ArchiveError> {
+    let (Some(first), Some(last)) = (sessions.first(), sessions.last()) else {
+        return Ok(PassProgress::default().into_quote_summary(0));
+    };
+    // Presence is read off the daily prefix, which is the last one written, so a pass that died
+    // partway reads as absent and is redone rather than left with its intraday half missing.
+    let present = present_partitions(
+        s3_client,
+        bucket,
+        &trade_archive_prefix(BarInterval::OneDay),
+        *first,
+        *last,
+    )
+    .await?;
+    let requested = sessions_for(scope.sessions, sessions, &present);
+
+    info!(
+        window_start = %first,
+        window_end = %last,
+        %scope,
+        offered = sessions.len(),
+        already_summarized = present.len(),
+        requested = requested.len(),
+        "Planned a trade pass"
+    );
+
+    let mut progress = PassProgress {
+        sessions_requested: requested.len(),
+        ..Default::default()
+    };
+    let mut trades_folded = 0usize;
+    for session in requested {
+        trades_folded += archive_trade_session(
+            s3_client,
+            flat_files,
+            calendar,
+            bucket,
+            session,
+            scope,
+            &mut progress,
+        )
+        .await?;
+    }
+
+    if progress.symbols_failed > 0 {
+        warn!(
+            symbols_failed = progress.symbols_failed,
+            "Some symbols are absent from the summaries this pass wrote; re-run those sessions to repair them"
+        );
+    }
+    info!(
+        sessions_requested = progress.sessions_requested,
+        sessions_written = progress.sessions_written,
+        sessions_without_data = progress.sessions_without_data,
+        sessions_failed = progress.sessions_failed.len(),
+        summaries_written = progress.rows_written,
+        symbols_failed = progress.symbols_failed,
+        trades_folded,
+        "Trade archive updated"
+    );
+    Ok(progress.into_quote_summary(trades_folded))
+}
+
+/// One session: derive the universe from the scope, fold the tape, write all three cadences.
+#[allow(clippy::too_many_arguments)]
+async fn archive_trade_session(
+    s3_client: &S3Client,
+    flat_files: &FlatFileClient,
+    calendar: &TradingCalendar,
+    bucket: &str,
+    session: SessionDate,
+    scope: &Scope,
+    progress: &mut PassProgress,
+) -> Result<usize, ArchiveError> {
+    let Some((open, close)) = quotes::trading_hours(calendar, session) else {
+        progress.sessions_without_data += 1;
+        return Ok(0);
+    };
+
+    let universe = match &scope.names {
+        NameSelection::Named(symbols) => symbols.clone(),
+        NameSelection::WholeMarket | NameSelection::Screened(_) => {
+            let key =
+                date_partitioned_key(&bar_archive_prefix(BarInterval::OneDay), session.date());
+            let Some(daily) = read_partition(s3_client, bucket, &key).await? else {
+                warn!(%session, "No daily partition to read a universe from; leaving the session unsummarized");
+                progress.sessions_without_data += 1;
+                return Ok(0);
+            };
+            names_from_partition(&scope.names, daily)?
+        }
+    };
+    if universe.is_empty() {
+        progress.sessions_without_data += 1;
+        return Ok(0);
+    }
+
+    info!(%session, %open, %close, universe = universe.len(), "Folding a session's printed tape");
+    let requested = universe.len();
+    let Some(fold) = trades::MarketFold::new(session, open, close, universe) else {
+        // Unreachable while `trading_hours` returns a published session, and cheap to say so rather
+        // than fold nothing and report the whole universe as its cost.
+        warn!(%session, %open, %close, "The session spans no time; leaving it unsummarized");
+        progress.sessions_without_data += 1;
+        return Ok(0);
+    };
+    let folded = match flat_files.fold_trades(session.date(), fold).await {
+        Ok((_, fold)) => fold.finish(),
+        Err(error) => {
+            // The file is the session: nothing partial survives it.
+            warn!(%session, %error, "A session's trade file could not be folded");
+            progress.sessions_failed.push(session);
+            return Ok(0);
+        }
+    };
+
+    let trades_folded = folded.folded;
+    progress.symbols_failed += requested.saturating_sub(folded.seen);
+    if !folded.resumed.is_empty() {
+        info!(%session, resumed = folded.resumed.len(), "Names whose trades arrived in more than one run");
+    }
+    if folded.summaries.is_empty() {
+        progress.sessions_without_data += 1;
+        return Ok(trades_folded);
+    }
+    write_trade_partitions(s3_client, bucket, session, folded.summaries, progress).await?;
+    Ok(trades_folded)
+}
+
+/// Writes a session's trade summaries, one partition per cadence, daily last.
+///
+/// The order is the recovery rule, matching the quote pass: presence is read off the daily prefix,
+/// so a pass that dies partway must leave the session looking absent.
+async fn write_trade_partitions(
+    s3_client: &S3Client,
+    bucket: &str,
+    session: SessionDate,
+    folded: Vec<TradeSummary>,
+    progress: &mut PassProgress,
+) -> Result<(), ArchiveError> {
+    let mut one_minute: Vec<TradeSummary> = Vec::new();
+    let mut five_minute: Vec<TradeSummary> = Vec::new();
+    let mut daily: Vec<TradeSummary> = Vec::new();
+    for row in folded {
+        match row.bar_interval() {
+            BarInterval::OneMinute => one_minute.push(row),
+            BarInterval::FiveMinute => five_minute.push(row),
+            BarInterval::OneDay => daily.push(row),
+        }
+    }
+
+    let mut written = 0usize;
+    for (interval, rows) in [
+        (BarInterval::OneMinute, one_minute),
+        (BarInterval::FiveMinute, five_minute),
+        (BarInterval::OneDay, daily),
+    ] {
+        if rows.is_empty() {
+            continue;
+        }
+        let frame = trades::summaries_to_dataframe(&rows)?;
+        let key = date_partitioned_key(&trade_archive_prefix(interval), session.date());
+        match write_merged(s3_client, bucket, key, frame, |existing, fetched, key| {
+            merge_or_replace(existing, fetched, key)
+        })
+        .await
+        {
+            Ok(()) => written += rows.len(),
+            Err(ArchiveError::Contended { key, attempts }) => {
+                warn!(key, attempts, %session, "Trade partition contended; this session was not summarized");
+                progress.sessions_failed.push(session);
+                return Ok(());
+            }
+            Err(error) => {
+                warn!(%error, %session, "Trade partition write failed; this session was not summarized");
+                progress.sessions_failed.push(session);
+                return Ok(());
+            }
+        }
+    }
+
+    progress.sessions_written += 1;
+    progress.rows_written += written;
+    Ok(())
+}
+
 /// Fetches the whole splits table and writes it, keeping each row's earliest `first_seen`.
 ///
 /// Not a gap scan like [`archive_missing_sessions`], because there are no gaps to find: the feed
@@ -2256,6 +2465,40 @@ mod tests {
             None,
         )
         .expect("a coherent candle must construct")
+    }
+
+    /// Each cadence lands under its own hive partition, and trades never collide with quotes.
+    ///
+    /// Pinned to literal keys because these are the archive's wire layout: a reader scanning the
+    /// tree gets `interval` as a column, and two cadences sharing a key would make whichever job
+    /// wrote last the one that mattered.
+    #[test]
+    fn test_every_trade_cadence_has_its_own_partition_prefix() {
+        let session = NaiveDate::from_ymd_opt(2026, 8, 21).expect("a real date");
+        let key = |interval| date_partitioned_key(&trade_archive_prefix(interval), session);
+
+        assert_eq!(
+            key(BarInterval::OneMinute),
+            "data/equity/trades/interval=one_minute/year=2026/month=08/day=21/data.parquet"
+        );
+        assert_eq!(
+            key(BarInterval::FiveMinute),
+            "data/equity/trades/interval=five_minute/year=2026/month=08/day=21/data.parquet"
+        );
+        assert_eq!(
+            key(BarInterval::OneDay),
+            "data/equity/trades/interval=one_day/year=2026/month=08/day=21/data.parquet"
+        );
+
+        // Disjoint from the quote archive at every cadence, so one session's two datasets cannot
+        // overwrite each other.
+        for interval in BarInterval::ALL {
+            assert_ne!(
+                trade_archive_prefix(interval),
+                quote_archive_prefix(interval),
+                "{interval} must not share a prefix with the quote archive"
+            );
+        }
     }
 
     /// One session's write failing must cost that session and no other.

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -181,6 +181,11 @@ pub enum PassOutput {
         summaries_written: usize,
         quotes_folded: usize,
     },
+    /// Summary rows written across all three cadences, and the prints folded to produce them.
+    Trades {
+        summaries_written: usize,
+        trades_folded: usize,
+    },
 }
 
 impl PassOutput {
@@ -192,6 +197,9 @@ impl PassOutput {
         match self {
             PassOutput::Bars { bars_written } => *bars_written,
             PassOutput::Quotes {
+                summaries_written, ..
+            }
+            | PassOutput::Trades {
                 summaries_written, ..
             } => *summaries_written,
         }
@@ -320,6 +328,13 @@ impl std::fmt::Display for PassSummary {
                 formatter,
                 ", {summaries_written} summaries, {quotes_folded} quotes folded"
             ),
+            PassOutput::Trades {
+                summaries_written,
+                trades_folded,
+            } => write!(
+                formatter,
+                ", {summaries_written} summaries, {trades_folded} trades folded"
+            ),
         }
     }
 }
@@ -366,6 +381,22 @@ impl PassProgress {
             output: PassOutput::Quotes {
                 summaries_written: self.rows_written,
                 quotes_folded,
+            },
+            sessions: SessionSource::TradingCalendar,
+        }
+    }
+
+    /// The trade counterpart, separate so neither pass can render the other's units.
+    fn into_trade_summary(self, trades_folded: usize) -> PassSummary {
+        PassSummary {
+            sessions_requested: self.sessions_requested,
+            sessions_written: self.sessions_written,
+            sessions_without_data: self.sessions_without_data,
+            sessions_failed: self.sessions_failed,
+            symbols_failed: self.symbols_failed,
+            output: PassOutput::Trades {
+                summaries_written: self.rows_written,
+                trades_folded,
             },
             sessions: SessionSource::TradingCalendar,
         }
@@ -1921,13 +1952,12 @@ async fn write_quote_partitions(
     Ok(())
 }
 
-/// Folds the printed tape across `sessions`, per `scope`, out of Massive's flat files.
+/// Folds the printed tape across `sessions`, per `scope`, out of Massive's flat files, which must
+/// already be calendar-filtered on the same terms as the quote pass.
 ///
-/// Session-major and flat-file only. There is no per-name variant because there is no repair path
-/// yet: a trade file is the session, so a name missing from it is missing from the tape rather than
-/// from a fetch that can be retried.
-///
-/// `sessions` must already be calendar-filtered, on the same terms as the quote pass.
+/// Session-major and flat-file only. There is no per-name variant because there is no repair path:
+/// a trade file is the session, so a name missing from it is missing from the tape rather than from
+/// a fetch that can be retried.
 pub async fn archive_trade_sessions(
     s3_client: &S3Client,
     flat_files: &FlatFileClient,
@@ -1937,7 +1967,7 @@ pub async fn archive_trade_sessions(
     scope: &Scope,
 ) -> Result<PassSummary, ArchiveError> {
     let (Some(first), Some(last)) = (sessions.first(), sessions.last()) else {
-        return Ok(PassProgress::default().into_quote_summary(0));
+        return Ok(PassProgress::default().into_trade_summary(0));
     };
     // Presence is read off the daily prefix, which is the last one written, so a pass that died
     // partway reads as absent and is redone rather than left with its intraday half missing.
@@ -1980,9 +2010,11 @@ pub async fn archive_trade_sessions(
     }
 
     if progress.symbols_failed > 0 {
+        // Deliberately not the quote pass's "re-run to repair": re-running skips the session, whose
+        // daily partition is now written, and the flat file would answer the same way if it did not.
         warn!(
             symbols_failed = progress.symbols_failed,
-            "Some symbols are absent from the summaries this pass wrote; re-run those sessions to repair them"
+            "Some symbols in the universe never printed in these sessions' trade files; only a widen pass revisits them"
         );
     }
     info!(
@@ -1995,7 +2027,7 @@ pub async fn archive_trade_sessions(
         trades_folded,
         "Trade archive updated"
     );
-    Ok(progress.into_quote_summary(trades_folded))
+    Ok(progress.into_trade_summary(trades_folded))
 }
 
 /// One session: derive the universe from the scope, fold the tape, write all three cadences.
@@ -2783,6 +2815,10 @@ mod tests {
             progress().into_quote_summary(412_000).to_string(),
             format!("{shared}, 2048 summaries, 412000 quotes folded")
         );
+        assert_eq!(
+            progress().into_trade_summary(871_159).to_string(),
+            format!("{shared}, 2048 summaries, 871159 trades folded")
+        );
     }
 
     /// The one figure that travels by return rather than through the accumulator, which is what
@@ -2807,6 +2843,26 @@ mod tests {
             158,
             "the shared accessor reads the rows, not the ticks folded to get them"
         );
+    }
+
+    /// Same shape on the trade path, which shares the `rows_written` arm with quotes: a variant
+    /// folded into that arm by mistake would report the prints it folded as rows it wrote.
+    #[test]
+    fn test_a_trade_pass_carries_what_it_cost() {
+        let summary = PassProgress {
+            rows_written: 158,
+            ..Default::default()
+        }
+        .into_trade_summary(871_159);
+
+        assert_eq!(
+            summary.output,
+            PassOutput::Trades {
+                summaries_written: 158,
+                trades_folded: 871_159
+            }
+        );
+        assert_eq!(summary.output.rows_written(), 158);
     }
 
     /// The rule the product exists to enforce, and the reason "may it create" is not a third axis.

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -21,7 +21,7 @@
 --
 -- Requirements:
 --   - AWS credentials configured in the environment (e.g. ~/.aws/credentials)
---   - AWS_S3_BUCKET_NAME set (start-duckdb passes the bucket argument)
+--   - AWS_S3_ARCHIVE_BUCKET_NAME set (start-duckdb passes the bucket argument)
 
 INSTALL aws;
 LOAD aws;
@@ -29,7 +29,8 @@ INSTALL httpfs;
 LOAD httpfs;
 CALL load_aws_credentials();
 
-SET VARIABLE bucket = getenv('AWS_S3_BUCKET_NAME');
+-- The shared archive, not this instance's records: every view below reads data/**.
+SET VARIABLE bucket = getenv('AWS_S3_ARCHIVE_BUCKET_NAME');
 
 .bail off
 

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -19,9 +19,14 @@
 -- exported as well, from the same Massive endpoint by a second path, and two
 -- writers of one fact is one too many.
 --
+-- The two prefixes live in two buckets, which is why there are two variables
+-- below. data/ is shared and the same for every instance; exports/ is this
+-- instance's own record and differs per profile.
+--
 -- Requirements:
 --   - AWS credentials configured in the environment (e.g. ~/.aws/credentials)
 --   - AWS_S3_ARCHIVE_BUCKET_NAME set (start-duckdb passes the bucket argument)
+--   - AWS_S3_BUCKET_NAME set (start-duckdb takes it from the profile)
 
 INSTALL aws;
 LOAD aws;
@@ -29,8 +34,10 @@ INSTALL httpfs;
 LOAD httpfs;
 CALL load_aws_credentials();
 
--- The shared archive, not this instance's records: every view below reads data/**.
-SET VARIABLE bucket = getenv('AWS_S3_ARCHIVE_BUCKET_NAME');
+-- Named for what they hold rather than which is default, so a view reading the wrong prefix from
+-- the wrong bucket is visible at the read_parquet call instead of in an empty result.
+SET VARIABLE archive_bucket = getenv('AWS_S3_ARCHIVE_BUCKET_NAME');
+SET VARIABLE records_bucket = getenv('AWS_S3_BUCKET_NAME');
 
 .bail off
 
@@ -47,7 +54,7 @@ DROP VIEW IF EXISTS training_bars;
 CREATE OR REPLACE VIEW training_bars AS
 SELECT *
 FROM read_parquet(
-    's3://' || getvariable('bucket') || '/data/equity/bars/interval=one_day/**/*.parquet',
+    's3://' || getvariable('archive_bucket') || '/data/equity/bars/interval=one_day/**/*.parquet',
     hive_partitioning = true
 );
 
@@ -56,7 +63,7 @@ DROP VIEW IF EXISTS training_details;
 CREATE OR REPLACE VIEW training_details AS
 SELECT *
 FROM read_csv(
-    's3://' || getvariable('bucket') || '/data/equity/details/details.csv',
+    's3://' || getvariable('archive_bucket') || '/data/equity/details/details.csv',
     auto_detect = true
 );
 
@@ -84,7 +91,7 @@ SELECT
     split_to,
     to_timestamp(first_seen / 1000.0) AS first_seen
 FROM read_parquet(
-    's3://' || getvariable('bucket') || '/data/equity/corporate_actions/splits.parquet'
+    's3://' || getvariable('archive_bucket') || '/data/equity/corporate_actions/splits.parquet'
 );
 
 -- The dates a symbol's series may not be read across. `related_ticker` is where a rename continues
@@ -101,7 +108,7 @@ SELECT
     related_ticker,
     to_timestamp(first_seen / 1000.0) AS first_seen
 FROM read_parquet(
-    's3://' || getvariable('bucket') || '/data/equity/corporate_actions/boundaries.parquet'
+    's3://' || getvariable('archive_bucket') || '/data/equity/corporate_actions/boundaries.parquet'
 );
 
 -- ---------------------------------------------------------------------------
@@ -117,7 +124,7 @@ DROP VIEW IF EXISTS equity_predictions;
 CREATE OR REPLACE VIEW equity_predictions AS
 SELECT *
 FROM read_parquet(
-    's3://' || getvariable('bucket') || '/exports/equity/predictions/**/*.parquet',
+    's3://' || getvariable('records_bucket') || '/exports/equity/predictions/**/*.parquet',
     hive_partitioning = true
 );
 
@@ -126,7 +133,7 @@ DROP VIEW IF EXISTS equity_pairs;
 CREATE OR REPLACE VIEW equity_pairs AS
 SELECT *
 FROM read_parquet(
-    's3://' || getvariable('bucket') || '/exports/equity/pairs/**/*.parquet',
+    's3://' || getvariable('records_bucket') || '/exports/equity/pairs/**/*.parquet',
     hive_partitioning = true
 );
 
@@ -135,7 +142,7 @@ DROP VIEW IF EXISTS account_snapshots;
 CREATE OR REPLACE VIEW account_snapshots AS
 SELECT *
 FROM read_parquet(
-    's3://' || getvariable('bucket') || '/exports/account/snapshots/**/*.parquet',
+    's3://' || getvariable('records_bucket') || '/exports/account/snapshots/**/*.parquet',
     hive_partitioning = true
 );
 
@@ -144,7 +151,7 @@ DROP VIEW IF EXISTS account_activities;
 CREATE OR REPLACE VIEW account_activities AS
 SELECT *
 FROM read_parquet(
-    's3://' || getvariable('bucket') || '/exports/account/activities/**/*.parquet',
+    's3://' || getvariable('records_bucket') || '/exports/account/activities/**/*.parquet',
     hive_partitioning = true
 );
 
@@ -156,7 +163,7 @@ DROP VIEW IF EXISTS events;
 CREATE OR REPLACE VIEW events AS
 SELECT *
 FROM read_parquet(
-    's3://' || getvariable('bucket') || '/exports/events/**/*.parquet',
+    's3://' || getvariable('records_bucket') || '/exports/events/**/*.parquet',
     hive_partitioning = true
 );
 
@@ -221,7 +228,7 @@ SELECT
     month,
     day
 FROM read_parquet(
-    's3://' || getvariable('bucket') || '/exports/journal/**/*.parquet',
+    's3://' || getvariable('records_bucket') || '/exports/journal/**/*.parquet',
     hive_partitioning = true
 );
 


### PR DESCRIPTION
# Overview

Two commits. The trade fold from #1121 gains a caller and a command; separately, every site that reads `data/**` moves to a dedicated archive bucket variable. **Nothing runs and nothing moves yet.**

## Changes

**`ed8a54d` — the trade archive write path**
- `TRADE_ARCHIVE_PREFIX` / `trade_archive_prefix`, hive-partitioned on interval.
- `archive_trade_sessions` / `archive_trade_session` — session-major, universe from the daily bars.
- `write_trade_partitions` — three cadences, **daily last**.
- `seed equity-trades {archive,widen}`.

**`e30e553` — the bucket split**
- Ten sites take `AWS_S3_ARCHIVE_BUCKET_NAME`; `handlers.rs` is untouched.
- The trainer holds **both**.
- `start-duckdb` takes the archive name; both names print in `enterShell` and `fund-buckets`.
- `.scratchpad/` added to `.sqlfluffignore`.

## Context

**Two trade actions where quotes have five.** No `repair`, no `measure`: a trade file *is* the session, so a name absent from it is absent from the tape rather than from a retryable fetch. A repair verb would imply a recovery that does not exist.

**The scope is pinned before the run, not after.** The quote backfill folded the screened universe — 1,100 names against 10,000 — for fifteen hours and 254 sessions because nothing asserted the scope the pass would use. `test_both_universe_trade_actions_fold_the_whole_market` is that assertion, and it matters more here: this is the last Advanced-only item, so a wrong universe cannot be re-read once the subscription lapses.

**The trainer needed splitting, not switching** — which reading the code showed and the plan did not. It repairs and reads the shared corpus *and* publishes an artifact belonging to whichever instance trained it. One variable would either scatter artifacts through the shared archive or give each instance a private copy of an irreproducible corpus. Every call site was checked individually; two archive calls are inline and a line-oriented rewrite missed them.

**A docstring that had become false.** `QUOTE_ARCHIVE_PREFIX` claimed `data/equity/bars` is Massive's and the quotes Alpaca's. The five-year backfill folded 1,254 sessions of quotes out of Massive, and repairs write Alpaca into the same partitions. It is keyed by what the rows describe, not who supplied them.

**Coverage falls to 81.25% from 81.69%.** The pass itself is uncovered — exercising it needs S3 and a 7 GB vendor file — and the parts testable without either, the key layout and the scope, are. Above the 75% floor, but a real reduction rather than a rounding one.

**`.sqlfluffignore`**: sqlfluff was linting gitignored DuckDB scripts under the `postgres` dialect, failing locally all session and becoming blocking the moment this change touched a `.sql` file. CI never saw it — those files are not in the repository.

`devenv tasks run checks:rust` and `checks:base` green, clippy unchanged. `AWS_S3_ARCHIVE_BUCKET_NAME` verified resolving in the shell to `oscm-fund-archive`.

Next: copying `data/**` into the archive, gated on the raw-retention prefix being final, because Deep Archive objects cannot be moved cheaply once written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KQiJumjK2WhBCNmhNV9sq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for archiving equity trade data across one-minute, five-minute, and daily intervals.
  * Added an `equity-trades` command with archive and widening actions.
  * Introduced a shared archive storage location for market data, separate from instance-specific model data.

* **Improvements**
  * Updated analysis, training, data seeding, and local database workflows to use the shared archive.
  * Improved environment and startup displays to show both storage locations.

* **Chores**
  * SQLFluff now ignores scratchpad files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->