### PR TITLE
Fold trade summaries from Alpaca as well as Massive's flat files

### DIFF
--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -15,12 +15,12 @@ use fund::common::flatfiles;
 use fund::common::log::init_tracing;
 use fund::common::massive::MassiveClient;
 use fund::common::types::{
-    BarInterval, IntradayCadence, LiquidityFloor, QuoteSummary, SessionDate, Ticker,
+    BarInterval, IntradayCadence, LiquidityFloor, QuoteSummary, SessionDate, Ticker, TradeSummary,
 };
 use fund::data::archive::{self, NameSelection, Scope, SessionSelection};
 use fund::data::cadence::CadenceTotals;
 use fund::data::calendar::TradingCalendar;
-use fund::data::{attribution, bars, details, quotes};
+use fund::data::{attribution, bars, details, quotes, trades};
 
 /// One file for the whole seeder, since it is one process however it was invoked.
 ///
@@ -388,8 +388,9 @@ impl QuoteAction {
 
 /// What a trade pass does with the sessions it is given.
 ///
-/// Two actions where quotes have five: there is no per-name repair, because a trade file *is* the
-/// session and a name missing from it is missing from the tape rather than from a retryable fetch.
+/// `repair` exists now that Alpaca serves prints per name. The whole-market actions still read a
+/// flat file, which is the only affordable route to five years; a repair reaches one name, and is
+/// also the only route that reaches past Massive's five-year window at all.
 #[derive(Debug, Subcommand)]
 enum TradeAction {
     /// Fold every name the daily archive holds into the sampled sessions that have no partition yet.
@@ -397,21 +398,35 @@ enum TradeAction {
     /// Fold every name the daily archive holds into every sampled session, widening ones already
     /// summarized.
     Widen(QuoteArguments),
+    /// Fold named symbols from Alpaca into the sampled sessions that already have a partition.
+    Repair(QuoteSymbolArguments),
+    /// Fold named symbols from Alpaca and print what they read, touching no partition.
+    ///
+    /// The seam between the two providers is only checkable read-only. Writing an Alpaca fold into
+    /// a partition built from flat files is how the quote archive ended up carrying rows from two
+    /// passes at once, and this exists so the comparison costs nothing.
+    Measure(QuoteSymbolArguments),
 }
 
 impl TradeAction {
-    /// The scope this action folds under. Both fold the whole market and differ only in sessions.
-    fn universe_scope(&self) -> Result<Scope, SeedError> {
-        whole_market(match self {
+    /// The scope an action that derives its universe from the archive folds under.
+    ///
+    /// `None` for the repair, which names its own symbols. Returned as one value so a test asserts
+    /// the scope the pass will use rather than a reconstruction of it beside it.
+    fn universe_scope(&self) -> Option<Result<Scope, SeedError>> {
+        let sessions = match self {
             TradeAction::Archive(_) => SessionSelection::Absent,
             TradeAction::Widen(_) => SessionSelection::Every,
-        })
+            TradeAction::Repair(_) | TradeAction::Measure(_) => return None,
+        };
+        Some(whole_market(sessions))
     }
 
     /// The window and stride this action runs over.
     fn arguments(&self) -> &QuoteArguments {
         match self {
             TradeAction::Archive(arguments) | TradeAction::Widen(arguments) => arguments,
+            TradeAction::Repair(symbols) | TradeAction::Measure(symbols) => &symbols.quotes,
         }
     }
 }
@@ -1510,8 +1525,22 @@ async fn seed_provenance(action: &ProvenanceAction) -> Result<Outcome, SeedError
 }
 
 async fn seed_trades(action: &TradeAction) -> Result<Outcome, SeedError> {
+    if let TradeAction::Measure(symbols) = action {
+        return measure_trades(symbols).await;
+    }
     let arguments = action.arguments();
-    let scope = action.universe_scope()?;
+    // Resolved before any credential is read, so a repair with no symbol set is refused in the first
+    // millisecond rather than after a calendar fetch.
+    let scope = match action {
+        TradeAction::Repair(symbols) => Scope::new(
+            NameSelection::Named(symbols.symbols.required_names()?),
+            SessionSelection::Present,
+        )
+        .map_err(|error| SeedError::Usage(error.to_string()))?,
+        whole_market_action => whole_market_action
+            .universe_scope()
+            .ok_or_else(|| SeedError::Usage(format!("{action:?} folds no universe")))??,
+    };
     let window = arguments.window.window()?;
 
     let credentials = AlpacaCredentials::from_env().map_err(box_error)?;
@@ -1523,21 +1552,102 @@ async fn seed_trades(action: &TradeAction) -> Result<Outcome, SeedError> {
     let sampled = sample(&calendar, &window, arguments.stride);
     report_sample(&window, arguments.stride, &calendar, &sampled);
 
-    let flat_files = flat_file_client(arguments).await?;
+    // Bound before the source so it outlives the borrow, and built only where it is used: a repair
+    // must not demand flat-file credentials to reach two names through Alpaca.
+    let flat_files;
+    let market_data;
+    let source = match action {
+        TradeAction::Repair(_) => {
+            market_data = quote_market_data()?;
+            archive::TradeSource::PerName(&market_data)
+        }
+        _ => {
+            flat_files = flat_file_client(arguments).await?;
+            archive::TradeSource::WholeSession(&flat_files)
+        }
+    };
+
     let bucket = bucket_name()?;
     let s3_client = fund::common::aws::s3_client().await;
     Ok(Outcome::Pass(
-        archive::archive_trade_sessions(
-            &s3_client,
-            &flat_files,
-            &calendar,
-            &bucket,
-            &sampled,
-            &scope,
-        )
-        .await
-        .map_err(box_error)?,
+        archive::archive_trade_sessions(&s3_client, &source, &calendar, &bucket, &sampled, &scope)
+            .await
+            .map_err(box_error)?,
     ))
+}
+
+/// Folds named symbols' prints and prints their session figures, writing nothing.
+///
+/// Sequential on purpose, as the quote measurement is: this exists to read a handful of numbers off
+/// real data and compare them against what the archive already holds.
+async fn measure_trades(symbols: &QuoteSymbolArguments) -> Result<Outcome, SeedError> {
+    let named = symbols.symbols.required_names()?;
+    let arguments = &symbols.quotes;
+    let window = arguments.window.window()?;
+    let (market_data, calendar) = quote_sources(&window).await?;
+    let sampled = sample(&calendar, &window, arguments.stride);
+    report_sample(&window, arguments.stride, &calendar, &sampled);
+
+    // The exclusion counters are printed beside the totals because they are the first thing a
+    // disagreement with the flat-file archive would be explained by: the two providers spell
+    // conditions differently, so they can admit different prints.
+    println!(
+        "{:<8}{:<12}{:>10}{:>16}{:>18}{:>11}{:>10}{:>10}",
+        "ticker", "session", "trades", "volume", "dollar_volume", "vwap", "inelig", "unresolv"
+    );
+    for session in &sampled {
+        let Some((open, close)) = quotes::trading_hours(&calendar, *session) else {
+            println!("{session}: not a published session");
+            continue;
+        };
+        for ticker in &named {
+            match trades::fold_session(&market_data, ticker, *session, open, close).await {
+                Ok((summaries, fetch)) => print_trade_row(ticker, *session, &summaries, fetch),
+                Err(error) => println!(
+                    "{:<8}{:<12} failed: {error}",
+                    ticker.as_str(),
+                    session.to_string()
+                ),
+            }
+        }
+    }
+    Ok(Outcome::Complete)
+}
+
+/// Prints one name's session row, which is the last summary the fold returns.
+fn print_trade_row(
+    ticker: &Ticker,
+    session: SessionDate,
+    summaries: &[TradeSummary],
+    fetch: fund::common::alpaca::TradeFetch,
+) {
+    let Some(row) = summaries
+        .iter()
+        .find(|row| row.bar_interval() == BarInterval::OneDay)
+    else {
+        println!(
+            "{:<8}{:<12} no prints (received {}, rejected {}, untaped {})",
+            ticker.as_str(),
+            session.to_string(),
+            fetch.received,
+            fetch.rejected,
+            fetch.untaped
+        );
+        return;
+    };
+    println!(
+        "{:<8}{:<12}{:>10}{:>16.2}{:>18.2}{:>11}{:>10}{:>10}",
+        ticker.as_str(),
+        session.to_string(),
+        row.trade_count(),
+        row.volume(),
+        row.dollar_volume(),
+        row.volume_weighted_average_price()
+            .map(|price| format!("{price:.4}"))
+            .unwrap_or_else(|| "none".to_string()),
+        row.exclusions().volume_ineligible_trades(),
+        row.exclusions().unresolved_condition_trades(),
+    );
 }
 
 /// Writes whole-market one-minute bars from Massive's flat files.
@@ -1759,6 +1869,16 @@ fn rate(quantity: f64, seconds: f64) -> f64 {
 }
 
 /// The Alpaca client and the calendar every quote action needs, measuring or writing.
+/// The SIP market-data client a per-name fold reads through.
+///
+/// SIP is pinned rather than read from `ALPACA_DATA_FEED`, for the reason [`quote_sources`] pins it:
+/// IEX's prints are one venue's, and an environment variable could put two incomparable series under
+/// one key.
+fn quote_market_data() -> Result<MarketDataClient, SeedError> {
+    let credentials = AlpacaCredentials::from_env().map_err(box_error)?;
+    Ok(MarketDataClient::new(credentials, DataFeed::Sip))
+}
+
 async fn quote_sources(
     window: &Window,
 ) -> Result<(MarketDataClient, TradingCalendar), Box<dyn std::error::Error>> {
@@ -2616,6 +2736,7 @@ mod tests {
             match arguments.command {
                 Command::EquityTrades { action } => action
                     .universe_scope()
+                    .expect("a whole-market action names a universe")
                     .expect("the whole market may write a partition")
                     .to_string(),
                 other => panic!("expected a trade action, got {other:?}"),
@@ -2626,6 +2747,21 @@ mod tests {
         // test moves with it and can never fail.
         assert_eq!(rendered("archive"), "every name, absent sessions only");
         assert_eq!(rendered("widen"), "every name, every session");
+
+        // The repair derives no universe: it names its symbols, so a scope built here would be a
+        // second answer to a question the symbol set has already answered.
+        let repair = parse(
+            &[
+                ["equity-trades", "repair", "--symbols", "AAPL"].as_slice(),
+                &window,
+            ]
+            .concat(),
+        )
+        .expect("a trade repair");
+        match repair.command {
+            Command::EquityTrades { action } => assert!(action.universe_scope().is_none()),
+            other => panic!("expected a trade action, got {other:?}"),
+        }
     }
 
     /// A scan that could not read a session found its names only in the ones it could, so both the

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -399,13 +399,30 @@ enum TradeAction {
     /// summarized.
     Widen(QuoteArguments),
     /// Fold named symbols from Alpaca into the sampled sessions that already have a partition.
-    Repair(QuoteSymbolArguments),
+    Repair(TradeSymbolArguments),
     /// Fold named symbols from Alpaca and print what they read, touching no partition.
     ///
     /// The seam between the two providers is only checkable read-only. Writing an Alpaca fold into
     /// a partition built from flat files is how the quote archive ended up carrying rows from two
     /// passes at once, and this exists so the comparison costs nothing.
-    Measure(QuoteSymbolArguments),
+    Measure(TradeSymbolArguments),
+}
+
+/// What a per-name trade pass takes, which is the window, the stride and the names.
+///
+/// Deliberately not [`QuoteSymbolArguments`]: these routes reach Alpaca one name at a time, so
+/// `--tee-raw`, `--staging-directory` and `--cadence` name nothing they can act on, and a flag the
+/// CLI accepts and ignores reads as a setting that was applied.
+#[derive(Debug, Args)]
+struct TradeSymbolArguments {
+    #[command(flatten)]
+    window: WindowArguments,
+    /// Sample every Nth published session, anchored at the start. A multiple of 5 samples one
+    /// weekday forever; 21 does not.
+    #[arg(long, default_value_t = DEFAULT_STRIDE, value_parser = stride)]
+    stride: usize,
+    #[command(flatten)]
+    symbols: SymbolArguments,
 }
 
 impl TradeAction {
@@ -422,11 +439,23 @@ impl TradeAction {
         Some(whole_market(sessions))
     }
 
-    /// The window and stride this action runs over.
-    fn arguments(&self) -> &QuoteArguments {
+    /// The window this action runs over.
+    ///
+    /// Read separately from the stride rather than through one arguments struct, because the two
+    /// routes no longer share one: a flat-file pass also carries the raw tee, and a per-name pass
+    /// has nothing to tee.
+    fn window(&self) -> &WindowArguments {
         match self {
-            TradeAction::Archive(arguments) | TradeAction::Widen(arguments) => arguments,
-            TradeAction::Repair(symbols) | TradeAction::Measure(symbols) => &symbols.quotes,
+            TradeAction::Archive(arguments) | TradeAction::Widen(arguments) => &arguments.window,
+            TradeAction::Repair(symbols) | TradeAction::Measure(symbols) => &symbols.window,
+        }
+    }
+
+    /// How many published sessions this action steps between folds.
+    fn stride(&self) -> usize {
+        match self {
+            TradeAction::Archive(arguments) | TradeAction::Widen(arguments) => arguments.stride,
+            TradeAction::Repair(symbols) | TradeAction::Measure(symbols) => symbols.stride,
         }
     }
 }
@@ -1528,7 +1557,6 @@ async fn seed_trades(action: &TradeAction) -> Result<Outcome, SeedError> {
     if let TradeAction::Measure(symbols) = action {
         return measure_trades(symbols).await;
     }
-    let arguments = action.arguments();
     // Resolved before any credential is read, so a repair with no symbol set is refused in the first
     // millisecond rather than after a calendar fetch.
     let scope = match action {
@@ -1541,7 +1569,8 @@ async fn seed_trades(action: &TradeAction) -> Result<Outcome, SeedError> {
             .universe_scope()
             .ok_or_else(|| SeedError::Usage(format!("{action:?} folds no universe")))??,
     };
-    let window = arguments.window.window()?;
+    let window = action.window().window()?;
+    let stride = action.stride();
 
     let credentials = AlpacaCredentials::from_env().map_err(box_error)?;
     let days = TradingClient::from_env(credentials)
@@ -1549,8 +1578,8 @@ async fn seed_trades(action: &TradeAction) -> Result<Outcome, SeedError> {
         .await
         .map_err(box_error)?;
     let calendar = TradingCalendar::from_days(days);
-    let sampled = sample(&calendar, &window, arguments.stride);
-    report_sample(&window, arguments.stride, &calendar, &sampled);
+    let sampled = sample(&calendar, &window, stride);
+    report_sample(&window, stride, &calendar, &sampled);
 
     // Bound before the source so it outlives the borrow, and built only where it is used: a repair
     // must not demand flat-file credentials to reach two names through Alpaca.
@@ -1558,12 +1587,20 @@ async fn seed_trades(action: &TradeAction) -> Result<Outcome, SeedError> {
     let market_data;
     let source = match action {
         TradeAction::Repair(_) => {
-            market_data = quote_market_data()?;
+            market_data = sip_market_data()?;
             archive::TradeSource::PerName(&market_data)
         }
-        _ => {
+        TradeAction::Archive(arguments) | TradeAction::Widen(arguments) => {
             flat_files = flat_file_client(arguments).await?;
             archive::TradeSource::WholeSession(&flat_files)
+        }
+        // Returned above, before any credential is read. Named rather than swept into a catch-all so
+        // a new action cannot silently inherit the flat-file route.
+        TradeAction::Measure(_) => {
+            return Err(SeedError::Usage(
+                "a measure pass writes nothing and is answered before a source is built"
+                    .to_string(),
+            ))
         }
     };
 
@@ -1580,13 +1617,12 @@ async fn seed_trades(action: &TradeAction) -> Result<Outcome, SeedError> {
 ///
 /// Sequential on purpose, as the quote measurement is: this exists to read a handful of numbers off
 /// real data and compare them against what the archive already holds.
-async fn measure_trades(symbols: &QuoteSymbolArguments) -> Result<Outcome, SeedError> {
+async fn measure_trades(symbols: &TradeSymbolArguments) -> Result<Outcome, SeedError> {
     let named = symbols.symbols.required_names()?;
-    let arguments = &symbols.quotes;
-    let window = arguments.window.window()?;
+    let window = symbols.window.window()?;
     let (market_data, calendar) = quote_sources(&window).await?;
-    let sampled = sample(&calendar, &window, arguments.stride);
-    report_sample(&window, arguments.stride, &calendar, &sampled);
+    let sampled = sample(&calendar, &window, symbols.stride);
+    report_sample(&window, symbols.stride, &calendar, &sampled);
 
     // The exclusion counters are printed beside the totals because they are the first thing a
     // disagreement with the flat-file archive would be explained by: the two providers spell
@@ -1874,7 +1910,7 @@ fn rate(quantity: f64, seconds: f64) -> f64 {
 /// SIP is pinned rather than read from `ALPACA_DATA_FEED`, for the reason [`quote_sources`] pins it:
 /// IEX's prints are one venue's, and an environment variable could put two incomparable series under
 /// one key.
-fn quote_market_data() -> Result<MarketDataClient, SeedError> {
+fn sip_market_data() -> Result<MarketDataClient, SeedError> {
     let credentials = AlpacaCredentials::from_env().map_err(box_error)?;
     Ok(MarketDataClient::new(credentials, DataFeed::Sip))
 }

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -11,7 +11,8 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::common::types::{
-    BoundaryReason, Dollars, EquityQuote, EquityTrade, SeriesBoundary, SessionDate, Ticker,
+    BoundaryReason, Dollars, EquityQuote, EquityTrade, SeriesBoundary, SessionDate, Tape, Ticker,
+    TradeConditions,
 };
 
 const PAPER_BASE_URL: &str = "https://paper-api.alpaca.markets";
@@ -2109,7 +2110,7 @@ pub struct TradeTick {
     timestamp: DateTime<Utc>,
     price: f64,
     size: f64,
-    conditions: Vec<u32>,
+    conditions: TradeConditions,
     corrected: bool,
 }
 
@@ -2122,7 +2123,7 @@ impl TradeTick {
         timestamp: DateTime<Utc>,
         price: f64,
         size: f64,
-        conditions: Vec<u32>,
+        conditions: TradeConditions,
         corrected: bool,
     ) -> Option<Self> {
         if !price.is_finite() || price <= 0.0 {
@@ -2152,7 +2153,8 @@ impl TradeTick {
         self.size
     }
 
-    pub fn conditions(&self) -> &[u32] {
+    /// How this print's conditions are spelled, which decides which table reads them.
+    pub fn conditions(&self) -> &TradeConditions {
         &self.conditions
     }
 
@@ -2167,6 +2169,76 @@ impl TradeTick {
     }
 }
 
+/// What one trade fetch moved, mirroring [`QuoteFetch`] and for the same reason.
+///
+/// `rejected` counts prints [`TradeTick::new`] refused, and `untaped` counts rows whose tape letter
+/// named no SIP — separated because a tapeless row is a row whose conditions cannot be read at all,
+/// which is a different fault from a price that made no sense.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TradeFetch {
+    pub received: usize,
+    pub rejected: usize,
+    pub untaped: usize,
+    pub pages: usize,
+    pub retries: usize,
+}
+
+/// The historical-trades envelope: rows keyed by symbol, plus the cursor.
+#[derive(Debug, Deserialize)]
+struct TradesResponse {
+    trades: Option<HashMap<String, Vec<HistoricalTradePayload>>>,
+    next_page_token: Option<String>,
+}
+
+/// One row of the historical trade stream, in the feed's own abbreviations.
+///
+/// The exchange and the trade identifier are parsed past: the archive folds a session's prints and
+/// keeps no per-print record, so the venue is not something any aggregate downstream can express.
+#[derive(Debug, Deserialize)]
+struct HistoricalTradePayload {
+    #[serde(rename = "t")]
+    timestamp: Option<DateTime<Utc>>,
+    #[serde(rename = "p", default)]
+    price: f64,
+    #[serde(rename = "s", default)]
+    size: f64,
+    /// The SIP characters, which name a condition only alongside `tape`.
+    #[serde(rename = "c", default)]
+    conditions: Vec<String>,
+    /// `A`, `B` or `C`. Absent on a row the feed did not tape, which is refused rather than guessed.
+    #[serde(rename = "z")]
+    tape: Option<String>,
+    /// Present only when the print was revised, whatever the revision was.
+    #[serde(rename = "u")]
+    update: Option<String>,
+}
+
+impl HistoricalTradePayload {
+    /// Reads one row into a tick, or `None` where it cannot carry weight.
+    ///
+    /// A missing or unrecognized tape is refused rather than defaulted: without it the conditions
+    /// cannot be resolved, and folding the print as unconditioned would silently admit exactly the
+    /// prints the exclusion policy exists to remove.
+    fn into_tick(self) -> Option<TradeTick> {
+        let tape = Tape::from_letter(*self.tape?.as_bytes().first()?)?;
+        // A SIP condition is one character. A longer token is not one this table can spell, and
+        // taking its first byte would silently read it as a different condition.
+        let characters: Vec<u8> = self
+            .conditions
+            .iter()
+            .filter(|condition| condition.len() == 1)
+            .filter_map(|condition| condition.as_bytes().first().copied())
+            .collect();
+        TradeTick::new(
+            self.timestamp?,
+            self.price,
+            self.size,
+            TradeConditions::Spelled { characters, tape },
+            self.update.is_some(),
+        )
+    }
+}
+
 /// Attempts per quote page before the fetch gives up on the whole symbol.
 ///
 /// Four, because the page is the unit that fails: one session of AAPL is 118 pages and a single
@@ -2175,8 +2247,8 @@ impl TradeTick {
 const QUOTES_PAGE_ATTEMPTS: usize = 4;
 
 /// One page and what it took to get it.
-struct FetchedPage {
-    page: QuotesResponse,
+struct FetchedPage<T> {
+    page: T,
     retries: usize,
 }
 
@@ -2520,11 +2592,11 @@ impl MarketDataClient {
     /// Separated from the retry loop so there is one place an attempt can fail from. A connection
     /// reset during `send` is the same transport fault as a body that arrives truncated, and the
     /// two have to be indistinguishable here or only one of them gets retried.
-    async fn attempt_quote_page(
+    async fn attempt_tick_page<T: serde::de::DeserializeOwned>(
         &self,
         url: &str,
         query: &[(&str, &str)],
-    ) -> Result<QuotesResponse, ClientError> {
+    ) -> Result<T, ClientError> {
         let response = self
             .get(url)
             .query(query)
@@ -2535,28 +2607,28 @@ impl MarketDataClient {
         // retries on the first real run.
         error_for_status(response)
             .await?
-            .json::<QuotesResponse>()
+            .json::<T>()
             .await
             .map_err(ClientError::Request)
     }
 
-    async fn quote_page(
+    async fn tick_page<T: serde::de::DeserializeOwned>(
         &self,
         url: &str,
         query: &[(&str, &str)],
         ticker: &Ticker,
         page: usize,
-    ) -> Result<FetchedPage, ClientError> {
+    ) -> Result<FetchedPage<T>, ClientError> {
         let mut retries = 0usize;
         let mut last_error = None;
         for attempt in 0..QUOTES_PAGE_ATTEMPTS {
             // No `?` anywhere in here. Every way the attempt can fail has to reach the match below
             // or it escapes the retry it was written for -- which is how the send arm was missed.
-            match self.attempt_quote_page(url, query).await {
+            match self.attempt_tick_page(url, query).await {
                 Ok(page) => return Ok(FetchedPage { page, retries }),
                 Err(error) if error.is_transient() => {
                     retries += 1;
-                    debug!(%ticker, page, attempt, %error, "Retrying a quote page");
+                    debug!(%ticker, page, attempt, %error, "Retrying a tick page");
                     last_error = Some(error);
                     tokio::time::sleep(page_retry_delay(attempt)).await;
                 }
@@ -2618,7 +2690,7 @@ impl MarketDataClient {
             }
 
             let payload = self
-                .quote_page(&url, &query, ticker, fetch.pages + 1)
+                .tick_page::<QuotesResponse>(&url, &query, ticker, fetch.pages + 1)
                 .await?;
             fetch.retries += payload.retries;
             let payload = payload.page;
@@ -2654,6 +2726,95 @@ impl MarketDataClient {
 
         Err(ClientError::Parse(format!(
             "{ticker} quote pagination did not end within {QUOTES_PAGE_LIMIT} pages"
+        )))
+    }
+
+    /// Streams one symbol's prints over `[start, end)` through `accept`, oldest first.
+    ///
+    /// The trade counterpart of [`MarketDataClient::fetch_quotes`], and folded rather than collected
+    /// for the same reason: a liquid name prints hundreds of thousands of times a session and the
+    /// archive keeps a dozen numbers out of it.
+    ///
+    /// `as_of` must be the session being fetched. The default is today, which would resolve a
+    /// historical window through today's symbol table and silently return another company's prints.
+    pub async fn fetch_trades<F>(
+        &self,
+        ticker: &Ticker,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        as_of: NaiveDate,
+        mut accept: F,
+    ) -> Result<TradeFetch, ClientError>
+    where
+        F: FnMut(TradeTick),
+    {
+        let url = format!("{}/v2/stocks/trades", self.base_url);
+        let start_text = start.to_rfc3339();
+        let end_text = end.to_rfc3339();
+        let as_of_text = as_of.to_string();
+        let page_size = QUOTES_PAGE_SIZE.to_string();
+        let feed = self.feed.as_str();
+
+        let mut fetch = TradeFetch::default();
+        let mut page_token: Option<String> = None;
+
+        for _ in 1..=QUOTES_PAGE_LIMIT {
+            let mut query: Vec<(&str, &str)> = vec![
+                ("symbols", ticker.as_str()),
+                ("start", start_text.as_str()),
+                ("end", end_text.as_str()),
+                ("limit", page_size.as_str()),
+                ("feed", feed),
+                // Stated rather than inherited, as on the quote path: the tick rule reads each
+                // print against the one before it, so a descending page would sign every trade
+                // backwards.
+                ("sort", "asc"),
+                ("asof", as_of_text.as_str()),
+            ];
+            if let Some(token) = page_token.as_deref() {
+                query.push(("page_token", token));
+            }
+
+            let payload = self
+                .tick_page::<TradesResponse>(&url, &query, ticker, fetch.pages + 1)
+                .await?;
+            fetch.retries += payload.retries;
+            let payload = payload.page;
+
+            fetch.pages += 1;
+            let rows = payload
+                .trades
+                .and_then(|mut symbols| symbols.remove(ticker.as_str()))
+                .unwrap_or_default();
+            fetch.received += rows.len();
+            for row in rows {
+                let taped = row.tape.is_some();
+                match row.into_tick() {
+                    Some(tick) => accept(tick),
+                    // Counted apart: a row with no readable tape is one whose conditions cannot be
+                    // resolved at all, which is not the same fault as an unusable price.
+                    None if taped => fetch.rejected += 1,
+                    None => fetch.untaped += 1,
+                }
+            }
+
+            let Some(token) = payload.next_page_token else {
+                if fetch.rejected > 0 || fetch.untaped > 0 {
+                    debug!(
+                        %ticker,
+                        rejected = fetch.rejected,
+                        untaped = fetch.untaped,
+                        received = fetch.received,
+                        "Dropped prints that could not be folded"
+                    );
+                }
+                return Ok(fetch);
+            };
+            page_token = Some(token);
+        }
+
+        Err(ClientError::Parse(format!(
+            "{ticker} trade pagination did not end within {QUOTES_PAGE_LIMIT} pages"
         )))
     }
 
@@ -4493,6 +4654,162 @@ mod tests {
         assert!(boundary_for(&boundaries, "SPCX").is_some());
         first.assert_async().await;
         second.assert_async().await;
+    }
+
+    /// Collects what a trade fold would have seen, for the reason `collect_quotes` exists.
+    async fn collect_trades(base_url: String) -> (Vec<TradeTick>, Result<TradeFetch, ClientError>) {
+        let (start, end) = quote_window();
+        let mut ticks = Vec::new();
+        let fetch = client(base_url)
+            .fetch_trades(&ticker("AAPL"), start, end, date(2026, 8, 20), |tick| {
+                ticks.push(tick)
+            })
+            .await;
+        (ticks, fetch)
+    }
+
+    /// Conditions arrive as SIP characters and are kept as such, with the tape that reads them.
+    ///
+    /// Translating them to identifiers here would be lossy in the one direction that matters: a
+    /// character can name two conditions, which is what `Eligibility::Ambiguous` exists to say.
+    #[tokio::test]
+    async fn test_a_print_keeps_its_characters_and_the_tape_that_spells_them() {
+        let mut server = mockito::Server::new_async().await;
+        let page = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"trades":{"AAPL":[
+                    {"t":"2026-08-20T13:30:01Z","p":100.5,"s":100,"c":["@","F"],"z":"C"}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+
+        let (ticks, fetch) = collect_trades(server.url()).await;
+        let fetch = fetch.expect("one page must parse");
+
+        assert_eq!(ticks.len(), 1);
+        assert_eq!(
+            ticks[0].conditions(),
+            &TradeConditions::Spelled {
+                characters: vec![b'@', b'F'],
+                tape: Tape::UnlistedTradingPrivileges,
+            }
+        );
+        assert!(!ticks[0].corrected());
+        assert_eq!(fetch.received, 1);
+        assert_eq!(fetch.rejected, 0);
+        assert_eq!(fetch.untaped, 0);
+        page.assert_async().await;
+    }
+
+    /// A row with no readable tape is refused and counted apart.
+    ///
+    /// Folding it as unconditioned would admit exactly the prints the exclusion policy exists to
+    /// remove, because without a tape none of its characters can be resolved at all.
+    #[tokio::test]
+    async fn test_a_print_with_no_readable_tape_is_refused_rather_than_folded_unconditioned() {
+        let mut server = mockito::Server::new_async().await;
+        let page = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"trades":{"AAPL":[
+                    {"t":"2026-08-20T13:30:01Z","p":100.5,"s":100,"c":["@"]},
+                    {"t":"2026-08-20T13:30:02Z","p":100.6,"s":100,"c":["@"],"z":"Q"},
+                    {"t":"2026-08-20T13:30:03Z","p":100.7,"s":100,"c":["@"],"z":"A"}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+
+        let (ticks, fetch) = collect_trades(server.url()).await;
+        let fetch = fetch.expect("one page must parse");
+
+        // Only the `A` row survives: one has no tape at all and `Q` names no SIP.
+        assert_eq!(ticks.len(), 1);
+        assert_eq!(fetch.received, 3);
+        assert_eq!(fetch.untaped, 1, "the row carrying no tape field");
+        assert_eq!(fetch.rejected, 1, "the row whose letter names no SIP");
+        page.assert_async().await;
+    }
+
+    /// A revised print is marked corrected whatever the revision was, which is what the fold reads
+    /// before it reads anything else about the trade.
+    #[tokio::test]
+    async fn test_a_revised_print_is_marked_corrected() {
+        let mut server = mockito::Server::new_async().await;
+        let page = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"trades":{"AAPL":[
+                    {"t":"2026-08-20T13:30:01Z","p":100.5,"s":100,"c":["@"],"z":"A","u":"corrected"}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+
+        let (ticks, _) = collect_trades(server.url()).await;
+
+        assert!(ticks[0].corrected());
+        page.assert_async().await;
+    }
+
+    /// A condition token longer than one character names nothing this table can spell, and taking
+    /// its first byte would read it as a different condition entirely.
+    #[tokio::test]
+    async fn test_a_multi_character_condition_token_is_dropped_rather_than_truncated() {
+        let mut server = mockito::Server::new_async().await;
+        let page = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"trades":{"AAPL":[
+                    {"t":"2026-08-20T13:30:01Z","p":100.5,"s":100,"c":["@","FT"],"z":"A"}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+
+        let (ticks, _) = collect_trades(server.url()).await;
+
+        assert_eq!(
+            ticks[0].conditions(),
+            &TradeConditions::Spelled {
+                characters: vec![b'@'],
+                tape: Tape::ConsolidatedTapeAssociation,
+            },
+            "`FT` is dropped, not read as `F`"
+        );
+        page.assert_async().await;
+    }
+
+    /// The tick rule reads each print against the one before it, so a descending page would sign
+    /// every trade backwards. Pinned for the reason the quote path pins it.
+    #[tokio::test]
+    async fn test_the_trade_request_pins_ascending_order_and_the_session_as_of() {
+        let mut server = mockito::Server::new_async().await;
+        let page = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("sort".into(), "asc".into()),
+                mockito::Matcher::UrlEncoded("asof".into(), "2026-08-20".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"trades":{"AAPL":[]}}"#)
+            .create_async()
+            .await;
+
+        collect_trades(server.url()).await.1.expect("one page");
+
+        page.assert_async().await;
     }
 
     fn quote_window() -> (DateTime<Utc>, DateTime<Utc>) {

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -2220,14 +2220,24 @@ impl HistoricalTradePayload {
     /// cannot be resolved, and folding the print as unconditioned would silently admit exactly the
     /// prints the exclusion policy exists to remove.
     fn into_tick(self) -> Option<TradeTick> {
-        let tape = Tape::from_letter(*self.tape?.as_bytes().first()?)?;
+        // Exactly one byte, not the first of however many: `"CTA"` would otherwise be read as tape
+        // `C` and its conditions resolved against the wrong table, with nothing counting the row as
+        // malformed.
+        let letters = self.tape?;
+        let [letter] = letters.as_bytes() else {
+            return None;
+        };
+        let tape = Tape::from_letter(*letter)?;
         // A SIP condition is one character. A longer token is not one this table can spell, and
-        // taking its first byte would silently read it as a different condition.
+        // taking its first byte would silently read it as a different condition — so it is carried
+        // as unspellable rather than dropped, which would leave a malformed print looking ordinary.
         let characters: Vec<u8> = self
             .conditions
             .iter()
-            .filter(|condition| condition.len() == 1)
-            .filter_map(|condition| condition.as_bytes().first().copied())
+            .map(|condition| match condition.as_bytes() {
+                [character] => *character,
+                _ => TradeConditions::UNSPELLABLE,
+            })
             .collect();
         TradeTick::new(
             self.timestamp?,
@@ -4705,6 +4715,42 @@ mod tests {
         page.assert_async().await;
     }
 
+    /// A tape field that is not one character is refused rather than read by its first byte.
+    ///
+    /// `"CTA"` used to be accepted as tape `C`, so its conditions were resolved against the UTP
+    /// table while nothing counted the row as malformed. Pinned to `"CTA"` specifically because its
+    /// first byte is a *valid* tape letter, which is the case a length check catches and a
+    /// `from_letter` check alone does not.
+    #[tokio::test]
+    async fn test_a_multi_character_tape_is_refused_rather_than_read_by_its_first_letter() {
+        let mut server = mockito::Server::new_async().await;
+        let page = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"trades":{"AAPL":[
+                    {"t":"2026-08-20T13:30:01Z","p":100.5,"s":100,"c":["@"],"z":"CTA"}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+
+        let (ticks, fetch) = collect_trades(server.url()).await;
+        let fetch = fetch.expect("one page must parse");
+
+        assert!(ticks.is_empty(), "a malformed tape must fold no tick");
+        assert_eq!(fetch.received, 1);
+        // `rejected`, not `untaped`: the row carries a tape field, so it is malformed rather than
+        // absent, and the two counters exist to tell those faults apart.
+        assert_eq!(
+            fetch.rejected, 1,
+            "the row must be counted, not silently dropped"
+        );
+        assert_eq!(fetch.untaped, 0);
+        page.assert_async().await;
+    }
+
     /// A row with no readable tape is refused and counted apart.
     ///
     /// Folding it as unconditioned would admit exactly the prints the exclusion policy exists to
@@ -4760,10 +4806,14 @@ mod tests {
         page.assert_async().await;
     }
 
-    /// A condition token longer than one character names nothing this table can spell, and taking
-    /// its first byte would read it as a different condition entirely.
+    /// A condition token longer than one character is kept as unknown, never truncated or dropped.
+    ///
+    /// Truncating would read `FT` as `F`, a different condition entirely. Dropping it — which this
+    /// did until it was measured — let a print whose every token was malformed fold as ordinary,
+    /// fully-eligible volume with no exclusion recorded, and `into_tick` still returned a tick so
+    /// the fetch counters reported nothing either.
     #[tokio::test]
-    async fn test_a_multi_character_condition_token_is_dropped_rather_than_truncated() {
+    async fn test_a_multi_character_condition_token_is_kept_as_unknown_not_truncated_or_dropped() {
         let mut server = mockito::Server::new_async().await;
         let page = server
             .mock("GET", mockito::Matcher::Any)
@@ -4779,13 +4829,15 @@ mod tests {
 
         let (ticks, _) = collect_trades(server.url()).await;
 
+        // Pinned to the literal `0xFF` rather than to `TradeConditions::UNSPELLABLE`, so changing the
+        // sentinel's value has to be a deliberate edit here too.
         assert_eq!(
             ticks[0].conditions(),
             &TradeConditions::Spelled {
-                characters: vec![b'@'],
+                characters: vec![b'@', 0xFF],
                 tape: Tape::ConsolidatedTapeAssociation,
             },
-            "`FT` is dropped, not read as `F`"
+            "`FT` is unknown and stays in place; it is never read as `F` nor removed"
         );
         page.assert_async().await;
     }

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -2939,6 +2939,10 @@ mod tests {
         let (mut client, _requested) = client_serving(body.clone());
 
         let directory = std::env::temp_dir().join("fund-tee-retention-test");
+        // Cleared rather than merely created: the assertion below counts the directory's entries, and
+        // a staged object deliberately outlives the run that wrote it, so a second run on the same
+        // machine would count two. The path is fixed, so without this the test passes only once.
+        let _ = std::fs::remove_dir_all(&directory);
         std::fs::create_dir_all(&directory).expect("a staging directory");
         // A destination that refuses everything, so `store` fails after the download succeeded.
         client = client.teeing_raw_to(RawTee::new(

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -14,7 +14,7 @@ use tracing::{info, warn};
 
 use crate::common::alpaca::{QuoteTick, TradeTick};
 use crate::common::provenance::{MassivePlan, MassiveTransport, PartitionProvenance, Provenance};
-use crate::common::types::{BarInterval, EquityBar, Ticker};
+use crate::common::types::{BarInterval, EquityBar, Ticker, TradeConditions};
 
 /// The bucket every dataset lives under, which Massive support named on 2026-08-24.
 const FLAT_FILE_BUCKET: &str = "flatfiles";
@@ -1462,7 +1462,7 @@ impl TradeColumns {
             timestamp,
             field(self.price)?.parse::<f64>().ok()?,
             field(self.size)?.parse::<f64>().ok()?,
-            parse_conditions(field(self.conditions)?),
+            TradeConditions::Identified(parse_conditions(field(self.conditions)?)),
             // A blank cell is "no correction", not an unreadable row. The provider has never
             // emitted one in the data measured, and a row rejected for it would disappear into the
             // `unusable` count with nothing naming the cause.
@@ -2060,7 +2060,10 @@ mod tests {
         assert_eq!(tick.timestamp().timestamp_nanos_opt(), Some(stamp(0)));
         assert_eq!(tick.price(), 156.30);
         assert_eq!(tick.size(), 0.000_8);
-        assert_eq!(tick.conditions(), &[14, 12, 37, 41]);
+        assert_eq!(
+            tick.conditions(),
+            &TradeConditions::Identified(vec![14, 12, 37, 41])
+        );
         assert!(!tick.corrected());
     }
 

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -791,6 +791,13 @@ pub enum TradeConditions {
 }
 
 impl TradeConditions {
+    /// Stands in for a token no condition table can spell, so it resolves as unknown.
+    ///
+    /// A SIP condition is one character, and `0xFF` is not one: it is outside ASCII, so no row can
+    /// claim it and every lookup answers empty. A malformed token therefore reads exactly like an
+    /// unrecognized character rather than vanishing and leaving the print looking ordinary.
+    pub const UNSPELLABLE: u8 = 0xFF;
+
     /// Whether anything is spelled here at all, which an unconditioned print is.
     pub fn is_empty(&self) -> bool {
         match self {

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -752,6 +752,18 @@ impl Tape {
             _ => None,
         }
     }
+
+    /// The tape Alpaca's letter names, which is the same three SIPs spelled differently.
+    ///
+    /// `A` and `B` are both CTA for the reason `1` and `2` are. There is no letter for FINRA: a TRF
+    /// print is disseminated on the tape of its listing venue, so it arrives as `A`, `B` or `C`.
+    pub fn from_letter(letter: u8) -> Option<Self> {
+        match letter {
+            b'A' | b'B' => Some(Tape::ConsolidatedTapeAssociation),
+            b'C' => Some(Tape::UnlistedTradingPrivileges),
+            _ => None,
+        }
+    }
 }
 
 impl std::fmt::Display for Tape {
@@ -761,6 +773,30 @@ impl std::fmt::Display for Tape {
             Tape::UnlistedTradingPrivileges => "UTP",
             Tape::TradeDataDissemination => "FINRA_TDDS",
         })
+    }
+}
+
+/// How a provider spells the sale conditions on a print.
+///
+/// Massive publishes identifiers, which name a condition outright, and Alpaca publishes the SIP
+/// characters, which name one only alongside the tape that carried them — the same condition is `B`
+/// on CTA and `W` on UTP. Carrying the spelling beside the values is what stops a character being
+/// read against the wrong table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TradeConditions {
+    /// The provider's own identifiers.
+    Identified(Vec<u32>),
+    /// SIP characters, readable only against the tape that published them.
+    Spelled { characters: Vec<u8>, tape: Tape },
+}
+
+impl TradeConditions {
+    /// Whether anything is spelled here at all, which an unconditioned print is.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            TradeConditions::Identified(identifiers) => identifiers.is_empty(),
+            TradeConditions::Spelled { characters, .. } => characters.is_empty(),
+        }
     }
 }
 

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -2603,17 +2603,11 @@ pub async fn check_cadence_agreement(
     Ok(totals)
 }
 
-/// Folds the printed tape across `sessions`, per `scope`, out of Massive's flat files, which must
-/// already be calendar-filtered on the same terms as the quote pass.
-///
-/// Session-major and flat-file only. There is no per-name variant because there is no repair path:
-/// a trade file is the session, so a name missing from it is missing from the tape rather than from
-/// a fetch that can be retried.
 /// Where a trade pass gets its prints.
 ///
-/// The same split as [`QuoteSource`], and load-bearing for the same reason it is on quotes: a Massive
-/// flat file is whole-market and the only affordable route to five years, while Alpaca answers one
-/// name at a time and is the only route that reaches past Massive's five-year window at all.
+/// The same split as [`QuoteSource`], and load-bearing for the same reason: a Massive flat file is
+/// whole-market and the only affordable route to five years, while Alpaca answers one name at a time
+/// and is the only route reaching past Massive's five-year window.
 pub enum TradeSource<'a> {
     /// One request per name, retried per name.
     PerName(&'a MarketDataClient),
@@ -2643,6 +2637,11 @@ impl std::fmt::Display for TradeSource<'_> {
     }
 }
 
+/// Folds the printed tape across `sessions`, per `scope`, from whichever route `source` names.
+///
+/// `sessions` must already be calendar-filtered on the same terms as the quote pass. A whole-session
+/// fold treats a name absent from the file as absent from the tape, while a per-name fold treats it
+/// as a fetch that can be retried — which is why the two report a failed symbol differently.
 pub async fn archive_trade_sessions(
     s3_client: &S3Client,
     source: &TradeSource<'_>,
@@ -2695,12 +2694,19 @@ pub async fn archive_trade_sessions(
     }
 
     if progress.symbols_failed > 0 {
-        // Deliberately not the quote pass's "re-run to repair": re-running skips the session, whose
-        // daily partition is now written, and the flat file would answer the same way if it did not.
-        warn!(
-            symbols_failed = progress.symbols_failed,
-            "Some symbols in the universe never printed in these sessions' trade files; only a widen pass revisits them"
-        );
+        // The two routes fail differently, and the remedy differs with them: a flat file that does
+        // not carry a name is answering, so re-running reads the same absence, while a per-name
+        // fetch that failed is a request to make again.
+        match source {
+            TradeSource::WholeSession(_) => warn!(
+                symbols_failed = progress.symbols_failed,
+                "Some symbols in the universe never printed in these sessions' trade files; only a widen pass revisits them"
+            ),
+            TradeSource::PerName(_) => warn!(
+                symbols_failed = progress.symbols_failed,
+                "Some symbols' trade fetches failed; a repair pass naming them fetches them again"
+            ),
+        }
     }
     info!(
         sessions_requested = progress.sessions_requested,
@@ -2791,7 +2797,15 @@ async fn archive_trade_session(
         progress.sessions_without_data += 1;
         return Ok(trades_folded);
     }
-    write_trade_partitions(s3_client, bucket, session, summaries, progress).await?;
+    write_trade_partitions(
+        s3_client,
+        bucket,
+        session,
+        summaries,
+        progress,
+        source.provenance(),
+    )
+    .await?;
     Ok(trades_folded)
 }
 
@@ -2961,6 +2975,7 @@ async fn write_trade_partitions(
     session: SessionDate,
     folded: Vec<TradeSummary>,
     progress: &mut PassProgress,
+    provenance: Provenance,
 ) -> Result<(), ArchiveError> {
     let mut one_minute: Vec<TradeSummary> = Vec::new();
     let mut five_minute: Vec<TradeSummary> = Vec::new();
@@ -2991,8 +3006,10 @@ async fn write_trade_partitions(
             frame,
             |existing, fetched, key| merge_or_replace(existing, fetched, key),
             DerivedDataset::Trades,
-            // Trades have one route and no repair path: a trade file *is* the session.
-            RawDataset::Trades.provenance(),
+            // Carried from the source rather than named here: a repair folds Alpaca into a partition
+            // a flat file built, and filing that as Massive-only would hide the provider seam in the
+            // one record that exists to expose it.
+            provenance,
         )
         .await
         {
@@ -3431,6 +3448,8 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use super::*;
+    use crate::common::alpaca::TradeTick;
+    use crate::common::types::TradeConditions;
     use aws_smithy_http_client::test_util::infallible_client_fn;
     use aws_smithy_types::body::SdkBody;
     use chrono::NaiveDate;
@@ -3472,6 +3491,39 @@ mod tests {
         )
     }
 
+    /// As [`scripted_s3_client`], but the responder also sees the request body.
+    ///
+    /// Needed where the assertion is about what was *written* rather than where: a provenance record
+    /// is only checkable by reading the bytes it put.
+    fn scripted_s3_client_capturing(
+        respond: impl Fn(&http::Method, &str, &str) -> http::Response<SdkBody> + Send + Sync + 'static,
+    ) -> S3Client {
+        let http_client = infallible_client_fn(move |request| {
+            let method = request.method().clone();
+            let key = percent_decode_str(request.uri().path()).decode_utf8_lossy();
+            let body = request
+                .body()
+                .bytes()
+                .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+                .unwrap_or_default();
+            respond(&method, &key, &body)
+        });
+        S3Client::from_conf(
+            aws_sdk_s3::Config::builder()
+                .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
+                .region(aws_sdk_s3::config::Region::new("us-east-1"))
+                .credentials_provider(aws_sdk_s3::config::Credentials::new(
+                    "test-key",
+                    "test-secret",
+                    None,
+                    None,
+                    "test",
+                ))
+                .http_client(http_client)
+                .build(),
+        )
+    }
+
     /// Absent, so `write_merged` takes its `Precondition::Absent` path and writes without a merge.
     fn no_such_key() -> http::Response<SdkBody> {
         http::Response::builder()
@@ -3496,6 +3548,99 @@ mod tests {
             None,
         )
         .expect("a coherent candle must construct")
+    }
+
+    /// One name's session, folded from a single ordinary print.
+    fn one_trade_summary(ticker_symbol: &str, at: SessionDate) -> Vec<TradeSummary> {
+        let open = at.midnight();
+        let close = open + chrono::Duration::minutes(5);
+        let mut fold = crate::data::trades::SessionFold::new(
+            Ticker::new(ticker_symbol).expect("a test ticker must parse"),
+            at,
+            open,
+            close,
+        )
+        .expect("a positive session must open");
+        fold.push(
+            TradeTick::new(
+                open + chrono::Duration::seconds(1),
+                100.0,
+                10.0,
+                TradeConditions::Identified(Vec::new()),
+                false,
+            )
+            .expect("an ordinary print must construct"),
+        );
+        fold.finish()
+    }
+
+    /// A partition records the route that actually built it, not the route trades used to have.
+    ///
+    /// `write_trade_partitions` hard-coded the flat-file provenance behind a comment reading "trades
+    /// have one route and no repair path". Adding the Alpaca per-name route made that false, and an
+    /// `equity-trades repair` would have filed Alpaca rows as Massive — hiding the provider seam in
+    /// the one record kept to expose it. `TradeSource::provenance()` existed throughout and was
+    /// never called.
+    #[tokio::test]
+    async fn test_a_trade_partition_is_attributed_to_the_route_that_built_it() {
+        let bodies: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let recorder = Arc::clone(&bodies);
+        let client = scripted_s3_client_capturing(move |method, key, body| {
+            if method == http::Method::PUT && key.ends_with(".provenance.json") {
+                recorder
+                    .lock()
+                    .expect("the recorder must not be poisoned")
+                    .push(body.to_string());
+                http::Response::builder()
+                    .status(200)
+                    .body(SdkBody::empty())
+                    .expect("a canned response must build")
+            } else if method == http::Method::PUT {
+                http::Response::builder()
+                    .status(200)
+                    .body(SdkBody::empty())
+                    .expect("a canned response must build")
+            } else {
+                no_such_key()
+            }
+        });
+
+        let at = session(2026, 9, 3);
+        let mut progress = PassProgress::default();
+        let credentials = crate::common::alpaca::AlpacaCredentials::new(
+            "test-key".to_string(),
+            "test-secret".to_string(),
+        )
+        .expect("test credentials must construct");
+        let market_data = MarketDataClient::new(credentials, crate::common::alpaca::DataFeed::Sip);
+        write_trade_partitions(
+            &client,
+            "test-bucket",
+            at,
+            one_trade_summary("AAPL", at),
+            &mut progress,
+            TradeSource::PerName(&market_data).provenance(),
+        )
+        .await
+        .expect("the partition must be written");
+
+        let written = bodies
+            .lock()
+            .expect("the recorder must not be poisoned")
+            .clone();
+        assert!(!written.is_empty(), "a sidecar must have been written");
+        // Pinned to the literal strings the record carries on the wire, not to `Provenance`'s own
+        // accessors, so a rename that moved both together would still fail here.
+        for record in &written {
+            assert!(
+                record.contains("\"provider\":\"alpaca\""),
+                "a per-name fold is Alpaca's; wrote {record}"
+            );
+            assert!(
+                !record.contains("\"provider\":\"massive\""),
+                "a per-name fold must not be filed as a flat file; wrote {record}"
+            );
+        }
     }
 
     /// Each cadence lands under its own hive partition, and trades never collide with quotes.

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -2609,9 +2609,43 @@ pub async fn check_cadence_agreement(
 /// Session-major and flat-file only. There is no per-name variant because there is no repair path:
 /// a trade file is the session, so a name missing from it is missing from the tape rather than from
 /// a fetch that can be retried.
+/// Where a trade pass gets its prints.
+///
+/// The same split as [`QuoteSource`], and load-bearing for the same reason it is on quotes: a Massive
+/// flat file is whole-market and the only affordable route to five years, while Alpaca answers one
+/// name at a time and is the only route that reaches past Massive's five-year window at all.
+pub enum TradeSource<'a> {
+    /// One request per name, retried per name.
+    PerName(&'a MarketDataClient),
+    /// One file per session, folded whole.
+    WholeSession(&'a FlatFileClient),
+}
+
+impl TradeSource<'_> {
+    /// Where this route's prints came from.
+    ///
+    /// Derived from the variant rather than passed beside it, so a session folded from Alpaca cannot
+    /// be filed as having come from a flat file.
+    pub const fn provenance(&self) -> Provenance {
+        match self {
+            TradeSource::PerName(_) => Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
+            TradeSource::WholeSession(_) => RawDataset::Trades.provenance(),
+        }
+    }
+}
+
+impl std::fmt::Display for TradeSource<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            TradeSource::PerName(_) => "per-name",
+            TradeSource::WholeSession(_) => "whole-session",
+        })
+    }
+}
+
 pub async fn archive_trade_sessions(
     s3_client: &S3Client,
-    flat_files: &FlatFileClient,
+    source: &TradeSource<'_>,
     calendar: &TradingCalendar,
     bucket: &str,
     sessions: &[SessionDate],
@@ -2650,7 +2684,7 @@ pub async fn archive_trade_sessions(
     for session in requested {
         trades_folded += archive_trade_session(
             s3_client,
-            flat_files,
+            source,
             calendar,
             bucket,
             session,
@@ -2685,7 +2719,7 @@ pub async fn archive_trade_sessions(
 #[allow(clippy::too_many_arguments)]
 async fn archive_trade_session(
     s3_client: &S3Client,
-    flat_files: &FlatFileClient,
+    source: &TradeSource<'_>,
     calendar: &TradingCalendar,
     bucket: &str,
     session: SessionDate,
@@ -2715,36 +2749,112 @@ async fn archive_trade_session(
         return Ok(0);
     }
 
-    info!(%session, %open, %close, universe = universe.len(), "Folding a session's printed tape");
+    info!(%session, %open, %close, %source, universe = universe.len(), "Folding a session's printed tape");
     let requested = universe.len();
-    let Some(fold) = trades::MarketFold::new(session, open, close, universe) else {
-        // Unreachable while `trading_hours` returns a published session, and cheap to say so rather
-        // than fold nothing and report the whole universe as its cost.
-        warn!(%session, %open, %close, "The session spans no time; leaving it unsummarized");
-        progress.sessions_without_data += 1;
-        return Ok(0);
-    };
-    let folded = match flat_files.fold_trades(session.date(), fold).await {
-        Ok((_, fold)) => fold.finish(),
-        Err(error) => {
-            // The file is the session: nothing partial survives it.
-            warn!(%session, %error, "A session's trade file could not be folded");
-            progress.sessions_failed.push(session);
-            return Ok(0);
+    // A tuple rather than a `SessionFolded` from both arms: `seen` is what the *file* carried, and
+    // the per-name route has no equivalent -- it counts failed fetches directly, so a value invented
+    // for it here would be read later as though a file had reported it.
+    let (summaries, trades_folded) = match source {
+        TradeSource::PerName(market_data) => {
+            fold_trade_universe(market_data, session, open, close, &universe, progress).await
+        }
+        TradeSource::WholeSession(flat_files) => {
+            let Some(fold) = trades::MarketFold::new(session, open, close, universe) else {
+                // Unreachable while `trading_hours` returns a published session, and cheap to say so
+                // rather than fold nothing and report the whole universe as its cost.
+                warn!(%session, %open, %close, "The session spans no time; leaving it unsummarized");
+                progress.sessions_without_data += 1;
+                return Ok(0);
+            };
+            match flat_files.fold_trades(session.date(), fold).await {
+                Ok((_, fold)) => {
+                    let folded = fold.finish();
+                    // Counted against what the file carried: a name that was there and never printed
+                    // is not a failure, and counting it would make almost every whole-market session
+                    // exit non-zero.
+                    progress.symbols_failed += requested.saturating_sub(folded.seen);
+                    if !folded.resumed.is_empty() {
+                        info!(%session, resumed = folded.resumed.len(), "Names whose trades arrived in more than one run");
+                    }
+                    (folded.summaries, folded.folded)
+                }
+                Err(error) => {
+                    // The file is the session: nothing partial survives it.
+                    warn!(%session, %error, "A session's trade file could not be folded");
+                    progress.sessions_failed.push(session);
+                    return Ok(0);
+                }
+            }
         }
     };
-
-    let trades_folded = folded.folded;
-    progress.symbols_failed += requested.saturating_sub(folded.seen);
-    if !folded.resumed.is_empty() {
-        info!(%session, resumed = folded.resumed.len(), "Names whose trades arrived in more than one run");
-    }
-    if folded.summaries.is_empty() {
+    if summaries.is_empty() {
         progress.sessions_without_data += 1;
         return Ok(trades_folded);
     }
-    write_trade_partitions(s3_client, bucket, session, folded.summaries, progress).await?;
+    write_trade_partitions(s3_client, bucket, session, summaries, progress).await?;
     Ok(trades_folded)
+}
+
+/// Fans out over the universe, folding each name's prints and keeping the summaries and the cost.
+///
+/// A symbol's failure costs that symbol rather than the session, as on the quote path: the other
+/// names are already fetched and discarding them would mean paying for them twice.
+async fn fold_trade_universe(
+    market_data: &MarketDataClient,
+    session: SessionDate,
+    open: DateTime<Utc>,
+    close: DateTime<Utc>,
+    universe: &BTreeSet<Ticker>,
+    progress: &mut PassProgress,
+) -> (Vec<TradeSummary>, usize) {
+    let mut pending: Vec<Ticker> = universe.iter().cloned().collect();
+    let mut tasks = tokio::task::JoinSet::new();
+    let mut folded: Vec<TradeSummary> = Vec::new();
+    let mut trades_folded = 0usize;
+
+    loop {
+        while tasks.len() < QUOTE_CONCURRENCY {
+            let Some(ticker) = pending.pop() else { break };
+            let client = market_data.clone();
+            tasks.spawn(async move {
+                let mut last_error = None;
+                for attempt in 0..QUOTE_SYMBOL_ATTEMPTS {
+                    match trades::fold_session(&client, &ticker, session, open, close).await {
+                        Ok(folded) => return Ok(folded),
+                        Err(error) => {
+                            if !error.is_transient() {
+                                return Err((ticker, error));
+                            }
+                            last_error = Some(error);
+                        }
+                    }
+                    tokio::time::sleep(retry_delay(attempt)).await;
+                }
+                Err((
+                    ticker,
+                    last_error.expect("a failed attempt records its error"),
+                ))
+            });
+        }
+        let Some(finished) = tasks.join_next().await else {
+            break;
+        };
+        match finished {
+            Ok(Ok((summaries, fetch))) => {
+                trades_folded += fetch.received;
+                folded.extend(summaries);
+            }
+            Ok(Err((ticker, error))) => {
+                progress.symbols_failed += 1;
+                warn!(%ticker, %session, %error, "A symbol's trade fetch failed; continuing the session");
+            }
+            Err(error) => {
+                progress.symbols_failed += 1;
+                warn!(%error, %session, "A trade fold task did not complete");
+            }
+        }
+    }
+    (folded, trades_folded)
 }
 
 /// Writes one-minute bar partitions across `sessions`, per `scope`.

--- a/src/data/conditions.rs
+++ b/src/data/conditions.rs
@@ -250,6 +250,41 @@ mod tests {
         assert_eq!(volume_eligibility(&[15, 9_999]), Eligibility::Ineligible);
     }
 
+    /// The unspellable sentinel resolves as unknown on every tape, which is the whole point of it.
+    ///
+    /// The transport substitutes it for a condition token no table can spell. If any tape ever
+    /// claimed that byte it would resolve to a real condition instead, and a malformed print would
+    /// silently acquire that condition's eligibility.
+    #[test]
+    fn test_the_unspellable_sentinel_is_ambiguous_on_every_tape() {
+        for tape in [
+            Tape::ConsolidatedTapeAssociation,
+            Tape::UnlistedTradingPrivileges,
+            Tape::TradeDataDissemination,
+        ] {
+            assert!(
+                by_character(TradeConditions::UNSPELLABLE, tape).is_empty(),
+                "no row may claim the sentinel on {tape:?}"
+            );
+            assert_eq!(
+                volume_eligibility_from_characters(&[TradeConditions::UNSPELLABLE], tape),
+                Eligibility::Ambiguous,
+                "an unspellable token must stay visible on {tape:?}"
+            );
+        }
+        // A token we cannot read does not rescue one we can. Pinned to `M` — "Market Center Official
+        // Close", identifier 15, `updates_volume: false` — rather than to a lookup, because a test
+        // that resolved the character through the table it is checking would pass against an empty
+        // one.
+        assert_eq!(
+            volume_eligibility_from_characters(
+                &[b'M', TradeConditions::UNSPELLABLE],
+                Tape::ConsolidatedTapeAssociation
+            ),
+            Eligibility::Ineligible
+        );
+    }
+
     /// The house rule keeps odd lots and drops the two conventions that are not market prices.
     #[test]
     fn test_the_house_spread_rule_drops_only_prices_that_are_not_market_prices() {

--- a/src/data/conditions.rs
+++ b/src/data/conditions.rs
@@ -2,7 +2,7 @@
 //!
 //! Massive spells a condition by identifier and Alpaca by SIP character; both resolve here first.
 
-use crate::common::types::Tape;
+use crate::common::types::{Tape, TradeConditions};
 use crate::data::conditions_table::SALE_CONDITIONS;
 
 /// One row of the provider's sale-condition reference.
@@ -90,6 +90,47 @@ pub fn volume_eligibility(identifiers: &[u32]) -> Eligibility {
     }
 }
 
+/// The marker a SIP spells "no condition applies" with, which is not a condition.
+///
+/// Tape-dependent like every other spelling here: CTA writes a space and UTP an at-sign. The
+/// provider's reference table has no row for either, because Massive says the same thing by sending
+/// no conditions at all while Alpaca states it on nearly every print.
+///
+/// Counting it unknown reported the whole tape as unreadable — measured on 2026-08-20, 688,578 of
+/// AAPL's 688,608 prints and 573,781 of SPY's 573,791. Fixing only the at-sign left SPY unchanged,
+/// which is what identified the tape as the axis rather than the character.
+fn regular_sale_on(tape: Tape) -> u8 {
+    match tape {
+        Tape::ConsolidatedTapeAssociation => b' ',
+        // Alpaca reaches neither of these with a `D`, so FINRA arrives spelled as its listing
+        // venue's tape rather than its own; the at-sign is UTP's and is what a `C` row carries.
+        Tape::UnlistedTradingPrivileges | Tape::TradeDataDissemination => b'@',
+    }
+}
+
+/// The volume rule, asked of however the provider spelled the conditions.
+///
+/// The dispatch lives here rather than at the fold, so a caller cannot read Alpaca's characters
+/// against the identifier table by reaching for the wrong function.
+pub fn volume_eligibility_of(conditions: &TradeConditions) -> Eligibility {
+    match conditions {
+        TradeConditions::Identified(identifiers) => volume_eligibility(identifiers),
+        TradeConditions::Spelled { characters, tape } => {
+            volume_eligibility_from_characters(characters, *tape)
+        }
+    }
+}
+
+/// The market-price question, asked of however the provider spelled the conditions.
+pub fn carries_a_market_price_of(conditions: &TradeConditions) -> bool {
+    match conditions {
+        TradeConditions::Identified(identifiers) => carries_a_market_price(identifiers),
+        TradeConditions::Spelled { characters, tape } => {
+            carries_a_market_price_from_characters(characters, *tape)
+        }
+    }
+}
+
 /// The same question asked of Alpaca's characters, which is answerable only when they agree.
 ///
 /// Every colliding character pair agrees on `updates_volume` today, so this returns [`Eligibility::
@@ -98,6 +139,9 @@ pub fn volume_eligibility(identifiers: &[u32]) -> Eligibility {
 pub fn volume_eligibility_from_characters(characters: &[u8], tape: Tape) -> Eligibility {
     let mut unresolved = false;
     for character in characters {
+        if *character == regular_sale_on(tape) {
+            continue;
+        }
         let candidates = by_character(*character, tape);
         if candidates.is_empty() {
             unresolved = true;
@@ -351,5 +395,90 @@ mod tests {
                 .all(|pair| pair[0].identifier < pair[1].identifier),
             "identifiers must ascend without repeating, which `by_identifier` assumes"
         );
+    }
+
+    /// The regular-sale marker is spelled differently per tape, and reading the wrong one reports
+    /// the whole tape as unreadable.
+    ///
+    /// Pinned per tape rather than as one character: fixing only the at-sign left every NYSE-listed
+    /// name at ~100% ambiguous, because CTA writes a space. Both are asserted as *eligible*, which
+    /// is the observable difference — an unrecognized character is merely ambiguous, so a test that
+    /// only checked "not ineligible" would pass with the marker unhandled.
+    #[test]
+    fn test_the_regular_sale_marker_is_read_on_each_tape_that_spells_it() {
+        assert_eq!(
+            volume_eligibility_from_characters(b" ", Tape::ConsolidatedTapeAssociation),
+            Eligibility::Eligible,
+            "CTA spells an ordinary print with a space"
+        );
+        assert_eq!(
+            volume_eligibility_from_characters(b"@", Tape::UnlistedTradingPrivileges),
+            Eligibility::Eligible,
+            "UTP spells it with an at-sign"
+        );
+
+        // Beside a real condition it still resolves, which is the common shape on the tape: a
+        // regular sale that also updates the last price arrives as two characters, not one.
+        assert_eq!(
+            volume_eligibility_from_characters(b" I", Tape::ConsolidatedTapeAssociation),
+            volume_eligibility_from_characters(b"I", Tape::ConsolidatedTapeAssociation),
+            "the marker contributes nothing beyond itself"
+        );
+    }
+
+    /// The dispatch is the point: Alpaca's characters must not reach the identifier table.
+    ///
+    /// Pinned on `M`, which is the one input where the two tables actually disagree. As a character
+    /// it is Market Center Official Close and volume-ineligible; its byte, 77, names no identifier
+    /// at all and would resolve as merely ambiguous. Comparing against the sibling function instead
+    /// proved nothing -- a mutation swapping the tables passed, because the inputs I first chose
+    /// happened to agree.
+    #[test]
+    fn test_each_spelling_is_read_against_its_own_table() {
+        let spelled = TradeConditions::Spelled {
+            characters: vec![b'M'],
+            tape: Tape::ConsolidatedTapeAssociation,
+        };
+        assert_eq!(volume_eligibility_of(&spelled), Eligibility::Ineligible);
+
+        // The same byte read as an identifier, which is what reading it against the wrong table
+        // would do. A different answer, which is what makes the assertion above load-bearing.
+        assert_eq!(
+            volume_eligibility(&[u32::from(b'M')]),
+            Eligibility::Ambiguous
+        );
+
+        // And the identifier spelling still resolves as an identifier.
+        assert_eq!(
+            volume_eligibility_of(&TradeConditions::Identified(vec![15])),
+            Eligibility::Ineligible,
+            "identifier 15 is the same condition, spelled the other way"
+        );
+    }
+
+    /// The same character names different conditions on different tapes, which is the whole reason
+    /// a character cannot be read without one.
+    #[test]
+    fn test_alpacas_tape_letters_name_the_same_sips_as_the_numeric_markers() {
+        assert_eq!(
+            Tape::from_letter(b'A'),
+            Some(Tape::ConsolidatedTapeAssociation)
+        );
+        assert_eq!(
+            Tape::from_letter(b'B'),
+            Some(Tape::ConsolidatedTapeAssociation)
+        );
+        assert_eq!(
+            Tape::from_letter(b'C'),
+            Some(Tape::UnlistedTradingPrivileges)
+        );
+        // No letter names FINRA: a TRF print is disseminated on its listing venue's tape.
+        assert_eq!(Tape::from_letter(b'D'), None);
+        assert_eq!(Tape::from_letter(b'Q'), None);
+
+        // The two spellings agree about which SIP they mean, which is what lets one table serve
+        // both providers.
+        assert_eq!(Tape::from_letter(b'A'), Tape::from_marker(1));
+        assert_eq!(Tape::from_letter(b'C'), Tape::from_marker(3));
     }
 }

--- a/src/data/trades.rs
+++ b/src/data/trades.rs
@@ -9,12 +9,12 @@ use chrono_tz::America::New_York;
 use polars::prelude::*;
 use tracing::warn;
 
-use crate::common::alpaca::TradeTick;
+use crate::common::alpaca::{ClientError, MarketDataClient, TradeFetch, TradeTick};
 use crate::common::flatfiles::TradeSink;
 use crate::common::types::{
     BarInterval, IntradayCadence, SessionDate, Ticker, TradeExclusions, TradeSummary,
 };
-use crate::data::conditions::{carries_a_market_price, volume_eligibility, Eligibility};
+use crate::data::conditions::{carries_a_market_price_of, volume_eligibility_of, Eligibility};
 
 /// The upper quantile every summary reports beside its median.
 const UPPER_QUANTILE: f64 = 0.9;
@@ -208,7 +208,7 @@ impl SessionFold {
             bucket.exclusions.record_correction(tick.notional());
             return;
         }
-        match volume_eligibility(tick.conditions()) {
+        match volume_eligibility_of(tick.conditions()) {
             Eligibility::Ineligible => {
                 bucket.exclusions.record_volume_ineligible(tick.notional());
                 return;
@@ -218,7 +218,7 @@ impl SessionFold {
             Eligibility::Ambiguous => bucket.exclusions.record_unresolved_condition(),
             Eligibility::Eligible => {}
         }
-        if !carries_a_market_price(tick.conditions()) {
+        if !carries_a_market_price_of(tick.conditions()) {
             bucket.exclusions.record_non_market_price(tick.notional());
         }
         bucket.add(&tick, direction);
@@ -461,6 +461,29 @@ impl TradeSink for MarketFold {
     }
 }
 
+/// Folds one name's session from Alpaca, holding the prints only long enough to weigh each one.
+///
+/// The per-name counterpart to the whole-market flat-file fold, and the only route that reaches past
+/// Massive's five-year window — which covers every Massive transport, so this is what a repair of an
+/// older session has to use.
+pub async fn fold_session(
+    market_data: &MarketDataClient,
+    ticker: &Ticker,
+    session: SessionDate,
+    open: DateTime<Utc>,
+    close: DateTime<Utc>,
+) -> Result<(Vec<TradeSummary>, TradeFetch), ClientError> {
+    let Some(mut fold) = SessionFold::new(ticker.clone(), session, open, close) else {
+        return Err(ClientError::Parse(format!(
+            "{session} spans no time between {open} and {close}"
+        )));
+    };
+    let fetch = market_data
+        .fetch_trades(ticker, open, close, session.date(), |tick| fold.push(tick))
+        .await?;
+    Ok((fold.finish(), fetch))
+}
+
 /// Builds the canonical trade frame, in [`TRADE_FRAME_COLUMNS`] order.
 pub fn summaries_to_dataframe(summaries: &[TradeSummary]) -> Result<DataFrame, PolarsError> {
     let column = |name: &str, values: Vec<f64>| Column::new(name.into(), values);
@@ -582,6 +605,8 @@ pub fn summaries_to_dataframe(summaries: &[TradeSummary]) -> Result<DataFrame, P
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::common::types::TradeConditions;
     use chrono::NaiveDate;
 
     fn ticker() -> Ticker {
@@ -602,7 +627,14 @@ mod tests {
     }
 
     fn trade(minute: u32, price: f64, size: f64) -> TradeTick {
-        TradeTick::new(at(minute, 0), price, size, Vec::new(), false).expect("a usable print")
+        TradeTick::new(
+            at(minute, 0),
+            price,
+            size,
+            TradeConditions::Identified(Vec::new()),
+            false,
+        )
+        .expect("a usable print")
     }
 
     fn marked(
@@ -612,7 +644,14 @@ mod tests {
         conditions: Vec<u32>,
         corrected: bool,
     ) -> TradeTick {
-        TradeTick::new(at(minute, 0), price, size, conditions, corrected).expect("a usable print")
+        TradeTick::new(
+            at(minute, 0),
+            price,
+            size,
+            TradeConditions::Identified(conditions),
+            corrected,
+        )
+        .expect("a usable print")
     }
 
     fn fold_of(ticks: Vec<TradeTick>) -> Vec<TradeSummary> {


### PR DESCRIPTION
# Overview

First of three for task 13, the nightly that keeps `data/**` current. Trade summaries were the one dataset with **no route to a nightly at all**: Massive's `trades_v1` needs Developer and the subscription reverts to Starter, while Alpaca had `fetch_quotes` and no trade equivalent.

## Changes

- `MarketDataClient::fetch_trades`, mirroring `fetch_quotes` — streamed through a closure, pinned `sort=asc` because the tick rule reads each print against the one before it, and `asof` set to the session being fetched so a reassigned symbol does not resolve through today's table.
- `TradeConditions` carries *how* a provider spells conditions, since a SIP character names a condition only alongside its tape. The dispatch lives beside the tables in `data/conditions.rs`, not at the fold.
- `TradeSource` mirrors `QuoteSource`, deriving provenance from the variant so an Alpaca fold cannot be filed as a flat file.
- The page-retry helper is now generic over the envelope rather than duplicated.
- `equity-trades repair` and `equity-trades measure`, which the `TradeAction` docstring previously said were impossible.

`conditions.rs` already had `volume_eligibility_from_characters` and `carries_a_market_price_from_characters` with **no production caller** — they were built in anticipation of exactly this. This is that caller.

## Two defects that only real data would have found

Both would have passed any fixture I would have thought to write.

**The regular-sale marker is not in the provider's table**, because it names the *absence* of a condition rather than one. Massive says that by sending no conditions; Alpaca states it explicitly on nearly every print. Read as unknown, it made **688,578 of AAPL's 688,608 prints ambiguous** on 2026-08-20 — the entire tape reported as unreadable.

**Fixing it as one character fixed Nasdaq and changed nothing for NYSE.** That is what identified the tape as the axis rather than the character: CTA writes a space, UTP an at-sign. Verified against Alpaca directly — SPY's prints arrive as `[" "]`, `[" ","I"]`, `[" ","F"]`.

After the fix, five names across three listing venues resolve every condition:

| ticker | venue | trades | unresolved |
|---|---|---|---|
| AAPL | Nasdaq | 688,608 | 0 |
| MSFT | Nasdaq | 339,490 | 0 |
| SPY | Arca | 573,791 | 0 |
| BAC | NYSE | 198,059 | 0 |
| XOM | NYSE | 158,302 | 0 |

## Review round: one P1, and it was load-bearing

**`write_trade_partitions` hard-coded the flat-file provenance**, behind a comment reading *"trades have one route and no repair path: a trade file is the session."* This pull request is exactly what made that false. `TradeSource::provenance()` was defined and **never called** — dead code — so an `equity-trades repair` would have folded Alpaca rows into a partition and filed them as Massive.

Flagged independently by Greptile and Copilot. It matters more than a metadata wart: the provenance sidecar is the only record of which provider built a partition, and the seam investigation below reads it to decide which sessions can be compared at all.

Fixed by threading `source.provenance()` through, as the quote path already did. The new test was mutated to confirm it is load-bearing — with the fix reverted it fails with the bug verbatim, a per-name fold recorded as `"provider":"massive","transport":"flat_file"`.

Also from the round:

- The stale docstring above `TradeSource` is removed and `archive_trade_sessions` documented for what it now does.
- The pass-level failure warning is source-aware: a failed per-name fetch is retryable and no longer directs operators to `Widen`.
- `equity-trades repair` and `measure` take their own arguments. They previously accepted `--tee-raw`, `--staging-directory` and `--cadence` and silently ignored all three — `measure` is read-only and can never tee.
- **A malformed tape is refused rather than read by its first byte.** `"CTA"` was accepted as tape `C` and its conditions resolved against the UTP table, with nothing counting the row as malformed. It now counts as `rejected`, which is the right counter: the field is present but unreadable, as distinct from `untaped`.
- **An unspellable condition token is carried as unknown rather than dropped.** This reverses a decision made earlier in this branch. Dropping preserved the original intent — never truncate `FT` into `F` — but let a print whose every token was malformed fold as ordinary, fully-eligible volume with no exclusion recorded, and `into_tick` still returned a tick so the fetch counters reported nothing either. It is now substituted with `TradeConditions::UNSPELLABLE`, which `volume_eligibility_from_characters` already answers `Ambiguous` and `trades.rs` already routes to `record_unresolved_condition`. No new machinery.

## The seam disagrees, and the earlier reading of it was wrong

This section previously called the difference "a real provider difference, not a fold error" on the strength of one name in one session. The direction was right; the explanation was not measured. Superseded by what follows.

**The two providers are byte-identical for most of the archive.** Folding five names through the new route against the stored flat-file partitions:

| session | names matching exactly | max volume difference |
|---|---|---|
| 2022-01-04 | 0 / 5 | 2.154% |
| 2022-12-09 | 3 / 5 | 0.913% |
| 2023-11-16 | 1 / 5 | 0.0000% (within 2 shares) |
| **2024-10-24** | **5 / 5** | **0.0000%** |
| **2025-10-03** | **5 / 5** | **0.0000%** |
| 2026-08-20 | 0 / 12 | 1.201% |

**The divergence begins on a single session.** The SIP began disseminating fractional trade quantities on **2026-02-23**: 0 of 11,452 names carried a fractional volume on 2026-02-20, and 10,276 of 11,432 did on 2026-02-23. The same boundary appears in Massive's grouped daily aggregate endpoint, so it is one upstream change reaching every Massive product rather than a flat-file quirk.

**The transform is `max(1, size)` per print.** From the 2026-08-20 trades flat file, AAPL regular hours: 220,283 of 688,766 prints carry fractional sizes, 99.3% of them smaller than one share, and **100% of them print on the FINRA TRF**. Alpaca reports each sub-1 print as one share:

| | shares |
|---|---|
| Massive stored | 24,306,145.14 |
| 218,821 sub-1 prints, totalling | 8,520.53 |
| lift if each becomes 1 share | +210,300.47 |
| predicted | 24,516,445.61 |
| **Alpaca reported** | **24,504,208** |
| residual | −12,238 (**0.05%**) |

That accounts for 99.95% of the gap. Across twelve names the gap correlates with off-exchange share at **0.918**, which is why it ranges 39-fold — it is a measure of retail internalization, not of provider quality.

**What is not explained:** the 2022 sessions. Rounding cannot be the cause there, because Massive's 2022 volumes are already whole numbers. That is a separate open question and is not addressed here.

Prices agree throughout: VWAP within 0.23 bp, daily bar closes to 0.00 bp, and every quoted-spread statistic identical to printed precision. **Every price field agrees; only size fields disagree.**

`measure` exists precisely so this comparison costs nothing: writing an Alpaca fold into a partition built from flat files is how the quote archive came to hold rows from two passes at once (#1131).

## Testing

Mock-server tests for the tape refusal, the malformed multi-character tape, unspellable condition tokens, the corrected flag, and the pinned `sort`/`asof`. Condition tests for the per-tape marker, the table dispatch, and the unspellable sentinel resolving as unknown on every tape.

Five mutations confirmed load-bearing: defaulting a missing tape, truncating a multi-character token, reading characters against the identifier table, spelling the marker the same on every tape, and hard-coding the trade partition's provenance. **Two initially passed** and were re-pinned — the condition dispatch on `M`, the one input where the two tables differ, and the provenance on the sidecar's own wire bytes.

One incidental fix: `test_a_failed_upload_keeps_the_staged_bytes` staged into a fixed path it never cleared, so it counted one more file on each run and passed only on a clean machine. It is now hermetic.

`devenv tasks run checks:all` passes.

## Not in scope

Concern C is still running and this is not deployed to the backfill box. The nightly scheduling itself is the third pull request; the symbol-level completeness scan is the second.

`QuoteArguments` is still shared by the quote passes and the trade flat-file passes, which is a naming imprecision rather than a defect — renaming it touches 11 sites for no behaviour change and is left out deliberately.
