### PR TITLE
Move the derived archive under `data/derived/`

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1071,7 +1071,7 @@ in {
       export AWS_S3_MODEL_ARTIFACT_PATH="models/tide-smoke/"
       export FUND_EPOCHS="''${FUND_EPOCHS:-1}"
       echo "Rehearsing against PRODUCTION ($FUND_EPOCHS epoch(s), lookback ''${FUND_LOOKBACK_DAYS:-trainer default})"
-      echo "  Reading and repairing s3://$AWS_S3_ARCHIVE_BUCKET_NAME/data/equity/bars/interval=one_day/"
+      echo "  Reading and repairing s3://$AWS_S3_ARCHIVE_BUCKET_NAME/data/derived/equity/bars/interval=one_day/"
       echo "  Publishing to s3://$AWS_S3_RECORDS_BUCKET_NAME/$AWS_S3_MODEL_ARTIFACT_PATH, which nothing serves from."
       secretspec run -- cargo run --release --bin tide_model_trainer
     '';

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -63,7 +63,7 @@ struct Arguments {
     command: Command,
 }
 
-/// The nouns, named for the prefixes they write: `data/equity/{bars,details,quotes}`.
+/// The nouns, named for the prefixes they write: `data/derived/equity/{bars,details,quotes}`.
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Bars from Massive, at whichever cadence the route beneath answers for.
@@ -131,7 +131,7 @@ enum BarRoute {
 enum DailyTarget {
     /// Into `equity_bars`, which the application trades from. Needs a database and Massive.
     Postgres(DatabaseBarsArguments),
-    /// Into `data/equity/bars/interval=one_day/`, which the trainer trains from. Needs AWS, Massive
+    /// Into `data/derived/equity/bars/interval=one_day/`, which the trainer trains from. Needs AWS, Massive
     /// and Alpaca.
     S3(ArchiveBarsArguments),
 }
@@ -140,7 +140,7 @@ enum DailyTarget {
 enum DetailsTarget {
     /// Into `equity_details`, which the pair screen's per-sector cap reads.
     Postgres,
-    /// Into `data/equity/details/details.csv`, which DuckDB's `training_details` view resolves to.
+    /// Into `data/derived/equity/details/details.csv`, which DuckDB's `training_details` view resolves to.
     S3,
 }
 

--- a/src/common/aws.rs
+++ b/src/common/aws.rs
@@ -11,7 +11,7 @@ pub async fn s3_client() -> aws_sdk_s3::Client {
 }
 
 /// Build the Hive-partitioned S3 key for one day of parquet data, e.g.
-/// `data/equity/bars/interval=one_day/year=2026/month=06/day=10/data.parquet`. The single
+/// `data/derived/equity/bars/interval=one_day/year=2026/month=06/day=10/data.parquet`. The single
 /// source of truth for the date-partition layout: the data manager's daily
 /// writers and exports, the historical backfill, and the tide trainer's
 /// reader all derive their keys here so they can never diverge.
@@ -55,8 +55,8 @@ mod tests {
     fn test_date_partitioned_key_zero_pads_month_and_day() {
         let date = chrono::NaiveDate::from_ymd_opt(2026, 6, 3).unwrap();
         assert_eq!(
-            date_partitioned_key("data/equity/bars", date),
-            "data/equity/bars/year=2026/month=06/day=03/data.parquet"
+            date_partitioned_key("data/derived/equity/bars", date),
+            "data/derived/equity/bars/year=2026/month=06/day=03/data.parquet"
         );
     }
 
@@ -76,7 +76,7 @@ mod tests {
     fn test_date_round_trips_through_a_partitioned_key() {
         for (year, month, day) in [(2026, 6, 3), (2025, 12, 31), (2024, 2, 29), (2026, 1, 1)] {
             let date = chrono::NaiveDate::from_ymd_opt(year, month, day).unwrap();
-            let key = date_partitioned_key("data/equity/bars", date);
+            let key = date_partitioned_key("data/derived/equity/bars", date);
             assert_eq!(date_from_partitioned_key(&key), Some(date), "key: {key}");
         }
     }
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn test_date_recovered_regardless_of_prefix() {
         let date = chrono::NaiveDate::from_ymd_opt(2026, 6, 3).unwrap();
-        for prefix in ["data/equity/bars", "exports/equity/orders", "a", ""] {
+        for prefix in ["data/derived/equity/bars", "exports/equity/orders", "a", ""] {
             let key = date_partitioned_key(prefix, date);
             assert_eq!(
                 date_from_partitioned_key(&key),
@@ -100,13 +100,13 @@ mod tests {
     fn test_malformed_keys_are_skipped_rather_than_parsed() {
         for key in [
             "",
-            "data/equity/bars/details.csv",
-            "data/equity/bars/year=2026/month=06/day=03/manifest.json",
-            "data/equity/bars/year=2026/month=06/data.parquet",
-            "data/equity/bars/year=2026/month=6x/day=03/data.parquet",
-            "data/equity/bars/year=2026/month=13/day=03/data.parquet",
-            "data/equity/bars/year=2026/month=02/day=30/data.parquet",
-            "data/equity/bars/2026/06/03/data.parquet",
+            "data/derived/equity/bars/details.csv",
+            "data/derived/equity/bars/year=2026/month=06/day=03/manifest.json",
+            "data/derived/equity/bars/year=2026/month=06/data.parquet",
+            "data/derived/equity/bars/year=2026/month=6x/day=03/data.parquet",
+            "data/derived/equity/bars/year=2026/month=13/day=03/data.parquet",
+            "data/derived/equity/bars/year=2026/month=02/day=30/data.parquet",
+            "data/derived/equity/bars/2026/06/03/data.parquet",
         ] {
             assert_eq!(date_from_partitioned_key(key), None, "key: {key}");
         }

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -1,6 +1,6 @@
 //! The S3 bar archive: the trainer's data, repaired to a window rather than topped up by a night.
 //!
-//! One partition per session and cadence under `data/equity/bars/interval=/year=/month=/day=/`.
+//! One partition per session and cadence under `data/derived/equity/bars/interval=/year=/month=/day=/`.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Cursor;
@@ -29,7 +29,7 @@ use crate::data::{bars, boundaries, quotes, splits, trades};
 /// Deliberately not under `exports/`, which is where the application's nightly database export
 /// lands. The two datasets live in one bucket and describe overlapping facts, and giving them one
 /// prefix would make whichever job ran second the one that mattered.
-pub const BAR_ARCHIVE_PREFIX: &str = "data/equity/bars";
+pub const BAR_ARCHIVE_PREFIX: &str = "data/derived/equity/bars";
 
 /// The archive prefix for one bar cadence.
 ///
@@ -46,7 +46,7 @@ pub fn bar_archive_prefix(interval: BarInterval) -> String {
 /// Written for external readers — DuckDB's `training_details` view resolves here. Training does not
 /// read it: the trainer parses the CSV compiled into its own binary, so this copy can be absent
 /// without a model run noticing.
-pub const DETAILS_ARCHIVE_KEY: &str = "data/equity/details/details.csv";
+pub const DETAILS_ARCHIVE_KEY: &str = "data/derived/equity/details/details.csv";
 
 /// S3 key for the stock splits the bars are adjusted against.
 ///
@@ -59,13 +59,13 @@ pub const DETAILS_ARCHIVE_KEY: &str = "data/equity/details/details.csv";
 ///
 /// Under `corporate_actions/` rather than a directory of its own, because spinoffs and symbol
 /// changes are the same kind of fact read the same way and belong beside it as sibling files.
-pub const SPLITS_ARCHIVE_KEY: &str = "data/equity/corporate_actions/splits.parquet";
+pub const SPLITS_ARCHIVE_KEY: &str = "data/derived/equity/corporate_actions/splits.parquet";
 
 /// Object holding every date a symbol's price series may not be read across.
 ///
 /// Beside the splits table rather than merged into it, because the two are read for opposite
 /// purposes: a split says how to restate a price across a date, a boundary says not to.
-pub const BOUNDARIES_ARCHIVE_KEY: &str = "data/equity/corporate_actions/boundaries.parquet";
+pub const BOUNDARIES_ARCHIVE_KEY: &str = "data/derived/equity/corporate_actions/boundaries.parquet";
 
 /// Trailing sessions re-fetched even when a partition already exists.
 ///
@@ -1557,7 +1557,7 @@ fn merge_or_replace(
 /// Keyed by what the rows describe, not by who supplied them: the five-year backfill folded these
 /// from Massive's flat files and a repair folds the same names from Alpaca, so one session's
 /// partition routinely holds both. Splitting by vendor would put one session under two keys.
-pub const QUOTE_ARCHIVE_PREFIX: &str = "data/equity/quotes";
+pub const QUOTE_ARCHIVE_PREFIX: &str = "data/derived/equity/quotes";
 
 /// The archive prefix for one summary cadence, hive-partitioned like the bars.
 pub fn quote_archive_prefix(interval: BarInterval) -> String {
@@ -1565,7 +1565,7 @@ pub fn quote_archive_prefix(interval: BarInterval) -> String {
 }
 
 /// Root of the trade-summary archive, beside the quotes it will eventually be differenced against.
-pub const TRADE_ARCHIVE_PREFIX: &str = "data/equity/trades";
+pub const TRADE_ARCHIVE_PREFIX: &str = "data/derived/equity/trades";
 
 /// The archive prefix for one trade cadence, hive-partitioned like the quotes.
 pub fn trade_archive_prefix(interval: BarInterval) -> String {
@@ -2511,15 +2511,15 @@ mod tests {
 
         assert_eq!(
             key(BarInterval::OneMinute),
-            "data/equity/trades/interval=one_minute/year=2026/month=08/day=21/data.parquet"
+            "data/derived/equity/trades/interval=one_minute/year=2026/month=08/day=21/data.parquet"
         );
         assert_eq!(
             key(BarInterval::FiveMinute),
-            "data/equity/trades/interval=five_minute/year=2026/month=08/day=21/data.parquet"
+            "data/derived/equity/trades/interval=five_minute/year=2026/month=08/day=21/data.parquet"
         );
         assert_eq!(
             key(BarInterval::OneDay),
-            "data/equity/trades/interval=one_day/year=2026/month=08/day=21/data.parquet"
+            "data/derived/equity/trades/interval=one_day/year=2026/month=08/day=21/data.parquet"
         );
 
         // Disjoint from the quote archive at every cadence, so one session's two datasets cannot
@@ -2592,15 +2592,15 @@ mod tests {
 
         assert_eq!(
             date_partitioned_key(&bar_archive_prefix(BarInterval::OneDay), date),
-            "data/equity/bars/interval=one_day/year=2026/month=08/day=19/data.parquet"
+            "data/derived/equity/bars/interval=one_day/year=2026/month=08/day=19/data.parquet"
         );
         assert_eq!(
             date_partitioned_key(&bar_archive_prefix(BarInterval::OneMinute), date),
-            "data/equity/bars/interval=one_minute/year=2026/month=08/day=19/data.parquet"
+            "data/derived/equity/bars/interval=one_minute/year=2026/month=08/day=19/data.parquet"
         );
         assert_eq!(
             date_partitioned_key(&bar_archive_prefix(BarInterval::FiveMinute), date),
-            "data/equity/bars/interval=five_minute/year=2026/month=08/day=19/data.parquet"
+            "data/derived/equity/bars/interval=five_minute/year=2026/month=08/day=19/data.parquet"
         );
     }
 
@@ -2613,11 +2613,11 @@ mod tests {
 
         assert_eq!(
             date_partitioned_key(&quote_archive_prefix(BarInterval::OneDay), date),
-            "data/equity/quotes/interval=one_day/year=2026/month=08/day=19/data.parquet"
+            "data/derived/equity/quotes/interval=one_day/year=2026/month=08/day=19/data.parquet"
         );
         assert_eq!(
             date_partitioned_key(&quote_archive_prefix(BarInterval::FiveMinute), date),
-            "data/equity/quotes/interval=five_minute/year=2026/month=08/day=19/data.parquet"
+            "data/derived/equity/quotes/interval=five_minute/year=2026/month=08/day=19/data.parquet"
         );
         for interval in BarInterval::ALL {
             let quotes = date_partitioned_key(&quote_archive_prefix(interval), date);

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -54,7 +54,7 @@ DROP VIEW IF EXISTS training_bars;
 CREATE OR REPLACE VIEW training_bars AS
 SELECT *
 FROM read_parquet(
-    's3://' || getvariable('archive_bucket') || '/data/equity/bars/interval=one_day/**/*.parquet',
+    's3://' || getvariable('archive_bucket') || '/data/derived/equity/bars/interval=one_day/**/*.parquet',
     hive_partitioning = true
 );
 
@@ -63,7 +63,7 @@ DROP VIEW IF EXISTS training_details;
 CREATE OR REPLACE VIEW training_details AS
 SELECT *
 FROM read_csv(
-    's3://' || getvariable('archive_bucket') || '/data/equity/details/details.csv',
+    's3://' || getvariable('archive_bucket') || '/data/derived/equity/details/details.csv',
     auto_detect = true
 );
 
@@ -91,7 +91,7 @@ SELECT
     split_to,
     to_timestamp(first_seen / 1000.0) AS first_seen
 FROM read_parquet(
-    's3://' || getvariable('archive_bucket') || '/data/equity/corporate_actions/splits.parquet'
+    's3://' || getvariable('archive_bucket') || '/data/derived/equity/corporate_actions/splits.parquet'
 );
 
 -- The dates a symbol's series may not be read across. `related_ticker` is where a rename continues
@@ -108,7 +108,7 @@ SELECT
     related_ticker,
     to_timestamp(first_seen / 1000.0) AS first_seen
 FROM read_parquet(
-    's3://' || getvariable('archive_bucket') || '/data/equity/corporate_actions/boundaries.parquet'
+    's3://' || getvariable('archive_bucket') || '/data/derived/equity/corporate_actions/boundaries.parquet'
 );
 
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
# Overview

## Changes

- Move the six archive constants from `data/equity/**` to `data/derived/equity/**`: the bar, quote and trade prefixes, plus the details, splits and boundaries keys
- Update the twenty pinned test literals that assert those keys, and the four doc comments naming the old prefix
- Repoint the four `data/**` DuckDB views in `tools/duckdb_initialization.sql`
- **The 8,794 objects in `oscm-fund-archive` have already been moved** — this pull request makes the code agree with the bucket

## Context

The bucket strategy settled on `data/derived/**` and `data/raw/**` as the top split, because that split is also the storage-class split: everything under `raw` is written cold and never read, everything under `derived` is read by every study. One prefix, one lifecycle rule, no wildcard in the middle of a key.

The sync that populated the archive on 2026-09-01 copied keys verbatim instead of rewriting them, so the corpus landed at `data/equity/**`. That sync *was* verified — all 5,026 objects present, sizes identical, zero differences — and the verification could not have caught this. **A copy proves fidelity, not correctness: diffing a source against its destination cannot see a layout decision that was applied to neither side.**

**Six constants, not the three the plan predicted.** `DETAILS_ARCHIVE_KEY`, `SPLITS_ARCHIVE_KEY` and `BOUNDARIES_ARCHIVE_KEY` sit under the same `data/equity/` root and a narrower change would have stranded them. `src/data/details.rs`'s `include_str!("../../data/equity_details.csv")` is a repository path rather than an S3 key and is deliberately untouched.

`data/raw/` does not move. It is already at the settled prefix, and Deep Archive is the expensive case — restore first (12–48h, ~$25), then eat the 180-day minimum on the abandoned originals. That asymmetry is why this task was pulled earlier, and why the raw tee was built to write its final prefix from the first byte.

### The move, and how it was verified

Timed for the gap between the trade pass finishing and the quote pass starting. Not before: the trade job wrote `data/equity/trades/**` continuously, and moving a prefix out from under a live writer splits the corpus. Not after: the quote pass adds ~2,500 objects over ~79 hours.

Copy-verify-delete rather than `aws s3 mv`, because the archive has versioning off and an interrupted `mv` on an irreplaceable corpus is worth avoiding for pennies of temporary double storage.

- 8,794 objects / 127.6 GB copied server-side, same region, 12m13s
- Manifest of size + path below the prefix: **zero differences in both directions**
- All 8,794 destination objects `STANDARD`
- Source deleted only after a gate asserting the destination held 8,794

**Four objects in the ETag sample appeared to mismatch and did not.** Objects above the CLI's 8 MB threshold are copied as multipart, and a multipart ETag is a function of part boundaries rather than of content — the destination ETags end `-2` where the sources are single-part MD5. Sizes were identical, and SHA-256 over the full downloaded bytes of two of them matched exactly. **ETag inequality across a multipart copy is not evidence of a content difference.**

### Verification

- `devenv tasks run checks:all` — exit 0
- The renamed assertions are load-bearing: reverting `TRADE_ARCHIVE_PREFIX` alone fails `test_every_trade_cadence_has_its_own_partition_prefix` with `left: "data/equity/..."` / `right: "data/derived/equity/..."`, then passes again on restore
- Post-move, `data/` in the archive contains exactly `derived/` and `raw/`, and every scratchpad coverage tool reads the new layout: bars 1,260, quotes 1,254, trades 1,256 across all three cadences, raw tee 1,256

**The backfill box needs a redeploy after this merges** — its `seed` is built from `ad2dd6d7` and still writes the old prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KQiJumjK2WhBCNmhNV9sq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Archive data paths now use the `data/derived/equity/` hierarchy for bars, quotes, trades, details, and corporate-action data.
  - Training data views now read from the updated archive locations.
  - Partitioning and archive key behavior remain unchanged apart from the path update.

- **Documentation**
  - Updated archive path references to reflect the new storage layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->