### PR TITLE
Name the records bucket variable for what it holds

### DIFF
--- a/.claude/skills/run-autotrain/SKILL.md
+++ b/.claude/skills/run-autotrain/SKILL.md
@@ -26,9 +26,10 @@ Autonomous model optimization via iterative architecture search. See
 
 ## Training Infrastructure
 
-Training runs **locally** via `cargo run --release --bin tide_model_trainer`. S3 data
-and model artifacts are accessed via AWS SDK using the `AWS_S3_RECORDS_BUCKET_NAME`
-environment variable.
+Training runs **locally** via `cargo run --release --bin tide_model_trainer`. It reads two
+buckets over the AWS SDK, and they are not interchangeable: training data comes from the
+shared archive named by `AWS_S3_ARCHIVE_BUCKET_NAME`, and the model artifact it publishes
+goes to this instance's own bucket, `AWS_S3_RECORDS_BUCKET_NAME`.
 
 ### Local Training
 
@@ -149,7 +150,9 @@ Priority order: architecture > hyperparameters > epoch depth > loss function > d
 
 - **Training crash**: Log as CRASH, fix the bug, commit fix, retry.
 - **Compilation errors**: Fix the Rust code, ensure `cargo build --release --features train` passes.
-- **Missing data**: Check `AWS_S3_RECORDS_BUCKET_NAME` and S3 connectivity via `secretspec run -- aws s3 ls`.
+- **Missing data**: Check `AWS_S3_ARCHIVE_BUCKET_NAME`, which is where training data is read from,
+  and S3 connectivity via `secretspec run -- aws s3 ls`. `AWS_S3_RECORDS_BUCKET_NAME` is the
+  publish target and a missing artifact points there instead.
 
 ## Files Modified During Loop
 

--- a/.claude/skills/run-autotrain/SKILL.md
+++ b/.claude/skills/run-autotrain/SKILL.md
@@ -27,7 +27,7 @@ Autonomous model optimization via iterative architecture search. See
 ## Training Infrastructure
 
 Training runs **locally** via `cargo run --release --bin tide_model_trainer`. S3 data
-and model artifacts are accessed via AWS SDK using the `AWS_S3_BUCKET_NAME`
+and model artifacts are accessed via AWS SDK using the `AWS_S3_RECORDS_BUCKET_NAME`
 environment variable.
 
 ### Local Training
@@ -149,7 +149,7 @@ Priority order: architecture > hyperparameters > epoch depth > loss function > d
 
 - **Training crash**: Log as CRASH, fix the bug, commit fix, retry.
 - **Compilation errors**: Fix the Rust code, ensure `cargo build --release --features train` passes.
-- **Missing data**: Check `AWS_S3_BUCKET_NAME` and S3 connectivity via `secretspec run -- aws s3 ls`.
+- **Missing data**: Check `AWS_S3_RECORDS_BUCKET_NAME` and S3 connectivity via `secretspec run -- aws s3 ls`.
 
 ## Files Modified During Loop
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -16,7 +16,7 @@
   # per-profile bucket, so a stray key is a bug rather than a judgement call.
   archiveBucket = "oscm-fund-archive";
   runtimeEnv = ''
-    export AWS_S3_BUCKET_NAME="oscm-fund-$(echo ''${FUND_PROFILE} | tr '/.' '--')"
+    export AWS_S3_RECORDS_BUCKET_NAME="oscm-fund-$(echo ''${FUND_PROFILE} | tr '/.' '--')"
     export AWS_S3_ARCHIVE_BUCKET_NAME="${archiveBucket}"
     export SECRETSPEC_PROFILE="''${FUND_PROFILE}"
     export AWS_S3_MODEL_ARTIFACT_PATH="models/tide/"
@@ -287,7 +287,7 @@ in {
     pg_dump -Fc -h localhost -p 5432 fund > /tmp/fund-latest.dump
     gzip -f /tmp/fund-latest.dump
     echo "Uploading backup to S3..."
-    aws s3 cp /tmp/fund-latest.dump.gz "s3://$AWS_S3_BUCKET_NAME/$BACKUP_KEY"
+    aws s3 cp /tmp/fund-latest.dump.gz "s3://$AWS_S3_RECORDS_BUCKET_NAME/$BACKUP_KEY"
     rm -f /tmp/fund-latest.dump.gz
     echo "Database backup complete"
   '';
@@ -309,7 +309,7 @@ in {
     ${runtimeEnv}
     unset AWS_ENDPOINT_URL
     echo "=== Fund S3 Buckets (profile: $FUND_PROFILE) ==="
-    echo "  Records: $AWS_S3_BUCKET_NAME"
+    echo "  Records: $AWS_S3_RECORDS_BUCKET_NAME"
     echo "  Archive: $AWS_S3_ARCHIVE_BUCKET_NAME (shared, holds data/**)"
     echo ""
     buckets=$(aws s3 ls)
@@ -718,7 +718,7 @@ in {
     fi
 
     export AWS_S3_ARCHIVE_BUCKET_NAME="$1"
-    echo "Opening DuckDB lab (archive: $AWS_S3_ARCHIVE_BUCKET_NAME, records: $AWS_S3_BUCKET_NAME)"
+    echo "Opening DuckDB lab (archive: $AWS_S3_ARCHIVE_BUCKET_NAME, records: $AWS_S3_RECORDS_BUCKET_NAME)"
 
     exec duckdb ~/lab.duckdb -init "$DEVENV_ROOT/tools/duckdb_initialization.sql"
   '';
@@ -1044,7 +1044,7 @@ in {
       export AWS_S3_MODEL_ARTIFACT_PATH="models/tide-smoke/"
       export FUND_EPOCHS="''${FUND_EPOCHS:-1}"
       echo "Rehearsing the tide training pipeline ($FUND_EPOCHS epoch(s), lookback ''${FUND_LOOKBACK_DAYS:-trainer default})"
-      echo "  Publishing to s3://$AWS_S3_BUCKET_NAME/$AWS_S3_MODEL_ARTIFACT_PATH, which nothing serves from."
+      echo "  Publishing to s3://$AWS_S3_RECORDS_BUCKET_NAME/$AWS_S3_MODEL_ARTIFACT_PATH, which nothing serves from."
       secretspec run -- cargo run --release --bin tide_model_trainer
     '';
 
@@ -1072,7 +1072,7 @@ in {
       export FUND_EPOCHS="''${FUND_EPOCHS:-1}"
       echo "Rehearsing against PRODUCTION ($FUND_EPOCHS epoch(s), lookback ''${FUND_LOOKBACK_DAYS:-trainer default})"
       echo "  Reading and repairing s3://$AWS_S3_ARCHIVE_BUCKET_NAME/data/equity/bars/interval=one_day/"
-      echo "  Publishing to s3://$AWS_S3_BUCKET_NAME/$AWS_S3_MODEL_ARTIFACT_PATH, which nothing serves from."
+      echo "  Publishing to s3://$AWS_S3_RECORDS_BUCKET_NAME/$AWS_S3_MODEL_ARTIFACT_PATH, which nothing serves from."
       secretspec run -- cargo run --release --bin tide_model_trainer
     '';
 
@@ -1327,7 +1327,7 @@ in {
     {
       echo "Fund development environment (profile: $FUND_PROFILE)"
       echo ""
-      echo "  Records: $AWS_S3_BUCKET_NAME"
+      echo "  Records: $AWS_S3_RECORDS_BUCKET_NAME"
       echo "  Archive: $AWS_S3_ARCHIVE_BUCKET_NAME (shared, holds data/**)"
       echo ""
       echo "  Profiles:"

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -76,8 +76,9 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // below belongs to the one instance that trained it.
     let archive_bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
         .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
-    let bucket = std::env::var("AWS_S3_RECORDS_BUCKET_NAME")
-        .map_err(|_| "AWS_S3_RECORDS_BUCKET_NAME must be set (derived from FUND_PROFILE)")?;
+    let records_bucket = std::env::var("AWS_S3_RECORDS_BUCKET_NAME").map_err(|_| {
+        "AWS_S3_RECORDS_BUCKET_NAME must be set (this instance's own, not the shared archive)"
+    })?;
     let artifact_prefix =
         std::env::var("AWS_S3_MODEL_ARTIFACT_PATH").unwrap_or_else(|_| "models/tide/".to_string());
     let lookback_days = read_positive_env("FUND_LOOKBACK_DAYS", DEFAULT_LOOKBACK_DAYS)?;
@@ -106,7 +107,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     info!(
-        bucket,
+        records_bucket,
         artifact_prefix,
         lookback_days,
         %session,
@@ -353,7 +354,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let model_key = format!("{artifact_prefix}{timestamp}/output/model.tar.gz");
     upload_artifact(
         &s3_client,
-        &bucket,
+        &records_bucket,
         &model_key,
         package_dir_to_tar_gz(staging.path())?,
         "application/gzip",
@@ -365,7 +366,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let prior_continuous_ranked_probability_scores =
         fetch_prior_continuous_ranked_probability_scores(
             &s3_client,
-            &bucket,
+            &records_bucket,
             &artifact_prefix,
             &current_folder,
             DRIFT_PRIOR_RUN_COUNT,
@@ -431,7 +432,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     for attempt in 1..=METADATA_UPLOAD_ATTEMPTS {
         match upload_artifact(
             &s3_client,
-            &bucket,
+            &records_bucket,
             &metadata_key,
             metadata_body.clone(),
             "application/json",
@@ -459,7 +460,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         return Err(format!("failed to publish run metadata for {current_folder}").into());
     }
 
-    println!("Training complete: artifact s3://{bucket}/{model_key}");
+    println!("Training complete: artifact s3://{records_bucket}/{model_key}");
     println!(
         "Metrics: CRPS={:.6} directional_accuracy={:.4} quantile_coverage={:.4}",
         metrics.continuous_ranked_probability_score,

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -76,8 +76,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // below belongs to the one instance that trained it.
     let archive_bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
         .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
-    let bucket = std::env::var("AWS_S3_BUCKET_NAME")
-        .map_err(|_| "AWS_S3_BUCKET_NAME must be set (this instance's records)")?;
+    let bucket = std::env::var("AWS_S3_RECORDS_BUCKET_NAME")
+        .map_err(|_| "AWS_S3_RECORDS_BUCKET_NAME must be set (derived from FUND_PROFILE)")?;
     let artifact_prefix =
         std::env::var("AWS_S3_MODEL_ARTIFACT_PATH").unwrap_or_else(|_| "models/tide/".to_string());
     let lookback_days = read_positive_env("FUND_LOOKBACK_DAYS", DEFAULT_LOOKBACK_DAYS)?;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -92,7 +92,7 @@ pub struct ServiceState {
     /// Massive, for daily bars. See [`crate::common::massive`] for why the two are split.
     massive: MassiveClient,
     s3_client: aws_sdk_s3::Client,
-    bucket: String,
+    records_bucket: String,
     artifact_prefix: String,
     model_version: String,
     calendar_cache: CalendarCache,
@@ -125,7 +125,7 @@ impl ServiceState {
         let massive = MassiveClient::from_env()
             .map_err(|error| HandlerError::Configuration(error.to_string()))?;
 
-        let bucket = std::env::var("AWS_S3_RECORDS_BUCKET_NAME").map_err(|_| {
+        let records_bucket = std::env::var("AWS_S3_RECORDS_BUCKET_NAME").map_err(|_| {
             HandlerError::Configuration("AWS_S3_RECORDS_BUCKET_NAME is not set".to_string())
         })?;
         let artifact_prefix = std::env::var("AWS_S3_MODEL_ARTIFACT_PATH")
@@ -140,7 +140,7 @@ impl ServiceState {
             market_data: MarketDataClient::new(credentials, DataFeed::Sip),
             massive,
             s3_client: crate::common::aws::s3_client().await,
-            bucket,
+            records_bucket,
             artifact_prefix,
             model_version,
             calendar_cache: CalendarCache::new(),
@@ -380,14 +380,14 @@ async fn handle_predictions(
     // liquidation consults no spread model.
     let splits = state
         .split_table_cache
-        .get(&state.s3_client, &state.bucket, now)
+        .get(&state.s3_client, &state.records_bucket, now)
         .await?;
     let unadjustable = SplitTable::default();
     // Absent boundaries do not block the way absent splits do: the guard they provide is worth far
     // less than the trading refusing to run without it would cost.
     let boundaries = state
         .boundary_table_cache
-        .get(&state.s3_client, &state.bucket, now)
+        .get(&state.s3_client, &state.records_bucket, now)
         .await?;
     let unbounded = BoundaryTable::default();
     let close_history = state
@@ -412,15 +412,19 @@ async fn handle_predictions(
 
     let artifact_key = artifact::resolve_artifact_key(
         &state.s3_client,
-        &state.bucket,
+        &state.records_bucket,
         &state.artifact_prefix,
         &state.model_version,
         None,
     )
     .await?;
-    let model_state =
-        artifact::download_and_load_model(&state.s3_client, &state.bucket, &artifact_key, None)
-            .await?;
+    let model_state = artifact::download_and_load_model(
+        &state.s3_client,
+        &state.records_bucket,
+        &artifact_key,
+        None,
+    )
+    .await?;
 
     let artifact_staleness_sessions =
         artifact_staleness_sessions(model_state.run_id(), &calendar, today);
@@ -491,13 +495,13 @@ async fn run_inference(
     // model would read a two-for-one as a genuine fifty percent fall.
     let splits = state
         .split_table_cache
-        .get(&state.s3_client, &state.bucket, now)
+        .get(&state.s3_client, &state.records_bucket, now)
         .await
         .map_err(|error| at("load_splits")(error.to_string()))?
         .ok_or_else(|| at("load_splits")("no splits table in the archive".to_string()))?;
     let boundaries = state
         .boundary_table_cache
-        .get(&state.s3_client, &state.bucket, now)
+        .get(&state.s3_client, &state.records_bucket, now)
         .await
         .map_err(|error| at("load_boundaries")(error.to_string()))?;
     let unbounded = BoundaryTable::default();
@@ -569,14 +573,14 @@ async fn handle_portfolio_evaluation(
     // liquidation consults no spread model.
     let splits = state
         .split_table_cache
-        .get(&state.s3_client, &state.bucket, now)
+        .get(&state.s3_client, &state.records_bucket, now)
         .await?;
     let unadjustable = SplitTable::default();
     // Absent boundaries do not block the way absent splits do: the guard they provide is worth far
     // less than the trading refusing to run without it would cost.
     let boundaries = state
         .boundary_table_cache
-        .get(&state.s3_client, &state.bucket, now)
+        .get(&state.s3_client, &state.records_bucket, now)
         .await?;
     let unbounded = BoundaryTable::default();
     let close_history = state
@@ -774,8 +778,13 @@ async fn handle_database_export(
 ) -> Result<Value, HandlerError> {
     let today = SessionDate::at(Utc::now());
 
-    let sessions =
-        export::export_journals(&state.journal, &state.s3_client, &state.bucket, today).await;
+    let sessions = export::export_journals(
+        &state.journal,
+        &state.s3_client,
+        &state.records_bucket,
+        today,
+    )
+    .await;
     // After the export, so the seal has released. This record lands in the session the export ran
     // in and ships on the next run, which is what lets the journal describe its own export.
     state
@@ -815,7 +824,7 @@ async fn handle_database_export(
     let logs = export::export_logs(
         &crate::common::log::log_directory(),
         &state.s3_client,
-        &state.bucket,
+        &state.records_bucket,
         today,
     )
     .await;
@@ -835,7 +844,8 @@ async fn handle_database_export(
         )
         .await;
 
-    let export = export::export_database(&state.pool, &state.s3_client, &state.bucket, today).await;
+    let export =
+        export::export_database(&state.pool, &state.s3_client, &state.records_bucket, today).await;
 
     // Skipped rather than attempted, because the purge deletes rows on the strength of S3 holding
     // them. `purge_skipped` on the record below is what separates this from a purge of zero rows.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -125,8 +125,8 @@ impl ServiceState {
         let massive = MassiveClient::from_env()
             .map_err(|error| HandlerError::Configuration(error.to_string()))?;
 
-        let bucket = std::env::var("AWS_S3_BUCKET_NAME").map_err(|_| {
-            HandlerError::Configuration("AWS_S3_BUCKET_NAME is not set".to_string())
+        let bucket = std::env::var("AWS_S3_RECORDS_BUCKET_NAME").map_err(|_| {
+            HandlerError::Configuration("AWS_S3_RECORDS_BUCKET_NAME is not set".to_string())
         })?;
         let artifact_prefix = std::env::var("AWS_S3_MODEL_ARTIFACT_PATH")
             .unwrap_or_else(|_| "models/tide/".to_string());

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -26,7 +26,7 @@
 -- Requirements:
 --   - AWS credentials configured in the environment (e.g. ~/.aws/credentials)
 --   - AWS_S3_ARCHIVE_BUCKET_NAME set (start-duckdb passes the bucket argument)
---   - AWS_S3_BUCKET_NAME set (start-duckdb takes it from the profile)
+--   - AWS_S3_RECORDS_BUCKET_NAME set (start-duckdb takes it from the profile)
 
 INSTALL aws;
 LOAD aws;
@@ -37,7 +37,7 @@ CALL load_aws_credentials();
 -- Named for what they hold rather than which is default, so a view reading the wrong prefix from
 -- the wrong bucket is visible at the read_parquet call instead of in an empty result.
 SET VARIABLE archive_bucket = getenv('AWS_S3_ARCHIVE_BUCKET_NAME');
-SET VARIABLE records_bucket = getenv('AWS_S3_BUCKET_NAME');
+SET VARIABLE records_bucket = getenv('AWS_S3_RECORDS_BUCKET_NAME');
 
 .bail off
 


### PR DESCRIPTION
# Overview

Renames `AWS_S3_BUCKET_NAME` to `AWS_S3_RECORDS_BUCKET_NAME`, so the pair introduced in #1122 reads as one decision instead of one named variable beside one unnamed one.

## Changes

- Rename across all 15 read sites: `devenv.nix` (7), `tools/duckdb_initialization.sql` (2), `src/handlers.rs` (2), `src/bin/tide_model_trainer.rs` (2), `.claude/skills/run-autotrain/SKILL.md` (2)
- Replace the trainer's `(this instance's records)` error hint with `(derived from FUND_PROFILE)` -- the name now carries the first, and cannot carry the second

## Context

`AWS_S3_ARCHIVE_BUCKET_NAME` landed in #1122 announcing what it holds. `AWS_S3_BUCKET_NAME` sat beside it saying only that it is a bucket, and the two are read on adjacent lines in `tide_model_trainer.rs` and in the DuckDB init -- the place the asymmetry costs the most.

`RECORDS` rather than `INSTANCE` or `PROFILE` because the vocabulary is already in the tree: `devenv.nix` prints `Records:` beside `Archive:`, the DuckDB variables are `archive_bucket` and `records_bucket`, and the bucket split is documented as provider-derived facts against a record of what one instance did. Naming for the contents keeps the pair symmetric; naming for the owner or for `FUND_PROFILE` would describe the mechanism, and the archive has an owner and a derivation too.

Renamed rather than aliased on purpose. Both Rust reads fail closed (`handlers.rs:128`, `tide_model_trainer.rs:79`), so an environment still carrying only the old name is a startup error rather than a silent write to the wrong bucket. Services take `runtimeEnv` at start, so anything long-running needs a restart -- no VMs are currently running, so there is nothing to restart for this deploy.

### Verification

- `devenv tasks run checks:all` -- clean, exit 0
- Live DuckDB against S3 under both new names in one session: `training_bars` returned 13,433,151 rows from the archive bucket and `journal` 2,838 from the records bucket, so each variable is exercised independently
- No references to the old name remain anywhere outside `target/` and `.git/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated training guidance to reference the renamed records storage bucket setting.

* **Chores**
  * Standardized the records bucket environment variable across development tools, training workflows, service configuration, and database initialization.
  * Updated related setup messages and configuration errors to use the new setting name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->