### PR TITLE
Read one-minute bars from Massive's flat files

### DIFF
--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -100,6 +100,7 @@ impl Command {
             Command::EquityBars { route } => match route {
                 BarRoute::Daily { .. } => "seed-equity-bars-daily",
                 BarRoute::Intraday { .. } => "seed-equity-bars-intraday",
+                BarRoute::FlatFile { .. } => "seed-equity-bars-flat-file",
             },
             Command::EquityDetails { .. } => "seed-equity-details",
             Command::EquityQuotes { .. } => "seed-equity-quotes",
@@ -125,6 +126,43 @@ enum BarRoute {
         #[command(subcommand)]
         action: IntradayAction,
     },
+    /// Whole-market one-minute bars off Massive's flat files, into the S3 archive.
+    ///
+    /// A third route rather than a cadence flag on `intraday`, for the reason the two above already
+    /// differ: this one reads a whole session from one object instead of 12,000 per-symbol
+    /// requests, carries no `vw`, and stamps its rows in nanoseconds.
+    FlatFile {
+        #[command(subcommand)]
+        action: BarFlatFileAction,
+    },
+}
+
+/// What a flat-file bar pass does about a session that already has a partition.
+#[derive(Debug, Subcommand)]
+enum BarFlatFileAction {
+    /// Write the sampled sessions that have no one-minute partition yet.
+    Archive(QuoteArguments),
+    /// Write every sampled session, replacing ones already written.
+    Widen(QuoteArguments),
+}
+
+impl BarFlatFileAction {
+    /// The scope this action writes under. Both are whole-market and differ only in sessions.
+    fn scope(&self) -> Result<Scope, SeedError> {
+        whole_market(match self {
+            BarFlatFileAction::Archive(_) => SessionSelection::Absent,
+            BarFlatFileAction::Widen(_) => SessionSelection::Every,
+        })
+    }
+
+    /// The window and stride this action runs over.
+    fn arguments(&self) -> &QuoteArguments {
+        match self {
+            BarFlatFileAction::Archive(arguments) | BarFlatFileAction::Widen(arguments) => {
+                arguments
+            }
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -680,6 +718,7 @@ async fn run(command: &Command, today: SessionDate) -> Result<Outcome, SeedError
                 )),
             },
             BarRoute::Intraday { action } => seed_intraday_bars(action).await,
+            BarRoute::FlatFile { action } => seed_flat_file_bars(action).await,
         },
         Command::EquityDetails { target } => {
             match target {
@@ -1189,6 +1228,42 @@ async fn seed_trades(action: &TradeAction) -> Result<Outcome, SeedError> {
             &bucket,
             &sampled,
             &scope,
+        )
+        .await
+        .map_err(box_error)?,
+    ))
+}
+
+/// Writes whole-market one-minute bars from Massive's flat files.
+///
+/// The trade pass's shape over a different dataset. Sessions come from the trading calendar rather
+/// than from the archive, because a bar file needs no universe to fold against -- the file is the
+/// whole market, which is the reason to read it at all.
+async fn seed_flat_file_bars(action: &BarFlatFileAction) -> Result<Outcome, SeedError> {
+    let arguments = action.arguments();
+    let scope = action.scope()?;
+    let window = arguments.window.window()?;
+
+    let credentials = AlpacaCredentials::from_env().map_err(box_error)?;
+    let days = TradingClient::from_env(credentials)
+        .fetch_calendar(window.start.date(), window.end.date())
+        .await
+        .map_err(box_error)?;
+    let calendar = TradingCalendar::from_days(days);
+    let sampled = sample(&calendar, &window, arguments.stride);
+    report_sample(&window, arguments.stride, &calendar, &sampled);
+
+    let flat_files = flat_file_client(arguments).await?;
+    let bucket = bucket_name()?;
+    let s3_client = fund::common::aws::s3_client().await;
+    Ok(Outcome::Pass(
+        archive::archive_bar_flat_file_sessions(
+            &s3_client,
+            &flat_files,
+            &bucket,
+            &sampled,
+            &scope,
+            Some(&calendar),
         )
         .await
         .map_err(box_error)?,

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -258,9 +258,8 @@ where
 /// partition. Quotes and trades cannot do this — their sinks aggregate ticks into summaries.
 impl BarSink for Vec<EquityBar> {
     fn push(&mut self, bar: EquityBar) {
-        // Spelled as an inherent call. `self.push(bar)` also resolves here -- an inherent method
-        // wins over a trait one -- but it reads as unbounded recursion, and the rule that saves it
-        // is not one a reader should have to recall to believe this line terminates.
+        // Explicit because `self.push(bar)` reads as unbounded recursion, even though the
+        // inherent method wins over the trait one.
         Vec::push(self, bar)
     }
 }
@@ -277,7 +276,7 @@ pub enum RawDataset {
     Trades,
     /// Massive's own name for one-minute OHLCV bars, kept over `bars` so provenance reads off the
     /// key: `minute_aggs_v1` is a vendor dataset, where `interval=one_minute` is our cadence.
-    MinuteAggs,
+    MinuteAggregates,
 }
 
 impl RawDataset {
@@ -286,7 +285,7 @@ impl RawDataset {
         match self {
             RawDataset::Quotes => "quotes",
             RawDataset::Trades => "trades",
-            RawDataset::MinuteAggs => "minute_aggs",
+            RawDataset::MinuteAggregates => "minute_aggs",
         }
     }
 
@@ -295,7 +294,7 @@ impl RawDataset {
         match self {
             RawDataset::Quotes => "quotes_v1",
             RawDataset::Trades => "trades_v1",
-            RawDataset::MinuteAggs => "minute_aggs_v1",
+            RawDataset::MinuteAggregates => "minute_aggs_v1",
         }
     }
 
@@ -334,7 +333,7 @@ pub fn trade_key(date: NaiveDate) -> String {
 
 /// The S3 key holding one day of one-minute bars.
 pub fn bar_key(date: NaiveDate) -> String {
-    RawDataset::MinuteAggs.key(date)
+    RawDataset::MinuteAggregates.key(date)
 }
 
 /// What one file cost and what it yielded.
@@ -880,9 +879,12 @@ impl FlatFileClient {
 
         let scoped = key.clone();
         let ((mut summary, fold), compressed_bytes) = self
-            .fold_object(key.clone(), RawDataset::MinuteAggs, date, move |reader| {
-                fold_gzipped_bars(reader, &scoped, fold)
-            })
+            .fold_object(
+                key.clone(),
+                RawDataset::MinuteAggregates,
+                date,
+                move |reader| fold_gzipped_bars(reader, &scoped, fold),
+            )
             .await?;
 
         summary.compressed_bytes = compressed_bytes;
@@ -1325,10 +1327,9 @@ impl TradeColumns {
 
 /// Where each field of a one-minute bar row sits.
 ///
-/// Resolved by *name*, which is not incidental here: the vendor orders the columns
-/// `volume,open,close,high,low` -- close before high and low. A positional read would swap close
-/// with high, and the result would still be a coherent-looking candle that passes every downstream
-/// check. Name resolution is what makes that unrepresentable rather than merely unlikely.
+/// Resolved by *name* because the vendor orders the columns `volume,open,close,high,low`, with
+/// close before high and low. A positional read would swap the two and still produce a coherent
+/// candle that passes every downstream check.
 struct BarColumns {
     ticker: usize,
     volume: usize,
@@ -2560,7 +2561,7 @@ mod tests {
             "data/raw/massive/equity/trades/schema=v1/year=2021/month=01/day=04/data.csv.gz"
         );
         assert_eq!(
-            raw_key(RawDataset::MinuteAggs, date),
+            raw_key(RawDataset::MinuteAggregates, date),
             "data/raw/massive/equity/minute_aggs/schema=v1/year=2026/month=08/day=28/data.csv.gz"
         );
     }

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -11,7 +11,7 @@ use flate2::read::GzDecoder;
 use tracing::{info, warn};
 
 use crate::common::alpaca::{QuoteTick, TradeTick};
-use crate::common::types::Ticker;
+use crate::common::types::{BarInterval, EquityBar, Ticker};
 
 /// The bucket every dataset lives under, which Massive support named on 2026-08-24.
 const FLAT_FILE_BUCKET: &str = "flatfiles";
@@ -74,6 +74,13 @@ const PRICE_COLUMN: &str = "price";
 const SIZE_COLUMN: &str = "size";
 const CONDITIONS_COLUMN: &str = "conditions";
 const CORRECTION_COLUMN: &str = "correction";
+const VOLUME_COLUMN: &str = "volume";
+const OPEN_COLUMN: &str = "open";
+const CLOSE_COLUMN: &str = "close";
+const HIGH_COLUMN: &str = "high";
+const LOW_COLUMN: &str = "low";
+const WINDOW_START_COLUMN: &str = "window_start";
+const TRANSACTIONS_COLUMN: &str = "transactions";
 
 /// Why a flat-file read failed.
 #[derive(Debug, thiserror::Error)]
@@ -225,32 +232,109 @@ where
     }
 }
 
-/// The S3 key holding one day of consolidated quotes.
+/// Somewhere for a file's bars to go, on the same reasoning as [`QuoteSink`].
 ///
-/// The `us_stocks_sip` prefix is Massive's own and corroborates the SIP sourcing behind their NBBO
-/// answer — a file under it is the consolidated book rather than one venue's.
+/// Takes a whole [`EquityBar`] rather than a tick, because a bar row *is* an output row: there is
+/// nothing to fold, only to validate and place.
+pub trait BarSink {
+    fn push(&mut self, bar: EquityBar);
+}
+
+/// The bar half of [`ForEach`], distinct for the same reason as [`ForEachTrade`].
+pub struct ForEachBar<F>(pub F);
+
+impl<F> BarSink for ForEachBar<F>
+where
+    F: FnMut(EquityBar),
+{
+    fn push(&mut self, bar: EquityBar) {
+        (self.0)(bar)
+    }
+}
+
+/// Collecting the session whole, which is what the archive pass wants.
+///
+/// No adapter needed: a bar row is already an output row, so the vector the fold returns *is* the
+/// partition. Quotes and trades cannot do this — their sinks aggregate ticks into summaries.
+impl BarSink for Vec<EquityBar> {
+    fn push(&mut self, bar: EquityBar) {
+        // Spelled as an inherent call. `self.push(bar)` also resolves here -- an inherent method
+        // wins over a trait one -- but it reads as unbounded recursion, and the rule that saves it
+        // is not one a reader should have to recall to believe this line terminates.
+        Vec::push(self, bar)
+    }
+}
+
+/// One of Massive's flat-file datasets, which is also which parser its rows want.
+///
+/// An enum rather than the string this used to be, because the value names two things that must
+/// agree — the vendor path a fold reads and the archive prefix its bytes are teed to — and a pair of
+/// strings passed separately can disagree. Both derive from the variant here, so a fold cannot read
+/// trades and file them under quotes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RawDataset {
+    Quotes,
+    Trades,
+    /// Massive's own name for one-minute OHLCV bars, kept over `bars` so provenance reads off the
+    /// key: `minute_aggs_v1` is a vendor dataset, where `interval=one_minute` is our cadence.
+    MinuteAggs,
+}
+
+impl RawDataset {
+    /// The segment naming this dataset under `data/raw/massive/equity/`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RawDataset::Quotes => "quotes",
+            RawDataset::Trades => "trades",
+            RawDataset::MinuteAggs => "minute_aggs",
+        }
+    }
+
+    /// Massive's own dataset directory, which carries their schema version in its name.
+    fn vendor_segment(self) -> &'static str {
+        match self {
+            RawDataset::Quotes => "quotes_v1",
+            RawDataset::Trades => "trades_v1",
+            RawDataset::MinuteAggs => "minute_aggs_v1",
+        }
+    }
+
+    /// The S3 key holding one day of this dataset.
+    ///
+    /// The `us_stocks_sip` prefix is Massive's own and corroborates the SIP sourcing behind their
+    /// NBBO answer — a file under it is the consolidated book rather than one venue's. One layout
+    /// across all three datasets is what lets a pass read any of them without a second convention.
+    pub fn key(self, date: NaiveDate) -> String {
+        use chrono::Datelike;
+        format!(
+            "us_stocks_sip/{}/{}/{:02}/{}.csv.gz",
+            self.vendor_segment(),
+            date.year(),
+            date.month(),
+            date.format("%Y-%m-%d")
+        )
+    }
+}
+
+impl std::fmt::Display for RawDataset {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// The S3 key holding one day of consolidated quotes.
 pub fn quote_key(date: NaiveDate) -> String {
-    use chrono::Datelike;
-    format!(
-        "us_stocks_sip/quotes_v1/{}/{:02}/{}.csv.gz",
-        date.year(),
-        date.month(),
-        date.format("%Y-%m-%d")
-    )
+    RawDataset::Quotes.key(date)
 }
 
 /// The S3 key holding one day of consolidated trades.
-///
-/// The same layout as [`quote_key`] under a sibling dataset, which is what lets one pass read both
-/// halves of a session without a second convention.
 pub fn trade_key(date: NaiveDate) -> String {
-    use chrono::Datelike;
-    format!(
-        "us_stocks_sip/trades_v1/{}/{:02}/{}.csv.gz",
-        date.year(),
-        date.month(),
-        date.format("%Y-%m-%d")
-    )
+    RawDataset::Trades.key(date)
+}
+
+/// The S3 key holding one day of one-minute bars.
+pub fn bar_key(date: NaiveDate) -> String {
+    RawDataset::MinuteAggs.key(date)
 }
 
 /// What one file cost and what it yielded.
@@ -644,10 +728,10 @@ fn read_fully(file: &mut std::fs::File, buffer: &mut [u8]) -> std::io::Result<us
 /// `schema=v1` is a hive dimension carrying Massive's *schema* version rather than their filename:
 /// the column layout and the quote size-unit change are both properties of `quotes_v1`, so a re-fold
 /// years from now knows which parser the bytes want.
-pub fn raw_key(dataset: &str, date: NaiveDate) -> String {
+pub fn raw_key(dataset: RawDataset, date: NaiveDate) -> String {
     format!(
         "data/raw/massive/equity/{}/schema=v1/year={}/month={:02}/day={:02}/data.csv.gz",
-        dataset,
+        dataset.as_str(),
         date.year(),
         date.month(),
         date.day()
@@ -725,7 +809,7 @@ impl FlatFileClient {
 
         let scoped = key.clone();
         let ((mut summary, fold), compressed_bytes) = self
-            .fold_object(key.clone(), "quotes", date, move |reader| {
+            .fold_object(key.clone(), RawDataset::Quotes, date, move |reader| {
                 fold_gzipped_quotes(reader, &scoped, fold)
             })
             .await?;
@@ -760,7 +844,7 @@ impl FlatFileClient {
 
         let scoped = key.clone();
         let ((mut summary, fold), compressed_bytes) = self
-            .fold_object(key.clone(), "trades", date, move |reader| {
+            .fold_object(key.clone(), RawDataset::Trades, date, move |reader| {
                 fold_gzipped_trades(reader, &scoped, fold)
             })
             .await?;
@@ -777,6 +861,42 @@ impl FlatFileClient {
                 .map_or("unmeasured", |layout| layout.as_str()),
             compressed_bytes,
             "Folded a flat file of trades"
+        );
+        Ok((summary, fold))
+    }
+
+    /// Streams one day of one-minute bars, handing every coherent candle to `fold`.
+    ///
+    /// The same transport as [`FlatFileClient::fold_quotes`] over a third dataset — the ranges, the
+    /// blocking parse, the ordering guarantee and the raw tee are all shared. What differs is that a
+    /// bar row is already an output row, so nothing is aggregated on the way through.
+    pub async fn fold_bars<S: BarSink + Send + 'static>(
+        &self,
+        date: NaiveDate,
+        fold: S,
+    ) -> Result<(FlatFileFold, S), FlatFileError> {
+        let key = bar_key(date);
+        info!(bucket = FLAT_FILE_BUCKET, key, %date, "Reading a flat file of bars");
+
+        let scoped = key.clone();
+        let ((mut summary, fold), compressed_bytes) = self
+            .fold_object(key.clone(), RawDataset::MinuteAggs, date, move |reader| {
+                fold_gzipped_bars(reader, &scoped, fold)
+            })
+            .await?;
+
+        summary.compressed_bytes = compressed_bytes;
+        info!(
+            key,
+            rows_read = summary.rows_read,
+            bars_folded = summary.ticks_folded,
+            unusable = summary.unusable,
+            tickers = summary.tickers,
+            layout = summary
+                .layout()
+                .map_or("unmeasured", |layout| layout.as_str()),
+            compressed_bytes,
+            "Folded a flat file of bars"
         );
         Ok((summary, fold))
     }
@@ -826,7 +946,7 @@ impl FlatFileClient {
     async fn fold_object<T>(
         &self,
         key: String,
-        dataset: &str,
+        dataset: RawDataset,
         date: NaiveDate,
         parse: impl FnOnce(ChunkReader) -> Result<T, FlatFileError> + Send + 'static,
     ) -> Result<(T, i64), FlatFileError>
@@ -1203,6 +1323,78 @@ impl TradeColumns {
     }
 }
 
+/// Where each field of a one-minute bar row sits.
+///
+/// Resolved by *name*, which is not incidental here: the vendor orders the columns
+/// `volume,open,close,high,low` -- close before high and low. A positional read would swap close
+/// with high, and the result would still be a coherent-looking candle that passes every downstream
+/// check. Name resolution is what makes that unrepresentable rather than merely unlikely.
+struct BarColumns {
+    ticker: usize,
+    volume: usize,
+    open: usize,
+    close: usize,
+    high: usize,
+    low: usize,
+    window_start: usize,
+    transactions: usize,
+}
+
+impl BarColumns {
+    fn resolve(header: &csv::StringRecord, key: &str) -> Result<Self, FlatFileError> {
+        let index = |column: &'static str| column_index(header, key, column);
+        Ok(Self {
+            ticker: index(TICKER_COLUMN)?,
+            volume: index(VOLUME_COLUMN)?,
+            open: index(OPEN_COLUMN)?,
+            close: index(CLOSE_COLUMN)?,
+            high: index(HIGH_COLUMN)?,
+            low: index(LOW_COLUMN)?,
+            window_start: index(WINDOW_START_COLUMN)?,
+            transactions: index(TRANSACTIONS_COLUMN)?,
+        })
+    }
+
+    /// Reads one row, or `None` if it is not a candle worth storing.
+    ///
+    /// The coherence rules -- finite, positive, low <= open/close <= high -- are not checked here.
+    /// `EquityBar::new` owns them, so a bar that exists is a bar that validated, and this path
+    /// cannot drift from the one every other producer goes through.
+    fn bar(&self, row: &csv::StringRecord) -> Option<EquityBar> {
+        let field = |index: usize| row.get(index).map(str::trim);
+        let ticker = Ticker::new(field(self.ticker)?)?;
+        let timestamp = nanoseconds_to_instant(field(self.window_start)?.parse::<i64>().ok()?)?;
+        let price = |index: usize| field(index)?.parse::<f64>().ok();
+
+        // Fractional, as the trade tape is: 109807.346392 shares is an ordinary row. Rounded on the
+        // same terms as the REST route (`massive.rs`), so the two agree on whole shares.
+        let volume = field(self.volume)?.parse::<f64>().ok()?;
+        if !volume.is_finite() || volume < 0.0 {
+            return None;
+        }
+        let rounded = volume.round();
+        if rounded > i64::MAX as f64 {
+            return None;
+        }
+
+        EquityBar::new(
+            ticker,
+            BarInterval::OneMinute,
+            timestamp,
+            price(self.open)?,
+            price(self.high)?,
+            price(self.low)?,
+            price(self.close)?,
+            rounded as i64,
+            // The flat file carries no `vw`, where the REST aggregates route does. Absent rather
+            // than zero: a zero would read as a real volume-weighted price of nothing.
+            None,
+            field(self.transactions)?.parse::<i64>().ok(),
+        )
+        .ok()
+    }
+}
+
 /// Splits the comma-separated condition set, dropping codes that are not numbers.
 ///
 /// Parsed to integers rather than matched as text, because the field holds a *set*: `"14,12,37,41"`
@@ -1364,6 +1556,56 @@ where
     Ok((summary, fold))
 }
 
+/// Parses one gzipped bar file, handing every coherent candle to `fold`.
+///
+/// The same shape as [`fold_gzipped_trades`] over a sibling dataset. `ticks_folded` counts bars
+/// here, which keeps one summary type across all three datasets rather than a third vocabulary for
+/// the same question: how many rows survived.
+fn fold_gzipped_bars<R, S>(
+    reader: R,
+    key: &str,
+    mut fold: S,
+) -> Result<(FlatFileFold, S), FlatFileError>
+where
+    R: std::io::Read,
+    S: BarSink,
+{
+    let mut records = csv::Reader::from_reader(GzDecoder::new(reader));
+    let header = records.headers().map_err(|error| read_error(key, error))?;
+    let columns = BarColumns::resolve(header, key)?;
+
+    let mut summary = FlatFileFold::default();
+    let mut runs = TickerRuns::default();
+    let mut row = csv::StringRecord::new();
+    while records
+        .read_record(&mut row)
+        .map_err(|error| read_error(key, error))?
+    {
+        summary.rows_read += 1;
+        let Some(bar) = columns.bar(&row) else {
+            summary.unusable += 1;
+            continue;
+        };
+        runs.observe(bar.ticker(), bar.timestamp(), &mut summary);
+        summary.ticks_folded += 1;
+        fold.push(bar);
+    }
+
+    summary.require_ascending(key)?;
+
+    if summary.unusable > 0 {
+        // A candle whose prices do not cohere, or a stamp in the wrong unit. Rare, and a file
+        // suddenly half unusable is a vendor change nobody announced.
+        warn!(
+            key,
+            unusable = summary.unusable,
+            rows_read = summary.rows_read,
+            "Skipped bars that are not coherent candles"
+        );
+    }
+    Ok((summary, fold))
+}
+
 fn read_error(key: &str, error: csv::Error) -> FlatFileError {
     FlatFileError::Read {
         key: key.to_string(),
@@ -1482,6 +1724,105 @@ mod tests {
         );
         let observed = seen.borrow().clone();
         (summary.map(|(summary, _)| summary), observed)
+    }
+
+    /// The header exactly as the vendor writes it, verified against a live file on 2026-08-21.
+    ///
+    /// `open,close,high,low` -- close sits before high and low. Kept verbatim so a test cannot
+    /// quietly "fix" the order into OHLC and stop covering the trap the real file sets.
+    const BAR_HEADER: &str = "ticker,volume,open,close,high,low,window_start,transactions";
+
+    fn fold_bars_body(body: &str) -> (Result<FlatFileFold, FlatFileError>, Vec<EquityBar>) {
+        let seen = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let collector = std::rc::Rc::clone(&seen);
+        let summary = fold_gzipped_bars(
+            std::io::Cursor::new(gzipped(body)),
+            "minute_aggs.csv.gz",
+            ForEachBar(move |bar: EquityBar| collector.borrow_mut().push(bar)),
+        );
+        let observed = seen.borrow().clone();
+        (summary.map(|(summary, _)| summary), observed)
+    }
+
+    /// A bar row is read by column *name*, so the vendor's `open,close,high,low` cannot invert it.
+    ///
+    /// The fixture is the real first row of 2026-08-21. Its close (158.00) equals its high and its
+    /// low (156.09) is neither, so a positional read that took the third numeric column as high
+    /// would still produce a candle `EquityBar::new` accepts -- which is exactly why the assertion
+    /// pins every price rather than checking the row merely parsed.
+    #[test]
+    fn test_a_bar_row_is_read_by_column_name_not_position() {
+        let body = format!("{BAR_HEADER}\nA,109807.346392,156.500000,158.000000,158.000000,156.090000,1787319000000000000,127\n");
+        let (summary, seen) = fold_bars_body(&body);
+        let summary = summary.expect("a usable file");
+        assert_eq!(summary.rows_read, 1);
+        assert_eq!(summary.unusable, 0);
+
+        let bar = seen.first().expect("one bar");
+        assert_eq!(bar.ticker().as_str(), "A");
+        assert_eq!(bar.open_price(), 156.50);
+        assert_eq!(bar.high_price(), 158.00);
+        assert_eq!(bar.low_price(), 156.09);
+        assert_eq!(bar.close_price(), 158.00);
+        assert_eq!(bar.bar_interval(), BarInterval::OneMinute);
+    }
+
+    /// Fractional volume rounds to whole shares, on the same terms as the REST route.
+    #[test]
+    fn test_a_fractional_volume_rounds_to_whole_shares() {
+        let body = format!("{BAR_HEADER}\nA,109807.346392,156.500000,158.000000,158.000000,156.090000,1787319000000000000,127\n");
+        let (_, seen) = fold_bars_body(&body);
+        assert_eq!(seen.first().expect("one bar").volume(), 109_807);
+    }
+
+    /// The flat file carries no `vw`, and its absence is `None` rather than a zero or an error.
+    ///
+    /// A zero would read as a real volume-weighted price of nothing, and anything comparing the
+    /// one-minute archive against the REST-built five-minute one would see a price of 0.00.
+    #[test]
+    fn test_a_flat_file_bar_carries_no_volume_weighted_price() {
+        let body = format!("{BAR_HEADER}\nA,100,156.500000,158.000000,158.000000,156.090000,1787319000000000000,127\n");
+        let (_, seen) = fold_bars_body(&body);
+        assert_eq!(
+            seen.first()
+                .expect("one bar")
+                .volume_weighted_average_price(),
+            None
+        );
+    }
+
+    /// A `window_start` in milliseconds is refused rather than placed in 1970.
+    ///
+    /// The same guard the trade fold relies on. A millisecond stamp converts without complaint and
+    /// lands fifty years early, where it would count as usable and sit in the wrong partition.
+    #[test]
+    fn test_a_bar_stamped_in_the_wrong_unit_is_unusable() {
+        let body = format!(
+            "{BAR_HEADER}\nA,100,156.500000,158.000000,158.000000,156.090000,1787319000000,127\n"
+        );
+        let (summary, seen) = fold_bars_body(&body);
+        let summary = summary.expect("a readable file");
+        assert_eq!(summary.rows_read, 1);
+        assert_eq!(summary.unusable, 1);
+        assert!(seen.is_empty());
+    }
+
+    /// A candle whose prices do not cohere is counted, not written.
+    ///
+    /// `EquityBar::new` owns the rule; this pins that the fold routes its rejection to `unusable`
+    /// rather than failing the whole file, which one bad row in five million should not do.
+    #[test]
+    fn test_an_incoherent_candle_is_counted_rather_than_failing_the_file() {
+        let good = "A,100,156.500000,158.000000,158.000000,156.090000,1787319000000000000,127";
+        // A low above its own high.
+        let bad = "B,100,156.500000,158.000000,150.000000,199.000000,1787319000000000000,12";
+        let body = format!("{BAR_HEADER}\n{good}\n{bad}\n");
+        let (summary, seen) = fold_bars_body(&body);
+        let summary = summary.expect("a readable file");
+        assert_eq!(summary.rows_read, 2);
+        assert_eq!(summary.unusable, 1);
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].ticker().as_str(), "A");
     }
 
     /// The trade fold reads the SIP clock, the fractional size, and the condition set.
@@ -2169,7 +2510,7 @@ mod tests {
 
         let date = NaiveDate::from_ymd_opt(2021, 9, 1).expect("a real date");
         let outcome = client
-            .fold_object(trade_key(date), "trades", date, |mut reader| {
+            .fold_object(trade_key(date), RawDataset::Trades, date, |mut reader| {
                 let mut sink = Vec::new();
                 std::io::copy(&mut reader, &mut sink).expect("the staged stream");
                 Ok(sink.len())
@@ -2208,12 +2549,19 @@ mod tests {
     fn test_the_raw_key_carries_the_prefix_the_lifecycle_rule_matches() {
         let date = NaiveDate::from_ymd_opt(2026, 8, 28).unwrap();
         assert_eq!(
-            raw_key("quotes", date),
+            raw_key(RawDataset::Quotes, date),
             "data/raw/massive/equity/quotes/schema=v1/year=2026/month=08/day=28/data.csv.gz"
         );
         assert_eq!(
-            raw_key("trades", NaiveDate::from_ymd_opt(2021, 1, 4).unwrap()),
+            raw_key(
+                RawDataset::Trades,
+                NaiveDate::from_ymd_opt(2021, 1, 4).unwrap()
+            ),
             "data/raw/massive/equity/trades/schema=v1/year=2021/month=01/day=04/data.csv.gz"
+        );
+        assert_eq!(
+            raw_key(RawDataset::MinuteAggs, date),
+            "data/raw/massive/equity/minute_aggs/schema=v1/year=2026/month=08/day=28/data.csv.gz"
         );
     }
 

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -621,9 +621,9 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for PairID {
 
 /// The sampling interval of an OHLCV bar.
 ///
-/// Part of the `equity_bars` primary key. Nothing writes [`BarInterval::OneMinute`] today; the
-/// CHECK constraint permits it, so "daily only" is a property of the current writers rather than of
-/// the table.
+/// Part of the `equity_bars` primary key. Every variant now has a writer:
+/// [`BarInterval::OneMinute`] gained one with the flat-file bar route, which had been the outstanding
+/// case this paragraph used to record.
 ///
 /// [`BarInterval::as_str`] must match the `bar_interval` CHECK constraint exactly. It is the
 /// snake_case of the variant name, which lets `rename_all` derive the same string for serde so what

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -2096,6 +2096,94 @@ async fn archive_trade_session(
     Ok(trades_folded)
 }
 
+/// Writes one-minute bar partitions across `sessions`, per `scope`.
+///
+/// The flat-file counterpart to [`archive_intraday_sessions`], and simpler in one way that matters:
+/// a bar row is already an output row, so there is no universe to derive and no fold to seed. The
+/// file is the whole market, which is the reason to read it rather than 12,000 per-symbol requests.
+pub async fn archive_bar_flat_file_sessions(
+    s3_client: &S3Client,
+    flat_files: &FlatFileClient,
+    bucket: &str,
+    sessions: &[SessionDate],
+    scope: &Scope,
+    calendar: Option<&TradingCalendar>,
+) -> Result<PassSummary, ArchiveError> {
+    let (Some(first), Some(last)) = (sessions.first(), sessions.last()) else {
+        return Ok(PassProgress::default().into_bar_summary(calendar));
+    };
+    // One cadence, so presence is read off the prefix this pass writes. The trade and quote passes
+    // read theirs off the daily prefix only because they write several and need the last one.
+    let present = present_partitions(
+        s3_client,
+        bucket,
+        &bar_archive_prefix(BarInterval::OneMinute),
+        *first,
+        *last,
+    )
+    .await?;
+    let requested = sessions_for(scope.sessions, sessions, &present);
+
+    info!(
+        window_start = %first,
+        window_end = %last,
+        %scope,
+        offered = sessions.len(),
+        already_written = present.len(),
+        requested = requested.len(),
+        "Planned a one-minute bar pass"
+    );
+
+    let mut progress = PassProgress {
+        sessions_requested: requested.len(),
+        ..Default::default()
+    };
+    for session in requested {
+        archive_bar_flat_file_session(s3_client, flat_files, bucket, session, &mut progress)
+            .await?;
+    }
+
+    info!(
+        sessions_requested = progress.sessions_requested,
+        sessions_written = progress.sessions_written,
+        sessions_without_data = progress.sessions_without_data,
+        sessions_failed = progress.sessions_failed.len(),
+        bars_written = progress.rows_written,
+        "One-minute bar archive updated"
+    );
+    Ok(progress.into_bar_summary(calendar))
+}
+
+/// One session: fold the file into bars and write the single partition they form.
+async fn archive_bar_flat_file_session(
+    s3_client: &S3Client,
+    flat_files: &FlatFileClient,
+    bucket: &str,
+    session: SessionDate,
+    progress: &mut PassProgress,
+) -> Result<(), ArchiveError> {
+    let bars: Vec<EquityBar> = match flat_files.fold_bars(session.date(), Vec::new()).await {
+        Ok((_, bars)) => bars,
+        Err(error) => {
+            // The file is the session: nothing partial survives it, exactly as for trades.
+            warn!(%session, %error, "A session's bar file could not be folded");
+            progress.sessions_failed.push(session);
+            return Ok(());
+        }
+    };
+    if bars.is_empty() {
+        progress.sessions_without_data += 1;
+        return Ok(());
+    }
+
+    let written = bars.len();
+    let frame = bars::bars_to_dataframe(&bars)?;
+    write_partition(s3_client, bucket, BarInterval::OneMinute, session, frame).await?;
+    progress.sessions_written += 1;
+    progress.rows_written += written;
+    Ok(())
+}
+
 /// Writes a session's trade summaries, one partition per cadence, daily last.
 ///
 /// The order is the recovery rule, matching the quote pass: presence is read off the daily prefix,

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -2176,12 +2176,17 @@ async fn archive_bar_flat_file_session(
         return Ok(());
     }
 
-    let written = bars.len();
-    let frame = bars::bars_to_dataframe(&bars)?;
-    write_partition(s3_client, bucket, BarInterval::OneMinute, session, frame).await?;
-    progress.sessions_written += 1;
-    progress.rows_written += written;
-    Ok(())
+    // Through `write_partitions` rather than `write_partition`, for one session at a time. The
+    // plural form is where contention and write faults are carried instead of ending the pass --
+    // the #1106 behaviour, and a third hand-written copy of those arms could drift from it.
+    write_partitions(
+        s3_client,
+        bucket,
+        BarInterval::OneMinute,
+        vec![(session, bars)],
+        progress,
+    )
+    .await
 }
 
 /// Writes a session's trade summaries, one partition per cadence, daily last.


### PR DESCRIPTION
# Overview

## Changes

- Add `RawDataset` (`Quotes`, `Trades`, `MinuteAggs`), replacing the string `raw_key` and `fold_object` took, so one value yields both the vendor path and the archive prefix
- Add the bar transport to `common::flatfiles`: `bar_key`, `BarSink`/`ForEachBar`, `BarColumns`, `fold_gzipped_bars`, `fold_bars`
- Add `archive::archive_bar_flat_file_sessions`, writing `data/derived/equity/bars/interval=one_minute/`
- Add the `equity-bars flat-file {archive,widen}` route to `seed`, with `--tee-raw`
- Correct the `BarInterval` docstring, which said nothing writes `OneMinute`

Closes task 14 of the laboratory expansion plan.

## Context

`BarInterval::OneMinute` has existed, been plumbed, and been written by nothing. The partition shape, the writer and the merge were all already there — what was missing was a transport, because nothing knew the `minute_aggs_v1` dataset existed. The plan called this "~14 minutes of transfer", which is true of the transfer and was misread as the size of the task.

The whole point of the flat file is that one object is the whole market. The REST alternative is 12,000 per-symbol requests a session, which is why five years of one-minute history has never been worth fetching and now costs minutes.

### The schema, verified against a live file

```
ticker,volume,open,close,high,low,window_start,transactions
A,109807.346392,156.500000,158.000000,158.000000,156.090000,1787319000000000000,127
```

**Close sits before high and low.** This is the one property worth dwelling on: a positional read takes close as high, and the result is not a parse error — it is a *coherent candle* that `EquityBar::new` accepts and every downstream consumer believes. `BarColumns` resolves by name, as the quote and trade columns already do.

Three more differences, all absorbed by code that already existed:

| difference | what handles it |
|---|---|
| `window_start` in nanoseconds | `nanoseconds_to_instant` already refuses other units by flooring at year 2000 — a millisecond stamp otherwise lands in 1970, counts as usable, and sits in the wrong partition |
| fractional volume | rounds on the same terms as `massive.rs`, so the two routes agree on whole shares |
| no `vw` column | `None`, never zero — a zero reads as a real volume-weighted price of nothing |

### Design notes

**`BarSink` is implemented for `Vec<EquityBar>` directly.** Quotes and trades cannot do this: their sinks fold ticks into summaries, where a bar row is already an output row. That is also why the archive pass needs no universe — there is nothing to fold against, so the daily-partition read the trade pass depends on has no counterpart.

**`RawDataset` replaces a stringly-typed parameter** that named two things which must agree: the vendor path a fold reads, and the archive prefix its bytes are teed to. Passing them separately let them disagree; adding a third dataset is the moment that stops being theoretical.

**The raw tee needed no new code.** `fold_object` already tees, keyed by dataset, so bars land under `data/raw/massive/equity/minute_aggs/` as Deep Archive. ~32 GB is rounding error against the 10.2 TB the retention decision already accepted, and buys the same reversibility once the subscription lapses.

**One prefix is written.** Five-minute stays as the REST route built it. Deriving it is a *check*, not a second writer, and that check is SQL rather than Rust because both sides are already parquet in S3 — it lives at `.scratchpad/tools/one-minute-vs-five-minute.sql` and runs after the backfill.

## Verification

- `devenv tasks run checks:all` — exit 0; 892 library tests pass
- Five new tests, one per schema property: column-name resolution, fractional volume, absent `vw`, wrong-unit stamp, incoherent candle
- **The column-name test is load-bearing.** Swapping `open` and `close` in `BarColumns::resolve` fails it with `left: 158.0, right: 156.5`, then passes on restore. The mutated candle is still coherent, so only the pinned prices catch it — a test asserting "the row parsed" would not have
- `seed equity-bars flat-file --help` renders both actions

Not yet run against the archive; the backfill and the five-minute diff follow this merge.

### Noted, not fixed

`seed.rs:66` documents the nouns as `data/derived/equity/{bars,details,quotes}` and has omitted `trades` since #1122. Out of scope here rather than folded into an unrelated change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KQiJumjK2WhBCNmhNV9sq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for archiving whole-market one-minute equity bars from flat files.
  * Added a new `equity-bars flat-file` route with archive and widen actions.
  * Added parsing and validation for one-minute bar data, including timestamps, prices, volume, and VWAP.
* **Bug Fixes**
  * Improved handling of invalid or incomplete bar data during ingestion.
* **Documentation**
  * Updated bar interval documentation to reflect one-minute bar writing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->