### PR TITLE
Reject Massive's lowercase preferred symbols before they merge into a common

### DIFF
--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -142,7 +142,11 @@ enum BarRoute {
 enum BarFlatFileAction {
     /// Write the sampled sessions that have no one-minute partition yet.
     Archive(QuoteArguments),
-    /// Write every sampled session, replacing ones already written.
+    /// Re-fold every sampled session and merge the result into what is already there.
+    ///
+    /// Merge, not replace: the write path unions the fold with the stored partition, so this adds
+    /// rows and collapses duplicate keys but cannot remove one an earlier pass wrote. Correcting a
+    /// partition downward means deleting it and running `archive` over the gap.
     Widen(QuoteArguments),
 }
 

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -144,9 +144,10 @@ enum BarFlatFileAction {
     Archive(QuoteArguments),
     /// Re-fold every sampled session and merge the result into what is already there.
     ///
-    /// Merge, not replace: the write path unions the fold with the stored partition, so this adds
-    /// rows and collapses duplicate keys but cannot remove one an earlier pass wrote. Correcting a
-    /// partition downward means deleting it and running `archive` over the gap.
+    /// Merge, not replace. A row the re-fold produces wins its key, so a corrected value does land;
+    /// a row the re-fold no longer produces is not matched, and survives. Shrinking a partition --
+    /// dropping a name that should never have been stored -- therefore means deleting it and running
+    /// `archive` over the gap, since no merge can remove what it does not overwrite.
     Widen(QuoteArguments),
 }
 

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -1262,7 +1262,7 @@ impl QuoteColumns {
     /// Reads one row, or `None` if it is not a book a spread can be read off.
     fn tick(&self, row: &csv::StringRecord) -> Option<(Ticker, QuoteTick)> {
         let field = |index: usize| row.get(index).map(str::trim);
-        let ticker = Ticker::new(field(self.ticker)?)?;
+        let ticker = flat_file_ticker(field(self.ticker)?)?;
         let timestamp = nanoseconds_to_instant(field(self.timestamp)?.parse::<i64>().ok()?)?;
         let tick = QuoteTick::new(
             timestamp,
@@ -1306,7 +1306,7 @@ impl TradeColumns {
     /// Reads one row, or `None` if it is not a print that can carry weight.
     fn tick(&self, row: &csv::StringRecord) -> Option<(Ticker, TradeTick)> {
         let field = |index: usize| row.get(index).map(str::trim);
-        let ticker = Ticker::new(field(self.ticker)?)?;
+        let ticker = flat_file_ticker(field(self.ticker)?)?;
         let timestamp = nanoseconds_to_instant(field(self.timestamp)?.parse::<i64>().ok()?)?;
         let tick = TradeTick::new(
             timestamp,
@@ -1363,7 +1363,7 @@ impl BarColumns {
     /// cannot drift from the one every other producer goes through.
     fn bar(&self, row: &csv::StringRecord) -> Option<EquityBar> {
         let field = |index: usize| row.get(index).map(str::trim);
-        let ticker = Ticker::new(field(self.ticker)?)?;
+        let ticker = flat_file_ticker(field(self.ticker)?)?;
         let timestamp = nanoseconds_to_instant(field(self.window_start)?.parse::<i64>().ok()?)?;
         let price = |index: usize| field(index)?.parse::<f64>().ok();
 
@@ -1405,6 +1405,20 @@ fn parse_conditions(field: &str) -> Vec<u32> {
         .split(',')
         .filter_map(|code| code.trim().parse::<u32>().ok())
         .collect()
+}
+
+/// Reads a flat-file symbol, rejecting the ones where Massive's case carries meaning.
+///
+/// Massive spells a preferred share with a lowercase `p` -- `ABRpD`, `BCpC`, `TpC` -- so case is
+/// semantic in this source alone. [`Ticker::new`] uppercases, which turns `BCpC` into `BCPC` and
+/// merges Balchem's preferred into Balchem's common at the same timestamp. Rejected rather than
+/// preserved: no other dataset in the archive holds preferreds, and admitting ~310 of them a
+/// session under mangled names would widen the universe by a side effect of parsing.
+fn flat_file_ticker(raw: &str) -> Option<Ticker> {
+    if raw.chars().any(|character| character.is_ascii_lowercase()) {
+        return None;
+    }
+    Ticker::new(raw)
 }
 
 /// Massive stamps a SIP quote in nanoseconds since the epoch, and `None` rejects any other unit.
@@ -1595,13 +1609,14 @@ where
     summary.require_ascending(key)?;
 
     if summary.unusable > 0 {
-        // A candle whose prices do not cohere, or a stamp in the wrong unit. Rare, and a file
-        // suddenly half unusable is a vendor change nobody announced.
+        // In practice this is entirely the symbol: preferred shares, which Massive spells with a
+        // lowercase `p`, are ~0.1% of a session's rows and no part of any archive. Named as the row
+        // it is, not the candle it is not -- measured over four sessions, none was a bad candle.
         warn!(
             key,
             unusable = summary.unusable,
             rows_read = summary.rows_read,
-            "Skipped bars that are not coherent candles"
+            "Skipped rows that did not yield a bar"
         );
     }
     Ok((summary, fold))
@@ -1824,6 +1839,49 @@ mod tests {
         assert_eq!(summary.unusable, 1);
         assert_eq!(seen.len(), 1);
         assert_eq!(seen[0].ticker().as_str(), "A");
+    }
+
+    /// A preferred share is skipped on its symbol, which is what `unusable` actually counts.
+    ///
+    /// Measured over four sessions spanning the corpus: ~380-450 rows a session carry a lowercase
+    /// `p`, and none of the skipped rows was a malformed candle. `TRTNpE` would also fail the
+    /// five-character base, and `VST.WS.A` fails the suffix rule, but neither is the rule that has
+    /// to hold -- `ABRpD` passes both and is still not a security this archive stores.
+    #[test]
+    fn test_a_preferred_share_symbol_is_skipped_rather_than_written() {
+        let common = "TRTN,100,156.500000,158.000000,158.000000,156.090000,1787319000000000000,127";
+        // Five characters uppercased, so length alone would have admitted it.
+        let preferred = "ABRpD,100,25.500000,25.600000,25.700000,25.400000,1787319000000000000,4";
+        let warrant_series =
+            "VST.WS.A,100,1.500000,1.600000,1.700000,1.400000,1787319000000000000,2";
+        let body = format!("{BAR_HEADER}\n{common}\n{preferred}\n{warrant_series}\n");
+        let (summary, seen) = fold_bars_body(&body);
+        let summary = summary.expect("a readable file");
+        assert_eq!(summary.rows_read, 3);
+        assert_eq!(summary.unusable, 2);
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].ticker().as_str(), "TRTN");
+    }
+
+    /// A preferred share must not merge into the common stock it uppercases onto.
+    ///
+    /// This is the one that cost a whole pass. `BCpC` is a preferred and `BCPC` is Balchem; folding
+    /// case put both under `BCPC` at the same minute, so a session held two rows for one key and a
+    /// five-minute close came out 157 points from the REST archive's. Three names collide this way
+    /// -- `BCpC`, `TpC` and `CpK` -- and every other lowercase name lands under a ticker that
+    /// belongs to nothing at all, which is quieter and no more correct.
+    #[test]
+    fn test_a_preferred_share_does_not_merge_into_the_common_it_uppercases_onto() {
+        let common = "BCPC,1136,178.120000,178.120000,178.120000,178.120000,1787319000000000000,81";
+        let preferred = "BCpC,806,23.680000,23.680000,23.680000,23.680000,1787319000000000000,1";
+        let body = format!("{BAR_HEADER}\n{common}\n{preferred}\n");
+        let (summary, seen) = fold_bars_body(&body);
+        let summary = summary.expect("a readable file");
+        assert_eq!(summary.rows_read, 2);
+        assert_eq!(summary.unusable, 1);
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].ticker().as_str(), "BCPC");
+        assert_eq!(seen[0].close_price(), 178.12);
     }
 
     /// The trade fold reads the SIP clock, the fractional size, and the condition set.

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -1609,9 +1609,10 @@ where
     summary.require_ascending(key)?;
 
     if summary.unusable > 0 {
-        // In practice this is entirely the symbol: preferred shares, which Massive spells with a
-        // lowercase `p`, are ~0.1% of a session's rows and no part of any archive. Named as the row
-        // it is, not the candle it is not -- measured over four sessions, none was a bad candle.
+        // `bar` rejects on the symbol, the stamp, the volume, an unparseable price and an incoherent
+        // candle, so this counter is five causes and the message names none of them. Measured, it is
+        // one: classifying four whole sessions found 0.7-0.9% of rows rejected and every one a
+        // symbol, mostly preferred shares. A candle or a stamp appearing here would be new.
         warn!(
             key,
             unusable = summary.unusable,


### PR DESCRIPTION
# Overview

Massive spells a preferred share with a lowercase `p` — `ABRpD`, `BCpC`, `TpC` — so case carries meaning in the flat files and nowhere else we read. `Ticker::new` uppercases, which put Balchem's preferred and Balchem's common under `BCPC` at the same minute.

## Changes

- Add `flat_file_ticker`, rejecting any flat-file symbol containing a lowercase letter, and route the quote, trade and bar parsers through it
- Add two tests: one that a preferred is skipped on its symbol, one that it does not merge into the common it uppercases onto
- Correct the skipped-row warning, which claimed incoherent candles when the skipped rows are entirely symbols
- Correct `BarFlatFileAction::Widen`, which claimed to replace a partition when the write path merges into it

## Context

**How it surfaced.** Task 14's acceptance check — fold the new one-minute bars up to five-minute and diff against the REST-built archive. Price disagreed on 0.3% of windows, volume on 7.3%. That asymmetry was the tell: a duplicated key adds volume to a window whose first and last price usually still come from the real name. The worst case was a `BCPC` close 157 points apart.

**Scope, measured over four sessions spanning the corpus:**

| session | rows with a lowercase letter | written under a mangled ticker | colliding with a real common |
|---|---|---|---|
| 2021-08-26 | 448 | 367 | 3 — `BCpC`, `CpK`, `TpC` |
| 2023-06-15 | 403 | 327 | 3 |
| 2024-10-15 | 378 | 307 | 2 |
| 2026-08-20 | 377 | 308 | 2 |

Checking all 377 names for 2026-08-20 against every dataset: one-minute bars held 308, while daily bars, five-minute bars, trade summaries and quote summaries held 2 — and those 2 are the genuine `BCPC` and `TPC` commons. No archive holds preferreds under any spelling, so these are rejected at the transport rather than preserved; admitting them would widen the universe as a side effect of parsing.

**Why the guard covers quotes and trades too.** Those datasets are clean today, but that is their composition rather than a guarantee. The convention belongs to the vendor, not to the dataset, so the guard belongs at the transport shared by all three.

**Why the `Widen` docstring is in here.** It cost a full pass. A rewrite ran to completion, logged the corrected counts, and left the old rows in place — `write_merged` unions the fold with the stored partition, so merging can add a row and collapse a duplicate key but can never remove one. The archive was corrected by deleting the 1,257 partitions and re-running `archive` over the empty prefix. The raw tee is independent of the fold and was untouched throughout, which is what made the delete cheap.

**Not in here:** the archive has no downward correction path at all. Every write is additive, so any future fix meaning "this row should never have existed" needs the same manual delete-and-rebuild. That wants its own issue and its own review rather than riding along with a correctness fix.

**Verification.** `devenv tasks run checks:rust` passes. Both new tests were proven load-bearing by removing the guard — they fail `left: 0, right: 1` and `left: 1, right: 2`. The rebuild against real data is running now; I will post the agreement-check result here when it lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Flat-file imports now skip symbols containing lowercase letters, preventing preferred-share symbols from being incorrectly normalized into common-stock symbols.
  - Bar processing warnings now more accurately identify skipped symbols.

- **Documentation**
  - Clarified that archiving merges re-folded data into stored partitions, combining rows and collapsing duplicate keys.
  - Documented that correcting a partition downward requires deleting it and archiving the affected gap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->