### PR TITLE
Refuse the two writes that made a partition unable to answer for itself

### DIFF
--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -1604,6 +1604,23 @@ async fn seed_trades(action: &TradeAction) -> Result<Outcome, SeedError> {
         }
     };
 
+    // Refused before a single print is fetched. Alpaca's early history carries an opening auction
+    // print the archive correctly excludes, so a repair reaching back past the floor would add
+    // 0.3-2.2% of session volume, silently and by a different amount per name.
+    let unfaithful = source.unfaithful_sessions(&sampled);
+    if let Some(earliest) = unfaithful.first() {
+        return Err(SeedError::Usage(format!(
+            "{source} trades are not faithful before {}: {} of {} sampled sessions are earlier, \
+             from {earliest}. Writing them would add volume the archive correctly excludes; \
+             re-fold from the raw tee instead.",
+            source
+                .faithful_from()
+                .expect("a route that refuses a session has a floor"),
+            unfaithful.len(),
+            sampled.len(),
+        )));
+    }
+
     let bucket = bucket_name()?;
     let s3_client = fund::common::aws::s3_client().await;
     Ok(Outcome::Pass(

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -1604,9 +1604,8 @@ async fn seed_trades(action: &TradeAction) -> Result<Outcome, SeedError> {
         }
     };
 
-    // Refused before a single print is fetched. Alpaca's early history carries an opening auction
-    // print the archive correctly excludes, so a repair reaching back past the floor would add
-    // 0.3-2.2% of session volume, silently and by a different amount per name.
+    // Refused before a single print is fetched: past the floor Alpaca folds an opening auction
+    // print the archive correctly excludes, adding 0.3-2.2% of session volume and varying by name.
     let unfaithful = source.unfaithful_sessions(&sampled);
     if let Some(earliest) = unfaithful.first() {
         return Err(SeedError::Usage(format!(

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -126,6 +126,22 @@ pub enum ArchiveError {
     },
     #[error("gave up on {key} after {attempts} concurrent writes by another pass")]
     Contended { key: String, attempts: usize },
+    /// A second provider tried to write into a partition a different one already built.
+    ///
+    /// Refused rather than merged. Mixing is what produced an archive whose cadences disagree about
+    /// the same name-session by a factor of thirty — the five-minute and daily quote partitions hold
+    /// Alpaca's rows for the names Massive's flat file is short on, and the one-minute cadence holds
+    /// Massive's. A partition must answer for one provider so that a reader comparing two of them is
+    /// comparing the vendors rather than the write order.
+    #[error(
+        "{key} was built by {existing} and {incoming} tried to write into it; a partition answers \
+         for one provider. Re-fold the whole partition from one source instead of merging."
+    )]
+    MixedProvenance {
+        key: String,
+        existing: String,
+        incoming: String,
+    },
     /// The trading calendar does not span the window, so which dates trade is unanswerable.
     ///
     /// Fatal rather than carried, unlike a failed session: a calendar short of the window drops real
@@ -1803,6 +1819,12 @@ where
         // overwrite would discard anything a later response happens to omit, and merging costs one
         // read of an object this pass is about to replace anyway.
         let existing = read_partition_with_etag(s3_client, bucket, &key).await?;
+        // Checked before the merge, not after: once two providers' rows are concatenated the
+        // partition cannot say which row came from which, and the sidecar records the set of routes
+        // rather than a route per row. Refusing here is the only point where that is still true.
+        if existing.is_some() {
+            refuse_a_second_provider(s3_client, bucket, &key, provenance).await?;
+        }
         let (mut frame, precondition) = match existing {
             Some((existing_frame, etag)) => (
                 merge(existing_frame, fetched.clone(), &key)?,
@@ -1840,6 +1862,38 @@ where
     Err(ArchiveError::Contended {
         key,
         attempts: CONTENDED_WRITE_ATTEMPTS,
+    })
+}
+
+/// Refuses a write into a partition a different provider already built.
+///
+/// A missing sidecar is allowed through: the archive predates provenance and a partition without a
+/// record is not evidence of a second provider, only of an older pass. An unreadable one is refused,
+/// because "could not tell" and "safe" are different answers and only one of them is worth acting
+/// on — the sweep that stamps sidecars is cheap and should be run rather than guessed past.
+async fn refuse_a_second_provider(
+    s3_client: &S3Client,
+    bucket: &str,
+    key: &str,
+    incoming: Provenance,
+) -> Result<(), ArchiveError> {
+    let sidecar = PartitionProvenance::sidecar_key(key);
+    let Some((record, _)) = read_sidecar(s3_client, bucket, &sidecar).await? else {
+        return Ok(());
+    };
+    let foreign: Vec<&str> = record
+        .routes
+        .iter()
+        .map(|route| route.provider_name())
+        .filter(|provider| *provider != incoming.provider_name())
+        .collect();
+    if foreign.is_empty() {
+        return Ok(());
+    }
+    Err(ArchiveError::MixedProvenance {
+        key: key.to_string(),
+        existing: foreign.join(" and "),
+        incoming: incoming.provider_name().to_string(),
     })
 }
 
@@ -2615,6 +2669,15 @@ pub enum TradeSource<'a> {
     WholeSession(&'a FlatFileClient),
 }
 
+/// The earliest session Alpaca's trade history reproduces faithfully.
+///
+/// Before this, Alpaca folds the opening auction print that the SIP also publishes as Market Center
+/// Official Open, which our conditions table marks volume-ineligible, so a fold from that route
+/// carries 0.3–2.2% of session volume the archive correctly excludes. Measured 2026-09-06: the
+/// disagreement ends 2022-11-07 on CTA-tape names but runs intermittently into June 2023 on
+/// Nasdaq-listed ones, and 2023-07-05 is the first session sampled clean across both.
+const ALPACA_TRADES_FAITHFUL_FROM: (i32, u32, u32) = (2023, 7, 5);
+
 impl TradeSource<'_> {
     /// Where this route's prints came from.
     ///
@@ -2625,6 +2688,43 @@ impl TradeSource<'_> {
             TradeSource::PerName(_) => Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
             TradeSource::WholeSession(_) => RawDataset::Trades.provenance(),
         }
+    }
+
+    /// The earliest session this route may be written into the archive from.
+    ///
+    /// `None` for the flat-file route, which is where the archive's trade partitions came from and
+    /// so cannot disagree with them. Some for Alpaca, whose early history differs — see
+    /// [`ALPACA_TRADES_FAITHFUL_FROM`]. Carried on the source rather than checked at the call site
+    /// because the constraint is a property of the provider, not of any one command.
+    pub fn faithful_from(&self) -> Option<SessionDate> {
+        match self {
+            TradeSource::PerName(_) => {
+                let (year, month, day) = ALPACA_TRADES_FAITHFUL_FROM;
+                Some(SessionDate::from_date(
+                    NaiveDate::from_ymd_opt(year, month, day)
+                        .expect("the faithful-from date is a real calendar date"),
+                ))
+            }
+            TradeSource::WholeSession(_) => None,
+        }
+    }
+
+    /// The sessions in `sessions` this route must not be written into, earliest first.
+    ///
+    /// Returned rather than logged so the caller refuses before fetching anything. A silent partial
+    /// skip would be worse than either refusing or proceeding: the pass would report success over a
+    /// window it only half covered.
+    pub fn unfaithful_sessions(&self, sessions: &[SessionDate]) -> Vec<SessionDate> {
+        let Some(floor) = self.faithful_from() else {
+            return Vec::new();
+        };
+        let mut refused: Vec<SessionDate> = sessions
+            .iter()
+            .copied()
+            .filter(|&day| day < floor)
+            .collect();
+        refused.sort();
+        refused
     }
 }
 
@@ -3459,6 +3559,132 @@ mod tests {
         SessionDate::from_date(
             NaiveDate::from_ymd_opt(year, month, day).expect("test date must be valid"),
         )
+    }
+
+    /// Builds an Alpaca route with throwaway credentials, for the checks that never make a request.
+    fn per_name_credentials() -> crate::common::alpaca::MarketDataClient {
+        let credentials = crate::common::alpaca::AlpacaCredentials::new(
+            "test-key".to_string(),
+            "test-secret".to_string(),
+        )
+        .expect("test credentials must construct");
+        MarketDataClient::new(credentials, crate::common::alpaca::DataFeed::Sip)
+    }
+
+    /// A second provider writing into a partition the first built is what produced quote cadences
+    /// that disagree about the same name-session by a factor of thirty.
+    ///
+    /// Refused rather than merged, because after the concatenation nothing can say which row came
+    /// from which vendor: the sidecar records a set of routes for the partition, never a route per
+    /// row.
+    #[tokio::test]
+    async fn test_a_second_provider_is_refused_rather_than_merged() {
+        let record = PartitionProvenance::new(
+            "equity_quotes",
+            Some("2022-01-04"),
+            Provenance::massive(MassivePlan::StocksAdvanced, MassiveTransport::FlatFile),
+        );
+        let body = serde_json::to_string(&record).expect("the record must serialize");
+        let client = scripted_s3_client(move |_method, _key| {
+            http::Response::builder()
+                .status(200)
+                .header("etag", "\"an-etag\"")
+                .body(SdkBody::from(body.clone()))
+                .expect("a canned response must build")
+        });
+
+        let refused = refuse_a_second_provider(
+            &client,
+            "test-bucket",
+            "data/derived/equity/quotes/interval=one_day/year=2022/month=01/day=04/data.parquet",
+            Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
+        )
+        .await;
+
+        match refused {
+            Err(ArchiveError::MixedProvenance {
+                existing, incoming, ..
+            }) => {
+                assert_eq!(existing, "massive");
+                assert_eq!(incoming, "alpaca");
+            }
+            other => panic!("a second provider must be refused, got {other:?}"),
+        }
+    }
+
+    /// The same provider re-folding its own partition is ordinary and must stay allowed — that is
+    /// what the re-fold from the raw tee will be.
+    #[tokio::test]
+    async fn test_the_same_provider_may_rewrite_its_own_partition() {
+        let record = PartitionProvenance::new(
+            "equity_quotes",
+            Some("2022-01-04"),
+            Provenance::massive(MassivePlan::StocksAdvanced, MassiveTransport::FlatFile),
+        );
+        let body = serde_json::to_string(&record).expect("the record must serialize");
+        let client = scripted_s3_client(move |_method, _key| {
+            http::Response::builder()
+                .status(200)
+                .header("etag", "\"an-etag\"")
+                .body(SdkBody::from(body.clone()))
+                .expect("a canned response must build")
+        });
+
+        // A different Massive plan and transport, deliberately: what must match is the vendor, not
+        // the route, so a Starter REST re-fold over an Advanced flat-file partition is allowed.
+        refuse_a_second_provider(
+            &client,
+            "test-bucket",
+            "data/derived/equity/quotes/interval=one_day/year=2022/month=01/day=04/data.parquet",
+            Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest),
+        )
+        .await
+        .expect("one vendor rewriting its own partition is not a mix");
+    }
+
+    /// Alpaca's early history carries the opening auction print the archive excludes, so a repair
+    /// reaching back that far would add 0.3-2.2% of session volume, silently and per name.
+    ///
+    /// Pinned to the literal date rather than read off `ALPACA_TRADES_FAITHFUL_FROM`, so moving the
+    /// constant has to move this too and cannot quietly widen what a repair may overwrite.
+    #[test]
+    fn test_the_alpaca_trade_route_refuses_sessions_before_its_floor() {
+        let market_data = per_name_credentials();
+        let source = TradeSource::PerName(&market_data);
+
+        assert_eq!(source.faithful_from(), Some(session(2023, 7, 5)));
+
+        let refused = source.unfaithful_sessions(&[
+            session(2022, 1, 4),
+            session(2023, 6, 15),
+            session(2023, 7, 5),
+            session(2026, 8, 21),
+        ]);
+        assert_eq!(
+            refused,
+            vec![session(2022, 1, 4), session(2023, 6, 15)],
+            "every session before the floor is refused, and the floor itself is not"
+        );
+    }
+
+    /// The flat file is where the archive's trade partitions came from, so it cannot disagree with
+    /// them and must never be refused — a floor on this route would block the only repair that
+    /// survives the Massive Advanced lapse.
+    #[test]
+    fn test_the_flat_file_trade_route_has_no_floor() {
+        let credentials = crate::common::flatfiles::FlatFileCredentials::new(
+            "https://example.invalid".to_string(),
+            "test-key".to_string(),
+            "test-secret".to_string(),
+        )
+        .expect("test credentials must construct");
+        let flat_files = FlatFileClient::new(credentials);
+        let source = TradeSource::WholeSession(&flat_files);
+
+        assert_eq!(source.faithful_from(), None);
+        assert!(source
+            .unfaithful_sessions(&[session(2021, 8, 26), session(2022, 1, 4)])
+            .is_empty());
     }
 
     /// An S3 client answering from `respond` instead of the network, given the method and the key.

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -128,11 +128,9 @@ pub enum ArchiveError {
     Contended { key: String, attempts: usize },
     /// A second provider tried to write into a partition a different one already built.
     ///
-    /// Refused rather than merged. Mixing is what produced an archive whose cadences disagree about
-    /// the same name-session by a factor of thirty — the five-minute and daily quote partitions hold
-    /// Alpaca's rows for the names Massive's flat file is short on, and the one-minute cadence holds
-    /// Massive's. A partition must answer for one provider so that a reader comparing two of them is
-    /// comparing the vendors rather than the write order.
+    /// Refused rather than merged: once two providers' rows are concatenated the partition cannot
+    /// say which row came from which. A partition answers for one provider so that a reader
+    /// comparing two of them is comparing the vendors rather than the write order.
     #[error(
         "{key} was built by {existing} and {incoming} tried to write into it; a partition answers \
          for one provider. Re-fold the whole partition from one source instead of merging."
@@ -1819,9 +1817,8 @@ where
         // overwrite would discard anything a later response happens to omit, and merging costs one
         // read of an object this pass is about to replace anyway.
         let existing = read_partition_with_etag(s3_client, bucket, &key).await?;
-        // Checked before the merge, not after: once two providers' rows are concatenated the
-        // partition cannot say which row came from which, and the sidecar records the set of routes
-        // rather than a route per row. Refusing here is the only point where that is still true.
+        // Checked before the merge, not after: the sidecar records a set of routes rather than a
+        // route per row, so this is the last point at which the two providers are still separable.
         if existing.is_some() {
             refuse_a_second_provider(s3_client, bucket, &key, provenance).await?;
         }
@@ -1867,10 +1864,10 @@ where
 
 /// Refuses a write into a partition a different provider already built.
 ///
-/// A missing sidecar is allowed through: the archive predates provenance and a partition without a
-/// record is not evidence of a second provider, only of an older pass. An unreadable one is refused,
-/// because "could not tell" and "safe" are different answers and only one of them is worth acting
-/// on — the sweep that stamps sidecars is cheap and should be run rather than guessed past.
+/// A missing sidecar is allowed through because the archive predates provenance, while an unreadable
+/// one is refused, since "could not tell" and "safe" are different answers. This stops a later pass
+/// rather than a simultaneous one: a writer landing between another's partition and its sidecar sees
+/// no record and passes, a window no ordering of two objects closes.
 async fn refuse_a_second_provider(
     s3_client: &S3Client,
     bucket: &str,
@@ -1878,8 +1875,17 @@ async fn refuse_a_second_provider(
     incoming: Provenance,
 ) -> Result<(), ArchiveError> {
     let sidecar = PartitionProvenance::sidecar_key(key);
-    let Some((record, _)) = read_sidecar(s3_client, bucket, &sidecar).await? else {
-        return Ok(());
+    let record = match read_sidecar(s3_client, bucket, &sidecar).await? {
+        SidecarRead::Found(record, _) => record,
+        SidecarRead::Absent => return Ok(()),
+        SidecarRead::Unreadable => {
+            return Err(ArchiveError::Read {
+                bucket: bucket.to_string(),
+                key: sidecar,
+                message: "the provenance record did not parse, so the provider it names is unknown"
+                    .to_string(),
+            })
+        }
     };
     let foreign: Vec<&str> = record
         .routes
@@ -3326,23 +3332,34 @@ async fn read_partition_with_etag(
     )))
 }
 
-/// Writes a partition only if the object at `key` still matches `precondition`.
+/// What was found at a sidecar key.
 ///
-/// Reads a partition's provenance and the ETag it carried, or `None` where there is no record.
+/// Three-way rather than an `Option` because absent and unreadable pull the two callers opposite
+/// ways: the guard must refuse a record it cannot interpret, and the writer must not spend its
+/// retries on one.
+enum SidecarRead {
+    /// The record parsed, and carried this ETag when it was read.
+    Found(PartitionProvenance, String),
+    /// No object at the key.
+    Absent,
+    /// An object is there and did not parse, so it can neither be trusted nor replaced.
+    Unreadable,
+}
+
+/// Reads a partition's provenance and the ETag it carried.
 ///
-/// Absent and unparseable are both `None` deliberately, because refusing to write over a corrupt
-/// object would make it permanent. **A failed request is neither**, and is propagated: treating a
-/// throttle as "no record" is what lets a single-route write replace a multi-route one.
+/// A failed request is neither absent nor unreadable and is propagated: treating a throttle as "no
+/// record" is what lets a single-route write replace a multi-route one.
 async fn read_sidecar(
     s3_client: &S3Client,
     bucket: &str,
     key: &str,
-) -> Result<Option<(PartitionProvenance, String)>, ArchiveError> {
+) -> Result<SidecarRead, ArchiveError> {
     let response = match s3_client.get_object().bucket(bucket).key(key).send().await {
         Ok(response) => response,
         Err(error) => {
             return match error.into_service_error() {
-                GetObjectError::NoSuchKey(_) => Ok(None),
+                GetObjectError::NoSuchKey(_) => Ok(SidecarRead::Absent),
                 other => Err(ArchiveError::Read {
                     bucket: bucket.to_string(),
                     key: key.to_string(),
@@ -3362,9 +3379,10 @@ async fn read_sidecar(
             message: error.to_string(),
         })?
         .into_bytes();
-    Ok(serde_json::from_slice(&bytes)
-        .ok()
-        .map(|record| (record, etag)))
+    Ok(match serde_json::from_slice(&bytes) {
+        Ok(record) => SidecarRead::Found(record, etag),
+        Err(_) => SidecarRead::Unreadable,
+    })
 }
 
 /// Records where an object's bytes came from, beside the object itself.
@@ -3393,11 +3411,19 @@ async fn write_sidecar(
             }
         };
         let (record, precondition) = match existing {
-            Some((record, etag)) => (record.contributed(provenance), Precondition::Match(etag)),
-            None => (
+            SidecarRead::Found(record, etag) => {
+                (record.contributed(provenance), Precondition::Match(etag))
+            }
+            SidecarRead::Absent => (
                 PartitionProvenance::new(dataset.as_str(), session.as_deref(), provenance),
                 Precondition::Absent,
             ),
+            // An `Absent` precondition cannot replace an object that is really there, so retrying
+            // would 409 until the attempts ran out under a warning naming the wrong cause.
+            SidecarRead::Unreadable => {
+                warn!(key, "Provenance did not parse; the sweep must rewrite it");
+                return;
+            }
         };
         let body = match serde_json::to_vec(&record) {
             Ok(body) => body,
@@ -3609,6 +3635,36 @@ mod tests {
                 assert_eq!(incoming, "alpaca");
             }
             other => panic!("a second provider must be refused, got {other:?}"),
+        }
+    }
+
+    /// A record that does not parse names no provider, and "could not tell" must not be spent as
+    /// "safe" — the write is refused so the sweep can rewrite the sidecar first.
+    #[tokio::test]
+    async fn test_an_unreadable_provenance_record_is_refused_rather_than_assumed_absent() {
+        let client = scripted_s3_client(move |_method, _key| {
+            http::Response::builder()
+                .status(200)
+                .header("etag", "\"an-etag\"")
+                .body(SdkBody::from("{ this is not the record it claims to be"))
+                .expect("a canned response must build")
+        });
+
+        let refused = refuse_a_second_provider(
+            &client,
+            "test-bucket",
+            "data/derived/equity/quotes/interval=one_day/year=2022/month=01/day=04/data.parquet",
+            Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
+        )
+        .await;
+
+        match refused {
+            Err(ArchiveError::Read { key, .. }) => assert_eq!(
+                key,
+                "data/derived/equity/quotes/interval=one_day/year=2022/month=01/day=04/\
+                 data.parquet.provenance.json"
+            ),
+            other => panic!("an unreadable record must be refused, got {other:?}"),
         }
     }
 
@@ -3998,6 +4054,52 @@ mod tests {
         assert!(
             written.is_empty(),
             "a sidecar that could not be read must be left alone; wrote {written:?}"
+        );
+    }
+
+    /// A record that does not parse is left for the sweep rather than retried against.
+    ///
+    /// An `Absent` precondition cannot replace an object that is really there, so the old lenient
+    /// read spent every attempt on writes that could only 409, then warned about losing a race.
+    #[tokio::test]
+    async fn test_a_sidecar_that_does_not_parse_is_left_for_the_sweep() {
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let recorder = Arc::clone(&seen);
+        let client = scripted_s3_client(move |method, key| {
+            if method == http::Method::PUT {
+                recorder
+                    .lock()
+                    .expect("the recorder must not be poisoned")
+                    .push(key.to_string());
+                http::Response::builder()
+                    .status(200)
+                    .body(SdkBody::empty())
+                    .expect("a canned response must build")
+            } else {
+                http::Response::builder()
+                    .status(200)
+                    .header("etag", "\"an-etag\"")
+                    .body(SdkBody::from("{ this is not the record it claims to be"))
+                    .expect("a canned response must build")
+            }
+        });
+
+        write_sidecar(
+            &client,
+            "test-bucket",
+            SPLITS_ARCHIVE_KEY,
+            DerivedDataset::Splits,
+            Provenance::massive(MassivePlan::StocksStarter, MassiveTransport::Rest),
+        )
+        .await;
+
+        let written = seen
+            .lock()
+            .expect("the recorder must not be poisoned")
+            .clone();
+        assert!(
+            written.is_empty(),
+            "a record that did not parse must not be written over; wrote {written:?}"
         );
     }
 


### PR DESCRIPTION
# Overview

Two guards on the archive's write path, from measuring the Massive/Alpaca seam across trades and quotes. Both refuse a write that would leave a partition unable to say what it holds.

## Changes

- `refuse_a_second_provider` in `write_merged` reads the provenance sidecar before merging and returns the new `ArchiveError::MixedProvenance` when the existing record names a different vendor. **A partition answers for one provider.** A vendor rewriting its *own* partition stays allowed — that is what a re-fold from the raw tee will be, and a Starter REST pass over an Advanced flat-file partition is one vendor, not two.
- `TradeSource::faithful_from` carries `2023-07-05` and `unfaithful_sessions` reports the sampled sessions before it; `seed_trades` refuses **before fetching a print**. An Alpaca trade fold answers for its own era.
- Four tests, each proven load-bearing by breaking the code it covers and watching it fail.

## Context

### A partition answers for one provider

Mixing was measurably producing a *better* archive, so the reasons belong on the record.

Massive's quote flat file is a **strict subset** of Alpaca's NBBO stream — 100% of its timestamps appear in Alpaca's, and its extra quotes are not redundant repeats (0.0–0.1% leave the book unchanged). Coverage runs **38.6% to 97.3%**; even the most liquid name sampled is short. Below roughly half coverage the archived time-weighted spread is wrong by **50 to 380%**, because dropped runs are long enough that surviving quotes inherit durations they never had. The Alpaca repairs that created the mixing were fixing real errors.

It is bought on the wrong securities. The 280 affected names on the session measured:

| | |
|---|---|
| clear $50M daily dollar volume | 0 |
| clear $10M | 1 |
| **median daily dollar volume** | **$18,094** |

The accuracy is on names no screen would admit; the legibility cost is permanent. `massive/flat_file` tells a reader what they hold, `massive/flat_file + alpaca/rest` tells them to re-derive it first. And the raw bytes make it reversible — a future question needing the tail adds a second *raw* source and stitches at read time, rather than making the archive carry the ambiguity forever.

The stated cost: a name absent from Massive's flat file can only come from Alpaca, so under this rule it stays absent. Prior backfill work puts that at roughly one name per session, mostly test symbols.

The archive survives the subset at all because `QuoteFold` is **time-weighted** rather than count-weighted — the quotes Massive drops are mostly flicker that never stood at the top of book. Fifteen names between 60% and 97% coverage came in within 9.1%, twelve of them under 2%.

### An Alpaca trade fold answers for its own era

Before `2023-07-05`, Alpaca folds the opening auction print that the SIP also publishes as Market Center Official Open, which our conditions table marks volume-ineligible. A repair reaching back added **0.3 to 2.2% of session volume**, silently and by a different amount per name. The disagreement ends 2022-11-07 on CTA-tape names but runs intermittently into June 2023 on Nasdaq-listed ones.

The date is conservative and may tighten: disagreement is measured at 2023-06-15 and absence of it at 2023-07-05, with the sessions between unsampled.

### Two deliberate choices

- **The refusal covers the whole window, not just its early part.** A partial skip would report success over a window it only half covered, which is a failure this archive has hit before.
- **No override flag.** A flag for this gets used reflexively; moving the constant shows up in a diff.

### Verification

`devenv tasks run checks:rust` passes across 19 test binaries. `cargo test --lib` is 961 passed, 0 failed. Both guards were confirmed against real credentials — a 2022 repair window and one straddling the floor are both refused before any fetch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented trade imports from including historical sessions outside the supported accuracy range.
  * Added clear guidance when an import includes unsupported early history.
  * Prevented merging archive data from different providers within the same partition.
  * Added safeguards for unreadable provenance records rather than silently combining data.

* **Tests**
  * Added coverage for provider-mixing prevention and historical trade-source boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->