### PR TITLE
Check a coarser cadence against the finer rows beneath it

### DIFF
--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -130,6 +130,24 @@ impl CadenceAction {
     }
 }
 
+impl CadenceArguments {
+    /// The pair to fold, refusing a direction the fold cannot run in.
+    ///
+    /// Checked here rather than by clap, which sees one argument at a time and so cannot express a
+    /// rule spanning two; `Window::new` sets the same precedent. Refused before the listing, so an
+    /// inverted pair costs no request and reports as the usage error it is.
+    fn intervals(&self) -> Result<(BarInterval, BarInterval), String> {
+        if self.from > self.to {
+            return Err(format!(
+                "--from {} is coarser than --to {}; a fold runs one way",
+                self.from.bar_interval(),
+                self.to.bar_interval()
+            ));
+        }
+        Ok((self.from.bar_interval(), self.to.bar_interval()))
+    }
+}
+
 #[derive(Debug, Args)]
 struct CadenceArguments {
     #[command(flatten)]
@@ -438,6 +456,13 @@ struct QuoteSymbolArguments {
     quotes: QuoteArguments,
     #[command(flatten)]
     symbols: SymbolArguments,
+    /// Cadence of the partition being repaired, which is the cadence the fold is opened at.
+    ///
+    /// A session can hold a one-minute quote partition, so a repair pinned to five minutes would
+    /// fold the wrong cadence, merge it into the wrong prefix and report success over an unrepaired
+    /// gap.
+    #[arg(long, value_enum, default_value = "five_minute")]
+    cadence: Cadence,
 }
 
 /// A whole-market quote fold, which is the only quote action that chooses its cadence.
@@ -540,7 +565,9 @@ impl Cadence {
 /// Separate from [`Cadence`], which names a bucket a fold can be opened at: a session row is the
 /// merge of the buckets rather than a grid of them, so it belongs to a comparison and never to a
 /// fold. The two enums are what keep `--cadence one_day` unrepresentable.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+///
+/// Ordered finest-first, which is the order a fold runs in: `--from` must not exceed `--to`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum Interval {
     #[value(name = "one_minute")]
     OneMinute,
@@ -770,13 +797,24 @@ impl Outcome {
             Outcome::Chunked(summary) => Some(summary.to_string()),
             Outcome::Checked(totals) => {
                 let (folded_only, stored_only) = totals.one_sided();
+                // The four ways a session did not agree, named rather than summed. A window where
+                // most sessions were absent reads identically to a clean one under a single count.
+                let unresolved: Vec<String> = totals
+                    .unresolved()
+                    .iter()
+                    .map(|(session, outcome)| format!("{session} {outcome}"))
+                    .collect();
                 Some(format!(
-                    "{} sessions checked, {} agreeing, {} compared nothing, {} rows compared, {} disagreements, {folded_only} folded-only, {stored_only} stored-only",
+                    "{} sessions reached, {} agreeing, {} rows compared, {} disagreements, {folded_only} folded-only, {stored_only} stored-only{}",
                     totals.sessions(),
                     totals.sessions_agreeing(),
-                    totals.uncompared().len(),
                     totals.compared(),
-                    totals.disagreements()
+                    totals.disagreements(),
+                    if unresolved.is_empty() {
+                        String::new()
+                    } else {
+                        format!("; unresolved: {}", unresolved.join(", "))
+                    }
                 ))
             }
             Outcome::Complete => None,
@@ -804,11 +842,11 @@ impl Outcome {
                 "Backfill finished"
             ),
             Outcome::Checked(totals) => info!(
-                sessions_checked = totals.sessions(),
+                sessions_reached = totals.sessions(),
                 sessions_agreeing = totals.sessions_agreeing(),
-                sessions_uncompared = totals.uncompared().len(),
                 rows_compared = totals.compared(),
                 disagreements = totals.disagreements(),
+                unresolved = ?totals.unresolved(),
                 agrees = totals.agrees(),
                 "Check finished"
             ),
@@ -1323,7 +1361,7 @@ async fn seed_quotes(action: &QuoteAction) -> Result<Outcome, SeedError> {
                 &symbols.quotes,
                 scope,
                 QuoteProvider::PerName,
-                QUOTE_CADENCE,
+                symbols.cadence.intraday(),
             )
             .await
         }
@@ -1547,7 +1585,14 @@ async fn measure_sampled(symbols: &QuoteSymbolArguments) -> Result<Outcome, Seed
     let sampled = sample(&calendar, &window, arguments.stride);
     report_sample(&window, arguments.stride, &calendar, &sampled);
 
-    measure(&market_data, &calendar, &sampled, &named).await;
+    measure(
+        &market_data,
+        &calendar,
+        &sampled,
+        &named,
+        symbols.cadence.intraday(),
+    )
+    .await;
     Ok(Outcome::Complete)
 }
 
@@ -1727,11 +1772,10 @@ async fn quote_sources(
     Ok((market_data, TradingCalendar::from_days(days)))
 }
 
-/// The cadence the quote actions that take no cadence flag fold at.
+/// The cadence a probe folds at, which reports numbers and writes no partition.
 ///
-/// A repair and a measurement both reach a handful of names through Alpaca, and both want the
-/// cadence the surrounding partition was written at: a repair that wrote one-minute rows would leave
-/// two names at a cadence the rest of the session does not carry.
+/// The only quote action left without a flag. Every action that touches the archive takes one,
+/// because a fold at the wrong cadence lands in the wrong prefix.
 const QUOTE_CADENCE: IntradayCadence = IntradayCadence::FiveMinute;
 
 /// Which provider a fold reads from.
@@ -1783,6 +1827,7 @@ async fn measure(
     calendar: &TradingCalendar,
     sampled: &[SessionDate],
     symbols: &BTreeSet<Ticker>,
+    cadence: IntradayCadence,
 ) {
     println!(
         "{:<8}{:<12}{:>10}{:>10}{:>10}{:>10}{:>10}{:>10}{:>12}",
@@ -1802,9 +1847,7 @@ async fn measure(
             continue;
         };
         for ticker in symbols {
-            match quotes::fold_session(market_data, ticker, *session, QUOTE_CADENCE, open, close)
-                .await
-            {
+            match quotes::fold_session(market_data, ticker, *session, cadence, open, close).await {
                 Ok((summaries, fetch)) => {
                     print_session_row(ticker, *session, &summaries, fetch.received)
                 }
@@ -1869,6 +1912,7 @@ fn print_session_row(
 /// credential — which is what makes it usable after a subscription lapses.
 async fn check_cadence(action: &CadenceAction) -> Result<Outcome, SeedError> {
     let arguments = action.arguments();
+    let (from, to) = arguments.intervals()?;
     let window = arguments.window.window()?;
     let bucket = bucket_name()?;
     let s3_client = fund::common::aws::s3_client().await;
@@ -1877,8 +1921,8 @@ async fn check_cadence(action: &CadenceAction) -> Result<Outcome, SeedError> {
         &s3_client,
         &bucket,
         action.family(),
-        arguments.from.bar_interval(),
-        arguments.to.bar_interval(),
+        from,
+        to,
         window.start,
         window.end,
         arguments.stride,
@@ -1889,10 +1933,10 @@ async fn check_cadence(action: &CadenceAction) -> Result<Outcome, SeedError> {
     // Named, not counted. The medians are not decomposable, so a run that printed only agreement
     // would read as covering the row -- which is the overstatement this whole check exists against.
     println!(
-        "{} {} -> {}: {} of {} sessions agree over {} rows; {} not checked: {}",
+        "{} {} -> {}: {} of {} sessions agree over {} rows; {} columns are not decomposable and were not checked: {}",
         action.family(),
-        arguments.from.bar_interval(),
-        arguments.to.bar_interval(),
+        from,
+        to,
         totals.sessions_agreeing(),
         totals.sessions(),
         totals.compared(),

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -18,6 +18,7 @@ use fund::common::types::{
     BarInterval, IntradayCadence, LiquidityFloor, QuoteSummary, SessionDate, Ticker,
 };
 use fund::data::archive::{self, NameSelection, Scope, SessionSelection};
+use fund::data::cadence::CadenceTotals;
 use fund::data::calendar::TradingCalendar;
 use fund::data::{attribution, bars, details, quotes};
 
@@ -93,6 +94,56 @@ enum Command {
         #[command(subcommand)]
         action: ProvenanceAction,
     },
+    /// Whether a family's coarser rows are the finer rows beneath them. Writes nothing.
+    ArchiveCadence {
+        #[command(subcommand)]
+        action: CadenceAction,
+    },
+}
+
+/// Which family to fold up and compare. Both arms read the archive and write nothing.
+///
+/// A subcommand rather than a flag because the two families store different columns under different
+/// prefixes, and a flag would let a run name the quote prefix and the trade column rules.
+#[derive(Debug, Subcommand)]
+enum CadenceAction {
+    /// Compare the quote archive's cadences against each other.
+    Quotes(CadenceArguments),
+    /// Compare the trade archive's cadences against each other.
+    Trades(CadenceArguments),
+}
+
+impl CadenceAction {
+    /// Which prefix and column rules this action reads.
+    fn family(&self) -> archive::SummaryFamily {
+        match self {
+            CadenceAction::Quotes(_) => archive::SummaryFamily::Quotes,
+            CadenceAction::Trades(_) => archive::SummaryFamily::Trades,
+        }
+    }
+
+    /// The window, stride and pair of cadences this action runs over.
+    fn arguments(&self) -> &CadenceArguments {
+        match self {
+            CadenceAction::Quotes(arguments) | CadenceAction::Trades(arguments) => arguments,
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+struct CadenceArguments {
+    #[command(flatten)]
+    window: WindowArguments,
+    /// Sample every Nth session the finer prefix holds, anchored at the oldest.
+    #[arg(long, default_value_t = DEFAULT_STRIDE, value_parser = stride)]
+    stride: usize,
+    /// The cadence to fold up from, which is also the prefix the session population is read off.
+    #[arg(long, value_enum, default_value = "one_minute")]
+    from: Interval,
+    /// The cadence to compare against. Refused if it is finer than `--from`, since the fold only
+    /// runs one way; equal to it is the degenerate fold, which compares each row against itself.
+    #[arg(long, value_enum, default_value = "one_day")]
+    to: Interval,
 }
 
 /// What to do about provenance the archive does not yet record.
@@ -145,6 +196,7 @@ impl Command {
             Command::EquityQuotes { .. } => "seed-equity-quotes",
             Command::EquityTrades { .. } => "seed-equity-trades",
             Command::ArchiveProvenance { .. } => "seed-archive-provenance",
+            Command::ArchiveCadence { .. } => "seed-archive-cadence",
         }
     }
 }
@@ -281,10 +333,10 @@ struct IntradayRepairArguments {
 enum QuoteAction {
     /// Fold every name the daily archive holds into the sampled sessions that have no partition
     /// yet.
-    Archive(QuoteArguments),
+    Archive(QuoteFoldArguments),
     /// Fold every name the daily archive holds into every sampled session, widening ones already
     /// summarized.
-    Widen(QuoteArguments),
+    Widen(QuoteFoldArguments),
     /// Fold named symbols and print what they read, touching no partition.
     Measure(QuoteSymbolArguments),
     /// Fold named symbols into the sampled sessions that already have a partition.
@@ -388,6 +440,20 @@ struct QuoteSymbolArguments {
     symbols: SymbolArguments,
 }
 
+/// A whole-market quote fold, which is the only quote action that chooses its cadence.
+#[derive(Debug, Args)]
+struct QuoteFoldArguments {
+    #[command(flatten)]
+    quotes: QuoteArguments,
+    /// Cadence to fold the intraday rows at, which is also the partition they land in.
+    ///
+    /// The session row is written only by the cadence that authors it. A fold at any other cadence
+    /// derives the same row, compares it against the stored one and reports — see
+    /// `archive-cadence quotes` for that comparison run over the archive afterwards.
+    #[arg(long, value_enum, default_value = "five_minute")]
+    cadence: Cadence,
+}
+
 /// The window an archive pass runs over, as the arguments give it.
 #[derive(Debug, Args)]
 struct WindowArguments {
@@ -455,10 +521,41 @@ enum Cadence {
 }
 
 impl Cadence {
-    fn interval(self) -> BarInterval {
+    /// The bucket width this names, which is what a fold is opened at.
+    fn intraday(self) -> IntradayCadence {
         match self {
-            Cadence::FiveMinute => BarInterval::FiveMinute,
-            Cadence::OneMinute => BarInterval::OneMinute,
+            Cadence::FiveMinute => IntradayCadence::FiveMinute,
+            Cadence::OneMinute => IntradayCadence::OneMinute,
+        }
+    }
+
+    /// The partition rows folded at this cadence land in.
+    fn interval(self) -> BarInterval {
+        self.intraday().bar_interval()
+    }
+}
+
+/// Any interval the archive stores, which is a cadence plus the session row.
+///
+/// Separate from [`Cadence`], which names a bucket a fold can be opened at: a session row is the
+/// merge of the buckets rather than a grid of them, so it belongs to a comparison and never to a
+/// fold. The two enums are what keep `--cadence one_day` unrepresentable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum Interval {
+    #[value(name = "one_minute")]
+    OneMinute,
+    #[value(name = "five_minute")]
+    FiveMinute,
+    #[value(name = "one_day")]
+    OneDay,
+}
+
+impl Interval {
+    fn bar_interval(self) -> BarInterval {
+        match self {
+            Interval::OneMinute => BarInterval::OneMinute,
+            Interval::FiveMinute => BarInterval::FiveMinute,
+            Interval::OneDay => BarInterval::OneDay,
         }
     }
 }
@@ -659,6 +756,8 @@ enum Outcome {
     Pass(archive::PassSummary),
     /// A chunked backfill into PostgreSQL, which steps over a failed window rather than aborting.
     Chunked(ChunkedSummary),
+    /// A read-only check, which always finished and reports whether what it read agreed.
+    Checked(CadenceTotals),
     /// A run with nothing to step over: it did all of its work, or returned an error instead of it.
     Complete,
 }
@@ -669,6 +768,17 @@ impl Outcome {
         match self {
             Outcome::Pass(summary) => Some(summary.to_string()),
             Outcome::Chunked(summary) => Some(summary.to_string()),
+            Outcome::Checked(totals) => {
+                let (folded_only, stored_only) = totals.one_sided();
+                Some(format!(
+                    "{} sessions checked, {} agreeing, {} compared nothing, {} rows compared, {} disagreements, {folded_only} folded-only, {stored_only} stored-only",
+                    totals.sessions(),
+                    totals.sessions_agreeing(),
+                    totals.uncompared().len(),
+                    totals.compared(),
+                    totals.disagreements()
+                ))
+            }
             Outcome::Complete => None,
         }
     }
@@ -693,6 +803,15 @@ impl Outcome {
                 complete = summary.is_complete(),
                 "Backfill finished"
             ),
+            Outcome::Checked(totals) => info!(
+                sessions_checked = totals.sessions(),
+                sessions_agreeing = totals.sessions_agreeing(),
+                sessions_uncompared = totals.uncompared().len(),
+                rows_compared = totals.compared(),
+                disagreements = totals.disagreements(),
+                agrees = totals.agrees(),
+                "Check finished"
+            ),
             Outcome::Complete => {}
         }
     }
@@ -703,6 +822,9 @@ impl Outcome {
         let complete = match self {
             Outcome::Pass(summary) => summary.is_complete(),
             Outcome::Chunked(summary) => summary.is_complete(),
+            // A disagreement is what this run exists to find, so it is the one outcome that must
+            // not exit zero: nothing downstream reads the report, and automation reads only this.
+            Outcome::Checked(totals) => totals.agrees(),
             Outcome::Complete => true,
         };
         if complete {
@@ -775,6 +897,7 @@ async fn run(command: &Command, today: SessionDate) -> Result<Outcome, SeedError
         Command::EquityQuotes { action } => seed_quotes(action).await,
         Command::EquityTrades { action } => seed_trades(action).await,
         Command::ArchiveProvenance { action } => seed_provenance(action).await,
+        Command::ArchiveCadence { action } => check_cadence(action).await,
     }
 }
 
@@ -1181,7 +1304,13 @@ async fn seed_quotes(action: &QuoteAction) -> Result<Outcome, SeedError> {
             let scope = action
                 .universe_scope()
                 .ok_or_else(|| SeedError::Usage(format!("{action:?} folds no universe")))??;
-            fold_sampled(arguments, scope, QuoteProvider::WholeSession).await
+            fold_sampled(
+                &arguments.quotes,
+                scope,
+                QuoteProvider::WholeSession,
+                arguments.cadence.intraday(),
+            )
+            .await
         }
         QuoteAction::Measure(symbols) => measure_sampled(symbols).await,
         QuoteAction::Repair(symbols) => {
@@ -1190,7 +1319,13 @@ async fn seed_quotes(action: &QuoteAction) -> Result<Outcome, SeedError> {
             let named = symbols.symbols.required_names()?;
             let scope = Scope::new(NameSelection::Named(named), SessionSelection::Present)
                 .map_err(|error| SeedError::Usage(error.to_string()))?;
-            fold_sampled(&symbols.quotes, scope, QuoteProvider::PerName).await
+            fold_sampled(
+                &symbols.quotes,
+                scope,
+                QuoteProvider::PerName,
+                QUOTE_CADENCE,
+            )
+            .await
         }
     }
 }
@@ -1203,6 +1338,7 @@ async fn fold_sampled(
     arguments: &QuoteArguments,
     scope: Scope,
     provider: QuoteProvider,
+    cadence: IntradayCadence,
 ) -> Result<Outcome, SeedError> {
     let window = arguments.window.window()?;
     let (market_data, calendar) = quote_sources(&window).await?;
@@ -1221,7 +1357,7 @@ async fn fold_sampled(
     };
 
     Ok(Outcome::Pass(
-        fold_quotes(&source, &calendar, &sampled, &scope).await?,
+        fold_quotes(&source, &calendar, &sampled, &scope, cadence).await?,
     ))
 }
 
@@ -1591,11 +1727,11 @@ async fn quote_sources(
     Ok((market_data, TradingCalendar::from_days(days)))
 }
 
-/// The cadence every quote action folds at.
+/// The cadence the quote actions that take no cadence flag fold at.
 ///
-/// One-minute is plumbed the whole way through [`IntradayCadence`] but deliberately unreachable from
-/// the command line: a one-minute pass re-derives the session row, and the check that compares it
-/// against the stored one rather than overwriting it does not exist yet.
+/// A repair and a measurement both reach a handful of names through Alpaca, and both want the
+/// cadence the surrounding partition was written at: a repair that wrote one-minute rows would leave
+/// two names at a cadence the rest of the session does not carry.
 const QUOTE_CADENCE: IntradayCadence = IntradayCadence::FiveMinute;
 
 /// Which provider a fold reads from.
@@ -1615,17 +1751,12 @@ async fn fold_quotes(
     calendar: &TradingCalendar,
     sampled: &[SessionDate],
     scope: &Scope,
+    cadence: IntradayCadence,
 ) -> Result<archive::PassSummary, Box<dyn std::error::Error>> {
     let bucket = bucket_name()?;
     let s3_client = fund::common::aws::s3_client().await;
     Ok(archive::archive_quote_sessions(
-        &s3_client,
-        source,
-        calendar,
-        &bucket,
-        sampled,
-        scope,
-        QUOTE_CADENCE,
+        &s3_client, source, calendar, &bucket, sampled, scope, cadence,
     )
     .await?)
 }
@@ -1729,6 +1860,48 @@ fn print_session_row(
     );
 }
 
+// --- Cross-cadence check --------------------------------------------------------------------
+
+/// Folds one stored cadence up to another and reports whether they agree, writing nothing.
+///
+/// Needs AWS and nothing else. The population is what the finer prefix holds rather than what a
+/// calendar publishes, so this runs against the archive as it stands and asks for no vendor
+/// credential — which is what makes it usable after a subscription lapses.
+async fn check_cadence(action: &CadenceAction) -> Result<Outcome, SeedError> {
+    let arguments = action.arguments();
+    let window = arguments.window.window()?;
+    let bucket = bucket_name()?;
+    let s3_client = fund::common::aws::s3_client().await;
+
+    let totals = archive::check_cadence_agreement(
+        &s3_client,
+        &bucket,
+        action.family(),
+        arguments.from.bar_interval(),
+        arguments.to.bar_interval(),
+        window.start,
+        window.end,
+        arguments.stride,
+    )
+    .await
+    .map_err(box_error)?;
+
+    // Named, not counted. The medians are not decomposable, so a run that printed only agreement
+    // would read as covering the row -- which is the overstatement this whole check exists against.
+    println!(
+        "{} {} -> {}: {} of {} sessions agree over {} rows; {} not checked: {}",
+        action.family(),
+        arguments.from.bar_interval(),
+        arguments.to.bar_interval(),
+        totals.sessions_agreeing(),
+        totals.sessions(),
+        totals.compared(),
+        action.family().opaque_columns().len(),
+        action.family().opaque_columns().join(", ")
+    );
+    Ok(Outcome::Checked(totals))
+}
+
 // --- Shared plumbing ------------------------------------------------------------------------
 
 /// The bucket every S3 subcommand writes into.
@@ -1810,6 +1983,84 @@ mod tests {
             Command::EquityQuotes { action } => action,
             _ => panic!("expected the quote subcommand"),
         }
+    }
+
+    fn cadence_action(arguments: &[&str]) -> CadenceAction {
+        let parsed = parse(arguments).expect("valid arguments");
+        match parsed.command {
+            Command::ArchiveCadence { action } => action,
+            _ => panic!("expected the cadence subcommand"),
+        }
+    }
+
+    /// A whole-market quote fold, which is the only quote action that names its own cadence.
+    fn quote_fold(arguments: &[&str]) -> QuoteFoldArguments {
+        match quotes(arguments) {
+            QuoteAction::Archive(arguments) | QuoteAction::Widen(arguments) => arguments,
+            other => panic!("expected a whole-market fold, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_quote_fold_defaults_to_five_minutes_and_reaches_one_minute() {
+        let window = ["--start", "2026-08-03", "--end", "2026-08-21"];
+        for action in ["archive", "widen"] {
+            let mut defaulted = vec!["equity-quotes", action];
+            defaulted.extend_from_slice(&window);
+            assert_eq!(
+                quote_fold(&defaulted).cadence.intraday(),
+                IntradayCadence::FiveMinute
+            );
+
+            let mut one = defaulted.clone();
+            one.extend_from_slice(&["--cadence", "one_minute"]);
+            assert_eq!(
+                quote_fold(&one).cadence.intraday(),
+                IntradayCadence::OneMinute
+            );
+        }
+    }
+
+    #[test]
+    fn test_a_session_is_not_a_cadence_a_quote_fold_can_be_opened_at() {
+        // A session row is the merge of the buckets rather than a grid of them, so `one_day` names
+        // no fold. Refused by the value enum rather than checked after parsing.
+        assert!(parse(&[
+            "equity-quotes",
+            "archive",
+            "--start",
+            "2026-08-03",
+            "--end",
+            "2026-08-21",
+            "--cadence",
+            "one_day",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn test_the_cadence_check_reads_both_families_and_defaults_to_the_session_row() {
+        let window = ["--start", "2021-08-23", "--end", "2026-08-21"];
+
+        let mut quotes = vec!["archive-cadence", "quotes"];
+        quotes.extend_from_slice(&window);
+        let action = cadence_action(&quotes);
+        assert!(matches!(action.family(), archive::SummaryFamily::Quotes));
+        assert_eq!(
+            action.arguments().from.bar_interval(),
+            BarInterval::OneMinute
+        );
+        assert_eq!(action.arguments().to.bar_interval(), BarInterval::OneDay);
+        assert_eq!(action.arguments().stride, 1);
+
+        let mut trades = vec!["archive-cadence", "trades", "--to", "five_minute"];
+        trades.extend_from_slice(&window);
+        let action = cadence_action(&trades);
+        assert!(matches!(action.family(), archive::SummaryFamily::Trades));
+        assert_eq!(
+            action.arguments().to.bar_interval(),
+            BarInterval::FiveMinute
+        );
     }
 
     #[test]
@@ -2130,7 +2381,7 @@ mod tests {
         ]) else {
             panic!("expected the archive action");
         };
-        assert_eq!(arguments.stride, 1);
+        assert_eq!(arguments.quotes.stride, 1);
 
         for value in ["0", "-1", "many"] {
             assert!(

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,6 +8,7 @@ pub mod attribution;
 pub mod bars;
 pub mod boundaries;
 pub mod cache;
+pub mod cadence;
 pub mod calendar;
 pub mod conditions;
 pub mod conditions_table;

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -24,6 +24,7 @@ use crate::common::types::{
     TradeSummary,
 };
 use crate::data::attribution::{Attribution, Declaration};
+use crate::data::cadence::{CadenceCheck, CadenceError, CadenceTotals};
 use crate::data::calendar::TradingCalendar;
 use crate::data::{bars, boundaries, quotes, splits, trades};
 
@@ -146,6 +147,10 @@ pub enum ArchiveError {
     },
     #[error("failed to build a bar frame: {0}")]
     Frame(#[from] PolarsError),
+    /// A cross-cadence comparison could not be made at all, which is separate from one that ran and
+    /// disagreed — a disagreement is a finding the pass reports and carries on past.
+    #[error("failed to compare cadences: {0}")]
+    Cadence(#[from] CadenceError),
 }
 
 /// What a partition write must be true of the object already at the key.
@@ -1959,7 +1964,7 @@ pub async fn archive_quote_sessions(
     let present = present_partitions(
         s3_client,
         bucket,
-        &quote_archive_prefix(BarInterval::OneDay),
+        &quote_archive_prefix(quote_presence_interval(cadence)),
         *first,
         *last,
     )
@@ -1999,6 +2004,7 @@ pub async fn archive_quote_sessions(
     // Summed here rather than accumulated through `progress`, which is what lets the published
     // summary carry it per variant without a bar pass holding a counter it can never fill.
     let mut quotes_folded = 0usize;
+    let mut agreement = CadenceTotals::default();
     for session in requested {
         quotes_folded += archive_quote_session(
             s3_client,
@@ -2009,6 +2015,7 @@ pub async fn archive_quote_sessions(
             scope,
             cadence,
             &mut progress,
+            &mut agreement,
         )
         .await?;
     }
@@ -2019,6 +2026,22 @@ pub async fn archive_quote_sessions(
         warn!(
             symbols_failed = progress.symbols_failed,
             "Some symbols are absent from the summaries this pass wrote; re-run those sessions to repair them"
+        );
+    }
+    if agreement.sessions() > 0 {
+        // Reported whichever way it went. A cadence that only speaks up when it disagrees leaves a
+        // clean run indistinguishable from one where the check never ran.
+        let (folded_only, stored_only) = agreement.one_sided();
+        info!(
+            sessions_checked = agreement.sessions(),
+            sessions_agreeing = agreement.sessions_agreeing(),
+            rows_compared = agreement.compared(),
+            disagreements = agreement.disagreements(),
+            folded_only,
+            stored_only,
+            disagreeing = ?agreement.disagreeing(),
+            uncompared = ?agreement.uncompared(),
+            "Checked the folded session rows against the stored ones"
         );
     }
     info!(
@@ -2048,6 +2071,7 @@ async fn archive_quote_session(
     scope: &Scope,
     cadence: IntradayCadence,
     progress: &mut PassProgress,
+    agreement: &mut CadenceTotals,
 ) -> Result<usize, ArchiveError> {
     let Some((open, close)) = quotes::trading_hours(calendar, session) else {
         // A date the calendar does not publish. Counted rather than fatal, so one unusable session
@@ -2120,7 +2144,9 @@ async fn archive_quote_session(
         bucket,
         session,
         folded,
+        cadence,
         progress,
+        agreement,
         source.provenance(),
     )
     .await?;
@@ -2224,64 +2250,90 @@ async fn fold_whole_session(
     Ok((folded.summaries, quotes_folded))
 }
 
-/// Writes a session's summaries, one partition per cadence, daily last.
+/// The prefix a quote pass reads presence from, which must be the last partition it writes.
 ///
-/// The order is the recovery rule, not a preference. Presence is read off the daily prefix, so a
-/// pass that dies partway leaves the session looking absent and the next pass redoes every cadence —
-/// where writing the daily first would mark it done with its intraday half missing.
+/// Presence has to name something the pass is certain to write, or `archive` skips sessions it only
+/// half-wrote. The five-minute pass writes the session row last and is keyed on it; a one-minute
+/// pass does not author that row at all, so it is keyed on its own cadence — without which every
+/// session already reads present and a one-minute `archive` silently does nothing.
+fn quote_presence_interval(cadence: IntradayCadence) -> BarInterval {
+    match cadence {
+        IntradayCadence::FiveMinute => BarInterval::OneDay,
+        IntradayCadence::OneMinute => BarInterval::OneMinute,
+    }
+}
+
+/// The cadence that authors the archive's daily quote row.
+///
+/// One cadence has to. Every session already carries a row the five-minute pass built, and a
+/// one-minute pass derives the same row from its own buckets — evidence about that row rather than a
+/// replacement for it. Re-emitting it would put an unverified figure over a stored one and destroy
+/// the disagreement in the act of hiding it, which is the whole of the cross-cadence check.
+const DAILY_QUOTE_AUTHOR: IntradayCadence = IntradayCadence::FiveMinute;
+
+/// Writes a session's summaries: the cadence it folded at, then the session row.
+///
+/// The order is the recovery rule, not a preference. Presence is read off the last prefix written,
+/// so a pass that dies partway leaves the session looking absent and the next pass redoes it — where
+/// writing the session row first would mark it done with its intraday half missing.
+///
+/// A pass at a cadence that does not author the session row *checks* that row instead of writing it,
+/// and writes it only where none exists, since there is nothing to overwrite.
+#[allow(clippy::too_many_arguments)]
 async fn write_quote_partitions(
     s3_client: &S3Client,
     bucket: &str,
     session: SessionDate,
     folded: Vec<QuoteSummary>,
+    cadence: IntradayCadence,
     progress: &mut PassProgress,
+    agreement: &mut CadenceTotals,
     provenance: Provenance,
 ) -> Result<(), ArchiveError> {
-    let mut one_minute: Vec<QuoteSummary> = Vec::new();
-    let mut five_minute: Vec<QuoteSummary> = Vec::new();
+    let mut intraday: Vec<QuoteSummary> = Vec::new();
     let mut daily: Vec<QuoteSummary> = Vec::new();
     for row in folded {
         match row.bar_interval() {
-            BarInterval::OneMinute => one_minute.push(row),
-            BarInterval::FiveMinute => five_minute.push(row),
             BarInterval::OneDay => daily.push(row),
+            BarInterval::OneMinute | BarInterval::FiveMinute => intraday.push(row),
         }
     }
 
     let mut written = 0usize;
-    for (interval, rows) in [
-        (BarInterval::OneMinute, one_minute),
-        (BarInterval::FiveMinute, five_minute),
-        (BarInterval::OneDay, daily),
-    ] {
-        if rows.is_empty() {
-            continue;
-        }
-        let frame = quotes::summaries_to_dataframe(&rows)?;
-        let key = date_partitioned_key(&quote_archive_prefix(interval), session.date());
-        match write_merged(
-            s3_client,
-            bucket,
-            key,
-            frame,
-            |existing, fetched, key| merge_or_replace(existing, fetched, key),
-            DerivedDataset::Quotes,
-            provenance,
-        )
-        .await
+    if !intraday.is_empty() {
+        let frame = quotes::summaries_to_dataframe(&intraday)?;
+        let key = date_partitioned_key(
+            &quote_archive_prefix(cadence.bar_interval()),
+            session.date(),
+        );
+        if !write_quote_partition(s3_client, bucket, session, key, frame, progress, provenance)
+            .await?
         {
-            Ok(()) => written += rows.len(),
-            // Both arms leave the session unsummarized at this cadence. A scope that skips sessions
-            // already present will not return to it, so re-running is the operator's to decide.
-            Err(ArchiveError::Contended { key, attempts }) => {
-                warn!(key, attempts, %session, "Quote partition contended; this session was not summarized");
-                progress.sessions_failed.push(session);
-                return Ok(());
+            return Ok(());
+        }
+        written += intraday.len();
+    }
+
+    if !daily.is_empty() {
+        let key = date_partitioned_key(&quote_archive_prefix(BarInterval::OneDay), session.date());
+        let stored = match cadence {
+            cadence if cadence == DAILY_QUOTE_AUTHOR => None,
+            _ => read_partition(s3_client, bucket, &key).await?,
+        };
+        match stored {
+            Some(stored) => {
+                check_session_row(session, &daily, &stored, agreement)?;
             }
-            Err(error) => {
-                warn!(%error, %session, "Quote partition write failed; this session was not summarized");
-                progress.sessions_failed.push(session);
-                return Ok(());
+            None => {
+                let frame = quotes::summaries_to_dataframe(&daily)?;
+                if !write_quote_partition(
+                    s3_client, bucket, session, key, frame, progress, provenance,
+                )
+                .await?
+                {
+                    return Ok(());
+                }
+                written += daily.len();
             }
         }
     }
@@ -2289,6 +2341,203 @@ async fn write_quote_partitions(
     progress.sessions_written += 1;
     progress.rows_written += written;
     Ok(())
+}
+
+/// Writes one quote partition, reporting whether the session survived it.
+///
+/// `false` means the session is left unsummarized at this cadence. A scope that skips sessions
+/// already present will not return to it, so re-running is the operator's to decide.
+async fn write_quote_partition(
+    s3_client: &S3Client,
+    bucket: &str,
+    session: SessionDate,
+    key: String,
+    frame: DataFrame,
+    progress: &mut PassProgress,
+    provenance: Provenance,
+) -> Result<bool, ArchiveError> {
+    match write_merged(
+        s3_client,
+        bucket,
+        key,
+        frame,
+        |existing, fetched, key| merge_or_replace(existing, fetched, key),
+        DerivedDataset::Quotes,
+        provenance,
+    )
+    .await
+    {
+        Ok(()) => Ok(true),
+        Err(ArchiveError::Contended { key, attempts }) => {
+            warn!(key, attempts, %session, "Quote partition contended; this session was not summarized");
+            progress.sessions_failed.push(session);
+            Ok(false)
+        }
+        Err(error) => {
+            warn!(%error, %session, "Quote partition write failed; this session was not summarized");
+            progress.sessions_failed.push(session);
+            Ok(false)
+        }
+    }
+}
+
+/// Compares a derived session row against the stored one, writing nothing either way.
+///
+/// A disagreement is warned rather than raised: the stored row is what the archive holds, this pass
+/// is not the one that wrote it, and stopping a multi-day backfill over a figure it deliberately
+/// does not own would cost the run to report something the standalone check can say afterwards.
+fn check_session_row(
+    session: SessionDate,
+    derived: &[QuoteSummary],
+    stored: &DataFrame,
+    totals: &mut CadenceTotals,
+) -> Result<(), ArchiveError> {
+    let derived = quotes::summaries_to_dataframe(derived)?;
+    let outcome = CadenceCheck::quotes().compare(&derived, stored, BarInterval::OneDay, session)?;
+    if outcome.agrees() {
+        info!(%outcome, "The folded session row agrees with the stored one");
+    } else {
+        warn!(%outcome, worst = ?outcome.worst().map(|(column, worst)| format!("{column}: {worst}")), "The folded session row disagrees with the stored one");
+    }
+    totals.absorb(&outcome);
+    Ok(())
+}
+
+/// A summary family, which is a prefix and the column rules stored under it.
+///
+/// The two families differ in where they live and what reconstructs, and in nothing else — which is
+/// what lets one check answer for both instead of being written twice and kept in step by hand.
+#[derive(Clone, Copy, Debug)]
+pub enum SummaryFamily {
+    Quotes,
+    Trades,
+}
+
+impl SummaryFamily {
+    /// The archive prefix this family stores `interval` under.
+    fn prefix(self, interval: BarInterval) -> String {
+        match self {
+            SummaryFamily::Quotes => quote_archive_prefix(interval),
+            SummaryFamily::Trades => trade_archive_prefix(interval),
+        }
+    }
+
+    /// Which columns a coarser row of this family reconstructs, and how.
+    fn check(self) -> CadenceCheck {
+        match self {
+            SummaryFamily::Quotes => CadenceCheck::quotes(),
+            SummaryFamily::Trades => CadenceCheck::trades(),
+        }
+    }
+
+    /// The columns of this family no coarser row reconstructs, for a report to name.
+    pub fn opaque_columns(self) -> &'static [&'static str] {
+        self.check().opaque()
+    }
+}
+
+impl std::fmt::Display for SummaryFamily {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            SummaryFamily::Quotes => "quotes",
+            SummaryFamily::Trades => "trades",
+        })
+    }
+}
+
+/// Folds each session's `finer` partition up to `coarser` and compares it to what is stored there.
+///
+/// Reads only, and needs no vendor credential: the population is what the finer prefix holds rather
+/// than what a calendar publishes, so the check speaks for the archive as it is. This is what makes
+/// sum-back a verified claim rather than an assumed one — the cadences are written by separate
+/// passes, and nothing else establishes that the coarse rows the archive serves are the fine ones
+/// beneath them.
+///
+/// One session at a time, and deliberately not concurrent: a session's one-minute quote partition is
+/// millions of rows, and holding several at once is how a check over five years exhausts a machine.
+#[allow(clippy::too_many_arguments)]
+pub async fn check_cadence_agreement(
+    s3_client: &S3Client,
+    bucket: &str,
+    family: SummaryFamily,
+    finer: BarInterval,
+    coarser: BarInterval,
+    window_start: SessionDate,
+    window_end: SessionDate,
+    stride: usize,
+) -> Result<CadenceTotals, ArchiveError> {
+    let check = family.check();
+    let sessions: Vec<SessionDate> = present_partitions(
+        s3_client,
+        bucket,
+        &family.prefix(finer),
+        window_start,
+        window_end,
+    )
+    .await?
+    .into_iter()
+    .step_by(stride.max(1))
+    .collect();
+    info!(
+        %family,
+        %finer,
+        %coarser,
+        window_start = %window_start,
+        window_end = %window_end,
+        stride,
+        sessions = sessions.len(),
+        "Planned a cross-cadence check"
+    );
+
+    let mut totals = CadenceTotals::default();
+    let mut absent = Vec::new();
+    for &session in &sessions {
+        let finer_key = date_partitioned_key(&family.prefix(finer), session.date());
+        let coarser_key = date_partitioned_key(&family.prefix(coarser), session.date());
+        // The coarse read is what can be absent: the session list came from the finer prefix.
+        let Some(coarse) = read_partition(s3_client, bucket, &coarser_key).await? else {
+            // Absent, not disagreeing. A session missing a cadence is a coverage gap for the
+            // backfill to answer, and counting it as a failed comparison would make a hole in one
+            // prefix read as evidence that the other prefix is wrong.
+            absent.push(session);
+            continue;
+        };
+        let Some(fine) = read_partition(s3_client, bucket, &finer_key).await? else {
+            absent.push(session);
+            continue;
+        };
+        let outcome = check.compare(&fine, &coarse, coarser, session)?;
+        if outcome.agrees() {
+            info!(%outcome, "Cadences agree");
+        } else {
+            warn!(%outcome, worst = ?outcome.worst().map(|(column, worst)| format!("{column}: {worst}")), "Cadences disagree");
+        }
+        totals.absorb(&outcome);
+    }
+
+    let (folded_only, stored_only) = totals.one_sided();
+    info!(
+        %family,
+        %finer,
+        %coarser,
+        sessions_listed = sessions.len(),
+        sessions_checked = totals.sessions(),
+        sessions_agreeing = totals.sessions_agreeing(),
+        sessions_absent = absent.len(),
+        rows_compared = totals.compared(),
+        disagreements = totals.disagreements(),
+        folded_only,
+        stored_only,
+        sessions_uncompared = totals.uncompared().len(),
+        // Dated rather than counted, all three: a count says a re-fold is needed and cannot say
+        // which sessions to run it over.
+        disagreeing = ?totals.disagreeing(),
+        uncompared = ?totals.uncompared(),
+        absent = ?absent,
+        opaque = ?check.opaque(),
+        "Cross-cadence check complete"
+    );
+    Ok(totals)
 }
 
 /// Folds the printed tape across `sessions`, per `scope`, out of Massive's flat files, which must
@@ -3346,6 +3595,58 @@ mod tests {
             );
             assert_eq!(date_from_partitioned_key(&quotes), Some(date));
         }
+    }
+
+    /// A pass has to read presence off something it is certain to write, or `archive` skips the
+    /// sessions it half-wrote. Pinned to literals because the failure is silent both ways: keyed on
+    /// a prefix the pass does not write, every session reads present and the pass does nothing at
+    /// all -- which is what a one-minute quote fold would have done against the daily prefix.
+    #[test]
+    fn test_a_pass_reads_presence_off_a_prefix_it_writes() {
+        assert_eq!(
+            quote_presence_interval(IntradayCadence::FiveMinute),
+            BarInterval::OneDay
+        );
+        assert_eq!(
+            quote_presence_interval(IntradayCadence::OneMinute),
+            BarInterval::OneMinute
+        );
+
+        for cadence in IntradayCadence::ALL {
+            let presence = quote_presence_interval(cadence);
+            // The session row is the last thing written only by the cadence that authors it.
+            let written = if cadence == DAILY_QUOTE_AUTHOR {
+                BarInterval::OneDay
+            } else {
+                cadence.bar_interval()
+            };
+            assert_eq!(presence, written);
+        }
+    }
+
+    /// The two families' cadence checks must not be able to name each other's columns: a quote
+    /// prefix read with trade rules would ask for `volume` in a partition that has never held one.
+    #[test]
+    fn test_each_summary_family_names_its_own_prefix_and_its_own_opaque_columns() {
+        assert_eq!(
+            SummaryFamily::Quotes.prefix(BarInterval::OneMinute),
+            "data/derived/equity/quotes/interval=one_minute"
+        );
+        assert_eq!(
+            SummaryFamily::Trades.prefix(BarInterval::OneMinute),
+            "data/derived/equity/trades/interval=one_minute"
+        );
+        assert_eq!(
+            SummaryFamily::Quotes.opaque_columns(),
+            [
+                "quoted_spread_basis_points_median",
+                "quoted_spread_basis_points_ninetieth_percentile"
+            ]
+        );
+        assert_eq!(
+            SummaryFamily::Trades.opaque_columns(),
+            ["median_trade_size", "ninetieth_percentile_trade_size"]
+        );
     }
 
     /// Each fault fails the pass on its own, and a clean pass passes. This is the rule all three

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -24,7 +24,7 @@ use crate::common::types::{
     TradeSummary,
 };
 use crate::data::attribution::{Attribution, Declaration};
-use crate::data::cadence::{CadenceCheck, CadenceError, CadenceTotals};
+use crate::data::cadence::{CadenceCheck, CadenceError, CadenceTotals, SessionOutcome};
 use crate::data::calendar::TradingCalendar;
 use crate::data::{bars, boundaries, quotes, splits, trades};
 
@@ -2039,8 +2039,7 @@ pub async fn archive_quote_sessions(
             disagreements = agreement.disagreements(),
             folded_only,
             stored_only,
-            disagreeing = ?agreement.disagreeing(),
-            uncompared = ?agreement.uncompared(),
+            unresolved = ?agreement.unresolved(),
             "Checked the folded session rows against the stored ones"
         );
     }
@@ -2265,20 +2264,27 @@ fn quote_presence_interval(cadence: IntradayCadence) -> BarInterval {
 
 /// The cadence that authors the archive's daily quote row.
 ///
-/// One cadence has to. Every session already carries a row the five-minute pass built, and a
-/// one-minute pass derives the same row from its own buckets — evidence about that row rather than a
-/// replacement for it. Re-emitting it would put an unverified figure over a stored one and destroy
-/// the disagreement in the act of hiding it, which is the whole of the cross-cadence check.
+/// A finer pass derives the same row from its own buckets, which is evidence about that row rather
+/// than a replacement for it. Re-emitting it would put an unverified figure over a stored one.
 const DAILY_QUOTE_AUTHOR: IntradayCadence = IntradayCadence::FiveMinute;
 
-/// Writes a session's summaries: the cadence it folded at, then the session row.
+/// The prefixes a quote pass writes, in the order it writes them.
 ///
-/// The order is the recovery rule, not a preference. Presence is read off the last prefix written,
-/// so a pass that dies partway leaves the session looking absent and the next pass redoes it — where
-/// writing the session row first would mark it done with its intraday half missing.
+/// Stated as an order rather than derived from [`quote_presence_interval`], so a test can pin both
+/// to literals and still assert they agree — the failure this guards is silent, and a derivation
+/// would move with whichever of the two it was derived from.
+fn quote_write_order(cadence: IntradayCadence) -> [BarInterval; 2] {
+    match cadence {
+        IntradayCadence::FiveMinute => [BarInterval::FiveMinute, BarInterval::OneDay],
+        IntradayCadence::OneMinute => [BarInterval::OneDay, BarInterval::OneMinute],
+    }
+}
+
+/// Writes a session's summaries, the prefix presence is read off last.
 ///
-/// A pass at a cadence that does not author the session row *checks* that row instead of writing it,
-/// and writes it only where none exists, since there is nothing to overwrite.
+/// The order is the recovery rule rather than a preference, and it flips between cadences because
+/// which prefix carries presence does: a pass that dies partway has to leave the session looking
+/// absent, or the next `archive` skips what it only half-wrote.
 #[allow(clippy::too_many_arguments)]
 async fn write_quote_partitions(
     s3_client: &S3Client,
@@ -2300,47 +2306,93 @@ async fn write_quote_partitions(
     }
 
     let mut written = 0usize;
-    if !intraday.is_empty() {
-        let frame = quotes::summaries_to_dataframe(&intraday)?;
-        let key = date_partitioned_key(
-            &quote_archive_prefix(cadence.bar_interval()),
-            session.date(),
-        );
-        if !write_quote_partition(s3_client, bucket, session, key, frame, progress, provenance)
-            .await?
-        {
-            return Ok(());
-        }
-        written += intraday.len();
-    }
-
-    if !daily.is_empty() {
-        let key = date_partitioned_key(&quote_archive_prefix(BarInterval::OneDay), session.date());
-        let stored = match cadence {
-            cadence if cadence == DAILY_QUOTE_AUTHOR => None,
-            _ => read_partition(s3_client, bucket, &key).await?,
-        };
-        match stored {
-            Some(stored) => {
-                check_session_row(session, &daily, &stored, agreement)?;
-            }
-            None => {
-                let frame = quotes::summaries_to_dataframe(&daily)?;
-                if !write_quote_partition(
-                    s3_client, bucket, session, key, frame, progress, provenance,
+    for prefix in quote_write_order(cadence) {
+        let rows = match prefix {
+            BarInterval::OneDay => {
+                settle_session_row(
+                    s3_client, bucket, session, &daily, cadence, progress, agreement, provenance,
                 )
                 .await?
-                {
-                    return Ok(());
-                }
-                written += daily.len();
             }
-        }
+            intraday_prefix => {
+                write_intraday_partition(
+                    s3_client,
+                    bucket,
+                    session,
+                    &intraday,
+                    intraday_prefix,
+                    progress,
+                    provenance,
+                )
+                .await?
+            }
+        };
+        let Some(rows) = rows else {
+            return Ok(());
+        };
+        written += rows;
     }
 
     progress.sessions_written += 1;
     progress.rows_written += written;
     Ok(())
+}
+
+/// Writes the session's intraday rows, returning how many landed.
+///
+/// `None` means the session failed and the caller should stop.
+async fn write_intraday_partition(
+    s3_client: &S3Client,
+    bucket: &str,
+    session: SessionDate,
+    intraday: &[QuoteSummary],
+    interval: BarInterval,
+    progress: &mut PassProgress,
+    provenance: Provenance,
+) -> Result<Option<usize>, ArchiveError> {
+    if intraday.is_empty() {
+        return Ok(Some(0));
+    }
+    let frame = quotes::summaries_to_dataframe(intraday)?;
+    let key = date_partitioned_key(&quote_archive_prefix(interval), session.date());
+    let survived =
+        write_quote_partition(s3_client, bucket, session, key, frame, progress, provenance).await?;
+    Ok(survived.then_some(intraday.len()))
+}
+
+/// Writes the session row, or checks it where one is already stored, returning the rows written.
+///
+/// `None` means the session failed and the caller should stop. A pass at a cadence that does not
+/// author this row writes it only where none exists, since there is nothing to overwrite.
+#[allow(clippy::too_many_arguments)]
+async fn settle_session_row(
+    s3_client: &S3Client,
+    bucket: &str,
+    session: SessionDate,
+    daily: &[QuoteSummary],
+    cadence: IntradayCadence,
+    progress: &mut PassProgress,
+    agreement: &mut CadenceTotals,
+    provenance: Provenance,
+) -> Result<Option<usize>, ArchiveError> {
+    if daily.is_empty() {
+        return Ok(Some(0));
+    }
+    let key = date_partitioned_key(&quote_archive_prefix(BarInterval::OneDay), session.date());
+    let stored = match cadence {
+        cadence if cadence == DAILY_QUOTE_AUTHOR => None,
+        _ => read_partition(s3_client, bucket, &key).await?,
+    };
+    let Some(stored) = stored else {
+        let frame = quotes::summaries_to_dataframe(daily)?;
+        let survived =
+            write_quote_partition(s3_client, bucket, session, key, frame, progress, provenance)
+                .await?;
+        return Ok(survived.then_some(daily.len()));
+    };
+
+    check_session_row(session, daily, &stored, agreement, progress)?;
+    Ok(Some(0))
 }
 
 /// Writes one quote partition, reporting whether the session survived it.
@@ -2383,17 +2435,28 @@ async fn write_quote_partition(
 
 /// Compares a derived session row against the stored one, writing nothing either way.
 ///
-/// A disagreement is warned rather than raised: the stored row is what the archive holds, this pass
-/// is not the one that wrote it, and stopping a multi-day backfill over a figure it deliberately
-/// does not own would cost the run to report something the standalone check can say afterwards.
+/// Neither a disagreement nor an uncomparable pair stops the pass: the stored row belongs to another
+/// cadence, and a multi-day backfill must not end over a figure it deliberately does not own.
 fn check_session_row(
     session: SessionDate,
     derived: &[QuoteSummary],
     stored: &DataFrame,
     totals: &mut CadenceTotals,
+    progress: &mut PassProgress,
 ) -> Result<(), ArchiveError> {
     let derived = quotes::summaries_to_dataframe(derived)?;
-    let outcome = CadenceCheck::quotes().compare(&derived, stored, BarInterval::OneDay, session)?;
+    let outcome =
+        match CadenceCheck::quotes().compare(&derived, stored, BarInterval::OneDay, session) {
+            Ok(outcome) => outcome,
+            // Carried like a failed fold rather than raised. A stored row this pass cannot read is one
+            // session's problem, and the intraday rows it did fold are still worth keeping.
+            Err(error) => {
+                warn!(%session, %error, "The stored session row could not be compared");
+                totals.note(session, SessionOutcome::Unusable);
+                progress.sessions_failed.push(session);
+                return Ok(());
+            }
+        };
     if outcome.agrees() {
         info!(%outcome, "The folded session row agrees with the stored one");
     } else {
@@ -2448,13 +2511,8 @@ impl std::fmt::Display for SummaryFamily {
 /// Folds each session's `finer` partition up to `coarser` and compares it to what is stored there.
 ///
 /// Reads only, and needs no vendor credential: the population is what the finer prefix holds rather
-/// than what a calendar publishes, so the check speaks for the archive as it is. This is what makes
-/// sum-back a verified claim rather than an assumed one — the cadences are written by separate
-/// passes, and nothing else establishes that the coarse rows the archive serves are the fine ones
-/// beneath them.
-///
-/// One session at a time, and deliberately not concurrent: a session's one-minute quote partition is
-/// millions of rows, and holding several at once is how a check over five years exhausts a machine.
+/// than what a calendar publishes, so the check speaks for the archive as it is. One session at a
+/// time, because a one-minute quote partition is millions of rows and several will not fit at once.
 #[allow(clippy::too_many_arguments)]
 pub async fn check_cadence_agreement(
     s3_client: &S3Client,
@@ -2490,7 +2548,6 @@ pub async fn check_cadence_agreement(
     );
 
     let mut totals = CadenceTotals::default();
-    let mut absent = Vec::new();
     for &session in &sessions {
         let finer_key = date_partitioned_key(&family.prefix(finer), session.date());
         let coarser_key = date_partitioned_key(&family.prefix(coarser), session.date());
@@ -2498,15 +2555,25 @@ pub async fn check_cadence_agreement(
         let Some(coarse) = read_partition(s3_client, bucket, &coarser_key).await? else {
             // Absent, not disagreeing. A session missing a cadence is a coverage gap for the
             // backfill to answer, and counting it as a failed comparison would make a hole in one
-            // prefix read as evidence that the other prefix is wrong.
-            absent.push(session);
+            // prefix read as evidence that the other prefix is wrong. It is still not agreement,
+            // so it is carried in the totals rather than logged beside them.
+            totals.note(session, SessionOutcome::Absent);
             continue;
         };
         let Some(fine) = read_partition(s3_client, bucket, &finer_key).await? else {
-            absent.push(session);
+            totals.note(session, SessionOutcome::Absent);
             continue;
         };
-        let outcome = check.compare(&fine, &coarse, coarser, session)?;
+        let outcome = match check.compare(&fine, &coarse, coarser, session) {
+            Ok(outcome) => outcome,
+            // One unusable session, not the window. Ending here would discard every session already
+            // compared and report nothing about the ones after it.
+            Err(error) => {
+                warn!(%session, %error, "A session could not be compared");
+                totals.note(session, SessionOutcome::Unusable);
+                continue;
+            }
+        };
         if outcome.agrees() {
             info!(%outcome, "Cadences agree");
         } else {
@@ -2521,19 +2588,15 @@ pub async fn check_cadence_agreement(
         %finer,
         %coarser,
         sessions_listed = sessions.len(),
-        sessions_checked = totals.sessions(),
+        sessions_reached = totals.sessions(),
         sessions_agreeing = totals.sessions_agreeing(),
-        sessions_absent = absent.len(),
         rows_compared = totals.compared(),
         disagreements = totals.disagreements(),
         folded_only,
         stored_only,
-        sessions_uncompared = totals.uncompared().len(),
-        // Dated rather than counted, all three: a count says a re-fold is needed and cannot say
-        // which sessions to run it over.
-        disagreeing = ?totals.disagreeing(),
-        uncompared = ?totals.uncompared(),
-        absent = ?absent,
+        // Dated and reasoned, not counted: a count says a re-fold is needed and cannot say which
+        // sessions to run it over, nor which of the four ways they failed to agree.
+        unresolved = ?totals.unresolved(),
         opaque = ?check.opaque(),
         "Cross-cadence check complete"
     );
@@ -3612,15 +3675,44 @@ mod tests {
             BarInterval::OneMinute
         );
 
+        // Literals, not a pairing read off `DAILY_QUOTE_AUTHOR`: an expectation derived from the
+        // constant under test moves with it and can never fail.
+        assert_eq!(DAILY_QUOTE_AUTHOR, IntradayCadence::FiveMinute);
+        for (cadence, presence) in [
+            (IntradayCadence::FiveMinute, BarInterval::OneDay),
+            (IntradayCadence::OneMinute, BarInterval::OneMinute),
+        ] {
+            assert_eq!(quote_presence_interval(cadence), presence, "{cadence:?}");
+        }
+    }
+
+    /// The prefix presence is read off has to be the last one written, or a pass that dies partway
+    /// marks the session done with half of it missing -- the `1106` partition-write-loss shape.
+    ///
+    /// Both sides are pinned to literals and then asserted to agree. Deriving either from the other
+    /// would make the assertion tautological, and the failure it guards against is silent: the
+    /// session simply never comes back.
+    #[test]
+    fn test_the_prefix_presence_is_read_off_is_written_last() {
+        assert_eq!(
+            quote_write_order(IntradayCadence::FiveMinute),
+            [BarInterval::FiveMinute, BarInterval::OneDay]
+        );
+        assert_eq!(
+            quote_write_order(IntradayCadence::OneMinute),
+            [BarInterval::OneDay, BarInterval::OneMinute]
+        );
+
         for cadence in IntradayCadence::ALL {
-            let presence = quote_presence_interval(cadence);
-            // The session row is the last thing written only by the cadence that authors it.
-            let written = if cadence == DAILY_QUOTE_AUTHOR {
-                BarInterval::OneDay
-            } else {
-                cadence.bar_interval()
-            };
-            assert_eq!(presence, written);
+            let order = quote_write_order(cadence);
+            assert_eq!(
+                order.last().copied(),
+                Some(quote_presence_interval(cadence)),
+                "{cadence:?} reads presence off a prefix it does not write last"
+            );
+            // Both partitions, never one twice: a pass that wrote its session row in place of its
+            // intraday one would still satisfy the rule above.
+            assert_ne!(order[0], order[1], "{cadence:?}");
         }
     }
 

--- a/src/data/cadence.rs
+++ b/src/data/cadence.rs
@@ -1,9 +1,9 @@
 //! Cross-cadence agreement over the summaries the archive already holds.
 //!
-//! Verifies rather than re-emits: the cadences are folded in separate passes, so sum-back is a
-//! cross-pass claim, and re-deriving all of them would hide a disagreement instead of surfacing it.
+//! Verifies rather than re-emits: the cadences are folded separately, so sum-back is a cross-pass
+//! claim that re-deriving both sides would hide.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use polars::prelude::*;
 use thiserror::Error;
@@ -163,6 +163,14 @@ pub enum CadenceError {
     },
     #[error("column {column} is missing a value the comparison needs")]
     NullKey { column: &'static str },
+    /// One partition holds rows of more than one cadence, so there is no interval to fold it as.
+    ///
+    /// Reachable from the archive rather than only from a malformed file: a merge keeps rows it does
+    /// not overwrite, so a partition written twice under different rules can carry both.
+    #[error("one partition holds both {first} and {second} rows")]
+    MixedIntervals { first: String, second: String },
+    #[error("{interval} is not a cadence this archive stores")]
+    UnknownInterval { interval: String },
 }
 
 /// The columns of one summary family, split by whether a coarser row reconstructs them.
@@ -354,16 +362,32 @@ fn reconstructed_name(column: &str) -> PlSmallStr {
     format!("{column}_reconstructed").into()
 }
 
-/// The interval every row of a partition carries, or `None` where it holds no rows.
+/// The interval every row of a partition carries, or `None` where the column is absent.
 ///
 /// Read from the frame rather than passed in, so a comparison cannot be told the fine side is
-/// one-minute while the partition it was handed is five.
+/// one-minute while the partition it was handed is five. A value that is present and unreadable is
+/// refused rather than treated as absent: absent falls back to the coarse interval, which would
+/// silently disable the [`CadenceError::NotCoarser`] guard the fallback exists beneath.
 fn sole_interval(frame: &DataFrame) -> Result<Option<BarInterval>, CadenceError> {
     let Ok(column) = frame.column("bar_interval") else {
         return Ok(None);
     };
     let intervals: BTreeSet<&str> = column.str()?.iter().flatten().collect();
-    Ok(intervals.into_iter().next().and_then(BarInterval::parse))
+    let mut named = intervals.into_iter();
+    let Some(interval) = named.next() else {
+        return Ok(None);
+    };
+    if let Some(second) = named.next() {
+        return Err(CadenceError::MixedIntervals {
+            first: interval.to_string(),
+            second: second.to_string(),
+        });
+    }
+    BarInterval::parse(interval)
+        .map(Some)
+        .ok_or_else(|| CadenceError::UnknownInterval {
+            interval: interval.to_string(),
+        })
 }
 
 /// Orders the intervals coarsest-last, which is the only comparison the fold direction needs.
@@ -576,45 +600,102 @@ impl std::fmt::Display for CadenceAgreement {
     }
 }
 
-/// Adds one session's outcome to a running total across a window.
+/// What became of one session's comparison.
+///
+/// One session reaches exactly one of these, so they are variants rather than parallel lists. Only
+/// [`SessionOutcome::Agreed`] is a pass: the other four are each a different way of not having
+/// checked something, and summing them into a clean figure is what makes a check overstate itself.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SessionOutcome {
+    /// Every reconstructed column matched, over a population that was not empty.
+    Agreed,
+    /// At least one column disagreed.
+    Disagreed,
+    /// The two cadences shared no row, so nothing was compared.
+    NothingCompared,
+    /// The coarser prefix holds no partition for this session.
+    Absent,
+    /// A partition was there and could not be read as a cadence.
+    Unusable,
+}
+
+impl SessionOutcome {
+    /// The outcome a finished comparison reached.
+    pub fn of(agreement: &CadenceAgreement) -> Self {
+        match agreement {
+            agreement if agreement.compared() == 0 => SessionOutcome::NothingCompared,
+            agreement if agreement.agrees() => SessionOutcome::Agreed,
+            _ => SessionOutcome::Disagreed,
+        }
+    }
+}
+
+impl std::fmt::Display for SessionOutcome {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            SessionOutcome::Agreed => "agreed",
+            SessionOutcome::Disagreed => "disagreed",
+            SessionOutcome::NothingCompared => "compared nothing",
+            SessionOutcome::Absent => "absent",
+            SessionOutcome::Unusable => "unusable",
+        })
+    }
+}
+
+/// What a check found across a window, one outcome per session.
 #[derive(Clone, Debug, Default)]
 pub struct CadenceTotals {
-    sessions: usize,
-    sessions_agreeing: usize,
+    outcomes: BTreeMap<SessionDate, SessionOutcome>,
     compared: usize,
     disagreements: usize,
     finer_only: usize,
     coarser_only: usize,
-    /// Sessions that disagreed, dated rather than counted: a count cannot say which to re-fold.
-    disagreeing: Vec<SessionDate>,
-    /// Sessions whose two cadences shared no row at all.
-    ///
-    /// Neither agreement nor disagreement — the check did not run. Kept apart from both so a window
-    /// where the fold never lined up cannot be summed into a passing figure.
-    uncompared: Vec<SessionDate>,
 }
 
 impl CadenceTotals {
+    /// Records a comparison that ran, whatever it found.
     pub fn absorb(&mut self, agreement: &CadenceAgreement) {
-        self.sessions += 1;
-        self.compared += agreement.compared;
+        self.compared += agreement.compared();
         self.disagreements += agreement.disagreements();
         let (finer_only, coarser_only) = agreement.one_sided();
         self.finer_only += finer_only;
         self.coarser_only += coarser_only;
-        match agreement {
-            agreement if agreement.compared() == 0 => self.uncompared.push(agreement.session()),
-            agreement if agreement.agrees() => self.sessions_agreeing += 1,
-            agreement => self.disagreeing.push(agreement.session()),
-        }
+        self.outcomes
+            .insert(agreement.session(), SessionOutcome::of(agreement));
     }
 
+    /// Records a session no comparison could be made for, which is not the same as one that agreed.
+    pub fn note(&mut self, session: SessionDate, outcome: SessionOutcome) {
+        self.outcomes.insert(session, outcome);
+    }
+
+    /// Sessions the check reached, by any route including the ones it could not compare.
     pub fn sessions(&self) -> usize {
-        self.sessions
+        self.outcomes.len()
     }
 
     pub fn sessions_agreeing(&self) -> usize {
-        self.sessions_agreeing
+        self.sessions_with(SessionOutcome::Agreed).len()
+    }
+
+    /// The sessions that reached `outcome`, dated rather than counted.
+    ///
+    /// A count says a re-fold is needed and cannot say which sessions to run it over.
+    pub fn sessions_with(&self, outcome: SessionOutcome) -> Vec<SessionDate> {
+        self.outcomes
+            .iter()
+            .filter(|(_, reached)| **reached == outcome)
+            .map(|(session, _)| *session)
+            .collect()
+    }
+
+    /// Every session that did not agree, with the reason it did not.
+    pub fn unresolved(&self) -> Vec<(SessionDate, SessionOutcome)> {
+        self.outcomes
+            .iter()
+            .filter(|(_, outcome)| **outcome != SessionOutcome::Agreed)
+            .map(|(session, outcome)| (*session, *outcome))
+            .collect()
     }
 
     pub fn compared(&self) -> usize {
@@ -629,22 +710,16 @@ impl CadenceTotals {
         (self.finer_only, self.coarser_only)
     }
 
-    pub fn disagreeing(&self) -> &[SessionDate] {
-        &self.disagreeing
-    }
-
-    /// Sessions the check could not run over, dated for the same reason the disagreeing ones are.
-    pub fn uncompared(&self) -> &[SessionDate] {
-        &self.uncompared
-    }
-
-    /// Whether every session agreed, which is the exit condition a check reports on.
+    /// Whether every session reached agreed, which is the exit condition a check reports on.
     ///
-    /// A window that compared nothing does not pass. Both halves are load-bearing and neither is
-    /// implied by the other: a run over an empty window and a run where no fold lined up both reach
-    /// zero disagreements without having checked a single row.
+    /// A window that checked nothing does not pass, and neither does one that could only pair half
+    /// its sessions -- both reach zero disagreements without establishing anything.
     pub fn agrees(&self) -> bool {
-        self.sessions > 0 && self.uncompared.is_empty() && self.disagreements == 0
+        !self.outcomes.is_empty()
+            && self
+                .outcomes
+                .values()
+                .all(|outcome| *outcome == SessionOutcome::Agreed)
     }
 }
 
@@ -655,7 +730,11 @@ mod tests {
     use chrono::NaiveDate;
 
     fn session() -> SessionDate {
-        SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 8, 20).expect("a real date"))
+        session_on(20)
+    }
+
+    fn session_on(day: u32) -> SessionDate {
+        SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 8, day).expect("a real date"))
     }
 
     /// The instant the archive stamps a session row at, which no intraday bucket lands on.
@@ -897,8 +976,8 @@ mod tests {
         assert_eq!(empty.disagreements(), 0);
         assert!(!empty.agrees());
 
-        let mut uncompared = CadenceTotals::default();
-        uncompared.absorb(&agreement(
+        let mut totals = CadenceTotals::default();
+        totals.absorb(&agreement(
             &five_one_minute_buckets([2.0; 5], [60.0; 5]),
             &quotes(
                 BarInterval::OneDay,
@@ -907,12 +986,40 @@ mod tests {
             BarInterval::OneDay,
         ));
 
-        assert_eq!(uncompared.sessions(), 1);
-        assert_eq!(uncompared.sessions_agreeing(), 0);
-        assert_eq!(uncompared.disagreements(), 0);
-        assert_eq!(uncompared.uncompared(), [session()]);
-        assert!(uncompared.disagreeing().is_empty());
-        assert!(!uncompared.agrees());
+        assert_eq!(totals.sessions(), 1);
+        assert_eq!(totals.sessions_agreeing(), 0);
+        assert_eq!(totals.disagreements(), 0);
+        assert_eq!(
+            totals.sessions_with(SessionOutcome::NothingCompared),
+            [session()]
+        );
+        assert!(totals.sessions_with(SessionOutcome::Disagreed).is_empty());
+        assert!(!totals.agrees());
+    }
+
+    /// Four ways a session fails to agree, and only one way it passes.
+    ///
+    /// Pinned as a whole rather than one variant at a time: the failure this guards against is a
+    /// window summing the four into a clean figure, which no single-variant assertion would catch.
+    #[test]
+    fn test_only_an_agreeing_window_passes() {
+        let finer = five_one_minute_buckets([2.0; 5], [60.0; 5]);
+        let agreeing = quotes(BarInterval::FiveMinute, &[("AAPL", 0, 50, 300.0, 2.0)]);
+
+        for absent in [
+            SessionOutcome::Disagreed,
+            SessionOutcome::NothingCompared,
+            SessionOutcome::Absent,
+            SessionOutcome::Unusable,
+        ] {
+            let mut totals = CadenceTotals::default();
+            totals.absorb(&agreement(&finer, &agreeing, BarInterval::FiveMinute));
+            assert!(totals.agrees(), "one agreeing session should pass");
+
+            totals.note(session_on(21), absent);
+            assert!(!totals.agrees(), "a {absent} session must not pass");
+            assert_eq!(totals.unresolved(), [(session_on(21), absent)]);
+        }
     }
 
     #[test]
@@ -925,18 +1032,162 @@ mod tests {
             &quotes(BarInterval::FiveMinute, &[("AAPL", 0, 50, 300.0, 2.0)]),
             BarInterval::FiveMinute,
         ));
-        totals.absorb(&agreement(
-            &finer,
-            &quotes(BarInterval::FiveMinute, &[("AAPL", 0, 49, 300.0, 2.0)]),
-            BarInterval::FiveMinute,
-        ));
+        // A second session, because the totals key on the date: absorbing the same session twice
+        // records one outcome, which is what makes a re-check correct rather than double-counted.
+        totals.absorb(
+            &CadenceCheck::quotes()
+                .compare(
+                    &finer,
+                    &quotes(BarInterval::FiveMinute, &[("AAPL", 0, 49, 300.0, 2.0)]),
+                    BarInterval::FiveMinute,
+                    session_on(21),
+                )
+                .expect("a comparable pair"),
+        );
 
         assert_eq!(totals.sessions(), 2);
         assert_eq!(totals.sessions_agreeing(), 1);
         assert_eq!(totals.compared(), 2);
         assert_eq!(totals.disagreements(), 1);
         assert!(!totals.agrees());
-        assert_eq!(totals.disagreeing(), [session()]);
+        assert_eq!(
+            totals.sessions_with(SessionOutcome::Disagreed),
+            [session_on(21)]
+        );
+    }
+
+    #[test]
+    fn test_re_checking_one_session_records_one_outcome() {
+        let mut totals = CadenceTotals::default();
+        let finer = five_one_minute_buckets([2.0; 5], [60.0; 5]);
+
+        totals.note(session(), SessionOutcome::Absent);
+        assert!(!totals.agrees());
+
+        // The same session, now comparable. Keyed on the date, so the later outcome replaces the
+        // earlier one rather than leaving the window permanently unresolved.
+        totals.absorb(&agreement(
+            &finer,
+            &quotes(BarInterval::FiveMinute, &[("AAPL", 0, 50, 300.0, 2.0)]),
+            BarInterval::FiveMinute,
+        ));
+        assert_eq!(totals.sessions(), 1);
+        assert!(totals.agrees());
+    }
+
+    #[test]
+    fn test_a_partition_holding_two_cadences_is_not_foldable() {
+        // Reachable from the archive, not only from a malformed file: a merge keeps rows it does not
+        // overwrite, so a partition written twice under different rules carries both.
+        let mut mixed = quotes(
+            BarInterval::OneMinute,
+            &[("AAPL", 0, 10, 60.0, 2.0), ("AAPL", 60_000, 10, 60.0, 2.0)],
+        );
+        mixed
+            .with_column(Column::new(
+                "bar_interval".into(),
+                vec!["one_minute", "five_minute"],
+            ))
+            .expect("a replaceable column");
+
+        let error = CadenceCheck::quotes()
+            .compare(
+                &mixed,
+                &quotes(BarInterval::FiveMinute, &[("AAPL", 0, 20, 120.0, 2.0)]),
+                BarInterval::FiveMinute,
+                session(),
+            )
+            .expect_err("one partition cannot be two cadences");
+
+        assert!(matches!(error, CadenceError::MixedIntervals { .. }));
+    }
+
+    #[test]
+    fn test_an_unreadable_interval_is_refused_rather_than_assumed() {
+        // Refused rather than treated as absent: absent falls back to the coarse interval, which
+        // would silently disable the `NotCoarser` guard the fallback sits beneath.
+        let mut unreadable = quotes(BarInterval::OneMinute, &[("AAPL", 0, 10, 60.0, 2.0)]);
+        unreadable
+            .with_column(Column::new("bar_interval".into(), vec!["1Min"]))
+            .expect("a replaceable column");
+
+        let error = CadenceCheck::quotes()
+            .compare(
+                &unreadable,
+                &quotes(BarInterval::FiveMinute, &[("AAPL", 0, 10, 60.0, 2.0)]),
+                BarInterval::FiveMinute,
+                session(),
+            )
+            .expect_err("an unreadable interval names no cadence");
+
+        assert!(matches!(
+            error,
+            CadenceError::UnknownInterval { ref interval } if interval == "1Min"
+        ));
+    }
+
+    #[test]
+    fn test_a_frame_without_an_interval_column_still_compares() {
+        // The column is optional, unlike its value: a frame that never carried one is legacy data
+        // rather than corrupt, and falls back to the interval it is being folded up to.
+        let mut legacy = five_one_minute_buckets([2.0; 5], [60.0; 5]);
+        legacy.drop_in_place("bar_interval").expect("the column");
+
+        let outcome = CadenceCheck::quotes()
+            .compare(
+                &legacy,
+                &quotes(BarInterval::FiveMinute, &[("AAPL", 0, 50, 300.0, 2.0)]),
+                BarInterval::FiveMinute,
+                session(),
+            )
+            .expect("a comparable pair");
+
+        assert!(outcome.agrees());
+    }
+
+    #[test]
+    fn test_a_daily_partition_of_two_stamps_is_not_a_session() {
+        let finer = five_one_minute_buckets([2.0; 5], [60.0; 5]);
+        let coarser = quotes(
+            BarInterval::OneDay,
+            &[
+                ("AAPL", SESSION_STAMP, 50, 300.0, 2.0),
+                ("AAPL", SESSION_STAMP + 1, 50, 300.0, 2.0),
+            ],
+        );
+
+        let error = CadenceCheck::quotes()
+            .compare(&finer, &coarser, BarInterval::OneDay, session())
+            .expect_err("two stamps is not one session");
+
+        assert!(matches!(
+            error,
+            CadenceError::AmbiguousSessionStamp { stamps: 2, .. }
+        ));
+    }
+
+    #[test]
+    fn test_a_null_timestamp_has_no_bucket_to_fold_into() {
+        let mut null_stamped = quotes(BarInterval::OneMinute, &[("AAPL", 0, 10, 60.0, 2.0)]);
+        null_stamped
+            .with_column(Column::new("timestamp".into(), vec![None::<i64>]))
+            .expect("a replaceable column");
+
+        let error = CadenceCheck::quotes()
+            .compare(
+                &null_stamped,
+                &quotes(BarInterval::FiveMinute, &[("AAPL", 0, 10, 60.0, 2.0)]),
+                BarInterval::FiveMinute,
+                session(),
+            )
+            .expect_err("a row with no stamp belongs to no bucket");
+
+        assert!(matches!(
+            error,
+            CadenceError::NullKey {
+                column: "timestamp"
+            }
+        ));
     }
 
     /// A trade frame carrying only what a comparison reads, with a nullable volume-weighted price.

--- a/src/data/cadence.rs
+++ b/src/data/cadence.rs
@@ -1,0 +1,1068 @@
+//! Cross-cadence agreement over the summaries the archive already holds.
+//!
+//! Verifies rather than re-emits: the cadences are folded in separate passes, so sum-back is a
+//! cross-pass claim, and re-deriving all of them would hide a disagreement instead of surfacing it.
+
+use std::collections::BTreeSet;
+
+use polars::prelude::*;
+use thiserror::Error;
+
+use crate::common::types::{BarInterval, IntradayCadence, SessionDate};
+
+/// Largest gap a reconstructed value may carry and still count as agreement.
+///
+/// Scaled by `1 + |coarse|` rather than taken absolute, because these columns span nine orders of
+/// magnitude -- covered seconds in the tens, dollar volume in the billions -- and one epsilon cannot
+/// serve both. A five-minute row is at most 390 one-minute terms, which accumulates roughly `1e-14`
+/// of relative float error, so this leaves five decades of headroom over the summing noise.
+const TOLERANCE: f64 = 1e-9;
+
+/// Disagreements carried in a report before it stops collecting them.
+///
+/// A session that disagrees on one name and one that disagrees on every name need different
+/// responses, and the counts already separate those -- what the examples are for is naming somewhere
+/// to start looking.
+const EXAMPLES_KEPT: usize = 5;
+
+/// How a coarse row's value is rebuilt from the fine rows beneath it.
+#[derive(Clone, Copy, Debug)]
+enum Reconstruction {
+    /// Added.
+    Sum,
+    /// Averaged across the fine rows, weighted by another column.
+    Weighted { by: &'static str },
+}
+
+/// One column, and the rule that rebuilds it.
+#[derive(Clone, Copy, Debug)]
+struct Reconstructed {
+    column: &'static str,
+    rule: Reconstruction,
+}
+
+/// The additive and weighted columns of a quote summary.
+const QUOTE_RECONSTRUCTED: &[Reconstructed] = &[
+    Reconstructed {
+        column: "quote_count",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "covered_seconds",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "quoted_spread_mean",
+        rule: Reconstruction::Weighted {
+            by: "covered_seconds",
+        },
+    },
+    Reconstructed {
+        column: "quoted_spread_basis_points_mean",
+        rule: Reconstruction::Weighted {
+            by: "covered_seconds",
+        },
+    },
+    Reconstructed {
+        column: "bid_size_mean",
+        rule: Reconstruction::Weighted {
+            by: "covered_seconds",
+        },
+    },
+    Reconstructed {
+        column: "ask_size_mean",
+        rule: Reconstruction::Weighted {
+            by: "covered_seconds",
+        },
+    },
+];
+
+/// The quote columns no fold reconstructs.
+///
+/// A five-minute median is not the median of five one-minute medians, and no weighting recovers it.
+/// Outside the check by construction rather than by omission, and named in the report so nothing
+/// reads a passing check as covering the whole row.
+const QUOTE_OPAQUE: &[&str] = &[
+    "quoted_spread_basis_points_median",
+    "quoted_spread_basis_points_ninetieth_percentile",
+];
+
+/// The additive and weighted columns of a trade summary, exclusion counters included.
+const TRADE_RECONSTRUCTED: &[Reconstructed] = &[
+    Reconstructed {
+        column: "trade_count",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "volume",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "dollar_volume",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "signed_volume",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "volume_ineligible_trades",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "volume_ineligible_dollar_volume",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "corrected_trades",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "corrected_dollar_volume",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "non_market_price_trades",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "non_market_price_dollar_volume",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "unresolved_condition_trades",
+        rule: Reconstruction::Sum,
+    },
+    Reconstructed {
+        column: "volume_weighted_average_price",
+        rule: Reconstruction::Weighted { by: "volume" },
+    },
+];
+
+/// The trade columns no fold reconstructs, for the reason the quote ones are not.
+const TRADE_OPAQUE: &[&str] = &["median_trade_size", "ninetieth_percentile_trade_size"];
+
+/// What can go wrong before any comparison happens.
+#[derive(Debug, Error)]
+pub enum CadenceError {
+    #[error("{0}")]
+    Frame(#[from] PolarsError),
+    /// The fold runs one way. A coarse row is built from fine ones and never the reverse.
+    #[error("{finer} rows do not fold into a {coarser} row")]
+    NotCoarser {
+        finer: BarInterval,
+        coarser: BarInterval,
+    },
+    /// A session's daily partition is one row per name at one instant, which is what makes the
+    /// whole-session fold a single bucket. More than one stamp means the partition is not a session.
+    #[error("the {interval} partition for {session} carries {stamps} distinct timestamps")]
+    AmbiguousSessionStamp {
+        interval: BarInterval,
+        session: SessionDate,
+        stamps: usize,
+    },
+    #[error("column {column} is missing a value the comparison needs")]
+    NullKey { column: &'static str },
+}
+
+/// The columns of one summary family, split by whether a coarser row reconstructs them.
+///
+/// Table-driven because the two families differ only in their columns and their weight, and a check
+/// that hardcoded either would have to be written twice and kept in step by hand.
+#[derive(Clone, Copy, Debug)]
+pub struct CadenceCheck {
+    family: &'static str,
+    reconstructed: &'static [Reconstructed],
+    opaque: &'static [&'static str],
+}
+
+impl CadenceCheck {
+    /// The quote summary's columns, weighted by prevailing time.
+    pub const fn quotes() -> Self {
+        Self {
+            family: "quotes",
+            reconstructed: QUOTE_RECONSTRUCTED,
+            opaque: QUOTE_OPAQUE,
+        }
+    }
+
+    /// The trade summary's columns, weighted by volume.
+    pub const fn trades() -> Self {
+        Self {
+            family: "trades",
+            reconstructed: TRADE_RECONSTRUCTED,
+            opaque: TRADE_OPAQUE,
+        }
+    }
+
+    /// The columns this check does not cover, named so a pass is never read as covering the row.
+    pub fn opaque(&self) -> &'static [&'static str] {
+        self.opaque
+    }
+
+    /// Folds `finer` up to `coarser_interval` and compares it to `coarser`, writing nothing.
+    ///
+    /// Equal intervals are permitted and are the degenerate fold: every row is its own bucket, which
+    /// is how a derived session row is checked against the stored one. Rows present on one side only
+    /// are counted as coverage rather than as disagreement -- the two cadences were written by
+    /// different passes over universes that need not match.
+    pub fn compare(
+        &self,
+        finer: &DataFrame,
+        coarser: &DataFrame,
+        coarser_interval: BarInterval,
+        session: SessionDate,
+    ) -> Result<CadenceAgreement, CadenceError> {
+        let finer_interval = sole_interval(finer)?.unwrap_or(coarser_interval);
+        if coarseness(finer_interval) > coarseness(coarser_interval) {
+            return Err(CadenceError::NotCoarser {
+                finer: finer_interval,
+                coarser: coarser_interval,
+            });
+        }
+
+        let bucketed = self.bucket(finer, coarser, coarser_interval, session)?;
+        let reconstructed = self.reconstruct(bucketed)?;
+        let matched = reconstructed
+            .clone()
+            .lazy()
+            .join(
+                coarser.clone().lazy(),
+                [col("ticker"), col(BUCKET)],
+                [col("ticker"), col("timestamp")],
+                JoinArgs::new(JoinType::Inner),
+            )
+            .collect()?;
+
+        let mut columns = Vec::with_capacity(self.reconstructed.len());
+        for entry in self.reconstructed {
+            columns.push(compare_column(&matched, entry.column)?);
+        }
+
+        Ok(CadenceAgreement {
+            family: self.family,
+            session,
+            finer: finer_interval,
+            coarser: coarser_interval,
+            compared: matched.height(),
+            // Subtracted rather than anti-joined: the reconstruction is unique on its key by
+            // construction, so an inflated join would mean the coarse partition holds a duplicate
+            // key -- which shows up as an impossible count here rather than being silently absorbed.
+            finer_only: reconstructed.height().saturating_sub(matched.height()),
+            coarser_only: coarser.height().saturating_sub(matched.height()),
+            columns,
+            opaque: self.opaque,
+        })
+    }
+
+    /// Tags each fine row with the coarse bucket it belongs to.
+    fn bucket(
+        &self,
+        finer: &DataFrame,
+        coarser: &DataFrame,
+        coarser_interval: BarInterval,
+        session: SessionDate,
+    ) -> Result<DataFrame, CadenceError> {
+        let stamps = finer.column("timestamp")?.i64()?;
+        let buckets: Vec<i64> = match coarser_interval {
+            // Read off the coarse frame rather than recomputed. The session stamp is a convention --
+            // 16:00 Eastern even on an early close -- so deriving it here would check this module
+            // against itself instead of against what the archive stores.
+            BarInterval::OneDay => {
+                let stored: BTreeSet<i64> = coarser
+                    .column("timestamp")?
+                    .i64()?
+                    .iter()
+                    .flatten()
+                    .collect();
+                let [stamp] = stored.iter().copied().collect::<Vec<_>>()[..] else {
+                    return Err(CadenceError::AmbiguousSessionStamp {
+                        interval: coarser_interval,
+                        session,
+                        stamps: stored.len(),
+                    });
+                };
+                vec![stamp; finer.height()]
+            }
+            BarInterval::OneMinute | BarInterval::FiveMinute => {
+                let width = IntradayCadence::from_bar_interval(coarser_interval)
+                    .expect("an intraday interval names a cadence")
+                    .seconds()
+                    * 1_000;
+                stamps
+                    .iter()
+                    .map(|stamp| {
+                        stamp.map(|stamp| stamp.div_euclid(width) * width).ok_or(
+                            CadenceError::NullKey {
+                                column: "timestamp",
+                            },
+                        )
+                    })
+                    .collect::<Result<_, _>>()?
+            }
+        };
+
+        let mut bucketed = finer.clone();
+        bucketed.with_column(Column::new(BUCKET.into(), buckets))?;
+        Ok(bucketed)
+    }
+
+    /// Rebuilds one coarse row per `(ticker, bucket)` out of the fine rows in it.
+    fn reconstruct(&self, bucketed: DataFrame) -> Result<DataFrame, CadenceError> {
+        let aggregations: Vec<Expr> = self
+            .reconstructed
+            .iter()
+            .map(|entry| {
+                let expression = match entry.rule {
+                    Reconstruction::Sum => col(entry.column).sum(),
+                    // Weighted only by the rows that carry a value: a null VWAP is a bar where
+                    // nothing eligible traded, and letting its volume into the denominator would
+                    // pull the reconstruction toward zero on exactly the bars it says nothing about.
+                    Reconstruction::Weighted { by } => {
+                        let weight = when(col(entry.column).is_null())
+                            .then(lit(0.0))
+                            .otherwise(col(by));
+                        let total = weight.clone().sum();
+                        // A bucket where nothing carried a value reconstructs to nothing, not to
+                        // `0/0`. NaN here compares against the stored null as a disagreement, which
+                        // on the trade archive fires on every window the exclusions emptied.
+                        when(total.clone().gt(lit(0.0)))
+                            .then(
+                                (col(entry.column).fill_null(lit(0.0)) * weight).sum()
+                                    / total.clone(),
+                            )
+                            .otherwise(lit(NULL).cast(DataType::Float64))
+                    }
+                };
+                expression.alias(reconstructed_name(entry.column))
+            })
+            .collect();
+
+        Ok(bucketed
+            .lazy()
+            .group_by([col("ticker"), col(BUCKET)])
+            .agg(aggregations)
+            .collect()?)
+    }
+}
+
+/// The column a bucketed fine frame carries its coarse key in.
+const BUCKET: &str = "coarse_timestamp";
+
+/// What the reconstruction of `column` is called once it sits beside the stored value.
+fn reconstructed_name(column: &str) -> PlSmallStr {
+    format!("{column}_reconstructed").into()
+}
+
+/// The interval every row of a partition carries, or `None` where it holds no rows.
+///
+/// Read from the frame rather than passed in, so a comparison cannot be told the fine side is
+/// one-minute while the partition it was handed is five.
+fn sole_interval(frame: &DataFrame) -> Result<Option<BarInterval>, CadenceError> {
+    let Ok(column) = frame.column("bar_interval") else {
+        return Ok(None);
+    };
+    let intervals: BTreeSet<&str> = column.str()?.iter().flatten().collect();
+    Ok(intervals.into_iter().next().and_then(BarInterval::parse))
+}
+
+/// Orders the intervals coarsest-last, which is the only comparison the fold direction needs.
+///
+/// Deliberately not a `seconds` method on [`BarInterval`]: a daily bar does not span 86,400 seconds
+/// of quoting, it spans a session, and a number saying otherwise would be read as a duration.
+fn coarseness(interval: BarInterval) -> u8 {
+    match interval {
+        BarInterval::OneMinute => 0,
+        BarInterval::FiveMinute => 1,
+        BarInterval::OneDay => 2,
+    }
+}
+
+/// Compares one column's reconstruction against the value stored beside it.
+///
+/// Row by row rather than as an expression: the arithmetic is trivial and the loop is what makes
+/// null-against-null an agreement, which no scalar comparison expresses.
+fn compare_column(matched: &DataFrame, column: &str) -> Result<ColumnAgreement, CadenceError> {
+    let reconstructed = matched
+        .column(&reconstructed_name(column))?
+        .cast(&DataType::Float64)?;
+    let stored = matched.column(column)?.cast(&DataType::Float64)?;
+    let tickers = matched.column("ticker")?.str()?.clone();
+    let stamps = matched.column(BUCKET)?.i64()?.clone();
+
+    let mut agreement = ColumnAgreement {
+        column: column.to_string(),
+        matched: 0,
+        worst: None,
+        examples: Vec::new(),
+    };
+    for (index, (left, right)) in reconstructed
+        .f64()?
+        .iter()
+        .zip(stored.f64()?.iter())
+        .enumerate()
+    {
+        let gap = match (left, right) {
+            // Neither pass produced a value, which is agreement about there being nothing to say.
+            (None, None) => {
+                agreement.matched += 1;
+                continue;
+            }
+            (Some(left), Some(right)) => (left - right).abs() / (1.0 + right.abs()),
+            // One side has a value and the other does not, which no tolerance can reconcile.
+            _ => f64::INFINITY,
+        };
+        if gap <= TOLERANCE {
+            agreement.matched += 1;
+            continue;
+        }
+        let disagreement = Disagreement {
+            ticker: tickers.get(index).unwrap_or("?").to_string(),
+            timestamp: stamps.get(index).unwrap_or_default(),
+            reconstructed: left,
+            stored: right,
+            gap,
+        };
+        if agreement.examples.len() < EXAMPLES_KEPT {
+            agreement.examples.push(disagreement.clone());
+        }
+        if agreement.worst.as_ref().is_none_or(|worst| gap > worst.gap) {
+            agreement.worst = Some(disagreement);
+        }
+    }
+    Ok(agreement)
+}
+
+/// One column's outcome across the rows both cadences hold.
+#[derive(Clone, Debug)]
+pub struct ColumnAgreement {
+    column: String,
+    matched: usize,
+    /// The largest gap seen, which is the one number that says how bad a disagreement is.
+    worst: Option<Disagreement>,
+    examples: Vec<Disagreement>,
+}
+
+impl ColumnAgreement {
+    pub fn column(&self) -> &str {
+        &self.column
+    }
+
+    pub fn matched(&self) -> usize {
+        self.matched
+    }
+
+    pub fn worst(&self) -> Option<&Disagreement> {
+        self.worst.as_ref()
+    }
+
+    pub fn examples(&self) -> &[Disagreement] {
+        &self.examples
+    }
+}
+
+/// One row where the two cadences do not agree.
+#[derive(Clone, Debug)]
+pub struct Disagreement {
+    ticker: String,
+    timestamp: i64,
+    reconstructed: Option<f64>,
+    stored: Option<f64>,
+    gap: f64,
+}
+
+impl std::fmt::Display for Disagreement {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = |value: Option<f64>| match value {
+            Some(value) => format!("{value}"),
+            None => "none".to_string(),
+        };
+        write!(
+            formatter,
+            "{} at {}: folded {} against stored {} (gap {:.3e})",
+            self.ticker,
+            self.timestamp,
+            value(self.reconstructed),
+            value(self.stored),
+            self.gap
+        )
+    }
+}
+
+/// What one session's cross-cadence comparison found.
+#[derive(Clone, Debug)]
+pub struct CadenceAgreement {
+    family: &'static str,
+    session: SessionDate,
+    finer: BarInterval,
+    coarser: BarInterval,
+    compared: usize,
+    finer_only: usize,
+    coarser_only: usize,
+    columns: Vec<ColumnAgreement>,
+    opaque: &'static [&'static str],
+}
+
+impl CadenceAgreement {
+    pub fn session(&self) -> SessionDate {
+        self.session
+    }
+
+    pub fn compared(&self) -> usize {
+        self.compared
+    }
+
+    /// Rows one cadence holds and the other does not.
+    ///
+    /// A universe difference rather than a disagreement: the cadences were written by separate
+    /// passes, and a name absent from one of them was never compared at all.
+    pub fn one_sided(&self) -> (usize, usize) {
+        (self.finer_only, self.coarser_only)
+    }
+
+    pub fn columns(&self) -> &[ColumnAgreement] {
+        &self.columns
+    }
+
+    /// Columns this check does not cover, named so a pass is never read as covering the row.
+    pub fn opaque(&self) -> &[&'static str] {
+        self.opaque
+    }
+
+    /// Rows that disagreed, summed across columns, which is what makes a session pass or fail.
+    pub fn disagreements(&self) -> usize {
+        self.columns
+            .iter()
+            .map(|column| self.compared.saturating_sub(column.matched))
+            .sum()
+    }
+
+    /// Whether every reconstructed column agreed on every row both cadences hold.
+    ///
+    /// Says nothing about the rows only one of them holds, which `one_sided` reports separately and
+    /// which no comparison can speak for.
+    ///
+    /// **A comparison that matched nothing has not agreed** — it failed to run. The join key is
+    /// `(ticker, bucket)`, so a fold that bucketed to the wrong stamp shares no row with the stored
+    /// partition and every column then agrees over an empty population. Requiring a population is
+    /// what keeps that from reading as a pass.
+    pub fn agrees(&self) -> bool {
+        self.compared > 0 && self.disagreements() == 0
+    }
+
+    /// The largest gap any column carried, for a one-line report.
+    pub fn worst(&self) -> Option<(&str, &Disagreement)> {
+        self.columns
+            .iter()
+            .filter_map(|column| column.worst().map(|worst| (column.column(), worst)))
+            .max_by(|left, right| left.1.gap.total_cmp(&right.1.gap))
+    }
+}
+
+impl std::fmt::Display for CadenceAgreement {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "{} {} {}->{}: {} rows compared, {} disagreements, {} folded-only, {} stored-only",
+            self.session,
+            self.family,
+            self.finer,
+            self.coarser,
+            self.compared,
+            self.disagreements(),
+            self.finer_only,
+            self.coarser_only
+        )
+    }
+}
+
+/// Adds one session's outcome to a running total across a window.
+#[derive(Clone, Debug, Default)]
+pub struct CadenceTotals {
+    sessions: usize,
+    sessions_agreeing: usize,
+    compared: usize,
+    disagreements: usize,
+    finer_only: usize,
+    coarser_only: usize,
+    /// Sessions that disagreed, dated rather than counted: a count cannot say which to re-fold.
+    disagreeing: Vec<SessionDate>,
+    /// Sessions whose two cadences shared no row at all.
+    ///
+    /// Neither agreement nor disagreement — the check did not run. Kept apart from both so a window
+    /// where the fold never lined up cannot be summed into a passing figure.
+    uncompared: Vec<SessionDate>,
+}
+
+impl CadenceTotals {
+    pub fn absorb(&mut self, agreement: &CadenceAgreement) {
+        self.sessions += 1;
+        self.compared += agreement.compared;
+        self.disagreements += agreement.disagreements();
+        let (finer_only, coarser_only) = agreement.one_sided();
+        self.finer_only += finer_only;
+        self.coarser_only += coarser_only;
+        match agreement {
+            agreement if agreement.compared() == 0 => self.uncompared.push(agreement.session()),
+            agreement if agreement.agrees() => self.sessions_agreeing += 1,
+            agreement => self.disagreeing.push(agreement.session()),
+        }
+    }
+
+    pub fn sessions(&self) -> usize {
+        self.sessions
+    }
+
+    pub fn sessions_agreeing(&self) -> usize {
+        self.sessions_agreeing
+    }
+
+    pub fn compared(&self) -> usize {
+        self.compared
+    }
+
+    pub fn disagreements(&self) -> usize {
+        self.disagreements
+    }
+
+    pub fn one_sided(&self) -> (usize, usize) {
+        (self.finer_only, self.coarser_only)
+    }
+
+    pub fn disagreeing(&self) -> &[SessionDate] {
+        &self.disagreeing
+    }
+
+    /// Sessions the check could not run over, dated for the same reason the disagreeing ones are.
+    pub fn uncompared(&self) -> &[SessionDate] {
+        &self.uncompared
+    }
+
+    /// Whether every session agreed, which is the exit condition a check reports on.
+    ///
+    /// A window that compared nothing does not pass. Both halves are load-bearing and neither is
+    /// implied by the other: a run over an empty window and a run where no fold lined up both reach
+    /// zero disagreements without having checked a single row.
+    pub fn agrees(&self) -> bool {
+        self.sessions > 0 && self.uncompared.is_empty() && self.disagreements == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chrono::NaiveDate;
+
+    fn session() -> SessionDate {
+        SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 8, 20).expect("a real date"))
+    }
+
+    /// The instant the archive stamps a session row at, which no intraday bucket lands on.
+    const SESSION_STAMP: i64 = 1_755_720_000_000;
+
+    /// A quote frame carrying only what a comparison reads.
+    ///
+    /// The four time-weighted columns are given one value per row, so a weighted reconstruction is
+    /// checkable by hand rather than by re-running the arithmetic under test.
+    fn quotes(interval: BarInterval, rows: &[(&str, i64, i64, f64, f64)]) -> DataFrame {
+        let spreads: Vec<f64> = rows.iter().map(|row| row.4).collect();
+        DataFrame::new(vec![
+            Column::new(
+                "ticker".into(),
+                rows.iter().map(|row| row.0).collect::<Vec<_>>(),
+            ),
+            Column::new("bar_interval".into(), vec![interval.as_str(); rows.len()]),
+            Column::new(
+                "timestamp".into(),
+                rows.iter().map(|row| row.1).collect::<Vec<_>>(),
+            ),
+            Column::new("quoted_spread_mean".into(), spreads.clone()),
+            Column::new("quoted_spread_basis_points_mean".into(), spreads.clone()),
+            // Deliberately absurd and deliberately different on the two sides: nothing reconstructs
+            // a median, and a check that quietly compared one would fail on every real session.
+            Column::new(
+                "quoted_spread_basis_points_median".into(),
+                vec![rows.len() as f64 * 1_000.0; rows.len()],
+            ),
+            Column::new(
+                "quoted_spread_basis_points_ninetieth_percentile".into(),
+                vec![rows.len() as f64 * 9_000.0; rows.len()],
+            ),
+            Column::new("bid_size_mean".into(), spreads.clone()),
+            Column::new("ask_size_mean".into(), spreads),
+            Column::new(
+                "quote_count".into(),
+                rows.iter().map(|row| row.2).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "covered_seconds".into(),
+                rows.iter().map(|row| row.3).collect::<Vec<_>>(),
+            ),
+        ])
+        .expect("a frame of equal-length columns")
+    }
+
+    /// Five one-minute buckets of one name, each a full minute of book at `spread`.
+    fn five_one_minute_buckets(spreads: [f64; 5], covered: [f64; 5]) -> DataFrame {
+        let rows: Vec<(&str, i64, i64, f64, f64)> = (0..5)
+            .map(|index| {
+                (
+                    "AAPL",
+                    index as i64 * 60_000,
+                    10,
+                    covered[index],
+                    spreads[index],
+                )
+            })
+            .collect();
+        quotes(BarInterval::OneMinute, &rows)
+    }
+
+    fn agreement(
+        finer: &DataFrame,
+        coarser: &DataFrame,
+        coarser_interval: BarInterval,
+    ) -> CadenceAgreement {
+        CadenceCheck::quotes()
+            .compare(finer, coarser, coarser_interval, session())
+            .expect("a comparable pair")
+    }
+
+    #[test]
+    fn test_five_one_minute_buckets_reconstruct_the_five_minute_row() {
+        let finer = five_one_minute_buckets([2.0; 5], [60.0; 5]);
+        let coarser = quotes(BarInterval::FiveMinute, &[("AAPL", 0, 50, 300.0, 2.0)]);
+
+        let outcome = agreement(&finer, &coarser, BarInterval::FiveMinute);
+
+        assert_eq!(outcome.compared(), 1);
+        assert_eq!(outcome.disagreements(), 0);
+        assert!(outcome.agrees());
+        assert_eq!(outcome.one_sided(), (0, 0));
+    }
+
+    #[test]
+    fn test_a_count_short_by_one_is_a_disagreement() {
+        let finer = five_one_minute_buckets([2.0; 5], [60.0; 5]);
+        // Forty-nine against the fifty the buckets hold. One quote, out of a session's hundreds of
+        // thousands, and the check has to see it or it cannot see a lost bucket either.
+        let coarser = quotes(BarInterval::FiveMinute, &[("AAPL", 0, 49, 300.0, 2.0)]);
+
+        let outcome = agreement(&finer, &coarser, BarInterval::FiveMinute);
+
+        assert!(!outcome.agrees());
+        assert_eq!(outcome.disagreements(), 1);
+        let (column, worst) = outcome.worst().expect("a disagreement names its column");
+        assert_eq!(column, "quote_count");
+        assert_eq!(worst.ticker, "AAPL");
+    }
+
+    #[test]
+    fn test_a_time_weighted_mean_reconstructs_from_uneven_buckets() {
+        // Ten seconds at one basis point and ninety at two, which is 1.9 and not the 1.5 an
+        // unweighted average of the two buckets would give.
+        let finer = quotes(
+            BarInterval::OneMinute,
+            &[("AAPL", 0, 4, 10.0, 1.0), ("AAPL", 60_000, 6, 90.0, 2.0)],
+        );
+        let coarser = quotes(BarInterval::FiveMinute, &[("AAPL", 0, 10, 100.0, 1.9)]);
+
+        assert!(agreement(&finer, &coarser, BarInterval::FiveMinute).agrees());
+    }
+
+    #[test]
+    fn test_an_unweighted_mean_would_fail_the_same_pair() {
+        let finer = quotes(
+            BarInterval::OneMinute,
+            &[("AAPL", 0, 4, 10.0, 1.0), ("AAPL", 60_000, 6, 90.0, 2.0)],
+        );
+        // 1.5 is what averaging the buckets without their weights gives. Asserted so the weighting
+        // is proved load-bearing here rather than by mutating the code and remembering to restore.
+        let coarser = quotes(BarInterval::FiveMinute, &[("AAPL", 0, 10, 100.0, 1.5)]);
+
+        let outcome = agreement(&finer, &coarser, BarInterval::FiveMinute);
+
+        assert!(!outcome.agrees());
+        // All four weighted columns carry the same value in this fixture, so all four disagree.
+        assert_eq!(outcome.disagreements(), 4);
+    }
+
+    #[test]
+    fn test_a_median_is_named_as_unchecked_rather_than_compared() {
+        let finer = five_one_minute_buckets([2.0; 5], [60.0; 5]);
+        let coarser = quotes(BarInterval::FiveMinute, &[("AAPL", 0, 50, 300.0, 2.0)]);
+
+        let outcome = agreement(&finer, &coarser, BarInterval::FiveMinute);
+
+        // The fixture's medians are 5,000 against 1,000 and its ninetieths 45,000 against 9,000.
+        assert!(outcome.agrees());
+        assert_eq!(
+            outcome.opaque(),
+            [
+                "quoted_spread_basis_points_median",
+                "quoted_spread_basis_points_ninetieth_percentile"
+            ]
+        );
+        assert!(outcome
+            .columns()
+            .iter()
+            .all(|column| !column.column().contains("median")));
+    }
+
+    #[test]
+    fn test_every_bucket_of_a_session_folds_into_the_stored_session_row() {
+        let finer = five_one_minute_buckets([1.0, 2.0, 3.0, 4.0, 5.0], [60.0; 5]);
+        // Stamped at 16:00 Eastern, which no one-minute bucket carries -- the fold has to take the
+        // coarse key off the stored row rather than off the fine ones.
+        let coarser = quotes(
+            BarInterval::OneDay,
+            &[("AAPL", SESSION_STAMP, 50, 300.0, 3.0)],
+        );
+
+        assert!(agreement(&finer, &coarser, BarInterval::OneDay).agrees());
+    }
+
+    #[test]
+    fn test_a_session_row_compared_against_itself_is_the_degenerate_fold() {
+        let stored = quotes(
+            BarInterval::OneDay,
+            &[("AAPL", SESSION_STAMP, 50, 300.0, 3.0)],
+        );
+
+        let outcome = agreement(&stored, &stored, BarInterval::OneDay);
+
+        assert_eq!(outcome.compared(), 1);
+        assert!(outcome.agrees());
+    }
+
+    #[test]
+    fn test_a_coarser_row_does_not_fold_into_a_finer_one() {
+        let five_minute = quotes(BarInterval::FiveMinute, &[("AAPL", 0, 50, 300.0, 2.0)]);
+        let one_minute = quotes(BarInterval::OneMinute, &[("AAPL", 0, 10, 60.0, 2.0)]);
+
+        let error = CadenceCheck::quotes()
+            .compare(&five_minute, &one_minute, BarInterval::OneMinute, session())
+            .expect_err("the fold runs one way");
+
+        assert!(matches!(
+            error,
+            CadenceError::NotCoarser {
+                finer: BarInterval::FiveMinute,
+                coarser: BarInterval::OneMinute
+            }
+        ));
+    }
+
+    #[test]
+    fn test_a_name_only_one_cadence_holds_is_coverage_rather_than_disagreement() {
+        let finer = quotes(
+            BarInterval::OneMinute,
+            &[("AAPL", 0, 10, 60.0, 2.0), ("MSFT", 0, 10, 60.0, 2.0)],
+        );
+        let coarser = quotes(
+            BarInterval::FiveMinute,
+            &[("AAPL", 0, 10, 60.0, 2.0), ("TSLA", 0, 10, 60.0, 2.0)],
+        );
+
+        let outcome = agreement(&finer, &coarser, BarInterval::FiveMinute);
+
+        // MSFT and TSLA were never compared, so nothing can be said about them either way.
+        assert_eq!(outcome.compared(), 1);
+        assert_eq!(outcome.one_sided(), (1, 1));
+        assert!(outcome.agrees());
+    }
+
+    #[test]
+    fn test_a_comparison_that_matched_nothing_has_not_agreed() {
+        let finer = five_one_minute_buckets([2.0; 5], [60.0; 5]);
+        // A stored session row for a name the fine side never held. Every column then "agrees" over
+        // an empty population, which is the shape a mis-bucketed fold produces.
+        let coarser = quotes(
+            BarInterval::OneDay,
+            &[("MSFT", SESSION_STAMP, 50, 300.0, 2.0)],
+        );
+
+        let outcome = agreement(&finer, &coarser, BarInterval::OneDay);
+
+        assert_eq!(outcome.compared(), 0);
+        assert_eq!(outcome.disagreements(), 0);
+        assert!(!outcome.agrees());
+    }
+
+    #[test]
+    fn test_a_window_that_checked_nothing_does_not_pass() {
+        let empty = CadenceTotals::default();
+        assert_eq!(empty.sessions(), 0);
+        assert_eq!(empty.disagreements(), 0);
+        assert!(!empty.agrees());
+
+        let mut uncompared = CadenceTotals::default();
+        uncompared.absorb(&agreement(
+            &five_one_minute_buckets([2.0; 5], [60.0; 5]),
+            &quotes(
+                BarInterval::OneDay,
+                &[("MSFT", SESSION_STAMP, 50, 300.0, 2.0)],
+            ),
+            BarInterval::OneDay,
+        ));
+
+        assert_eq!(uncompared.sessions(), 1);
+        assert_eq!(uncompared.sessions_agreeing(), 0);
+        assert_eq!(uncompared.disagreements(), 0);
+        assert_eq!(uncompared.uncompared(), [session()]);
+        assert!(uncompared.disagreeing().is_empty());
+        assert!(!uncompared.agrees());
+    }
+
+    #[test]
+    fn test_totals_date_the_sessions_that_disagreed() {
+        let mut totals = CadenceTotals::default();
+        let finer = five_one_minute_buckets([2.0; 5], [60.0; 5]);
+
+        totals.absorb(&agreement(
+            &finer,
+            &quotes(BarInterval::FiveMinute, &[("AAPL", 0, 50, 300.0, 2.0)]),
+            BarInterval::FiveMinute,
+        ));
+        totals.absorb(&agreement(
+            &finer,
+            &quotes(BarInterval::FiveMinute, &[("AAPL", 0, 49, 300.0, 2.0)]),
+            BarInterval::FiveMinute,
+        ));
+
+        assert_eq!(totals.sessions(), 2);
+        assert_eq!(totals.sessions_agreeing(), 1);
+        assert_eq!(totals.compared(), 2);
+        assert_eq!(totals.disagreements(), 1);
+        assert!(!totals.agrees());
+        assert_eq!(totals.disagreeing(), [session()]);
+    }
+
+    /// A trade frame carrying only what a comparison reads, with a nullable volume-weighted price.
+    fn trades(interval: BarInterval, rows: &[(&str, i64, i64, f64, Option<f64>)]) -> DataFrame {
+        let counted = |name: &str, value: i64| Column::new(name.into(), vec![value; rows.len()]);
+        let summed = |name: &str, value: f64| Column::new(name.into(), vec![value; rows.len()]);
+        DataFrame::new(vec![
+            Column::new(
+                "ticker".into(),
+                rows.iter().map(|row| row.0).collect::<Vec<_>>(),
+            ),
+            Column::new("bar_interval".into(), vec![interval.as_str(); rows.len()]),
+            Column::new(
+                "timestamp".into(),
+                rows.iter().map(|row| row.1).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "trade_count".into(),
+                rows.iter().map(|row| row.2).collect::<Vec<_>>(),
+            ),
+            Column::new(
+                "volume".into(),
+                rows.iter().map(|row| row.3).collect::<Vec<_>>(),
+            ),
+            summed("dollar_volume", 0.0),
+            Column::new(
+                "volume_weighted_average_price".into(),
+                rows.iter().map(|row| row.4).collect::<Vec<_>>(),
+            ),
+            summed("median_trade_size", 0.0),
+            summed("ninetieth_percentile_trade_size", 0.0),
+            summed("signed_volume", 0.0),
+            counted("volume_ineligible_trades", 0),
+            summed("volume_ineligible_dollar_volume", 0.0),
+            counted("corrected_trades", 0),
+            summed("corrected_dollar_volume", 0.0),
+            counted("non_market_price_trades", 0),
+            summed("non_market_price_dollar_volume", 0.0),
+            counted("unresolved_condition_trades", 0),
+        ])
+        .expect("a frame of equal-length columns")
+    }
+
+    #[test]
+    fn test_a_volume_weighted_price_reconstructs_across_trade_buckets() {
+        // A hundred shares at ten dollars and three hundred at fourteen, which is thirteen and not
+        // the twelve an unweighted average of the two buckets gives.
+        let finer = trades(
+            BarInterval::OneMinute,
+            &[
+                ("AAPL", 0, 3, 100.0, Some(10.0)),
+                ("AAPL", 60_000, 5, 300.0, Some(14.0)),
+            ],
+        );
+        let coarser = trades(
+            BarInterval::FiveMinute,
+            &[("AAPL", 0, 8, 400.0, Some(13.0))],
+        );
+
+        let outcome = CadenceCheck::trades()
+            .compare(&finer, &coarser, BarInterval::FiveMinute, session())
+            .expect("a comparable pair");
+
+        assert!(outcome.agrees());
+        assert_eq!(outcome.compared(), 1);
+    }
+
+    #[test]
+    fn test_a_bar_that_admitted_no_eligible_share_keeps_its_weight_out_of_the_average() {
+        // The null bucket carries volume the exclusions account for. Letting it into the denominator
+        // would report 5.0 against the stored 10.0 and fail a session that is entirely correct.
+        let finer = trades(
+            BarInterval::OneMinute,
+            &[
+                ("AAPL", 0, 3, 100.0, Some(10.0)),
+                ("AAPL", 60_000, 0, 100.0, None),
+            ],
+        );
+        let coarser = trades(
+            BarInterval::FiveMinute,
+            &[("AAPL", 0, 3, 200.0, Some(10.0))],
+        );
+
+        assert!(CadenceCheck::trades()
+            .compare(&finer, &coarser, BarInterval::FiveMinute, session())
+            .expect("a comparable pair")
+            .agrees());
+    }
+
+    #[test]
+    fn test_a_window_where_nothing_eligible_traded_reconstructs_to_nothing() {
+        // Every bucket null, so the weight sums to zero. Dividing there gives NaN, which compares
+        // against the stored null as a disagreement -- and on the real trade archive this fires on
+        // every window the exclusions emptied, which is hundreds a session.
+        let finer = trades(
+            BarInterval::OneMinute,
+            &[
+                ("AAPL", 0, 0, 100.0, None),
+                ("AAPL", 60_000, 0, 100.0, None),
+            ],
+        );
+        let coarser = trades(BarInterval::FiveMinute, &[("AAPL", 0, 0, 200.0, None)]);
+
+        let outcome = CadenceCheck::trades()
+            .compare(&finer, &coarser, BarInterval::FiveMinute, session())
+            .expect("a comparable pair");
+
+        assert_eq!(outcome.compared(), 1);
+        assert!(outcome.agrees());
+    }
+
+    #[test]
+    fn test_a_value_against_no_value_is_a_disagreement_no_tolerance_reconciles() {
+        let finer = trades(BarInterval::OneMinute, &[("AAPL", 0, 3, 100.0, Some(10.0))]);
+        // Stored as null where the tape says ten dollars, which is a pass that lost a column rather
+        // than one that rounded it.
+        let coarser = trades(BarInterval::FiveMinute, &[("AAPL", 0, 3, 100.0, None)]);
+
+        let outcome = CadenceCheck::trades()
+            .compare(&finer, &coarser, BarInterval::FiveMinute, session())
+            .expect("a comparable pair");
+
+        assert!(!outcome.agrees());
+        assert_eq!(
+            outcome.worst().expect("a disagreement names its column").0,
+            "volume_weighted_average_price"
+        );
+    }
+}


### PR DESCRIPTION
# Overview

Concern D from `.scratchpad/plan_laboratory_expansion.md`: the cross-cadence check, which gates the one-minute quote pass (concern C) before the Massive Advanced shutdown.

## Changes

- Add `src/data/cadence.rs`: folds a stored finer cadence up and compares it to the coarser rows already there. Table-driven over two rules, `Sum` and `Weighted { by }` — quotes weigh by covered seconds, trades by volume — so one check answers for both families instead of being written twice.
- The median and ninetieth-percentile columns are **not decomposable** and are reported as uncovered rather than silently skipped. A five-minute median is not the median of five one-minute medians, and no weighting recovers it.
- `write_quote_partitions` now takes the cadence. A pass at a cadence that does not author the session row **compares** that row and reports it, writing it only where none exists.
- Add `seed archive-cadence {quotes,trades}`, which writes nothing. It takes its population from the finer prefix rather than from a calendar, so it needs no vendor credential and stays usable after a subscription lapses.
- Unpin `QUOTE_CADENCE` into a real `--cadence` flag on the whole-market quote folds. The flag and the check land together, as the plan requires — exposing it first would let a re-fold replace the archive's session figures with its own.

## Context

### Two latent faults this surfaced, both of which concern C would have paid for

**Presence was read off the daily prefix for every cadence.** A one-minute `archive` would have found all 1,254 sessions already present and written nothing — a 79-hour pass exiting clean in under a minute. Presence now follows the prefix the pass actually writes last.

**`write_quote_partitions` wrote whichever cadences the fold produced, the session row included.** The one-minute pass would have merged its own session figures over the five-minute pass's.

A third was found by mutation, in the check itself: a comparison that matched no rows reported agreement, because zero disagreements over an empty population is zero. `agrees()` now requires a population, and `CadenceTotals` keeps sessions that compared nothing apart from both the agreeing and the disagreeing ones.

### Verification, against the archive rather than fixtures

Route: `seed archive-cadence` against `s3://oscm-fund-archive`, plus DuckDB over the same parquet.

**Trades agree exactly.** 21 sessions sampled across five years, one-minute folded to the session row: 221,806 rows, 0 disagreements. Three sessions of one-minute against five-minute: 2,016,296 rows, 0 disagreements. `trades.rs` builds its coarser rows as merges of its finer ones inside one pass, and this is what that looks like from outside. It is also the control that says the check can report agreement at all.

**Quotes disagree on ~0.05% of name-sessions**, and the shape identifies the cause. Across six sessions, 30 disagreeing name-sessions out of ~64,000; every gap a whole number of five-minute buckets, the five-minute side always holding more, quote counts identical, all 78 buckets present.

A single fold cannot produce that: `SessionFold::finish` calls `session.absorb(bucket)` for every bucket including ones too empty to emit a row, so within one pass the session row can only be the larger. Two passes did. A merge cannot remove a row it does not overwrite, so the five-minute partition accumulates the union of every pass over it while the session row, being one row per name, is replaced outright. The sidecars from #1130 name both routes on the affected sessions:

```
interval=five_minute  routes: [massive/stocks_advanced/flat_file, alpaca/algo_trader_plus]
interval=one_day      routes: [massive/stocks_advanced/flat_file, alpaca/algo_trader_plus]
```

This is the missing downward correction path from #1129, now with a measured cost.

### A single-session rehearsal of concern C

`seed equity-quotes archive --start 2026-08-20 --end 2026-08-20 --cadence one_minute`, on the real flat file: 12,104 names, 484,446,188 quotes folded, 4,710,252 one-minute summaries written, 0 sessions failed, no `ERROR` lines. The session-row guard fired and **the stored daily row was not touched**.

It reported a disagreement, and that disagreement is real but not a defect here. Against the stored partitions for the same session:

| comparison | result |
|---|---|
| stored five-minute vs stored daily | 12,125 / 12,125 match on counts, coverage and spread |
| fresh one-minute vs stored five-minute | 3,265 / 12,078 counts, 3 / 12,078 coverage |

Coverage is higher on the one-minute side for **12,075 names and lower for none** — one-directional, so not provider noise. The fresh fold reaches the full session where the stored rows fall tens of milliseconds short:

| name | fresh one-minute | stored five-minute |
|---|---|---|
| AAPL | 23,399.999999999996 | 23,399.966849664 |
| MSFT | 23,400.0 | 23,399.993983543 |
| SPY | 23,400.000000000004 | 23,399.999312443 |

A continuously-quoted name covers the whole 23,400-second session, which is what a clean single-provider Massive fold gives. **The mechanism is inferred, not proved**: the likely cause is that the Alpaca repair route is windowed to regular hours while the flat file carries pre-open quotes that clamp to the open, and the stored partition carries both routes. Folding one session at both cadences in one process and diffing in memory would settle it; that is not in this pull request.

The practical consequence for concern C: the inline session-row report will disagree on most sessions for this known reason, so its value during the pass is the **guard**, not the report. The standalone `archive-cadence` check is what answers the question afterwards.

### Testing

16 tests in `data::cadence`, plus coverage of the presence rule and the family split in `data::archive` and the flag surface in `seed`. Four mutations were confirmed load-bearing: keying presence on the daily prefix for every cadence, dropping the weight from a weighted mean, taking the session bucket off the fine rows, and letting null-valued rows keep their weight in the denominator. Each failed a test; each was restored.

`devenv tasks run checks:all` passes. Clippy warning count is unchanged from master apart from one `too_many_arguments` allow, matching the five already in the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `archive-cadence` command to compare archived data across time intervals and report agreement or discrepancies.
  * Added cadence selection to whole-market quote archive and widen actions.
  * Added support for validating quote and trade summaries across finer and coarser intervals.

* **Bug Fixes**
  * Improved quote archiving to use cadence-specific session data and preserve consistency between intraday and daily summaries.

* **Tests**
  * Added coverage for cadence comparisons, weighted calculations, session handling, and archive validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->