### PR TITLE
Record which vendor and subscription built every archived partition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,14 @@ wandb/
 **/target/
 data/*
 !data/equity_details.csv
+!data/archive_provenance.json
 **/model.tar.gz
 **/*.safetensor
 **/*.json
 !.sqlx/*.json
+# Declared archive routes. Re-included after the `**/*.json` rule as well as after `data/*`,
+# because a negation only counts if nothing later re-excludes the path.
+!data/archive_provenance.json
 # Hand-applied AWS documents live here so a fixture can be rebuilt by reading rather than by
 # remembering. A glob rather than one filename, because the failure this fixes is a file being
 # silently ignored -- which is what a narrower rule would do to the next one.

--- a/data/archive_provenance.json
+++ b/data/archive_provenance.json
@@ -1,0 +1,58 @@
+{
+  "_comment": "Routes that are true by construction rather than observable in a log. Read by `seed archive-provenance backfill --from-configuration`. Logs win where both answer.",
+  "declarations": [
+    {
+      "_why": "Massive's per-ticker and grouped aggregate routes, which Starter answers inside its rolling five-year window. No pass logs these, so nothing else can attribute them.",
+      "dataset": "equity_bars",
+      "interval": "five_minute",
+      "provider": "massive",
+      "subscription": "stocks_starter",
+      "transport": "rest"
+    },
+    {
+      "dataset": "equity_bars",
+      "interval": "one_day",
+      "provider": "massive",
+      "subscription": "stocks_starter",
+      "transport": "rest"
+    },
+    {
+      "_why": "Trades have one route by construction and no repair path: a trade file *is* the session, so a name absent from it is absent from the tape. Declared because two sessions were folded outside the logs kept here.",
+      "dataset": "equity_trades",
+      "provider": "massive",
+      "subscription": "stocks_advanced",
+      "transport": "flat_file"
+    },
+    {
+      "_why": "Splits are rewritten whole from Massive's reference route; boundaries are windowed from Alpaca. Both are one object rather than a partition tree, so no session-keyed log can attribute them.",
+      "dataset": "equity_corporate_action_splits",
+      "provider": "massive",
+      "subscription": "stocks_starter",
+      "transport": "rest"
+    },
+    {
+      "dataset": "equity_corporate_action_boundaries",
+      "provider": "alpaca",
+      "subscription": "algo_trader_plus"
+    },
+    {
+      "_why": "The raw tee is Massive's own bytes by construction; all three datasets sit behind Stocks Advanced.",
+      "dataset": "raw_equity_quotes",
+      "provider": "massive",
+      "subscription": "stocks_advanced",
+      "transport": "flat_file"
+    },
+    {
+      "dataset": "raw_equity_trades",
+      "provider": "massive",
+      "subscription": "stocks_advanced",
+      "transport": "flat_file"
+    },
+    {
+      "dataset": "raw_equity_minute_aggs",
+      "provider": "massive",
+      "subscription": "stocks_advanced",
+      "transport": "flat_file"
+    }
+  ]
+}

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -121,9 +121,12 @@ struct ProvenanceArguments {
     /// where both answer, because observed beats declared.
     #[arg(long)]
     from_configuration: Option<std::path::PathBuf>,
-    /// Count what would be written without writing it.
+    /// Write the sidecars. Without it the pass reports what it would write and writes nothing.
+    ///
+    /// Opt-in rather than opt-out: the archive holds tens of thousands of objects, and a flag that
+    /// has to be remembered in order to *avoid* writing them is the wrong default.
     #[arg(long)]
-    dry_run: bool,
+    apply: bool,
 }
 
 impl Command {
@@ -1267,7 +1270,7 @@ async fn seed_provenance(action: &ProvenanceAction) -> Result<Outcome, SeedError
             info!(
                 observed = attribution.len(),
                 declared = declarations.len(),
-                dry_run = arguments.dry_run,
+                apply = arguments.apply,
                 "Read an attribution"
             );
             archive::stamp_partition_provenance(
@@ -1275,7 +1278,7 @@ async fn seed_provenance(action: &ProvenanceAction) -> Result<Outcome, SeedError
                 &bucket,
                 &attribution,
                 &declarations,
-                arguments.dry_run,
+                arguments.apply,
             )
             .await
             .map_err(box_error)?
@@ -1286,27 +1289,49 @@ async fn seed_provenance(action: &ProvenanceAction) -> Result<Outcome, SeedError
     };
 
     // The population, not just the difference: a run that wrote nothing because everything was
-    // already stamped reads identically to one that found no partitions at all.
+    // already stamped reads identically to one that found no objects at all.
     info!(
-        partitions_seen = outcome.partitions_seen,
+        objects_seen = outcome.objects_seen,
         sidecars_present = outcome.sidecars_present,
+        sidecars_planned = outcome.sidecars_planned,
         sidecars_written = outcome.sidecars_written,
+        sidecars_missing = outcome.sidecars_missing.len(),
         unattributed = outcome.unattributed.len(),
+        write_failures = outcome.write_failures.len(),
         "Provenance pass finished"
     );
     for key in outcome.unattributed.iter().take(20) {
         warn!(
             key,
-            "Partition carries no provenance and none could be attributed"
+            "Object carries no provenance and none could be attributed"
         );
     }
-    println!(
-        "{} partitions, {} already recorded, {} written, {} unattributed",
-        outcome.partitions_seen,
-        outcome.sidecars_present,
-        outcome.sidecars_written,
-        outcome.unattributed.len()
-    );
+    for key in outcome.sidecars_missing.iter().take(20) {
+        warn!(key, "Object carries no provenance record");
+    }
+    match action {
+        ProvenanceAction::Backfill(arguments) if arguments.apply => println!(
+            "{} objects, {} already recorded, {} written, {} failed, {} unattributed",
+            outcome.objects_seen,
+            outcome.sidecars_present,
+            outcome.sidecars_written,
+            outcome.write_failures.len(),
+            outcome.unattributed.len()
+        ),
+        // Says "would write". A reporting run that printed "written" is the output an operator would
+        // act on, and it would be false.
+        ProvenanceAction::Backfill(_) => println!(
+            "{} objects, {} already recorded, {} would be written, {} unattributed -- pass --apply to write",
+            outcome.objects_seen,
+            outcome.sidecars_present,
+            outcome.sidecars_planned,
+            outcome.unattributed.len()
+        ),
+        ProvenanceAction::Sweep => println!(
+            "{} objects, {} recorded, {} missing a provenance record",
+            outcome.objects_seen, outcome.sidecars_present, outcome.sidecars_missing.len()
+        ),
+    }
     Ok(Outcome::Complete)
 }
 
@@ -1964,6 +1989,43 @@ mod tests {
             .expect("a named set");
         assert_eq!(names.len(), 3);
         assert!(names.contains(&Ticker::new("SCAN").expect("a valid ticker")));
+    }
+
+    /// Writing must be asked for. The pass touches every object in the archive, so a flag that has
+    /// to be remembered in order to *avoid* writing is the wrong way round.
+    #[test]
+    fn test_provenance_backfill_does_not_write_without_apply() {
+        let parsed = parse(&["archive-provenance", "backfill", "--from-logs", "/tmp/logs"])
+            .expect("valid arguments");
+        let Command::ArchiveProvenance {
+            action: ProvenanceAction::Backfill(arguments),
+        } = parsed.command
+        else {
+            panic!("expected a provenance backfill");
+        };
+        assert!(!arguments.apply, "the default must not write");
+
+        let parsed = parse(&[
+            "archive-provenance",
+            "backfill",
+            "--from-logs",
+            "/tmp/logs",
+            "--apply",
+        ])
+        .expect("valid arguments");
+        let Command::ArchiveProvenance {
+            action: ProvenanceAction::Backfill(arguments),
+        } = parsed.command
+        else {
+            panic!("expected a provenance backfill");
+        };
+        assert!(arguments.apply);
+    }
+
+    /// A backfill with neither source would silently stamp nothing.
+    #[test]
+    fn test_provenance_backfill_needs_a_source() {
+        assert!(parse(&["archive-provenance", "backfill"]).is_err());
     }
 
     #[test]

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -19,7 +19,7 @@ use fund::common::types::{
 };
 use fund::data::archive::{self, NameSelection, Scope, SessionSelection};
 use fund::data::calendar::TradingCalendar;
-use fund::data::{bars, details, quotes};
+use fund::data::{attribution, bars, details, quotes};
 
 /// One file for the whole seeder, since it is one process however it was invoked.
 ///
@@ -88,6 +88,33 @@ enum Command {
         #[command(subcommand)]
         action: TradeAction,
     },
+    /// Which vendor and subscription built each archived partition.
+    ArchiveProvenance {
+        #[command(subcommand)]
+        action: ProvenanceAction,
+    },
+}
+
+/// What to do about provenance the archive does not yet record.
+#[derive(Debug, Subcommand)]
+enum ProvenanceAction {
+    /// Write sidecars for partitions that have none, reading the attribution from pass logs.
+    ///
+    /// The logs are one configuration source. A partition already carrying a sidecar is left
+    /// alone: a record written at the time of the write beats one reconstructed afterwards.
+    Backfill(ProvenanceArguments),
+    /// Report partitions carrying no sidecar, writing nothing.
+    Sweep,
+}
+
+#[derive(Debug, Args)]
+struct ProvenanceArguments {
+    /// Directory of pass logs to attribute from, searched recursively for `*.log`.
+    #[arg(long)]
+    from_logs: std::path::PathBuf,
+    /// Count what would be written without writing it.
+    #[arg(long)]
+    dry_run: bool,
 }
 
 impl Command {
@@ -105,6 +132,7 @@ impl Command {
             Command::EquityDetails { .. } => "seed-equity-details",
             Command::EquityQuotes { .. } => "seed-equity-quotes",
             Command::EquityTrades { .. } => "seed-equity-trades",
+            Command::ArchiveProvenance { .. } => "seed-archive-provenance",
         }
     }
 }
@@ -734,6 +762,7 @@ async fn run(command: &Command, today: SessionDate) -> Result<Outcome, SeedError
         }
         Command::EquityQuotes { action } => seed_quotes(action).await,
         Command::EquityTrades { action } => seed_trades(action).await,
+        Command::ArchiveProvenance { action } => seed_provenance(action).await,
     }
 }
 
@@ -1208,6 +1237,63 @@ async fn flat_file_client(
 ///
 /// The calendar comes from Alpaca and the tape from Massive, which is the same split the quote
 /// pass uses: only the exchange publishes its own hours, and only the flat files hold every print.
+/// Records, or reports, which route built each archived partition.
+///
+/// Reads the archive rather than the calendar: this is about objects that exist, so a session the
+/// archive never held is not a gap here.
+async fn seed_provenance(action: &ProvenanceAction) -> Result<Outcome, SeedError> {
+    let bucket = bucket_name()?;
+    let s3_client = fund::common::aws::s3_client().await;
+
+    let outcome = match action {
+        ProvenanceAction::Backfill(arguments) => {
+            let attribution =
+                attribution::routes_from_logs(&arguments.from_logs).map_err(box_error)?;
+            info!(
+                logs = %arguments.from_logs.display(),
+                attributed = attribution.len(),
+                dry_run = arguments.dry_run,
+                "Read an attribution from pass logs"
+            );
+            archive::stamp_partition_provenance(
+                &s3_client,
+                &bucket,
+                &attribution,
+                arguments.dry_run,
+            )
+            .await
+            .map_err(box_error)?
+        }
+        ProvenanceAction::Sweep => archive::sweep_partition_provenance(&s3_client, &bucket)
+            .await
+            .map_err(box_error)?,
+    };
+
+    // The population, not just the difference: a run that wrote nothing because everything was
+    // already stamped reads identically to one that found no partitions at all.
+    info!(
+        partitions_seen = outcome.partitions_seen,
+        sidecars_present = outcome.sidecars_present,
+        sidecars_written = outcome.sidecars_written,
+        unattributed = outcome.unattributed.len(),
+        "Provenance pass finished"
+    );
+    for key in outcome.unattributed.iter().take(20) {
+        warn!(
+            key,
+            "Partition carries no provenance and none could be attributed"
+        );
+    }
+    println!(
+        "{} partitions, {} already recorded, {} written, {} unattributed",
+        outcome.partitions_seen,
+        outcome.sidecars_present,
+        outcome.sidecars_written,
+        outcome.unattributed.len()
+    );
+    Ok(Outcome::Complete)
+}
+
 async fn seed_trades(action: &TradeAction) -> Result<Outcome, SeedError> {
     let arguments = action.arguments();
     let scope = action.universe_scope()?;

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -108,10 +108,19 @@ enum ProvenanceAction {
 }
 
 #[derive(Debug, Args)]
+#[group(required = true, multiple = true)]
 struct ProvenanceArguments {
     /// Directory of pass logs to attribute from, searched recursively for `*.log`.
+    ///
+    /// What a pass observed. Only speaks for sessions a pass actually logged.
     #[arg(long)]
-    from_logs: std::path::PathBuf,
+    from_logs: Option<std::path::PathBuf>,
+    /// JSON file declaring routes for whole prefixes.
+    ///
+    /// What is true by construction: Massive's REST bar cadences, and every raw flat file. Logs win
+    /// where both answer, because observed beats declared.
+    #[arg(long)]
+    from_configuration: Option<std::path::PathBuf>,
     /// Count what would be written without writing it.
     #[arg(long)]
     dry_run: bool,
@@ -1247,18 +1256,25 @@ async fn seed_provenance(action: &ProvenanceAction) -> Result<Outcome, SeedError
 
     let outcome = match action {
         ProvenanceAction::Backfill(arguments) => {
-            let attribution =
-                attribution::routes_from_logs(&arguments.from_logs).map_err(box_error)?;
+            let attribution = match &arguments.from_logs {
+                Some(logs) => attribution::routes_from_logs(logs).map_err(box_error)?,
+                None => Default::default(),
+            };
+            let declarations = match &arguments.from_configuration {
+                Some(path) => attribution::routes_from_configuration(path).map_err(box_error)?,
+                None => Vec::new(),
+            };
             info!(
-                logs = %arguments.from_logs.display(),
-                attributed = attribution.len(),
+                observed = attribution.len(),
+                declared = declarations.len(),
                 dry_run = arguments.dry_run,
-                "Read an attribution from pass logs"
+                "Read an attribution"
             );
             archive::stamp_partition_provenance(
                 &s3_client,
                 &bucket,
                 &attribution,
+                &declarations,
                 arguments.dry_run,
             )
             .await

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,4 +9,5 @@ pub mod flatfiles;
 pub mod journal;
 pub mod log;
 pub mod massive;
+pub mod provenance;
 pub mod types;

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -527,6 +527,10 @@ impl RawTee {
                 bytes = expected,
                 "Raw object already archived; skipping the upload"
             );
+            // Stamped anyway. The sidecar is best-effort, so an earlier run may have uploaded the
+            // object and failed to record it; returning here would make that permanent, because
+            // nothing re-uploads an object already at the right length.
+            self.record_provenance(key, dataset, date).await;
             return Ok(());
         }
 
@@ -561,7 +565,7 @@ impl RawTee {
         let sidecar = PartitionProvenance::sidecar_key(key);
         let record = PartitionProvenance::new(
             &format!("raw_equity_{}", dataset.as_str()),
-            &date.to_string(),
+            Some(&date.to_string()),
             dataset.provenance(),
         );
         let body = match serde_json::to_vec(&record) {
@@ -2438,20 +2442,29 @@ mod tests {
         let http_client = infallible_client_fn(move |request| {
             let method = request.method().clone();
             let query = request.uri().query().unwrap_or_default().to_string();
+            // The sidecar is the one unqueried PUT: every multipart part carries `partNumber`. Its
+            // path is recorded so a test can assert the key literally rather than that "a PUT
+            // happened".
             let label = match (&method, query.as_str()) {
-                (&http::Method::HEAD, _) => "HEAD",
-                (&http::Method::POST, q) if q.contains("uploads") => "CREATE",
-                (&http::Method::PUT, _) => "PART",
-                (&http::Method::POST, _) => "COMPLETE",
-                (&http::Method::DELETE, _) => "ABORT",
-                _ => "OTHER",
+                (&http::Method::HEAD, _) => "HEAD".to_string(),
+                (&http::Method::POST, q) if q.contains("uploads") => "CREATE".to_string(),
+                (&http::Method::PUT, q) if q.contains("partNumber") => "PART".to_string(),
+                // Decoded, because S3 percent-encodes the `=` in every hive segment and a key
+                // built by `raw_key` never matches the wire form.
+                (&http::Method::PUT, _) => format!(
+                    "SIDECAR {}",
+                    percent_encoding::percent_decode_str(request.uri().path()).decode_utf8_lossy()
+                ),
+                (&http::Method::POST, _) => "COMPLETE".to_string(),
+                (&http::Method::DELETE, _) => "ABORT".to_string(),
+                _ => "OTHER".to_string(),
             };
             recorder
                 .lock()
                 .expect("no test thread panics holding this")
-                .push(label.to_string());
+                .push(label.clone());
 
-            match label {
+            match label.as_str() {
                 "HEAD" => match heads
                     .lock()
                     .expect("no test thread panics holding this")
@@ -2568,7 +2581,46 @@ mod tests {
         let sent = requested
             .lock()
             .expect("no test thread panics holding this");
-        assert_eq!(*sent, vec!["HEAD".to_string()], "{sent:?}");
+        // The upload is still skipped; the sidecar is not. An object archived before provenance
+        // existed, or one whose best-effort sidecar failed, is never re-uploaded -- so returning
+        // before the stamp would leave it unattributed permanently.
+        assert_eq!(
+            *sent,
+            vec![
+                "HEAD".to_string(),
+                "SIDECAR /data/raw/whatever.csv.gz.provenance.json".to_string()
+            ],
+            "{sent:?}"
+        );
+        std::fs::remove_dir_all(&directory).ok();
+    }
+
+    /// A raw upload must leave a record naming the subscription that served the bytes.
+    #[tokio::test]
+    async fn test_a_raw_object_records_the_subscription_that_served_it() {
+        let (directory, path) = staged_object("stamped", 4096);
+        let (tee, requested) = tee_against(vec![None, Some(4096)], 200, directory.clone());
+
+        tee.store(
+            &raw_key(RawDataset::Trades, a_date()),
+            &path,
+            4096,
+            RawDataset::Trades,
+            a_date(),
+        )
+        .await
+        .expect("the upload succeeds");
+
+        let sent = requested
+            .lock()
+            .expect("no test thread panics holding this")
+            .clone();
+        // Pinned to the literal rather than built from `raw_key`, so relocating the prefix has to be
+        // a deliberate change to this expectation.
+        assert!(
+            sent.contains(&"SIDECAR /data/raw/massive/equity/trades/schema=v1/year=2026/month=08/day=31/data.csv.gz.provenance.json".to_string()),
+            "{sent:?}"
+        );
         std::fs::remove_dir_all(&directory).ok();
     }
 

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -11,6 +11,7 @@ use flate2::read::GzDecoder;
 use tracing::{info, warn};
 
 use crate::common::alpaca::{QuoteTick, TradeTick};
+use crate::common::provenance::{MassivePlan, MassiveTransport, PartitionProvenance, Provenance};
 use crate::common::types::{BarInterval, EquityBar, Ticker};
 
 /// The bucket every dataset lives under, which Massive support named on 2026-08-24.
@@ -280,6 +281,15 @@ pub enum RawDataset {
 }
 
 impl RawDataset {
+    /// Where these bytes come from, and under which subscription.
+    ///
+    /// Static here and only here: a flat file is Massive's by construction, and every one of the
+    /// three lives behind Stocks Advanced. Derived partitions carry no such constant, because the
+    /// same dataset has arrived by more than one route.
+    pub const fn provenance(self) -> Provenance {
+        Provenance::massive(MassivePlan::StocksAdvanced, MassiveTransport::FlatFile)
+    }
+
     /// The segment naming this dataset under `data/raw/massive/equity/`.
     pub fn as_str(self) -> &'static str {
         match self {
@@ -489,7 +499,14 @@ impl RawTee {
     ///
     /// Verified on length rather than ETag: a multipart ETag is a function of the part size, so ours
     /// never matches the vendor's and would fail every comparison it was asked to make.
-    async fn store(&self, key: &str, staged: &Path, expected: i64) -> Result<(), FlatFileError> {
+    async fn store(
+        &self,
+        key: &str,
+        staged: &Path,
+        expected: i64,
+        dataset: RawDataset,
+        date: NaiveDate,
+    ) -> Result<(), FlatFileError> {
         let written = std::fs::metadata(staged)
             .map_err(|source| FlatFileError::Tee {
                 key: key.to_string(),
@@ -531,7 +548,41 @@ impl RawTee {
             bytes = expected,
             "Archived the vendor's raw object"
         );
+        self.record_provenance(key, dataset, date).await;
         Ok(())
+    }
+
+    /// Records which subscription these bytes came from, beside the object itself.
+    ///
+    /// Written in the default storage class rather than Deep Archive: a record that needs a
+    /// 12-to-48-hour restore before it can be read is not a record. Best-effort for the same reason
+    /// the tee's own abort is — a sidecar must never fail an upload that has already landed.
+    async fn record_provenance(&self, key: &str, dataset: RawDataset, date: NaiveDate) {
+        let sidecar = PartitionProvenance::sidecar_key(key);
+        let record = PartitionProvenance::new(
+            &format!("raw_equity_{}", dataset.as_str()),
+            &date.to_string(),
+            dataset.provenance(),
+        );
+        let body = match serde_json::to_vec(&record) {
+            Ok(body) => body,
+            Err(error) => {
+                warn!(key = sidecar, %error, "Raw provenance did not serialize");
+                return;
+            }
+        };
+        if let Err(error) = self
+            .s3_client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(&sidecar)
+            .body(aws_sdk_s3::primitives::ByteStream::from(body))
+            .content_type("application/json")
+            .send()
+            .await
+        {
+            warn!(key = sidecar, %error, "Raw provenance sidecar was not written");
+        }
     }
 
     /// Whether `key` is already present at the length the source reports.
@@ -976,7 +1027,13 @@ impl FlatFileClient {
             // upload would destroy the one local copy of the expensive half and force the whole
             // object to be downloaded again — the exact cost this tee exists to stop paying.
             match tee
-                .store(&raw_key(dataset, date), staged, compressed_bytes)
+                .store(
+                    &raw_key(dataset, date),
+                    staged,
+                    compressed_bytes,
+                    dataset,
+                    date,
+                )
                 .await
             {
                 Ok(()) => {
@@ -1633,6 +1690,11 @@ fn read_error(key: &str, error: csv::Error) -> FlatFileError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A fixed session, so a tee test never reads the clock.
+    fn a_date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 8, 31).expect("a real date")
+    }
 
     use std::io::Write;
 
@@ -2461,7 +2523,15 @@ mod tests {
         let (directory, path) = staged_object("wrong-length", 4096);
         let (tee, requested) = tee_against(vec![], 200, directory.clone());
 
-        let outcome = tee.store("data/raw/whatever.csv.gz", &path, 8192).await;
+        let outcome = tee
+            .store(
+                "data/raw/whatever.csv.gz",
+                &path,
+                8192,
+                RawDataset::Trades,
+                a_date(),
+            )
+            .await;
 
         assert!(
             matches!(outcome, Err(FlatFileError::TeeLength { staged, expected, .. })
@@ -2485,9 +2555,15 @@ mod tests {
         let (directory, path) = staged_object("already-there", 4096);
         let (tee, requested) = tee_against(vec![Some(4096)], 200, directory.clone());
 
-        tee.store("data/raw/whatever.csv.gz", &path, 4096)
-            .await
-            .expect("an object already present is not an error");
+        tee.store(
+            "data/raw/whatever.csv.gz",
+            &path,
+            4096,
+            RawDataset::Trades,
+            a_date(),
+        )
+        .await
+        .expect("an object already present is not an error");
 
         let sent = requested
             .lock()
@@ -2504,7 +2580,15 @@ mod tests {
         // Absent to begin with, then present at the wrong length once the upload claims success.
         let (tee, requested) = tee_against(vec![None, Some(17)], 200, directory.clone());
 
-        let outcome = tee.store("data/raw/whatever.csv.gz", &path, 4096).await;
+        let outcome = tee
+            .store(
+                "data/raw/whatever.csv.gz",
+                &path,
+                4096,
+                RawDataset::Trades,
+                a_date(),
+            )
+            .await;
 
         assert!(
             matches!(outcome, Err(FlatFileError::TeeLength { staged, expected, .. })
@@ -2526,7 +2610,15 @@ mod tests {
         let (directory, path) = staged_object("failed-completion", 4096);
         let (tee, requested) = tee_against(vec![None], 500, directory.clone());
 
-        let outcome = tee.store("data/raw/whatever.csv.gz", &path, 4096).await;
+        let outcome = tee
+            .store(
+                "data/raw/whatever.csv.gz",
+                &path,
+                4096,
+                RawDataset::Trades,
+                a_date(),
+            )
+            .await;
 
         assert!(outcome.is_err(), "a failed completion must fail the store");
         let sent = requested

--- a/src/common/provenance.rs
+++ b/src/common/provenance.rs
@@ -104,30 +104,28 @@ impl Provenance {
     }
 }
 
-/// What a partition's sidecar records: every route that has contributed to it, and when.
+/// What an object's sidecar records: every route that has contributed to it, and when.
 ///
-/// **A set rather than a single route, because a partition is not sourced once.** The quote archive
-/// is the worked example: the whole-market walk folded 1,254 sessions from Massive flat files, and
-/// a repair pass then wrote 1,107 names into *every one of those same sessions* from Alpaca. A
-/// single-valued record would name whichever route wrote last and silently disown the other.
-///
-/// `written_at` is deliberately *content* rather than metadata. A server-side copy rewrites an
-/// object's `LastModified` — the 2026-09-03 prefix rewrite did exactly that to the whole archive —
-/// so the only durable answer to "when was this session built" is one written inside the object.
+/// A set rather than one route, because an object is not sourced once: 1,249 of 1,254 quote sessions
+/// were built by both a flat-file walk and an Alpaca repair, and a single-valued record would name
+/// whichever wrote last and disown the other. `written_at` is content rather than metadata because a
+/// server-side copy rewrites `LastModified`, as the 2026-09-03 prefix rewrite did to the archive.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PartitionProvenance {
     pub dataset: String,
-    pub session: String,
+    /// Absent for a whole-table object, which the splits and boundaries tables both are.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<String>,
     pub routes: Vec<Provenance>,
     pub written_at: DateTime<Utc>,
 }
 
 impl PartitionProvenance {
     /// The record for one partition, stamped now, naming the single route that just wrote.
-    pub fn new(dataset: &str, session: &str, provenance: Provenance) -> Self {
+    pub fn new(dataset: &str, session: Option<&str>, provenance: Provenance) -> Self {
         PartitionProvenance {
             dataset: dataset.to_string(),
-            session: session.to_string(),
+            session: session.map(str::to_string),
             routes: vec![provenance],
             written_at: Utc::now(),
         }
@@ -152,15 +150,12 @@ impl PartitionProvenance {
             .any(|route| route.requires_massive_advanced())
     }
 
-    /// The sidecar's key, beside the partition it describes.
+    /// The sidecar's key: the object's own key, with a suffix.
     ///
-    /// Takes the partition key rather than rebuilding one, so the two can never disagree about
-    /// which session they belong to.
-    pub fn sidecar_key(partition_key: &str) -> String {
-        match partition_key.rsplit_once('/') {
-            Some((directory, _)) => format!("{directory}/provenance.json"),
-            None => "provenance.json".to_string(),
-        }
+    /// Suffixed rather than named `provenance.json` beside the object, because the splits and
+    /// boundaries tables share one directory and would otherwise overwrite each other's record.
+    pub fn sidecar_key(object_key: &str) -> String {
+        format!("{object_key}.provenance.json")
     }
 }
 
@@ -200,20 +195,28 @@ mod tests {
     }
 
     #[test]
-    fn the_sidecar_sits_beside_its_partition() {
+    fn the_sidecar_sits_beside_its_object() {
         assert_eq!(
             PartitionProvenance::sidecar_key(
                 "data/derived/equity/trades/interval=one_day/year=2023/month=06/day=14/data.parquet"
             ),
-            "data/derived/equity/trades/interval=one_day/year=2023/month=06/day=14/provenance.json"
+            "data/derived/equity/trades/interval=one_day/year=2023/month=06/day=14/data.parquet.provenance.json"
         );
     }
 
+    /// Two whole-table objects share a directory, so a per-directory sidecar would collide.
     #[test]
-    fn a_bare_key_still_yields_a_sidecar() {
+    fn two_objects_in_one_directory_get_their_own_records() {
+        let splits = PartitionProvenance::sidecar_key(
+            "data/derived/equity/corporate_actions/splits.parquet",
+        );
+        let boundaries = PartitionProvenance::sidecar_key(
+            "data/derived/equity/corporate_actions/boundaries.parquet",
+        );
+        assert_ne!(splits, boundaries);
         assert_eq!(
-            PartitionProvenance::sidecar_key("data.parquet"),
-            "provenance.json"
+            splits,
+            "data/derived/equity/corporate_actions/splits.parquet.provenance.json"
         );
     }
 
@@ -221,7 +224,7 @@ mod tests {
     fn the_serialized_shape_names_both_provider_and_subscription() {
         let record = PartitionProvenance {
             dataset: "equity_trades".to_string(),
-            session: "2023-06-14".to_string(),
+            session: Some("2023-06-14".to_string()),
             routes: vec![Provenance::massive(
                 MassivePlan::StocksAdvanced,
                 MassiveTransport::FlatFile,
@@ -243,7 +246,7 @@ mod tests {
     fn an_alpaca_route_carries_no_transport() {
         let record = PartitionProvenance::new(
             "equity_quotes",
-            "2026-08-25",
+            Some("2026-08-25"),
             Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
         );
 
@@ -261,7 +264,7 @@ mod tests {
         let bulk = Provenance::massive(MassivePlan::StocksAdvanced, MassiveTransport::FlatFile);
         let repair = Provenance::alpaca(AlpacaPlan::AlgoTraderPlus);
 
-        let record = PartitionProvenance::new("equity_quotes", "2025-11-14", bulk)
+        let record = PartitionProvenance::new("equity_quotes", Some("2025-11-14"), bulk)
             .contributed(repair)
             // The same route twice must not grow the set; a re-run is not a new source.
             .contributed(repair);
@@ -277,7 +280,7 @@ mod tests {
     fn a_partition_alpaca_alone_built_survives_the_lapse() {
         let record = PartitionProvenance::new(
             "equity_quotes",
-            "2026-08-25",
+            Some("2026-08-25"),
             Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
         );
         assert!(!record.requires_massive_advanced());
@@ -287,7 +290,7 @@ mod tests {
     fn a_record_round_trips() {
         let record = PartitionProvenance::new(
             "equity_bars",
-            "2026-08-28",
+            Some("2026-08-28"),
             Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest),
         );
         let encoded = serde_json::to_string(&record).expect("the record serializes");

--- a/src/common/provenance.rs
+++ b/src/common/provenance.rs
@@ -1,0 +1,298 @@
+//! Which vendor and which subscription answer for a dataset.
+//!
+//! Declared in the type system rather than in prose so a new dataset cannot be added without saying
+//! where it comes from, and so "what stops working when a subscription lapses" is a query.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// The Alpaca subscription a dataset is served under.
+///
+/// One variant today, kept as an enum because the plan is a fact about the account rather than a
+/// constant of the vendor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AlpacaPlan {
+    AlgoTraderPlus,
+}
+
+/// The Massive subscription a dataset is served under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MassivePlan {
+    StocksStarter,
+    StocksAdvanced,
+}
+
+/// How a Massive dataset arrives: per-request, or as a whole-session file.
+///
+/// The distinction is not cosmetic — the flat files are the only affordable bulk route, and the
+/// REST tail is what survives a downgrade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MassiveTransport {
+    Rest,
+    FlatFile,
+}
+
+/// Which vendor answers for a dataset, under which subscription, and over which route.
+///
+/// Each provider carries its own plan, so a Massive subscription cannot be attached to Alpaca; and
+/// only Massive carries a transport, because Alpaca publishes no bulk files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "provider", rename_all = "snake_case")]
+pub enum Provenance {
+    Alpaca {
+        subscription: AlpacaPlan,
+    },
+    Massive {
+        subscription: MassivePlan,
+        transport: MassiveTransport,
+    },
+}
+
+impl Provenance {
+    /// Alpaca over REST, which is every route Alpaca has.
+    pub const fn alpaca(subscription: AlpacaPlan) -> Self {
+        Provenance::Alpaca { subscription }
+    }
+
+    /// Massive, over the named route.
+    pub const fn massive(subscription: MassivePlan, transport: MassiveTransport) -> Self {
+        Provenance::Massive {
+            subscription,
+            transport,
+        }
+    }
+
+    /// Whether this route stops answering when the Massive Advanced subscription lapses.
+    ///
+    /// The question the shutdown checklist asks, answered by the compiler rather than by memory.
+    pub const fn requires_massive_advanced(self) -> bool {
+        matches!(
+            self,
+            Provenance::Massive {
+                subscription: MassivePlan::StocksAdvanced,
+                ..
+            }
+        )
+    }
+
+    /// The vendor's name, for a log field or a sidecar a human reads.
+    pub const fn provider_name(self) -> &'static str {
+        match self {
+            Provenance::Alpaca { .. } => "alpaca",
+            Provenance::Massive { .. } => "massive",
+        }
+    }
+
+    /// The subscription's name, flattened across providers for the same purpose.
+    pub const fn subscription_name(self) -> &'static str {
+        match self {
+            Provenance::Alpaca {
+                subscription: AlpacaPlan::AlgoTraderPlus,
+            } => "algo_trader_plus",
+            Provenance::Massive {
+                subscription: MassivePlan::StocksStarter,
+                ..
+            } => "stocks_starter",
+            Provenance::Massive {
+                subscription: MassivePlan::StocksAdvanced,
+                ..
+            } => "stocks_advanced",
+        }
+    }
+}
+
+/// What a partition's sidecar records: every route that has contributed to it, and when.
+///
+/// **A set rather than a single route, because a partition is not sourced once.** The quote archive
+/// is the worked example: the whole-market walk folded 1,254 sessions from Massive flat files, and
+/// a repair pass then wrote 1,107 names into *every one of those same sessions* from Alpaca. A
+/// single-valued record would name whichever route wrote last and silently disown the other.
+///
+/// `written_at` is deliberately *content* rather than metadata. A server-side copy rewrites an
+/// object's `LastModified` — the 2026-09-03 prefix rewrite did exactly that to the whole archive —
+/// so the only durable answer to "when was this session built" is one written inside the object.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PartitionProvenance {
+    pub dataset: String,
+    pub session: String,
+    pub routes: Vec<Provenance>,
+    pub written_at: DateTime<Utc>,
+}
+
+impl PartitionProvenance {
+    /// The record for one partition, stamped now, naming the single route that just wrote.
+    pub fn new(dataset: &str, session: &str, provenance: Provenance) -> Self {
+        PartitionProvenance {
+            dataset: dataset.to_string(),
+            session: session.to_string(),
+            routes: vec![provenance],
+            written_at: Utc::now(),
+        }
+    }
+
+    /// Folds a further route into an existing record, keeping the set ordered and duplicate-free.
+    ///
+    /// Order is insertion order rather than sorted, so the first route to touch a partition stays
+    /// first and a reader can tell the bulk source from the repair that followed it.
+    pub fn contributed(mut self, provenance: Provenance) -> Self {
+        if !self.routes.contains(&provenance) {
+            self.routes.push(provenance);
+        }
+        self.written_at = Utc::now();
+        self
+    }
+
+    /// Whether any route behind this partition stops answering when Advanced lapses.
+    pub fn requires_massive_advanced(&self) -> bool {
+        self.routes
+            .iter()
+            .any(|route| route.requires_massive_advanced())
+    }
+
+    /// The sidecar's key, beside the partition it describes.
+    ///
+    /// Takes the partition key rather than rebuilding one, so the two can never disagree about
+    /// which session they belong to.
+    pub fn sidecar_key(partition_key: &str) -> String {
+        match partition_key.rsplit_once('/') {
+            Some((directory, _)) => format!("{directory}/provenance.json"),
+            None => "provenance.json".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advanced_is_the_only_route_that_lapses() {
+        assert!(
+            Provenance::massive(MassivePlan::StocksAdvanced, MassiveTransport::FlatFile)
+                .requires_massive_advanced()
+        );
+        assert!(
+            Provenance::massive(MassivePlan::StocksAdvanced, MassiveTransport::Rest)
+                .requires_massive_advanced()
+        );
+        assert!(
+            !Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::FlatFile)
+                .requires_massive_advanced()
+        );
+        assert!(!Provenance::alpaca(AlpacaPlan::AlgoTraderPlus).requires_massive_advanced());
+    }
+
+    #[test]
+    fn names_are_pinned_to_literals() {
+        let alpaca = Provenance::alpaca(AlpacaPlan::AlgoTraderPlus);
+        assert_eq!(alpaca.provider_name(), "alpaca");
+        assert_eq!(alpaca.subscription_name(), "algo_trader_plus");
+
+        let starter = Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest);
+        assert_eq!(starter.provider_name(), "massive");
+        assert_eq!(starter.subscription_name(), "stocks_starter");
+
+        let advanced = Provenance::massive(MassivePlan::StocksAdvanced, MassiveTransport::FlatFile);
+        assert_eq!(advanced.subscription_name(), "stocks_advanced");
+    }
+
+    #[test]
+    fn the_sidecar_sits_beside_its_partition() {
+        assert_eq!(
+            PartitionProvenance::sidecar_key(
+                "data/derived/equity/trades/interval=one_day/year=2023/month=06/day=14/data.parquet"
+            ),
+            "data/derived/equity/trades/interval=one_day/year=2023/month=06/day=14/provenance.json"
+        );
+    }
+
+    #[test]
+    fn a_bare_key_still_yields_a_sidecar() {
+        assert_eq!(
+            PartitionProvenance::sidecar_key("data.parquet"),
+            "provenance.json"
+        );
+    }
+
+    #[test]
+    fn the_serialized_shape_names_both_provider_and_subscription() {
+        let record = PartitionProvenance {
+            dataset: "equity_trades".to_string(),
+            session: "2023-06-14".to_string(),
+            routes: vec![Provenance::massive(
+                MassivePlan::StocksAdvanced,
+                MassiveTransport::FlatFile,
+            )],
+            written_at: "2026-09-04T00:36:48Z".parse().expect("a valid instant"),
+        };
+
+        let value: serde_json::Value =
+            serde_json::to_value(&record).expect("the record serializes");
+        assert_eq!(value["dataset"], "equity_trades");
+        assert_eq!(value["session"], "2023-06-14");
+        assert_eq!(value["routes"][0]["provider"], "massive");
+        assert_eq!(value["routes"][0]["subscription"], "stocks_advanced");
+        assert_eq!(value["routes"][0]["transport"], "flat_file");
+        assert_eq!(value["written_at"], "2026-09-04T00:36:48Z");
+    }
+
+    #[test]
+    fn an_alpaca_route_carries_no_transport() {
+        let record = PartitionProvenance::new(
+            "equity_quotes",
+            "2026-08-25",
+            Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
+        );
+
+        let value: serde_json::Value =
+            serde_json::to_value(&record).expect("the record serializes");
+        assert_eq!(value["routes"][0]["provider"], "alpaca");
+        assert_eq!(value["routes"][0]["subscription"], "algo_trader_plus");
+        assert!(value["routes"][0].get("transport").is_none());
+    }
+
+    /// The quote archive's actual shape: a whole-market flat-file walk, then an Alpaca repair that
+    /// wrote 1,107 names into every one of the same sessions.
+    #[test]
+    fn a_repaired_partition_names_both_routes_that_built_it() {
+        let bulk = Provenance::massive(MassivePlan::StocksAdvanced, MassiveTransport::FlatFile);
+        let repair = Provenance::alpaca(AlpacaPlan::AlgoTraderPlus);
+
+        let record = PartitionProvenance::new("equity_quotes", "2025-11-14", bulk)
+            .contributed(repair)
+            // The same route twice must not grow the set; a re-run is not a new source.
+            .contributed(repair);
+
+        assert_eq!(record.routes, vec![bulk, repair]);
+        assert!(
+            record.requires_massive_advanced(),
+            "a partition the flat files built still depends on them, whatever wrote last"
+        );
+    }
+
+    #[test]
+    fn a_partition_alpaca_alone_built_survives_the_lapse() {
+        let record = PartitionProvenance::new(
+            "equity_quotes",
+            "2026-08-25",
+            Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
+        );
+        assert!(!record.requires_massive_advanced());
+    }
+
+    #[test]
+    fn a_record_round_trips() {
+        let record = PartitionProvenance::new(
+            "equity_bars",
+            "2026-08-28",
+            Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest),
+        );
+        let encoded = serde_json::to_string(&record).expect("the record serializes");
+        let decoded: PartitionProvenance =
+            serde_json::from_str(&encoded).expect("the record deserializes");
+        assert_eq!(record, decoded);
+    }
+}

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -628,7 +628,7 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for PairID {
 /// [`BarInterval::as_str`] must match the `bar_interval` CHECK constraint exactly. It is the
 /// snake_case of the variant name, which lets `rename_all` derive the same string for serde so what
 /// is serialized and what is stored cannot drift apart.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BarInterval {
     OneMinute,

--- a/src/data.rs
+++ b/src/data.rs
@@ -4,6 +4,7 @@
 
 pub mod adjust;
 pub mod archive;
+pub mod attribution;
 pub mod bars;
 pub mod boundaries;
 pub mod cache;

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -8,7 +8,7 @@ use std::io::Cursor;
 use aws_sdk_s3::operation::get_object::GetObjectError;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client as S3Client;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use polars::prelude::*;
 use tracing::{info, warn};
 
@@ -23,7 +23,7 @@ use crate::common::types::{
     BarInterval, EquityBar, IntradayCadence, LiquidityFloor, QuoteSummary, SessionDate, Ticker,
     TradeSummary,
 };
-use crate::data::attribution::Attribution;
+use crate::data::attribution::{Attribution, Declaration};
 use crate::data::calendar::TradingCalendar;
 use crate::data::{bars, boundaries, quotes, splits, trades};
 
@@ -528,33 +528,72 @@ pub struct ProvenanceOutcome {
     pub unattributed: Vec<String>,
 }
 
-/// Every archive prefix one dataset name covers.
+/// One prefix a provenance pass covers, and what its objects are called.
 ///
 /// Named rather than derived from a listing, so a dataset that stops being written still reports
-/// its partitions instead of silently leaving the sweep.
-fn dataset_prefixes(dataset: &str) -> Vec<(BarInterval, String)> {
-    let cadences = |build: fn(BarInterval) -> String| -> Vec<(BarInterval, String)> {
-        BarInterval::ALL
-            .iter()
-            .map(|at| (*at, build(*at)))
-            .collect()
-    };
-    match dataset {
-        "equity_bars" => cadences(bar_archive_prefix),
-        "equity_quotes" => cadences(quote_archive_prefix),
-        "equity_trades" => cadences(trade_archive_prefix),
-        _ => Vec::new(),
-    }
+/// its objects instead of silently leaving the sweep.
+struct StampablePrefix {
+    dataset: String,
+    /// `None` for a prefix that has no cadence, which is every raw dataset.
+    interval: Option<BarInterval>,
+    prefix: String,
+    /// Derived partitions are parquet; the raw tee keeps the vendor's own gzip.
+    object: &'static str,
 }
 
-/// The datasets a provenance pass covers.
-pub const PROVENANCE_DATASETS: [&str; 3] = ["equity_bars", "equity_quotes", "equity_trades"];
+/// Every prefix a provenance pass covers: the derived cadences, and the raw tee beside them.
+fn stampable_prefixes() -> Vec<StampablePrefix> {
+    let mut found = Vec::new();
+    for (dataset, build) in [
+        (
+            "equity_bars",
+            bar_archive_prefix as fn(BarInterval) -> String,
+        ),
+        ("equity_quotes", quote_archive_prefix),
+        ("equity_trades", trade_archive_prefix),
+    ] {
+        for interval in BarInterval::ALL {
+            found.push(StampablePrefix {
+                dataset: dataset.to_string(),
+                interval: Some(interval),
+                prefix: build(interval),
+                object: "data.parquet",
+            });
+        }
+    }
+    for raw in [
+        RawDataset::Quotes,
+        RawDataset::Trades,
+        RawDataset::MinuteAggregates,
+    ] {
+        found.push(StampablePrefix {
+            dataset: format!("raw_equity_{}", raw.as_str()),
+            interval: None,
+            prefix: format!("data/raw/massive/equity/{}", raw.as_str()),
+            object: "data.csv.gz",
+        });
+    }
+    found
+}
+
+/// The session a partition or raw key belongs to, whatever its object is called.
+fn session_from_key(key: &str, object: &str) -> Option<NaiveDate> {
+    let mut segments = key.rsplit('/');
+    if segments.next()? != object {
+        return None;
+    }
+    let day: u32 = segments.next()?.strip_prefix("day=")?.parse().ok()?;
+    let month: u32 = segments.next()?.strip_prefix("month=")?.parse().ok()?;
+    let year: i32 = segments.next()?.strip_prefix("year=")?.parse().ok()?;
+    NaiveDate::from_ymd_opt(year, month, day)
+}
 
 /// Every partition key under `prefix`, with whether it already carries a sidecar.
 async fn partitions_and_sidecars(
     s3_client: &S3Client,
     bucket: &str,
     prefix: &str,
+    object: &str,
 ) -> Result<(Vec<String>, BTreeSet<String>), ArchiveError> {
     let mut partitions = Vec::new();
     let mut sidecars = BTreeSet::new();
@@ -571,9 +610,9 @@ async fn partitions_and_sidecars(
             prefix: prefix.to_string(),
             message: error.to_string(),
         })?;
-        for object in page.contents() {
-            let Some(key) = object.key() else { continue };
-            if key.ends_with("/data.parquet") {
+        for listed in page.contents() {
+            let Some(key) = listed.key() else { continue };
+            if key.ends_with(&format!("/{object}")) {
                 partitions.push(key.to_string());
             } else if key.ends_with("/provenance.json") {
                 sidecars.insert(key.to_string());
@@ -591,53 +630,64 @@ pub async fn stamp_partition_provenance(
     s3_client: &S3Client,
     bucket: &str,
     attribution: &Attribution,
+    declarations: &[Declaration],
     dry_run: bool,
 ) -> Result<ProvenanceOutcome, ArchiveError> {
     let mut outcome = ProvenanceOutcome::default();
-    for dataset in PROVENANCE_DATASETS {
-        for (interval, prefix) in dataset_prefixes(dataset) {
-            let (partitions, sidecars) =
-                partitions_and_sidecars(s3_client, bucket, &prefix).await?;
-            for key in partitions {
-                outcome.partitions_seen += 1;
-                let sidecar = PartitionProvenance::sidecar_key(&key);
-                if sidecars.contains(&sidecar) {
-                    outcome.sidecars_present += 1;
-                    continue;
-                }
-                let Some(date) = date_from_partitioned_key(&key) else {
-                    outcome.unattributed.push(key);
-                    continue;
-                };
-                // Cadence-specific first, then the whole-dataset claim. A source that named one
-                // cadence must never speak for the others written on the same session.
-                let routes = attribution
-                    .get(&(dataset.to_string(), Some(interval), date))
-                    .or_else(|| attribution.get(&(dataset.to_string(), None, date)));
-                let Some(routes) = routes else {
-                    outcome.unattributed.push(key);
-                    continue;
-                };
-                let record = PartitionProvenance {
-                    dataset: dataset.to_string(),
-                    session: date.to_string(),
-                    routes: routes.clone(),
-                    written_at: Utc::now(),
-                };
-                if !dry_run {
-                    let body =
-                        serde_json::to_vec(&record).map_err(|error| ArchiveError::Write {
-                            bucket: bucket.to_string(),
-                            key: sidecar.clone(),
-                            message: error.to_string(),
-                        })?;
-                    put_bytes(s3_client, bucket, &sidecar, body, "application/json").await?;
-                }
-                outcome.sidecars_written += 1;
+    for target in stampable_prefixes() {
+        let (objects, sidecars) =
+            partitions_and_sidecars(s3_client, bucket, &target.prefix, target.object).await?;
+        for key in objects {
+            outcome.partitions_seen += 1;
+            let sidecar = PartitionProvenance::sidecar_key(&key);
+            if sidecars.contains(&sidecar) {
+                outcome.sidecars_present += 1;
+                continue;
             }
+            let Some(date) = session_from_key(&key, target.object) else {
+                outcome.unattributed.push(key);
+                continue;
+            };
+            // Observed beats declared, and cadence-specific beats dataset-wide. A source that named
+            // one cadence must never speak for the others written on the same session.
+            let routes = attribution
+                .get(&(target.dataset.clone(), target.interval, date))
+                .or_else(|| attribution.get(&(target.dataset.clone(), None, date)))
+                .cloned()
+                .or_else(|| declared(declarations, &target).map(|route| vec![route]));
+            let Some(routes) = routes else {
+                outcome.unattributed.push(key);
+                continue;
+            };
+            let record = PartitionProvenance {
+                dataset: target.dataset.clone(),
+                session: date.to_string(),
+                routes,
+                written_at: Utc::now(),
+            };
+            if !dry_run {
+                let body = serde_json::to_vec(&record).map_err(|error| ArchiveError::Write {
+                    bucket: bucket.to_string(),
+                    key: sidecar.clone(),
+                    message: error.to_string(),
+                })?;
+                put_bytes(s3_client, bucket, &sidecar, body, "application/json").await?;
+            }
+            outcome.sidecars_written += 1;
         }
     }
     Ok(outcome)
+}
+
+/// The declared route for a prefix, preferring one that names its cadence.
+fn declared(declarations: &[Declaration], target: &StampablePrefix) -> Option<Provenance> {
+    let matching = |wanted: Option<BarInterval>| {
+        declarations
+            .iter()
+            .find(|entry| entry.dataset == target.dataset && entry.interval == wanted)
+            .map(|entry| entry.provenance)
+    };
+    matching(target.interval).or_else(|| matching(None))
 }
 
 /// Reports partitions carrying no provenance sidecar, which is the check the best-effort write
@@ -647,17 +697,15 @@ pub async fn sweep_partition_provenance(
     bucket: &str,
 ) -> Result<ProvenanceOutcome, ArchiveError> {
     let mut outcome = ProvenanceOutcome::default();
-    for dataset in PROVENANCE_DATASETS {
-        for (_, prefix) in dataset_prefixes(dataset) {
-            let (partitions, sidecars) =
-                partitions_and_sidecars(s3_client, bucket, &prefix).await?;
-            for key in partitions {
-                outcome.partitions_seen += 1;
-                if sidecars.contains(&PartitionProvenance::sidecar_key(&key)) {
-                    outcome.sidecars_present += 1;
-                } else {
-                    outcome.unattributed.push(key);
-                }
+    for target in stampable_prefixes() {
+        let (objects, sidecars) =
+            partitions_and_sidecars(s3_client, bucket, &target.prefix, target.object).await?;
+        for key in objects {
+            outcome.partitions_seen += 1;
+            if sidecars.contains(&PartitionProvenance::sidecar_key(&key)) {
+                outcome.sidecars_present += 1;
+            } else {
+                outcome.unattributed.push(key);
             }
         }
     }

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -521,44 +521,95 @@ async fn present_partitions(
 /// What a provenance pass did, counted so a run can be believed rather than assumed.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct ProvenanceOutcome {
-    pub partitions_seen: usize,
+    pub objects_seen: usize,
     pub sidecars_present: usize,
+    /// What a stamp would write. Counted apart from `sidecars_written` so a reporting run cannot
+    /// claim writes it did not make.
+    pub sidecars_planned: usize,
     pub sidecars_written: usize,
-    /// Partitions no source could attribute. Reported rather than guessed at.
+    /// Objects no source could attribute. Reported rather than guessed at.
     pub unattributed: Vec<String>,
+    /// Objects carrying no sidecar, which is what a sweep finds. Distinct from `unattributed`,
+    /// because a sweep consults no attribution and so cannot say anything failed to attribute.
+    pub sidecars_missing: Vec<String>,
+    /// Sidecars a stamp meant to write and could not. One fault costs one object, not the pass.
+    pub write_failures: Vec<String>,
+}
+
+/// A dataset the archive writes, named once so a prefix and a provenance record cannot disagree.
+///
+/// An enum rather than the `&str` this began as: the same name reaches `write_merged`, the stamp and
+/// the sweep, and nothing linked those lists. A dataset added at one and forgotten at the others was
+/// skipped in silence; now it does not compile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DerivedDataset {
+    Bars,
+    Quotes,
+    Trades,
+    Splits,
+    Boundaries,
+}
+
+impl DerivedDataset {
+    /// Every dataset, so a pass cannot iterate a subset by accident.
+    pub const ALL: [DerivedDataset; 5] = [
+        DerivedDataset::Bars,
+        DerivedDataset::Quotes,
+        DerivedDataset::Trades,
+        DerivedDataset::Splits,
+        DerivedDataset::Boundaries,
+    ];
+
+    /// The name a provenance record carries, and the name a declaration matches on.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            DerivedDataset::Bars => "equity_bars",
+            DerivedDataset::Quotes => "equity_quotes",
+            DerivedDataset::Trades => "equity_trades",
+            DerivedDataset::Splits => "equity_corporate_action_splits",
+            DerivedDataset::Boundaries => "equity_corporate_action_boundaries",
+        }
+    }
 }
 
 /// One prefix a provenance pass covers, and what its objects are called.
 ///
-/// Named rather than derived from a listing, so a dataset that stops being written still reports
-/// its objects instead of silently leaving the sweep.
+/// Named rather than derived from a listing, so a dataset that stops being written still reports its
+/// objects instead of silently leaving the sweep.
 struct StampablePrefix {
     dataset: String,
-    /// `None` for a prefix that has no cadence, which is every raw dataset.
+    /// `None` for a prefix that has no cadence: every raw dataset, and both corporate-action tables.
     interval: Option<BarInterval>,
     prefix: String,
-    /// Derived partitions are parquet; the raw tee keeps the vendor's own gzip.
+    /// Derived partitions are parquet, the raw tee keeps the vendor's gzip, and the corporate-action
+    /// tables are a single object rather than a partition.
     object: &'static str,
 }
 
-/// Every prefix a provenance pass covers: the derived cadences, and the raw tee beside them.
+/// Every prefix a provenance pass covers: the derived cadences, the whole-table objects, and the raw
+/// tee beside them.
 fn stampable_prefixes() -> Vec<StampablePrefix> {
     let mut found = Vec::new();
-    for (dataset, build) in [
-        (
-            "equity_bars",
-            bar_archive_prefix as fn(BarInterval) -> String,
-        ),
-        ("equity_quotes", quote_archive_prefix),
-        ("equity_trades", trade_archive_prefix),
-    ] {
-        for interval in BarInterval::ALL {
-            found.push(StampablePrefix {
-                dataset: dataset.to_string(),
-                interval: Some(interval),
-                prefix: build(interval),
-                object: "data.parquet",
-            });
+    for dataset in DerivedDataset::ALL {
+        match dataset {
+            DerivedDataset::Bars | DerivedDataset::Quotes | DerivedDataset::Trades => {
+                let build: fn(BarInterval) -> String = match dataset {
+                    DerivedDataset::Bars => bar_archive_prefix,
+                    DerivedDataset::Quotes => quote_archive_prefix,
+                    _ => trade_archive_prefix,
+                };
+                for interval in BarInterval::ALL {
+                    found.push(StampablePrefix {
+                        dataset: dataset.as_str().to_string(),
+                        interval: Some(interval),
+                        prefix: build(interval),
+                        object: "data.parquet",
+                    });
+                }
+            }
+            // One object, not a partition tree, so the prefix is its parent and the object its name.
+            DerivedDataset::Splits => found.push(whole_table(dataset, SPLITS_ARCHIVE_KEY)),
+            DerivedDataset::Boundaries => found.push(whole_table(dataset, BOUNDARIES_ARCHIVE_KEY)),
         }
     }
     for raw in [
@@ -574,6 +625,19 @@ fn stampable_prefixes() -> Vec<StampablePrefix> {
         });
     }
     found
+}
+
+/// A whole-table object described as a prefix and a filename, so the sweep can list it like any other.
+fn whole_table(dataset: DerivedDataset, key: &'static str) -> StampablePrefix {
+    let (prefix, object) = key
+        .rsplit_once('/')
+        .expect("an archive key has a parent prefix");
+    StampablePrefix {
+        dataset: dataset.as_str().to_string(),
+        interval: None,
+        prefix: prefix.to_string(),
+        object,
+    }
 }
 
 /// The session a partition or raw key belongs to, whatever its object is called.
@@ -614,7 +678,7 @@ async fn partitions_and_sidecars(
             let Some(key) = listed.key() else { continue };
             if key.ends_with(&format!("/{object}")) {
                 partitions.push(key.to_string());
-            } else if key.ends_with("/provenance.json") {
+            } else if key.ends_with(".provenance.json") {
                 sidecars.insert(key.to_string());
             }
         }
@@ -631,49 +695,71 @@ pub async fn stamp_partition_provenance(
     bucket: &str,
     attribution: &Attribution,
     declarations: &[Declaration],
-    dry_run: bool,
+    apply: bool,
 ) -> Result<ProvenanceOutcome, ArchiveError> {
     let mut outcome = ProvenanceOutcome::default();
     for target in stampable_prefixes() {
         let (objects, sidecars) =
             partitions_and_sidecars(s3_client, bucket, &target.prefix, target.object).await?;
         for key in objects {
-            outcome.partitions_seen += 1;
+            outcome.objects_seen += 1;
             let sidecar = PartitionProvenance::sidecar_key(&key);
             if sidecars.contains(&sidecar) {
                 outcome.sidecars_present += 1;
                 continue;
             }
-            let Some(date) = session_from_key(&key, target.object) else {
-                outcome.unattributed.push(key);
-                continue;
-            };
+            let session = session_from_key(&key, target.object);
             // Observed beats declared, and cadence-specific beats dataset-wide. A source that named
             // one cadence must never speak for the others written on the same session.
-            let routes = attribution
-                .get(&(target.dataset.clone(), target.interval, date))
-                .or_else(|| attribution.get(&(target.dataset.clone(), None, date)))
+            let routes = session
+                .and_then(|date| {
+                    attribution
+                        .get(&(target.dataset.clone(), target.interval, date))
+                        .or_else(|| attribution.get(&(target.dataset.clone(), None, date)))
+                })
                 .cloned()
                 .or_else(|| declared(declarations, &target).map(|route| vec![route]));
             let Some(routes) = routes else {
                 outcome.unattributed.push(key);
                 continue;
             };
+            outcome.sidecars_planned += 1;
+            if !apply {
+                continue;
+            }
             let record = PartitionProvenance {
                 dataset: target.dataset.clone(),
-                session: date.to_string(),
+                session: session.map(|at| at.to_string()),
                 routes,
                 written_at: Utc::now(),
             };
-            if !dry_run {
-                let body = serde_json::to_vec(&record).map_err(|error| ArchiveError::Write {
-                    bucket: bucket.to_string(),
-                    key: sidecar.clone(),
-                    message: error.to_string(),
-                })?;
-                put_bytes(s3_client, bucket, &sidecar, body, "application/json").await?;
+            let body = match serde_json::to_vec(&record) {
+                Ok(body) => body,
+                Err(error) => {
+                    warn!(key = sidecar, %error, "Provenance did not serialize");
+                    outcome.write_failures.push(sidecar);
+                    continue;
+                }
+            };
+            // One fault costs one object rather than the pass, matching `write_partitions`. A run
+            // that dies on a transient S3 error would otherwise discard everything it had done.
+            match put_object_with_precondition(
+                s3_client,
+                bucket,
+                &sidecar,
+                body,
+                "application/json",
+                &Precondition::Absent,
+            )
+            .await
+            {
+                WriteOutcome::Written => outcome.sidecars_written += 1,
+                WriteOutcome::Contended => outcome.sidecars_present += 1,
+                WriteOutcome::Failed(message) => {
+                    warn!(key = sidecar, message, "Provenance sidecar was not written");
+                    outcome.write_failures.push(sidecar);
+                }
             }
-            outcome.sidecars_written += 1;
         }
     }
     Ok(outcome)
@@ -701,11 +787,13 @@ pub async fn sweep_partition_provenance(
         let (objects, sidecars) =
             partitions_and_sidecars(s3_client, bucket, &target.prefix, target.object).await?;
         for key in objects {
-            outcome.partitions_seen += 1;
+            outcome.objects_seen += 1;
             if sidecars.contains(&PartitionProvenance::sidecar_key(&key)) {
                 outcome.sidecars_present += 1;
             } else {
-                outcome.unattributed.push(key);
+                // Missing, not unattributable: a sweep reads no attribution and so cannot say
+                // whether anything could have named this object's route.
+                outcome.sidecars_missing.push(key);
             }
         }
     }
@@ -1683,7 +1771,7 @@ async fn write_partition(
         key,
         fetched,
         |existing, fetched, key| merge_or_replace(existing, fetched, key),
-        "equity_bars",
+        DerivedDataset::Bars,
         provenance,
     )
     .await
@@ -1699,7 +1787,7 @@ async fn write_merged<F>(
     key: String,
     fetched: DataFrame,
     merge: F,
-    dataset: &str,
+    dataset: DerivedDataset,
     provenance: Provenance,
 ) -> Result<(), ArchiveError>
 where
@@ -2177,7 +2265,7 @@ async fn write_quote_partitions(
             key,
             frame,
             |existing, fetched, key| merge_or_replace(existing, fetched, key),
-            "equity_quotes",
+            DerivedDataset::Quotes,
             provenance,
         )
         .await
@@ -2480,7 +2568,7 @@ async fn write_trade_partitions(
             key,
             frame,
             |existing, fetched, key| merge_or_replace(existing, fetched, key),
-            "equity_trades",
+            DerivedDataset::Trades,
             // Trades have one route and no repair path: a trade file *is* the session.
             RawDataset::Trades.provenance(),
         )
@@ -2555,7 +2643,7 @@ pub async fn archive_splits(
                 Ok(fetched)
             }
         },
-        "equity_corporate_action_splits",
+        DerivedDataset::Splits,
         Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest),
     )
     .await?;
@@ -2606,7 +2694,7 @@ pub async fn archive_boundaries(
                 ))
             })
         },
-        "equity_corporate_action_boundaries",
+        DerivedDataset::Boundaries,
         Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
     )
     .await?;
@@ -2701,64 +2789,112 @@ async fn read_partition_with_etag(
 
 /// Writes a partition only if the object at `key` still matches `precondition`.
 ///
-/// Reads a partition's existing provenance, treating anything unreadable as absent.
+/// Reads a partition's provenance and the ETag it carried, or `None` where there is no record.
 ///
-/// Absent and corrupt are the same outcome deliberately: the sidecar is a record, not a lock, and
-/// refusing to write a fresh one because the old one will not parse would make a bad object
-/// permanent.
+/// Absent and unparseable are both `None` deliberately, because refusing to write over a corrupt
+/// object would make it permanent. **A failed request is neither**, and is propagated: treating a
+/// throttle as "no record" is what lets a single-route write replace a multi-route one.
 async fn read_sidecar(
     s3_client: &S3Client,
     bucket: &str,
     key: &str,
-) -> Option<PartitionProvenance> {
-    let response = s3_client
-        .get_object()
-        .bucket(bucket)
-        .key(key)
-        .send()
+) -> Result<Option<(PartitionProvenance, String)>, ArchiveError> {
+    let response = match s3_client.get_object().bucket(bucket).key(key).send().await {
+        Ok(response) => response,
+        Err(error) => {
+            return match error.into_service_error() {
+                GetObjectError::NoSuchKey(_) => Ok(None),
+                other => Err(ArchiveError::Read {
+                    bucket: bucket.to_string(),
+                    key: key.to_string(),
+                    message: other.to_string(),
+                }),
+            }
+        }
+    };
+    let etag = response.e_tag().unwrap_or_default().to_string();
+    let bytes = response
+        .body
+        .collect()
         .await
-        .ok()?;
-    let body = response.body.collect().await.ok()?.into_bytes();
-    serde_json::from_slice(&body).ok()
+        .map_err(|error| ArchiveError::Read {
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+            message: error.to_string(),
+        })?
+        .into_bytes();
+    Ok(serde_json::from_slice(&bytes)
+        .ok()
+        .map(|record| (record, etag)))
 }
 
-/// Records where a partition's bytes came from, beside the partition itself.
+/// Records where an object's bytes came from, beside the object itself.
 ///
-/// Best-effort by design, and warned rather than propagated: a 200-byte sidecar must never fail a
-/// fold that has already landed, and the write is idempotent so a later pass restores it. A
-/// coverage sweep finds partitions missing one, which is the check this trades for.
+/// Best-effort and warned rather than propagated: a 200-byte sidecar must never fail a fold that has
+/// already landed, and the sweep finds whatever this misses. The write is conditional, so a repair
+/// racing a bulk walk retries against what the other wrote instead of discarding it.
 async fn write_sidecar(
     s3_client: &S3Client,
     bucket: &str,
-    partition_key: &str,
-    dataset: &str,
+    object_key: &str,
+    dataset: DerivedDataset,
     provenance: Provenance,
 ) {
-    let key = PartitionProvenance::sidecar_key(partition_key);
-    let Some(session) = date_from_partitioned_key(partition_key) else {
-        warn!(
-            partition_key,
-            "Partition key carries no session; no provenance written"
-        );
-        return;
-    };
-    // Read-modify-write, so a repair that follows a bulk walk adds itself rather than erasing what
-    // built the partition first. The extra GET is one small object against a parquet write.
-    let existing = read_sidecar(s3_client, bucket, &key).await;
-    let record = match existing {
-        Some(record) => record.contributed(provenance),
-        None => PartitionProvenance::new(dataset, &session.to_string(), provenance),
-    };
-    let body = match serde_json::to_vec(&record) {
-        Ok(body) => body,
-        Err(error) => {
-            warn!(key, %error, "Provenance did not serialize");
-            return;
+    let key = PartitionProvenance::sidecar_key(object_key);
+    let session = session_from_key(object_key, "data.parquet").map(|at| at.to_string());
+
+    for attempt in 1..=CONTENDED_WRITE_ATTEMPTS {
+        let existing = match read_sidecar(s3_client, bucket, &key).await {
+            Ok(existing) => existing,
+            // Never overwrite a record that could not be read. The whole point of the set is that a
+            // later route adds itself; guessing "absent" here is how it would lose one.
+            Err(error) => {
+                warn!(key, %error, "Provenance could not be read; leaving the record alone");
+                return;
+            }
+        };
+        let (record, precondition) = match existing {
+            Some((record, etag)) => (record.contributed(provenance), Precondition::Match(etag)),
+            None => (
+                PartitionProvenance::new(dataset.as_str(), session.as_deref(), provenance),
+                Precondition::Absent,
+            ),
+        };
+        let body = match serde_json::to_vec(&record) {
+            Ok(body) => body,
+            Err(error) => {
+                warn!(key, %error, "Provenance did not serialize");
+                return;
+            }
+        };
+        match put_object_with_precondition(
+            s3_client,
+            bucket,
+            &key,
+            body,
+            "application/json",
+            &precondition,
+        )
+        .await
+        {
+            WriteOutcome::Written => return,
+            WriteOutcome::Contended => {
+                warn!(
+                    key,
+                    attempt, "Provenance changed under a write; merging again"
+                )
+            }
+            WriteOutcome::Failed(message) => {
+                warn!(key, message, "Provenance sidecar was not written");
+                return;
+            }
         }
-    };
-    if let Err(error) = put_bytes(s3_client, bucket, &key, body, "application/json").await {
-        warn!(key, %error, "Provenance sidecar was not written");
     }
+    warn!(
+        key,
+        attempts = CONTENDED_WRITE_ATTEMPTS,
+        "Provenance sidecar lost every race; the sweep will report it"
+    );
 }
 
 /// S3 answers a failed precondition with `412 Precondition Failed`, and `If-None-Match: *` against
@@ -2771,12 +2907,35 @@ async fn put_partition(
     body: Vec<u8>,
     precondition: &Precondition,
 ) -> WriteOutcome {
+    put_object_with_precondition(
+        s3_client,
+        bucket,
+        key,
+        body,
+        "application/vnd.apache.parquet",
+        precondition,
+    )
+    .await
+}
+
+/// The conditional write itself, over any content type.
+///
+/// Shared with the provenance sidecar, whose contention window is the same one partitions have: two
+/// routes touching a session at once must merge rather than overwrite.
+async fn put_object_with_precondition(
+    s3_client: &S3Client,
+    bucket: &str,
+    key: &str,
+    body: Vec<u8>,
+    content_type: &str,
+    precondition: &Precondition,
+) -> WriteOutcome {
     let request = s3_client
         .put_object()
         .bucket(bucket)
         .key(key)
         .body(ByteStream::from(body))
-        .content_type("application/vnd.apache.parquet");
+        .content_type(content_type);
 
     let request = match precondition {
         Precondition::Match(etag) => request.if_match(etag),
@@ -2995,9 +3154,100 @@ mod tests {
         // Pinned to the literal rather than derived from the constant under test.
         assert!(
             written.iter().any(|key| key.ends_with(
-                "data/derived/equity/bars/interval=five_minute/year=2026/month=09/day=03/provenance.json"
+                "data/derived/equity/bars/interval=five_minute/year=2026/month=09/day=03/data.parquet.provenance.json"
             )),
             "a sidecar must sit beside the partition; wrote {written:?}"
+        );
+    }
+
+    /// A failed read must never become an overwrite.
+    ///
+    /// `read_sidecar` once mapped every error to "absent", so a throttle or a 503 made the next write
+    /// build a fresh single-route record over a multi-route one -- the exact loss the set exists to
+    /// prevent. The record is only ever replaced by one that read the old one first.
+    #[tokio::test]
+    async fn test_a_sidecar_that_cannot_be_read_is_not_overwritten() {
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let recorder = Arc::clone(&seen);
+        let client = scripted_s3_client(move |method, key| {
+            if method == http::Method::PUT {
+                recorder
+                    .lock()
+                    .expect("the recorder must not be poisoned")
+                    .push(key.to_string());
+                http::Response::builder()
+                    .status(200)
+                    .body(SdkBody::empty())
+                    .expect("a canned response must build")
+            } else {
+                // Throttled, not absent. A 503 is the vendor saying "ask again", not "there is
+                // nothing here".
+                http::Response::builder()
+                    .status(503)
+                    .body(SdkBody::from("<Error><Code>SlowDown</Code></Error>"))
+                    .expect("a canned response must build")
+            }
+        });
+
+        write_sidecar(
+            &client,
+            "test-bucket",
+            SPLITS_ARCHIVE_KEY,
+            DerivedDataset::Splits,
+            Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest),
+        )
+        .await;
+
+        let written = seen
+            .lock()
+            .expect("the recorder must not be poisoned")
+            .clone();
+        assert!(
+            written.is_empty(),
+            "a sidecar that could not be read must be left alone; wrote {written:?}"
+        );
+    }
+
+    /// A whole-table object must carry provenance too, and must not be reported as sessionless.
+    ///
+    /// The splits and boundaries tables are one object rather than a partition tree, so a stamp that
+    /// insisted on a date-partitioned key wrote nothing for them and warned on every single write.
+    #[tokio::test]
+    async fn test_a_whole_table_object_records_its_route() {
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let recorder = Arc::clone(&seen);
+        let client = scripted_s3_client(move |method, key| {
+            if method == http::Method::PUT {
+                recorder
+                    .lock()
+                    .expect("the recorder must not be poisoned")
+                    .push(key.to_string());
+                http::Response::builder()
+                    .status(200)
+                    .body(SdkBody::empty())
+                    .expect("a canned response must build")
+            } else {
+                no_such_key()
+            }
+        });
+
+        write_sidecar(
+            &client,
+            "test-bucket",
+            SPLITS_ARCHIVE_KEY,
+            DerivedDataset::Splits,
+            Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest),
+        )
+        .await;
+
+        let written = seen
+            .lock()
+            .expect("the recorder must not be poisoned")
+            .clone();
+        assert!(
+            written.iter().any(|key| key
+                .ends_with("data/derived/equity/corporate_actions/splits.parquet.provenance.json")),
+            "a whole-table object needs a sidecar; wrote {written:?}"
         );
     }
 

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -14,12 +14,16 @@ use tracing::{info, warn};
 
 use crate::common::alpaca::MarketDataClient;
 use crate::common::aws::{date_from_partitioned_key, date_partitioned_key};
-use crate::common::flatfiles::{FlatFileClient, FlatFileError};
+use crate::common::flatfiles::{FlatFileClient, FlatFileError, RawDataset};
 use crate::common::massive::MassiveClient;
+use crate::common::provenance::{
+    AlpacaPlan, MassivePlan, MassiveTransport, PartitionProvenance, Provenance,
+};
 use crate::common::types::{
     BarInterval, EquityBar, IntradayCadence, LiquidityFloor, QuoteSummary, SessionDate, Ticker,
     TradeSummary,
 };
+use crate::data::attribution::Attribution;
 use crate::data::calendar::TradingCalendar;
 use crate::data::{bars, boundaries, quotes, splits, trades};
 
@@ -514,6 +518,152 @@ async fn present_partitions(
     Ok(present)
 }
 
+/// What a provenance pass did, counted so a run can be believed rather than assumed.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ProvenanceOutcome {
+    pub partitions_seen: usize,
+    pub sidecars_present: usize,
+    pub sidecars_written: usize,
+    /// Partitions no source could attribute. Reported rather than guessed at.
+    pub unattributed: Vec<String>,
+}
+
+/// Every archive prefix one dataset name covers.
+///
+/// Named rather than derived from a listing, so a dataset that stops being written still reports
+/// its partitions instead of silently leaving the sweep.
+fn dataset_prefixes(dataset: &str) -> Vec<(BarInterval, String)> {
+    let cadences = |build: fn(BarInterval) -> String| -> Vec<(BarInterval, String)> {
+        BarInterval::ALL
+            .iter()
+            .map(|at| (*at, build(*at)))
+            .collect()
+    };
+    match dataset {
+        "equity_bars" => cadences(bar_archive_prefix),
+        "equity_quotes" => cadences(quote_archive_prefix),
+        "equity_trades" => cadences(trade_archive_prefix),
+        _ => Vec::new(),
+    }
+}
+
+/// The datasets a provenance pass covers.
+pub const PROVENANCE_DATASETS: [&str; 3] = ["equity_bars", "equity_quotes", "equity_trades"];
+
+/// Every partition key under `prefix`, with whether it already carries a sidecar.
+async fn partitions_and_sidecars(
+    s3_client: &S3Client,
+    bucket: &str,
+    prefix: &str,
+) -> Result<(Vec<String>, BTreeSet<String>), ArchiveError> {
+    let mut partitions = Vec::new();
+    let mut sidecars = BTreeSet::new();
+    let mut pages = s3_client
+        .list_objects_v2()
+        .bucket(bucket)
+        .prefix(format!("{prefix}/"))
+        .into_paginator()
+        .send();
+
+    while let Some(page) = pages.next().await {
+        let page = page.map_err(|error| ArchiveError::List {
+            bucket: bucket.to_string(),
+            prefix: prefix.to_string(),
+            message: error.to_string(),
+        })?;
+        for object in page.contents() {
+            let Some(key) = object.key() else { continue };
+            if key.ends_with("/data.parquet") {
+                partitions.push(key.to_string());
+            } else if key.ends_with("/provenance.json") {
+                sidecars.insert(key.to_string());
+            }
+        }
+    }
+    Ok((partitions, sidecars))
+}
+
+/// Writes provenance sidecars for partitions that have none, from an attribution built elsewhere.
+///
+/// Only ever adds: a partition that already carries a sidecar is left alone, because the record
+/// written at the time of the write is better evidence than one reconstructed afterwards.
+pub async fn stamp_partition_provenance(
+    s3_client: &S3Client,
+    bucket: &str,
+    attribution: &Attribution,
+    dry_run: bool,
+) -> Result<ProvenanceOutcome, ArchiveError> {
+    let mut outcome = ProvenanceOutcome::default();
+    for dataset in PROVENANCE_DATASETS {
+        for (interval, prefix) in dataset_prefixes(dataset) {
+            let (partitions, sidecars) =
+                partitions_and_sidecars(s3_client, bucket, &prefix).await?;
+            for key in partitions {
+                outcome.partitions_seen += 1;
+                let sidecar = PartitionProvenance::sidecar_key(&key);
+                if sidecars.contains(&sidecar) {
+                    outcome.sidecars_present += 1;
+                    continue;
+                }
+                let Some(date) = date_from_partitioned_key(&key) else {
+                    outcome.unattributed.push(key);
+                    continue;
+                };
+                // Cadence-specific first, then the whole-dataset claim. A source that named one
+                // cadence must never speak for the others written on the same session.
+                let routes = attribution
+                    .get(&(dataset.to_string(), Some(interval), date))
+                    .or_else(|| attribution.get(&(dataset.to_string(), None, date)));
+                let Some(routes) = routes else {
+                    outcome.unattributed.push(key);
+                    continue;
+                };
+                let record = PartitionProvenance {
+                    dataset: dataset.to_string(),
+                    session: date.to_string(),
+                    routes: routes.clone(),
+                    written_at: Utc::now(),
+                };
+                if !dry_run {
+                    let body =
+                        serde_json::to_vec(&record).map_err(|error| ArchiveError::Write {
+                            bucket: bucket.to_string(),
+                            key: sidecar.clone(),
+                            message: error.to_string(),
+                        })?;
+                    put_bytes(s3_client, bucket, &sidecar, body, "application/json").await?;
+                }
+                outcome.sidecars_written += 1;
+            }
+        }
+    }
+    Ok(outcome)
+}
+
+/// Reports partitions carrying no provenance sidecar, which is the check the best-effort write
+/// trades against.
+pub async fn sweep_partition_provenance(
+    s3_client: &S3Client,
+    bucket: &str,
+) -> Result<ProvenanceOutcome, ArchiveError> {
+    let mut outcome = ProvenanceOutcome::default();
+    for dataset in PROVENANCE_DATASETS {
+        for (_, prefix) in dataset_prefixes(dataset) {
+            let (partitions, sidecars) =
+                partitions_and_sidecars(s3_client, bucket, &prefix).await?;
+            for key in partitions {
+                outcome.partitions_seen += 1;
+                if sidecars.contains(&PartitionProvenance::sidecar_key(&key)) {
+                    outcome.sidecars_present += 1;
+                } else {
+                    outcome.unattributed.push(key);
+                }
+            }
+        }
+    }
+    Ok(outcome)
+}
+
 /// Fetches and writes every session in `[window_start, window_end]` the archive is missing.
 ///
 /// **A set difference, not a lookback**, so a missed night, a week of downtime, and an empty bucket
@@ -663,6 +813,7 @@ async fn archive_chunk(
             BarInterval::OneDay,
             session,
             fetched_frame,
+            Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest),
         )
         .await
         {
@@ -1092,7 +1243,17 @@ async fn archive_intraday_chunk(
         );
     }
 
-    write_partitions(s3_client, bucket, interval, writable, progress).await
+    // Massive's per-ticker aggregate route, which the Starter tier answers within its rolling
+    // five-year window.
+    write_partitions(
+        s3_client,
+        bucket,
+        interval,
+        writable,
+        progress,
+        Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest),
+    )
+    .await
 }
 
 /// Whether this pass may write the partition for `session`.
@@ -1127,6 +1288,7 @@ async fn write_partitions(
     interval: BarInterval,
     partitions: Vec<(SessionDate, Vec<EquityBar>)>,
     progress: &mut PassProgress,
+    provenance: Provenance,
 ) -> Result<(), ArchiveError> {
     let mut queued = partitions.into_iter();
     let mut writes = tokio::task::JoinSet::new();
@@ -1141,7 +1303,8 @@ async fn write_partitions(
             let bucket = bucket.to_string();
             let rows = frame.height();
             writes.spawn(async move {
-                let written = write_partition(&client, &bucket, interval, session, frame).await;
+                let written =
+                    write_partition(&client, &bucket, interval, session, frame, provenance).await;
                 (session, rows, written)
             });
         }
@@ -1463,11 +1626,18 @@ async fn write_partition(
     interval: BarInterval,
     session: SessionDate,
     fetched: DataFrame,
+    provenance: Provenance,
 ) -> Result<(), ArchiveError> {
     let key = date_partitioned_key(&bar_archive_prefix(interval), session.date());
-    write_merged(s3_client, bucket, key, fetched, |existing, fetched, key| {
-        merge_or_replace(existing, fetched, key)
-    })
+    write_merged(
+        s3_client,
+        bucket,
+        key,
+        fetched,
+        |existing, fetched, key| merge_or_replace(existing, fetched, key),
+        "equity_bars",
+        provenance,
+    )
     .await
 }
 
@@ -1481,6 +1651,8 @@ async fn write_merged<F>(
     key: String,
     fetched: DataFrame,
     merge: F,
+    dataset: &str,
+    provenance: Provenance,
 ) -> Result<(), ArchiveError>
 where
     F: Fn(DataFrame, DataFrame, &str) -> Result<DataFrame, ArchiveError>,
@@ -1502,7 +1674,10 @@ where
         ParquetWriter::new(&mut buffer).finish(&mut frame)?;
 
         match put_partition(s3_client, bucket, &key, buffer, &precondition).await {
-            WriteOutcome::Written => return Ok(()),
+            WriteOutcome::Written => {
+                write_sidecar(s3_client, bucket, &key, dataset, provenance).await;
+                return Ok(());
+            }
             // Someone else wrote between this read and this write. Go round again so the merge is
             // redone against what they left, rather than resending a buffer built from stale rows.
             WriteOutcome::Contended => {
@@ -1597,6 +1772,19 @@ pub enum QuoteSource<'a> {
     PerName(&'a MarketDataClient),
     /// One file per session, folded whole.
     WholeSession(&'a FlatFileClient),
+}
+
+impl QuoteSource<'_> {
+    /// Where this route's ticks come from.
+    ///
+    /// Derived from the variant rather than passed alongside it, so a session folded from Alpaca
+    /// cannot be filed as having come from a flat file.
+    pub const fn provenance(&self) -> Provenance {
+        match self {
+            QuoteSource::PerName(_) => Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
+            QuoteSource::WholeSession(_) => RawDataset::Quotes.provenance(),
+        }
+    }
 }
 
 impl std::fmt::Display for QuoteSource<'_> {
@@ -1791,7 +1979,15 @@ async fn archive_quote_session(
         progress.sessions_without_data += 1;
         return Ok(quotes_folded);
     }
-    write_quote_partitions(s3_client, bucket, session, folded, progress).await?;
+    write_quote_partitions(
+        s3_client,
+        bucket,
+        session,
+        folded,
+        progress,
+        source.provenance(),
+    )
+    .await?;
     Ok(quotes_folded)
 }
 
@@ -1903,6 +2099,7 @@ async fn write_quote_partitions(
     session: SessionDate,
     folded: Vec<QuoteSummary>,
     progress: &mut PassProgress,
+    provenance: Provenance,
 ) -> Result<(), ArchiveError> {
     let mut one_minute: Vec<QuoteSummary> = Vec::new();
     let mut five_minute: Vec<QuoteSummary> = Vec::new();
@@ -1926,9 +2123,15 @@ async fn write_quote_partitions(
         }
         let frame = quotes::summaries_to_dataframe(&rows)?;
         let key = date_partitioned_key(&quote_archive_prefix(interval), session.date());
-        match write_merged(s3_client, bucket, key, frame, |existing, fetched, key| {
-            merge_or_replace(existing, fetched, key)
-        })
+        match write_merged(
+            s3_client,
+            bucket,
+            key,
+            frame,
+            |existing, fetched, key| merge_or_replace(existing, fetched, key),
+            "equity_quotes",
+            provenance,
+        )
         .await
         {
             Ok(()) => written += rows.len(),
@@ -2185,6 +2388,7 @@ async fn archive_bar_flat_file_session(
         BarInterval::OneMinute,
         vec![(session, bars)],
         progress,
+        RawDataset::MinuteAggregates.provenance(),
     )
     .await
 }
@@ -2222,9 +2426,16 @@ async fn write_trade_partitions(
         }
         let frame = trades::summaries_to_dataframe(&rows)?;
         let key = date_partitioned_key(&trade_archive_prefix(interval), session.date());
-        match write_merged(s3_client, bucket, key, frame, |existing, fetched, key| {
-            merge_or_replace(existing, fetched, key)
-        })
+        match write_merged(
+            s3_client,
+            bucket,
+            key,
+            frame,
+            |existing, fetched, key| merge_or_replace(existing, fetched, key),
+            "equity_trades",
+            // Trades have one route and no repair path: a trade file *is* the session.
+            RawDataset::Trades.provenance(),
+        )
         .await
         {
             Ok(()) => written += rows.len(),
@@ -2296,6 +2507,8 @@ pub async fn archive_splits(
                 Ok(fetched)
             }
         },
+        "equity_corporate_action_splits",
+        Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest),
     )
     .await?;
 
@@ -2345,6 +2558,8 @@ pub async fn archive_boundaries(
                 ))
             })
         },
+        "equity_corporate_action_boundaries",
+        Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
     )
     .await?;
 
@@ -2438,6 +2653,66 @@ async fn read_partition_with_etag(
 
 /// Writes a partition only if the object at `key` still matches `precondition`.
 ///
+/// Reads a partition's existing provenance, treating anything unreadable as absent.
+///
+/// Absent and corrupt are the same outcome deliberately: the sidecar is a record, not a lock, and
+/// refusing to write a fresh one because the old one will not parse would make a bad object
+/// permanent.
+async fn read_sidecar(
+    s3_client: &S3Client,
+    bucket: &str,
+    key: &str,
+) -> Option<PartitionProvenance> {
+    let response = s3_client
+        .get_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .ok()?;
+    let body = response.body.collect().await.ok()?.into_bytes();
+    serde_json::from_slice(&body).ok()
+}
+
+/// Records where a partition's bytes came from, beside the partition itself.
+///
+/// Best-effort by design, and warned rather than propagated: a 200-byte sidecar must never fail a
+/// fold that has already landed, and the write is idempotent so a later pass restores it. A
+/// coverage sweep finds partitions missing one, which is the check this trades for.
+async fn write_sidecar(
+    s3_client: &S3Client,
+    bucket: &str,
+    partition_key: &str,
+    dataset: &str,
+    provenance: Provenance,
+) {
+    let key = PartitionProvenance::sidecar_key(partition_key);
+    let Some(session) = date_from_partitioned_key(partition_key) else {
+        warn!(
+            partition_key,
+            "Partition key carries no session; no provenance written"
+        );
+        return;
+    };
+    // Read-modify-write, so a repair that follows a bulk walk adds itself rather than erasing what
+    // built the partition first. The extra GET is one small object against a parquet write.
+    let existing = read_sidecar(s3_client, bucket, &key).await;
+    let record = match existing {
+        Some(record) => record.contributed(provenance),
+        None => PartitionProvenance::new(dataset, &session.to_string(), provenance),
+    };
+    let body = match serde_json::to_vec(&record) {
+        Ok(body) => body,
+        Err(error) => {
+            warn!(key, %error, "Provenance did not serialize");
+            return;
+        }
+    };
+    if let Err(error) = put_bytes(s3_client, bucket, &key, body, "application/json").await {
+        warn!(key, %error, "Provenance sidecar was not written");
+    }
+}
+
 /// S3 answers a failed precondition with `412 Precondition Failed`, and `If-None-Match: *` against
 /// an object that has appeared since the read with `409 Conflict`. Both mean the same thing here —
 /// another pass got there first — so both become [`WriteOutcome::Contended`] rather than an error.
@@ -2524,6 +2799,8 @@ async fn put_bytes(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use super::*;
     use aws_smithy_http_client::test_util::infallible_client_fn;
     use aws_smithy_types::body::SdkBody;
@@ -2626,6 +2903,56 @@ mod tests {
         }
     }
 
+    /// A written partition must leave a provenance sidecar beside it, naming the route.
+    ///
+    /// The sidecar is the only durable answer to "where did this session come from": the prefix
+    /// rewrite of 2026-09-03 reset `LastModified` across the whole archive, so object metadata
+    /// cannot date or attribute a partition, and the summary itself carries no vendor.
+    #[tokio::test]
+    async fn test_a_written_partition_records_where_its_bytes_came_from() {
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let recorder = Arc::clone(&seen);
+        let client = scripted_s3_client(move |method, key| {
+            if method == http::Method::PUT {
+                recorder
+                    .lock()
+                    .expect("the recorder must not be poisoned")
+                    .push(key.to_string());
+                http::Response::builder()
+                    .status(200)
+                    .body(SdkBody::empty())
+                    .expect("a canned response must build")
+            } else {
+                no_such_key()
+            }
+        });
+
+        let at = session(2026, 9, 3);
+        let mut progress = PassProgress::default();
+        write_partitions(
+            &client,
+            "test-bucket",
+            BarInterval::FiveMinute,
+            vec![(at, vec![one_bar("AAPL", at)])],
+            &mut progress,
+            Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest),
+        )
+        .await
+        .expect("the partition must be written");
+
+        let written = seen
+            .lock()
+            .expect("the recorder must not be poisoned")
+            .clone();
+        // Pinned to the literal rather than derived from the constant under test.
+        assert!(
+            written.iter().any(|key| key.ends_with(
+                "data/derived/equity/bars/interval=five_minute/year=2026/month=09/day=03/provenance.json"
+            )),
+            "a sidecar must sit beside the partition; wrote {written:?}"
+        );
+    }
+
     /// One session's write failing must cost that session and no other.
     ///
     /// The regression test #1106 could not have: before it, any non-contention error returned from
@@ -2666,6 +2993,7 @@ mod tests {
             BarInterval::FiveMinute,
             partitions,
             &mut progress,
+            Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest),
         )
         .await;
 

--- a/src/data/attribution.rs
+++ b/src/data/attribution.rs
@@ -1,0 +1,247 @@
+//! Recovers which route built each archived session, from the passes' own logs.
+//!
+//! The logs are a configuration source, not a special case: they happen to be the only place the
+//! quote archive's two routes were ever recorded.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use chrono::NaiveDate;
+use serde::Deserialize;
+
+use crate::common::provenance::{AlpacaPlan, MassivePlan, MassiveTransport, Provenance};
+use crate::common::types::BarInterval;
+
+/// What one log line attests to: a dataset, optionally one cadence of it, and a session.
+///
+/// The cadence is `None` where a pass writes every cadence from a single fold — quotes and trades
+/// both do — and `Some` where it does not. **One-minute bars are the case that forces this**: they
+/// come from a flat file while the five-minute and daily partitions for the same session come from
+/// Massive's REST route, so a key without a cadence would attribute all three to the flat file.
+pub type Attribution = BTreeMap<(String, Option<BarInterval>, NaiveDate), Vec<Provenance>>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum AttributionError {
+    #[error("could not read {path}: {source}")]
+    Read {
+        path: String,
+        source: std::io::Error,
+    },
+}
+
+/// One log line, of the two shapes that name a route.
+#[derive(Deserialize)]
+struct Line {
+    fields: Fields,
+}
+
+#[derive(Deserialize)]
+struct Fields {
+    message: String,
+    /// Present on `Folding a session's quoted book`, which names its route directly.
+    #[serde(default)]
+    session: Option<String>,
+    #[serde(default)]
+    source: Option<String>,
+    /// Present on `Folded a flat file of ...`, whose vendor key names dataset and date together.
+    #[serde(default)]
+    key: Option<String>,
+}
+
+/// Reads every `*.log` under `directory`, recursively, and returns what each session was built by.
+///
+/// Unparseable lines are skipped rather than refused: a log is an artifact of a run that already
+/// happened, and one malformed line must not cost the other ten thousand.
+pub fn routes_from_logs(directory: &Path) -> Result<Attribution, AttributionError> {
+    let mut found: Attribution = BTreeMap::new();
+    for path in log_files(directory)? {
+        let text = std::fs::read_to_string(&path).map_err(|source| AttributionError::Read {
+            path: path.display().to_string(),
+            source,
+        })?;
+        for line in text.lines() {
+            let Ok(parsed) = serde_json::from_str::<Line>(line) else {
+                continue;
+            };
+            if let Some((dataset, interval, date, route)) = attribute(&parsed.fields) {
+                let routes = found.entry((dataset, interval, date)).or_default();
+                if !routes.contains(&route) {
+                    routes.push(route);
+                }
+            }
+        }
+    }
+    Ok(found)
+}
+
+/// What one log line says, where it says anything.
+fn attribute(fields: &Fields) -> Option<(String, Option<BarInterval>, NaiveDate, Provenance)> {
+    match fields.message.as_str() {
+        // The quote pass names its route in the line itself, which is the only reason the two
+        // sources are separable at all.
+        "Folding a session's quoted book" => {
+            let date = fields.session.as_deref()?.parse().ok()?;
+            let route = match fields.source.as_deref()? {
+                "per-name" => Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
+                "whole-session" => {
+                    Provenance::massive(MassivePlan::StocksAdvanced, MassiveTransport::FlatFile)
+                }
+                _ => return None,
+            };
+            // Every cadence, because one fold writes all of them.
+            Some(("equity_quotes".to_string(), None, date, route))
+        }
+        // A flat-file fold names the vendor object, which carries both dataset and date.
+        "Folded a flat file of trades" | "Folded a flat file of bars" => {
+            let (dataset, interval, date) = vendor_key_parts(fields.key.as_deref()?)?;
+            Some((
+                dataset,
+                interval,
+                date,
+                Provenance::massive(MassivePlan::StocksAdvanced, MassiveTransport::FlatFile),
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// Splits `us_stocks_sip/trades_v1/2023/06/2023-06-14.csv.gz` into our dataset name and its date.
+fn vendor_key_parts(key: &str) -> Option<(String, Option<BarInterval>, NaiveDate)> {
+    let mut segments = key.split('/');
+    segments.next()?;
+    // `minute_aggs_v1` attests to the one-minute cadence and to nothing else; the other two folds
+    // write every cadence they have from the same read.
+    let (dataset, interval) = match segments.next()? {
+        "trades_v1" => ("equity_trades", None),
+        "minute_aggs_v1" => ("equity_bars", Some(BarInterval::OneMinute)),
+        "quotes_v1" => ("equity_quotes", None),
+        _ => return None,
+    };
+    let file = key.rsplit('/').next()?;
+    let date = file.split('.').next()?.parse().ok()?;
+    Some((dataset.to_string(), interval, date))
+}
+
+/// Every `*.log` beneath `directory`, including subdirectories.
+fn log_files(directory: &Path) -> Result<Vec<std::path::PathBuf>, AttributionError> {
+    let mut found = Vec::new();
+    let entries = std::fs::read_dir(directory).map_err(|source| AttributionError::Read {
+        path: directory.display().to_string(),
+        source,
+    })?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            found.extend(log_files(&path)?);
+        } else if path.extension().is_some_and(|extension| extension == "log") {
+            found.push(path);
+        }
+    }
+    found.sort();
+    Ok(found)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(directory: &Path, name: &str, lines: &[&str]) {
+        std::fs::write(directory.join(name), lines.join("\n")).expect("the fixture writes");
+    }
+
+    fn session(year: i32, month: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(year, month, day).expect("a real date")
+    }
+
+    #[test]
+    fn a_quote_session_touched_twice_records_both_routes_in_order() {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        write(
+            directory.path(),
+            "a.log",
+            &[
+                r#"{"fields":{"message":"Folding a session's quoted book","session":"2025-11-14","source":"whole-session"}}"#,
+                r#"{"fields":{"message":"Folding a session's quoted book","session":"2025-11-14","source":"per-name"}}"#,
+                // A re-run of the same route must not grow the set.
+                r#"{"fields":{"message":"Folding a session's quoted book","session":"2025-11-14","source":"per-name"}}"#,
+            ],
+        );
+
+        let found = routes_from_logs(directory.path()).expect("the logs parse");
+        assert_eq!(
+            found[&("equity_quotes".to_string(), None, session(2025, 11, 14))],
+            vec![
+                Provenance::massive(MassivePlan::StocksAdvanced, MassiveTransport::FlatFile),
+                Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_flat_file_fold_is_attributed_from_its_vendor_key() {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        write(
+            directory.path(),
+            "a.log",
+            &[
+                r#"{"fields":{"message":"Folded a flat file of trades","key":"us_stocks_sip/trades_v1/2023/06/2023-06-14.csv.gz"}}"#,
+                r#"{"fields":{"message":"Folded a flat file of bars","key":"us_stocks_sip/minute_aggs_v1/2023/12/2023-12-20.csv.gz"}}"#,
+            ],
+        );
+
+        let found = routes_from_logs(directory.path()).expect("the logs parse");
+        let flat_file =
+            Provenance::massive(MassivePlan::StocksAdvanced, MassiveTransport::FlatFile);
+        assert_eq!(
+            found[&("equity_trades".to_string(), None, session(2023, 6, 14))],
+            vec![flat_file]
+        );
+        assert_eq!(
+            found[&(
+                "equity_bars".to_string(),
+                Some(BarInterval::OneMinute),
+                session(2023, 12, 20)
+            )],
+            vec![flat_file]
+        );
+        // The five-minute and daily partitions for that session came from Massive's REST route, so
+        // the flat-file line must not speak for them.
+        assert!(!found.contains_key(&("equity_bars".to_string(), None, session(2023, 12, 20))));
+    }
+
+    #[test]
+    fn a_malformed_line_costs_only_itself() {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        write(
+            directory.path(),
+            "a.log",
+            &[
+                "not json at all",
+                r#"{"fields":{"message":"Something else entirely"}}"#,
+                r#"{"fields":{"message":"Folding a session's quoted book","session":"nonsense","source":"per-name"}}"#,
+                r#"{"fields":{"message":"Folding a session's quoted book","session":"2026-08-25","source":"per-name"}}"#,
+            ],
+        );
+
+        let found = routes_from_logs(directory.path()).expect("the logs parse");
+        assert_eq!(found.len(), 1, "only the one well-formed line counts");
+        assert!(found.contains_key(&("equity_quotes".to_string(), None, session(2026, 8, 25))));
+    }
+
+    #[test]
+    fn logs_are_found_in_subdirectories_too() {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let nested = directory.path().join("superseded");
+        std::fs::create_dir(&nested).expect("the subdirectory is created");
+        write(
+            &nested,
+            "old.log",
+            &[
+                r#"{"fields":{"message":"Folded a flat file of trades","key":"us_stocks_sip/trades_v1/2021/08/2021-08-26.csv.gz"}}"#,
+            ],
+        );
+
+        let found = routes_from_logs(directory.path()).expect("the logs parse");
+        assert!(found.contains_key(&("equity_trades".to_string(), None, session(2021, 8, 26))));
+    }
+}

--- a/src/data/attribution.rs
+++ b/src/data/attribution.rs
@@ -27,6 +27,8 @@ pub enum AttributionError {
         path: String,
         source: std::io::Error,
     },
+    #[error("could not parse {path}: {message}")]
+    Parse { path: String, message: String },
 }
 
 /// One log line, of the two shapes that name a route.
@@ -120,6 +122,43 @@ fn vendor_key_parts(key: &str) -> Option<(String, Option<BarInterval>, NaiveDate
     let file = key.rsplit('/').next()?;
     let date = file.split('.').next()?.parse().ok()?;
     Some((dataset.to_string(), interval, date))
+}
+
+/// A route declared for a whole prefix rather than observed on a session.
+///
+/// The other half of an attribution. Logs can only speak for passes that logged; a dataset whose
+/// route is uniform by construction — Massive's REST bar cadences, every raw flat file — is
+/// described rather than discovered, and saying so is not a guess.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct Declaration {
+    pub dataset: String,
+    /// One cadence, or every cadence of the dataset when absent.
+    #[serde(default)]
+    pub interval: Option<BarInterval>,
+    #[serde(flatten)]
+    pub provenance: Provenance,
+}
+
+#[derive(Deserialize)]
+struct DeclarationFile {
+    declarations: Vec<Declaration>,
+}
+
+/// Reads declared routes from a JSON file.
+///
+/// Refused rather than skipped on a parse failure, unlike a log line: a configuration that does not
+/// parse is a mistake being made now, where a malformed log line is a run that already happened.
+pub fn routes_from_configuration(path: &Path) -> Result<Vec<Declaration>, AttributionError> {
+    let text = std::fs::read_to_string(path).map_err(|source| AttributionError::Read {
+        path: path.display().to_string(),
+        source,
+    })?;
+    let parsed: DeclarationFile =
+        serde_json::from_str(&text).map_err(|source| AttributionError::Parse {
+            path: path.display().to_string(),
+            message: source.to_string(),
+        })?;
+    Ok(parsed.declarations)
 }
 
 /// Every `*.log` beneath `directory`, including subdirectories.
@@ -226,6 +265,62 @@ mod tests {
         let found = routes_from_logs(directory.path()).expect("the logs parse");
         assert_eq!(found.len(), 1, "only the one well-formed line counts");
         assert!(found.contains_key(&("equity_quotes".to_string(), None, session(2026, 8, 25))));
+    }
+
+    #[test]
+    fn a_declaration_names_a_route_for_a_whole_prefix() {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let path = directory.path().join("declared.json");
+        std::fs::write(
+            &path,
+            r#"{"declarations":[
+                {"dataset":"equity_bars","interval":"five_minute",
+                 "provider":"massive","subscription":"stocks_starter","transport":"rest"},
+                {"dataset":"raw_equity_trades",
+                 "provider":"massive","subscription":"stocks_advanced","transport":"flat_file"}
+            ]}"#,
+        )
+        .expect("the fixture writes");
+
+        let declared = routes_from_configuration(&path).expect("the configuration parses");
+        assert_eq!(declared.len(), 2);
+        assert_eq!(declared[0].dataset, "equity_bars");
+        assert_eq!(declared[0].interval, Some(BarInterval::FiveMinute));
+        assert_eq!(
+            declared[0].provenance,
+            Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest)
+        );
+        // A raw dataset has no cadence, and an absent field must read as "every one".
+        assert_eq!(declared[1].interval, None);
+    }
+
+    /// A configuration that does not parse is a mistake being made now, unlike a malformed log line.
+    #[test]
+    fn a_broken_configuration_is_refused_rather_than_skipped() {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let path = directory.path().join("declared.json");
+        std::fs::write(&path, r#"{"declarations":[{"dataset":"equity_bars"}]}"#)
+            .expect("the fixture writes");
+        assert!(routes_from_configuration(&path).is_err());
+    }
+
+    /// The file shipped in the repository must be the shape the reader expects.
+    #[test]
+    fn the_checked_in_declaration_parses() {
+        let declared = routes_from_configuration(Path::new("data/archive_provenance.json"))
+            .expect("the shipped configuration parses");
+        assert!(
+            declared
+                .iter()
+                .any(|entry| entry.dataset == "raw_equity_trades"),
+            "the raw tee must be declared; nothing else can attribute it"
+        );
+        assert!(
+            declared
+                .iter()
+                .any(|entry| entry.interval == Some(BarInterval::OneDay)),
+            "daily bars have no log to attribute them"
+        );
     }
 
     #[test]

--- a/src/data/attribution.rs
+++ b/src/data/attribution.rs
@@ -1,7 +1,7 @@
-//! Recovers which route built each archived session, from the passes' own logs.
+//! Recovers which route built each archived object, from pass logs and from declared configuration.
 //!
-//! The logs are a configuration source, not a special case: they happen to be the only place the
-//! quote archive's two routes were ever recorded.
+//! Logs are one source among two, not a special case; they are simply the only record of the quote
+//! archive's two routes.
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -126,9 +126,8 @@ fn vendor_key_parts(key: &str) -> Option<(String, Option<BarInterval>, NaiveDate
 
 /// A route declared for a whole prefix rather than observed on a session.
 ///
-/// The other half of an attribution. Logs can only speak for passes that logged; a dataset whose
-/// route is uniform by construction — Massive's REST bar cadences, every raw flat file — is
-/// described rather than discovered, and saying so is not a guess.
+/// The other half of an attribution: a dataset whose route is uniform by construction is described
+/// rather than discovered, which logs cannot do for a pass that never logged.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Declaration {
     pub dataset: String,
@@ -168,7 +167,13 @@ fn log_files(directory: &Path) -> Result<Vec<std::path::PathBuf>, AttributionErr
         path: directory.display().to_string(),
         source,
     })?;
-    for entry in entries.flatten() {
+    for entry in entries {
+        // Propagated rather than skipped: a directory that cannot be walked yields a partial
+        // attribution, and a partial attribution silently under-stamps the archive.
+        let entry = entry.map_err(|source| AttributionError::Read {
+            path: directory.display().to_string(),
+            source,
+        })?;
         let path = entry.path();
         if path.is_dir() {
             found.extend(log_files(&path)?);


### PR DESCRIPTION
# Overview

The archive could not say where its own bytes came from. Two things this week made that
expensive: the 2026-09-03 prefix rewrite reset `LastModified` across all 12,564 derived objects,
so metadata can no longer date or attribute a partition; and Massive Stocks Advanced is being
shut down, making "what stops working" a question nothing in the tree could answer.

## Changes

- Add `common::provenance`, declaring which vendor and subscription answer for a dataset. Each
  provider variant carries **its own** plan, so a Massive subscription cannot be attached to
  Alpaca, and only Massive carries a transport, because Alpaca publishes no bulk files. Both
  invalid pairings are unrepresentable rather than merely unlikely.
- Require a `Provenance` at `write_merged`, the single choke point for every partition write.
  **Enforcement is on the write, not the dataset**: a static `DerivedDataset::provenance()` would
  have been a lie, since one-minute bars come from a flat file while daily bars for the same
  session come from REST. The compiler found all nine call sites.
- Write a `provenance.json` sidecar beside each partition, recording a **set** of routes.
  Read-modify-write and union, so a repair adds itself rather than erasing what built the
  partition first. `written_at` is content rather than metadata, which is the direct fix for the
  `LastModified` reset.
- Give `RawDataset` a static provenance and tee a sidecar beside each raw object, in the default
  storage class — a record needing a 12-to-48-hour restore before it can be read is not a record.
- Add `seed archive-provenance backfill` and `sweep`, with `data::attribution` supplying routes
  from two sources: `--from-logs` for what a pass **observed**, and `--from-configuration` for what
  is true **by construction**. Either or both; observed beats declared, and cadence-specific beats
  dataset-wide, so a declaration can never overrule a pass's own record.
- Cover the raw tee in the same pass, which needed the prefix set to carry its object name —
  derived partitions are `data.parquet`, raw objects the vendor's `data.csv.gz`.
- Ship `data/archive_provenance.json` with the declarations. Quotes are deliberately absent: they
  have two routes, so only a log can say which built a given session.
- Derive `Ord` on `BarInterval` so it can key the attribution map.

## Context

**The sidecar records a set because a partition is not sourced once.** Logs recovered from the
backfill box show **1,249 of 1,254** quote sessions were built by *both* the Massive flat-file walk
and the Alpaca repair, and only **5** by Alpaca alone. A single-valued record would have named
whichever route wrote last and silently disowned the other on essentially every quote partition.
`requires_massive_advanced()` is therefore true if *any* contributing route needs it, so an Alpaca
repair does not erase a flat-file dependency.

**Attribution is keyed by cadence, and a dry run is why.** Run against the real archive, the first
version stamped 2,509 five-minute and daily bar partitions as flat-file, because the one-minute
fold shares their sessions. Keyed by cadence it reads **7,530 attributed, 2,521 not** — and the
2,521 are exactly the REST-sourced bar cadences that no log attests to. That is the honest answer
rather than a guess, and it is the case a later `--from-configuration` source would serve.

**Coverage is now complete.** A dry run against the real archive reads **12,565 of 12,565 objects
attributed, none unattributed** — against 7,530 of 10,051 with logs alone. The last six were trade
partitions from two sessions folded outside the logs kept here, closed by declaring the trade
route, which is true by construction: a trade file *is* the session, and there is no repair path.

**Nothing has been stamped yet.** The backfill has only been dry-run; the write is additive,
idempotent, and gated behind `--dry-run` until this merges.

Verification: `devenv tasks run checks:rust` clean, 911 tests pass, line coverage 81.2%. The
sidecar assertion was proven load-bearing by removing the `write_sidecar` call, watching the test
fail, and restoring it.
