### PR TITLE
Codify the research discipline, then fix what violated it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,116 +6,68 @@
 
 This is a collection of guidelines and references.
 
-- Rust is the primary project language
 - [devenv](https://devenv.sh/) manages the development environment, tasks, and local services
 - Services run on a single exe.dev VM via `devenv --profile application up` in both dev and production
-- Secrets are managed via [secretspec](https://secretspec.dev/) with the `awssm` provider
-- Rust code follows Cargo workspace conventions
-- AWS S3 is used for blob storage
-- AWS Secrets Manager stores secrets in secretspec format (`secretspec/{project}/{profile}/{key}`)
-- Use `devenv tasks run checks:rust` for comprehensive Rust checks
+- Secrets are managed via [secretspec](https://secretspec.dev/) with the `awssm` provider, stored in AWS
+  Secrets Manager as `secretspec/{project}/{profile}/{key}`
+- Use `devenv tasks run checks:rust` for comprehensive Rust checks; `devenv tasks run` supports prefix group
+  execution, so `checks:rust` runs every `checks:rust:*` subtask
+- Introduce new dependencies only after approval
+- Use Polars for [Rust](https://docs.rs/polars/latest/polars/) dataframes
+- See `README.md` "Principles" section for developer philosophy
 - Docstrings are one sentence on what the item is for, plus at most two more for a caveat, invariant, or
-  assumption a caller cannot read off the signature; never multi-paragraph, and never longer than the
-  item it documents
-- Module documentation is three lines maximum
-- In-line comments are one line and appear only where a step is genuinely surprising, with two lines the
-  hard ceiling
+  assumption a caller cannot read off the signature; module documentation is three lines maximum, and an
+  in-line comment is one line where a step is genuinely surprising, with two the hard ceiling
 - Rationale belongs in the commit message rather than the source — why this approach and not the obvious
   one, what broke before, what the alternative would cost; the source states the constraint and the commit
   argues it
 - Spell identifiers out fully in code (variables, functions, fields, modules): prefer `dataframe` over
-  `df`, `message` over `msg`, `error_message` over `err_msg`, `quantity` over `qty`, `index` over `idx`,
-  `column` over `col`, `value` over `val`, `volatility` over `vol`, `profit_and_loss` over `pnl`,
-  `timezone` over `tz`, and `aggregate` over `agg`
+  `df`, `message` over `msg`, `quantity` over `qty`, `index` over `idx`, `value` over `val`, `column` over
+  `col`, and `volatility` over `vol`
 - Expand metric and domain acronyms in identifiers too: `root_mean_squared_error` (not `rmse`),
-  `mean_absolute_error` (not `mae`), `mean_squared_error` (not `mse`), `r_squared` (not `r2`),
-  `continuous_ranked_probability_score` (not `crps`), `end_of_day` (not `eod`), and `postgres` (not `pg`)
-- Keep only universally-understood acronyms as-is: formats, protocols, and identity (`csv`, `json`,
-  `sql`, `http`, `url`, `uri`, `io`, `id`, `uuid`, `api`) and established domain or proper-noun terms
-  (`aws`, `utc`, `etf`, `ohlcv`, `guc`); case acronyms as ordinary words per language convention
-- Never rename fixed external identifiers: devenv profile names (`application`, `trainer`), the `awssm` secretspec
-  provider, the `tide` model and package name, environment variables and secret keys (e.g.
-  `DATABASE_URL`, `ALPACA_API_KEY_ID`), library import aliases (`np`, `pl`, `pa`), linter directives
-  (`noqa`), and external library fields and parameters (e.g. the Alpaca/Massive `vw` deserialization
-  field, datetime `tz=`/`tzinfo`)
-- Apply the spell-it-out rule to new code, to identifiers you touch, and to dedicated cleanup passes;
-  already-shipped database and schema identifiers (index, constraint, and column names) and stored
-  values are effectively fixed and change only via an explicit migration
-- Follow Rust recommended casing conventions
-- Introduce new dependencies only after approval
-- Use Polars for [Rust](https://docs.rs/polars/latest/polars/) dataframes
-- Ensure Rust automated test suites achieve at least 75% line or statement coverage
-- Exclude generated code, third-party code, tooling boilerplate, and anything explicitly excluded in this repository
-  from test coverage calculations
-- Structured log messages should be short sentences with sentence case (e.g., "Starting data sync" not "STARTING DATA SYNC")
-- When debugging or fixing bugs, check structured logs and error log files in `/var/log/fund/` to understand what happened
-- After fixing a bug, create a Git commit with a detailed summary of the root cause and fix in the commit message
-- When creating GitHub issues or pull requests, use the templates in the `.github/` directory and follow commented instructions
-- When naming branches, use an all-lowercase, hyphenated, and concise summary of the work being done
-- `models/` folder contains model definitions and training code and `src/` contains application code
-- See `README.md` "Principles" section for developer philosophy
-- If something goes wrong during a task, stop immediately and re-plan rather than continuing
-- Use subagents to keep main context window clean and offload research, exploration, and analysis work
-- Prove changes work before marking tasks complete - run `devenv tasks run` checks, compare behavior, demonstrate correctness
-- Verify against real data before reporting done, and say which route was used: `secretspec run --
-  curl` against Alpaca or Massive, DuckDB over the S3 parquet, or a trainer rehearsal read back from
-  `/var/log/fund/`; when only fixtures were exercised, say so plainly, and ask to be pointed at real
-  data rather than inferring
-- Before filtering a provider feed by date, check whether the filter matches the event's own date or
-  the provider's record time — Alpaca's activity `date=`/`after=` match record time, so a date-only
-  row dated D is returned by a query for D+1
-- For non-trivial changes, pause and ask "Is there a more elegant way?" before implementing
-- Make every change as simple as possible and impact minimal code
-- Find root causes and avoid temporary fixes - maintain high standards
-- Changes should only touch what's necessary to avoid introducing bugs
-- If uncertainty arises, ask for help or input rather than guessing
-- Do not introduce abstractions for single-use code
+  `mean_absolute_error` (not `mae`), `continuous_ranked_probability_score` (not `crps`), and `end_of_day`
+  (not `eod`)
+- Keep only universally-understood acronyms as-is: formats, protocols, and identity (`csv`, `json`, `sql`,
+  `http`, `url`, `uri`, `io`, `id`, `uuid`, `api`) and established domain or proper-noun terms (`aws`,
+  `utc`, `etf`, `ohlcv`); case acronyms as ordinary words per language convention
+- Never rename fixed external identifiers: devenv profile names (`application`, `trainer`), the `awssm`
+  secretspec provider, the `tide` model and package name, environment variables and secret keys, library
+  import aliases, linter directives, and external library fields and parameters
+- Apply the spell-it-out rule to new code and to identifiers you touch; already-shipped schema identifiers
+  and stored values are effectively fixed and change only via an explicit migration
 - Always match existing styles and patterns in the codebase for consistency
-- When fixing a bug, write tests that reproduce the bug before fixing it, then verify the tests pass after the fix
-- Pin test expectations to literals, never to the constant or list the test is checking — an
-  expectation derived from the value under test moves with it and can never fail
-- Prove a new assertion is load-bearing before trusting it: break the code it covers, watch the test
-  fail, restore
-- Do not use emojis in commit messages, GitHub issues, or pull requests - maintain a professional tone
-- When possible, use GitHub's GraphQL API directly for scripts and tools where token efficiency matters
-- When the user indicates pull request review bots have provided feedback, suggest running `/update-pull-request`
-- Invoke skills and suggest commands based on conversational context rather than waiting for explicit slash commands
-- Guard against division by zero when computing ratios or percentages from DataFrame aggregations
-- When Polars `Series.sum()` is used on a potentially empty or all-null series, handle the `None` return case
-- `devenv tasks run` supports prefix group execution: `checks:rust` runs all `checks:rust:*` subtasks
-- Prefer validated constructors with private fields over public struct literals — a value in scope should be proof of its
-  own validity, not a candidate for re-checking downstream
-- `schema.sql` is the single source of truth for the database schema; all DDL must use idempotent forms
-  (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`,
-  `DO` block checking `cron.job` for existence before calling `cron.schedule*(...)`, etc.)
-  so the file can be safely re-run against any populated database — never add migration-style
-  `ALTER TABLE`, `DROP TABLE`, or bare `UPDATE` blocks
-- Utilize category theory when designing data transformations and model architectures - functors, monads, and natural
-  transformations; this leads to more composable, reusable, and maintainable code
-- Only use existing repository labels for GitHub issues and pull requests
-- After any change to `schema.sql` or a `query!` macro, run `cargo sqlx prepare -- --all-features` to
-  regenerate the `.sqlx/` offline cache; if Postgres is not already running, start it first with
-  `devenv up -d --no-tui` then poll `pg_isready` until it accepts connections; use
-  `cargo sqlx prepare --check -- --all-features` to verify without updating the cache; the
-  `dashboard` uses raw `sqlx::query()` (no macros) and has no offline cache entries
+- Structured log messages should be short sentences with sentence case (e.g., "Starting data sync" not
+  "STARTING DATA SYNC")
 - Encode domain constraints in the type system: use enums with per-variant data to make invalid states
   unrepresentable at compile time rather than checking validity at runtime
-- Use `match` (not `if let` chains) when handling enum variants — exhaustive matching ensures every variant is
-  handled and the compiler flags missing cases when variants change
-- Wrap primitive types in tuple structs to enforce domain type safety (e.g., `struct Price(f64)`); never accept
-  a raw `f64` or `String` where a specific domain value is required
+- Wrap primitive types in tuple structs to enforce domain type safety (e.g., `struct Price(f64)`); never
+  accept a raw `f64` or `String` where a specific domain value is required
+- Prefer validated constructors with private fields over public struct literals — a value in scope should
+  be proof of its own validity, not a candidate for re-checking downstream
+- Use `match` (not `if let` chains) when handling enum variants, and never write a wildcard arm — the
+  compiler flags every site that needs attention when a variant is added, but only if no arm swallows the rest
+- Model state machines with two enums (states and transitions) matched as a tuple:
+  `match (current_state, transition) { ... }` — keeps business logic exhaustive and legible
+- `Option` means unmeasurable, never zero — zero is a measurement and absence is not
+- An absence carries its cause: when something is missing or refused, the type records why, along with the
+  number that produced the refusal
+- Two fields that must agree will eventually not; if one is a function of the other, derive it rather than
+  storing both
+- Write a comparison in one place — four call sites checking against the same constant are four rules that
+  agree only by coincidence
+- Design structs to be flat and normalized: each struct represents one concept with only its own fields;
+  avoid deep nesting or struct embedding as a substitute for inheritance
+- Prefer transformations that compose: a mapping that preserves structure, an operation with an identity
+  and an associative combine, and a round trip that returns the original are the shapes worth reaching for
 - Time has exactly two kinds and they never mix: an instant is a moment on the timeline and is always UTC
   (`DateTime<Utc>`, `TIMESTAMPTZ`), while a session is a trading day and is always an `America/New_York`
-  calendar date — that is what the exchange's day is, not a display preference. A session is
-  `data::calendar::SessionDate`, never a bare `NaiveDate`: derive one from an instant with `SessionDate::at`
-  and convert back with `.midnight()`/`.bounds()`, never via `Utc::now().date_naive()` or a hardcoded offset
-- `SessionDate::from_date` is for dates already expressed in Eastern terms — a parsed argument, a `DATE`
-  column, an exchange calendar entry — so transport modules (`common::alpaca`, `common::massive`,
-  `common::aws`) keep `NaiveDate` and the wrap happens at the domain boundary; render Eastern only at the
-  display boundary; `.midnight()` is for genuinely date-only values, such as an Alpaca transfer that
-  arrives with a date and no time, and never for a daily bar — those are stamped at the session
-  close (16:00 Eastern, so 20:00 UTC under daylight saving and 21:00 outside it), and a fixture
-  stamped at midnight sits on the edge of `bounds()` in a way ingestion never produces
+  calendar date — that is what the exchange's day is, not a display preference
+- A session is `data::calendar::SessionDate`, never a bare `NaiveDate`: derive one from an instant with
+  `SessionDate::at` and convert back with `.midnight()`/`.bounds()`, never via `Utc::now().date_naive()`
+  or a hardcoded offset
+- `SessionDate::from_date` is for dates already expressed in Eastern terms, so transport modules keep
+  `NaiveDate` and the wrap happens at the domain boundary; `.midnight()` is for genuinely date-only values
+  and never for a daily bar, which is stamped at the 16:00 Eastern close
 - `SessionDate` guarantees the timezone, not tradability: weekends and holidays are representable and
   `plus_calendar_days` will land on them, so only `TradingCalendar::is_trading_day` answers whether a date
   trades — never infer it from the type
@@ -123,7 +75,85 @@ This is a collection of guidelines and references.
   durations and timeouts carry no zone, so measure them on a monotonic clock (`tokio::time::Instant`), and
   schedule trading jobs with a UTC cron expression gated on the Eastern wall clock, a pairing that
   `tests/test_schedules.rs` enforces
-- Model state machines with two enums (states and transitions) matched as a tuple:
-  `match (current_state, transition) { ... }` — keeps business logic exhaustive and legible
-- Design structs to be flat and normalized: each struct represents one concept with only its own fields;
-  avoid deep nesting or struct embedding as a substitute for inheritance
+- Guard against division by zero when computing ratios or percentages from DataFrame aggregations, and
+  handle the `None` that Polars `Series.sum()` returns on an empty or all-null series
+- Ensure Rust automated test suites achieve at least 75% line or statement coverage, excluding generated
+  code, third-party code, tooling boilerplate, and anything explicitly excluded in this repository
+- When fixing a bug, write tests that reproduce the bug before fixing it, then verify the tests pass after
+  the fix
+- Pin test expectations to literals, never to the constant or list the test is checking — an expectation
+  derived from the value under test moves with it and can never fail
+- Prove a new assertion is load-bearing before trusting it: break the code it covers, watch the test fail,
+  restore
+- Assert the key set before comparing values — "for every element of the result" is vacuously true when the
+  result is empty
+- Never build a fixture from the belief under test; probe the live payload before typing a struct against
+  it, because a mock only proves the parser agrees with the fixture
+- Test the seam between components — two units that are each correct and each individually tested can still
+  be jointly broken
+- Assert mathematical properties the output must have as an object (mass integrates to one, no negative
+  probabilities, a mean that lands on the forward) rather than agreement with a fixture
+- Before believing a result, actively attempt to produce it from nothing — permute the labels, shuffle the
+  target, or feed the pipeline noise, and confirm the effect disappears
+- Run the identical pipeline on an input that cannot contain the effect; whatever it reports is the
+  machinery's own bias, and every real reading has to clear it
+- A control must differ from the treatment in exactly one respect, and it must be able to vary — a control
+  that cannot fail is not a control
+- Before trusting a measurement that reports nothing, confirm the instrument reports something when
+  something is there
+- State the trivial baseline before reading any metric, and quote skill against a named baseline rather
+  than a raw score
+- Unusually low variance across seeds is a warning rather than a quality signal — it means the metric is
+  pinned by the shape of the data rather than by anything the model learned
+- Magnitude before significance: ask whether the effect could pay for itself at measured cost before asking
+  whether it is real
+- Split the sample and test the difference between the halves, never whether both halves point the same way
+- Fix every free choice before looking at the result, and record each one with the number it produced
+- Scope a kill precisely — say exactly what was refuted and under what conditions, because over-claiming a
+  refutation closes doors that are still open and under-claiming reopens ones that are shut
+- Correcting an instance does not generalise the lesson; run the check deliberately against each new
+  measurement rather than remembering it as a past mistake
+- Standard errors assume independent observations, which financial data never is — aggregate to the level
+  that actually varies and report effective sample size rather than row count
+- Always report the undefined share alongside an estimate; an estimator silently defined on 60% of its
+  inputs reads exactly like a complete measurement
+- Print the population and the boundary values beside any difference — `1254 / 1254 / 0 / 0` is a proof and
+  a bare `0` is not
+- Screen on the quantity being paid for rather than a correlate of it, and check a screen's units before
+  checking its threshold
+- Levels drift and ranks do not — a threshold fixed in absolute units is a moving quantile, so scale
+  windows and cutoffs to the distribution's own width
+- Screen first, then average: a subset's cost read off the whole distribution's deciles is the wrong
+  number, and so is costing a strategy at an average over buckets it does not trade
+- Never quantile-bin an unordered category — nominal is not ordinal, and binning one merges unrelated
+  groups on the basis of the order they happened to arrive in
+- Compare mutual information as a share of the target's entropy rather than in raw bits, and subtract a
+  permutation-null baseline before reading the table
+- The universe is part of the answer, so journal it beside the result — the set of instruments collected
+  and the set measured over are different questions with different answers
+- Before filtering a provider feed by date, check whether the filter matches the event's own date or the
+  provider's record time — Alpaca's activity `date=`/`after=` match record time, so a date-only row dated
+  D is returned by a query for D+1
+- If something goes wrong during a task, stop immediately and re-plan rather than continuing
+- For non-trivial changes, pause and ask "Is there a more elegant way?" before implementing
+- Make every change as simple as possible, touching only what is necessary to avoid introducing bugs
+- Find root causes and avoid temporary fixes - maintain high standards
+- Do not introduce abstractions for single-use code
+- Use subagents to keep main context window clean and offload research, exploration, and analysis work
+- Invoke skills and suggest commands based on conversational context rather than waiting for explicit slash
+  commands
+- Prove changes work before marking tasks complete - run `devenv tasks run` checks, compare behavior,
+  demonstrate correctness
+- Verify against real data before reporting done, and say which route was used: `secretspec run -- curl`
+  against a provider, DuckDB over the S3 parquet, or a trainer rehearsal read back from `/var/log/fund/`;
+  when only fixtures were exercised, say so plainly, and ask to be pointed at real data rather than
+  inferring
+- When debugging or fixing bugs, check structured logs and error log files in `/var/log/fund/` to
+  understand what happened
+- A bug-fix commit message states the root cause and the fix rather than restating the diff
+- When creating GitHub issues or pull requests, use the templates in the `.github/` directory and follow
+  commented instructions
+- When naming branches, use an all-lowercase, hyphenated, and concise summary of the work being done
+- Only use existing repository labels for GitHub issues and pull requests
+- Do not use emojis in commit messages, GitHub issues, or pull requests - maintain a professional tone
+- When possible, use GitHub's GraphQL API directly for scripts and tools where token efficiency matters

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,9 @@ percent-encoding = "2.3"
 mockito = "1.7"
 serial_test = "4.0"
 tower = { version = "0.5", features = ["util"] }
+
+# Full debug info pushes the test binary past the size where macOS arm64 unwinding faults: the
+# panic message prints and the process then dies with SIGSEGV, so a failing test is reported as a
+# crash and names no assertion. Line tables keep file-and-line backtraces at a fraction of the size.
+[profile.test]
+debug = "line-tables-only"

--- a/src/bin/backfill_account_snapshots.rs
+++ b/src/bin/backfill_account_snapshots.rs
@@ -1,12 +1,6 @@
-//! Rebuilds missing `account_snapshots` rows from Alpaca's portfolio history.
-//!
-//! Recovery tooling, and the only import path this table has: a session the post-close sync missed
-//! is otherwise unrecoverable.
-//!
-//! Usage: `backfill_account_snapshots [--dry-run] <start YYYY-MM-DD> [end YYYY-MM-DD]`
-//! The end date defaults to today (Eastern) when omitted; `--dry-run` reports without writing.
-//!
-//! Reconstructed rows carry equity and no balances, which is all portfolio history reports.
+//! Rebuilds missing `account_snapshots` rows from Alpaca's portfolio history, the only import path
+//! this table has: `backfill_account_snapshots [--dry-run] <start YYYY-MM-DD> [end YYYY-MM-DD]`,
+//! the end date defaulting to today (Eastern). Reconstructed rows carry equity and no balances.
 
 use std::collections::BTreeMap;
 

--- a/src/bin/fund.rs
+++ b/src/bin/fund.rs
@@ -1,13 +1,6 @@
-//! The service: one process, woken entirely by pg_cron.
-//!
-//! There is no `--module` flag, no in-process scheduler, and no WebSocket. The process connects,
-//! replays anything today's cron fired while it was down, then listens on the `events` channel and
-//! dispatches. Every unit of work is a row somebody else wrote.
-//!
-//! Each notification is handled on its own task. The five-minute evaluation and a post-close sync
-//! can legitimately overlap, and serializing the listener would mean a slow export delaying an
-//! exit. Two instances of the *same* command cannot overlap; that is the in-flight claim in
-//! [`fund::handlers`].
+//! The service: one process, woken entirely by pg_cron, with no in-process scheduler.
+//! It replays what cron fired while it was down, then handles each `events` notification on its own
+//! task; two instances of the *same* command cannot overlap, via the claim in [`fund::handlers`].
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -31,17 +24,11 @@ const LISTENER_RECONNECT_DELAY: Duration = Duration::from_secs(5);
 
 /// How long to wait for running handlers after shutdown is requested.
 ///
-/// What matters is a handler with side effects part-applied: a liquidation between two broker
-/// orders, an export between S3 and the purge, or one that has not yet written its terminal event.
-/// Dropping one leaves a `_requested` row with no outcome while the process logs a clean stop.
-///
-/// Derived from the work. The longest wait is one pair opening, two legs at
-/// [`fund::portfolio::execute::FILL_TIMEOUT`] each — sixty seconds. Seventy-five leaves margin for
-/// the terminal event write and stays inside the 120 process-compose allows before escalating.
-///
-/// The bound holds only because the evaluation pass stops *starting* pairs once shutdown is
-/// requested; see `entries_abandoned` in [`fund::portfolio::evaluate`]. Without that the pass works
-/// through every approved candidate and no fixed timeout covers it.
+/// Derived from the longest unit of work: one pair opening is two legs at
+/// [`fund::portfolio::execute::FILL_TIMEOUT`] each, and seventy-five seconds leaves margin for the
+/// terminal event write inside the 120 process-compose allows before escalating. The bound holds
+/// only because the evaluation pass stops *starting* pairs once shutdown is requested; see
+/// `entries_abandoned` in [`fund::portfolio::evaluate`].
 const HANDLER_DRAIN_TIMEOUT: Duration = Duration::from_secs(75);
 
 #[tokio::main]
@@ -268,10 +255,9 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc as StdArc;
 
-    /// The property the whole change exists for: work still running when shutdown is requested runs
-    /// to completion rather than being dropped at its next await point. Before this, `tokio::spawn`
-    /// detached the task and the runtime cancelled it when `main` returned — truncating a
-    /// liquidation between broker orders, or a handler before it wrote its terminal event.
+    /// Work still running when shutdown is requested runs to completion rather than being dropped at
+    /// its next await point. A detached `tokio::spawn` is cancelled when `main` returns, which would
+    /// truncate a liquidation between broker orders or a handler before its terminal event.
     #[tokio::test]
     async fn test_drain_waits_for_a_running_handler_to_finish() {
         let finished = StdArc::new(AtomicUsize::new(0));

--- a/src/bin/laboratory_convergence.rs
+++ b/src/bin/laboratory_convergence.rs
@@ -257,7 +257,7 @@ fn render(measured: &[laboratory::ConvergenceMeasured]) -> String {
 
         rendered.push_str(&format!("{:>8}", "horizon"));
         for arm in &arms {
-            rendered.push_str(&format!("{:>34}", arm.selection));
+            rendered.push_str(&format!("{:>43}", arm.selection));
         }
         rendered.push('\n');
         rendered.push_str(&format!("{:>8}", ""));

--- a/src/bin/laboratory_convergence.rs
+++ b/src/bin/laboratory_convergence.rs
@@ -263,8 +263,8 @@ fn render(measured: &[laboratory::ConvergenceMeasured]) -> String {
         rendered.push_str(&format!("{:>8}", ""));
         for _ in &arms {
             rendered.push_str(&format!(
-                "{:>9}{:>9}{:>9}{:>7}",
-                "converged", "stopped", "open", "n"
+                "{:>9}{:>9}{:>9}{:>9}{:>7}",
+                "converged", "error", "stopped", "open", "n"
             ));
         }
         rendered.push('\n');
@@ -276,10 +276,17 @@ fn render(measured: &[laboratory::ConvergenceMeasured]) -> String {
                 // which would read as a cohort that was followed and did nothing.
                 match arm.curves.iter().find(|curve| curve.horizon == horizon) {
                     Some(curve) if curve.entries > 0 => rendered.push_str(&format!(
-                        "{:>9.4}{:>9.4}{:>9.4}{:>7}",
-                        curve.converged, curve.stopped, curve.open, curve.entries
+                        "{:>9.4}{:>9}{:>9.4}{:>9.4}{:>7}",
+                        curve.converged,
+                        // A share with no error beside it reads as a result rather than an estimate.
+                        curve
+                            .converged_standard_error
+                            .map_or_else(|| "--".to_string(), |error| format!("{error:.4}")),
+                        curve.stopped,
+                        curve.open,
+                        curve.entries
                     )),
-                    Some(_) | None => rendered.push_str(&format!("{:>34}", "unmeasured")),
+                    Some(_) | None => rendered.push_str(&format!("{:>43}", "unmeasured")),
                 }
             }
             rendered.push('\n');
@@ -344,6 +351,8 @@ mod tests {
                     stopped: 0.1,
                     open: 0.9 - converged,
                     entries: 1_284,
+                    sessions: 499,
+                    converged_standard_error: Some(0.02),
                 })
                 .collect(),
         }

--- a/src/bin/laboratory_information.rs
+++ b/src/bin/laboratory_information.rs
@@ -226,11 +226,11 @@ async fn run(
         triaged.push(triage(column, &paired, parameters.seed));
     }
 
-    // Ranked, because the question is which input carries the most and a table in column order
-    // makes that a search rather than a reading.
+    // Ranked by the share rather than the raw bits: bits are capped by the target's own entropy, so
+    // ranking on them ranks the ceilings wherever two runs cut the target differently.
     triaged.sort_by(|left, right| {
-        bits_of(right)
-            .partial_cmp(&bits_of(left))
+        share_of(right)
+            .partial_cmp(&share_of(left))
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
@@ -238,7 +238,9 @@ async fn run(
         info!(
             feature = record.feature,
             sessions = record.sessions,
+            excess_share = record.excess_share.map(|value| value.mean),
             excess_bits = record.excess_bits.map(|value| value.mean),
+            target_entropy_bits = record.target_entropy_bits.map(|value| value.mean),
             "Triaged a feature"
         );
         if let Some(journal) = journal.as_ref() {
@@ -280,27 +282,39 @@ fn triage(feature: &str, paired: &Paired, seed: u64) -> laboratory::FeatureTriag
                 .iter()
                 .map(|value| value.map(|value| value.excess())),
         ),
+        target_entropy_bits: metrics::summarize(
+            measured
+                .iter()
+                .map(|value| value.map(|value| value.target_entropy)),
+        ),
+        excess_share: metrics::summarize(
+            measured
+                .iter()
+                .map(|value| value.and_then(|value| value.excess_share())),
+        ),
     }
 }
 
-fn bits_of(record: &laboratory::FeatureTriaged) -> f64 {
+/// What the ranking is by: excess bits as a share of what the target itself can carry.
+fn share_of(record: &laboratory::FeatureTriaged) -> f64 {
     record
-        .excess_bits
+        .excess_share
         .map_or(f64::NEG_INFINITY, |value| value.mean)
 }
 
 fn render(triaged: &[laboratory::FeatureTriaged]) -> String {
     let mut rendered = format!(
-        "{:<32}{:>10}{:>28}{:>28}{:>28}\n",
-        "feature", "sessions", "excess_bits", "bits", "null_bits"
+        "{:<32}{:>10}{:>28}{:>28}{:>28}{:>28}\n",
+        "feature", "sessions", "excess_share", "excess_bits", "target_entropy_bits", "null_bits"
     );
     for record in triaged {
         rendered.push_str(&format!(
-            "{:<32}{:>10}{:>28}{:>28}{:>28}\n",
+            "{:<32}{:>10}{:>28}{:>28}{:>28}{:>28}\n",
             record.feature,
             record.sessions,
+            distribution(record.excess_share),
             distribution(record.excess_bits),
-            distribution(record.bits),
+            distribution(record.target_entropy_bits),
             distribution(record.null_bits),
         ));
     }
@@ -359,6 +373,46 @@ mod tests {
         assert!(Parameters::parse(&arguments(&["365", "0"])).is_err());
         assert!(Parameters::parse(&arguments(&["365", "3", "extra"])).is_err());
         assert!(Parameters::parse(&arguments(&["365", "3", "signed", "more"])).is_err());
+    }
+
+    fn distribution_of(mean: f64) -> Distribution {
+        Distribution {
+            mean,
+            standard_error: 0.001,
+            sessions: 499,
+        }
+    }
+
+    /// The reported figure is the share of the target's own entropy, because raw bits are capped by
+    /// that entropy and comparing them compares the caps.
+    #[test]
+    fn test_the_share_of_the_target_entropy_is_what_is_ranked_and_rendered() {
+        let record = laboratory::FeatureTriaged {
+            feature: "daily_return".to_string(),
+            sessions: 499,
+            bits: Some(distribution_of(3.1000)),
+            null_bits: Some(distribution_of(3.0000)),
+            excess_bits: Some(distribution_of(0.1000)),
+            target_entropy_bits: Some(distribution_of(3.3000)),
+            excess_share: Some(distribution_of(0.0301)),
+        };
+
+        assert!((share_of(&record) - 0.0301).abs() < 1e-12);
+
+        let rendered = render(std::slice::from_ref(&record));
+        assert!(rendered.contains("excess_share"), "{rendered}");
+        assert!(rendered.contains("target_entropy_bits"), "{rendered}");
+        assert!(rendered.contains("+0.030100"), "{rendered}");
+
+        let unmeasured = laboratory::FeatureTriaged {
+            excess_share: None,
+            ..record
+        };
+        assert_eq!(
+            share_of(&unmeasured),
+            f64::NEG_INFINITY,
+            "a feature with no share ranks last rather than at zero"
+        );
     }
 
     /// The calendar columns are excluded because they hold one value for every name in a session,

--- a/src/bin/laboratory_intraday_baselines.rs
+++ b/src/bin/laboratory_intraday_baselines.rs
@@ -180,27 +180,38 @@ async fn session_hours(
 
 /// Prints the bounce reading, which decides whether anything below it can be believed.
 fn report_bounce(sessions: &[SessionReturns]) {
-    let Some(BounceReading {
+    let Some(reading) = intraday::bounce(sessions) else {
+        println!("\nbounce: no name-session carried enough returns to measure");
+        return;
+    };
+    let BounceReading {
         lag_one,
         lag_two,
         roll_spread,
         measured,
         share_negative,
-    }) = intraday::bounce(sessions)
-    else {
-        println!("\nbounce: no name-session carried enough returns to measure");
-        return;
-    };
+        lag_two_measured,
+        roll_spread_measured,
+    } = reading;
 
     println!("\nbid-ask bounce, over {measured} name-sessions");
     println!("  lag-1 autocorrelation  {lag_one:+.4}");
+    // An estimate defined on part of the population reads exactly like one defined on all of it,
+    // so the undefined share travels with every number below.
     match lag_two {
-        Some(value) => println!("  lag-2 autocorrelation  {value:+.4}"),
+        Some(value) => println!(
+            "  lag-2 autocorrelation  {value:+.4} over {lag_two_measured} name-sessions, {:.1}% undefined",
+            reading.lag_two_undefined_share() * 100.0
+        ),
         None => println!("  lag-2 autocorrelation  not estimable"),
     }
     println!("  share negative at lag-1 {share_negative:.4}");
     match roll_spread {
-        Some(spread) => println!("  Roll effective spread   {:.4}%", spread * 100.0),
+        Some(spread) => println!(
+            "  Roll effective spread   {:.4}% over {roll_spread_measured} name-sessions, {:.1}% undefined",
+            spread * 100.0,
+            reading.roll_spread_undefined_share() * 100.0
+        ),
         None => println!("  Roll effective spread   not estimable"),
     }
 }

--- a/src/bin/laboratory_intraday_convergence.rs
+++ b/src/bin/laboratory_intraday_convergence.rs
@@ -8,7 +8,9 @@ use tracing::{error, info};
 use fund::common::alpaca::{AlpacaCredentials, TradingClient};
 use fund::common::log::init_tracing;
 use fund::common::types::{BarInterval, SessionDate};
-use fund::laboratory::convergence::{curves_of, sample_universe, Closes, Curve, Selection};
+use fund::laboratory::convergence::{
+    curves_of, sample_universe, state_at, Closes, Curve, Selection,
+};
 use fund::laboratory::intraday::{self, SessionHours};
 use fund::laboratory::intraday_convergence::{self, IntradayEntry};
 use fund::laboratory::{dataset, intraday_convergence as measure};
@@ -27,17 +29,20 @@ const DEFAULT_LOOKBACK_DAYS: i64 = 90;
 /// Names sampled from the universe by default.
 ///
 /// Pairs grow with the square, so the whole intraday universe is millions of pairs per session.
-/// Two hundred names is ~19,900 pairs, which is what #1091 measured the daily version over.
+/// Two hundred names is ~19,900 pairs, matching what the daily measurement runs over.
 const DEFAULT_UNIVERSE: usize = 200;
 
 /// Fixed, so two runs over one archive draw the same sample and differ only where the data does.
 const SAMPLE_SEED: u64 = 0x5EED;
 
-/// Round-trip cost in z-score units is not knowable without the fitted sigma, so the cost is
-/// reported in basis points beside the result rather than folded into it.
+/// Roll's effective spread for a *single* name, in basis points, measured over the same archive.
 ///
-/// Measured by Roll's estimator over the same archive: 9 to 13 basis points.
+/// Cost in z-score units is not knowable without the fitted sigma, so it is reported in basis points
+/// beside the result rather than folded into it.
 const EFFECTIVE_SPREAD_BASIS_POINTS: f64 = 10.0;
+
+/// Crossings a pair round trip pays: both legs in and both legs out.
+const PAIR_ROUND_TRIP_CROSSINGS: f64 = 4.0;
 
 struct Parameters {
     session: SessionDate,
@@ -207,21 +212,33 @@ fn report(selection: Selection, entries: &[IntradayEntry]) {
         println!("no entries");
         return;
     }
-    let states: Vec<_> = entries.iter().map(IntradayEntry::state).collect();
+    let states: Vec<_> = entries
+        .iter()
+        .map(|entry| (entry.session, entry.resolution, entry.observed))
+        .collect();
     let curves = curves_of(&states);
-    let mean_z = intraday_convergence::mean_entry_z_score(entries).unwrap_or(0.0);
 
-    println!("entries {}, mean entry z {mean_z:.3}", entries.len());
-    println!("  horizon  entries  converged  stopped  open");
+    match intraday_convergence::mean_entry_z_score(entries) {
+        Some(mean_z_score) => println!("entries {}, mean entry z {mean_z_score:.3}", entries.len()),
+        None => println!("entries {}, mean entry z not measurable", entries.len()),
+    }
+    println!("  horizon  entries  sessions  converged      se  stopped  open");
     for Curve {
         horizon,
         converged,
         stopped,
         open,
         entries: standing,
+        sessions,
+        converged_standard_error,
     } in &curves
     {
-        println!("  {horizon:>7}  {standing:>7}  {converged:>9.4}  {stopped:>7.4}  {open:>5.4}");
+        let error = converged_standard_error
+            .map_or_else(|| "      -".to_string(), |value| format!("{value:>7.4}"));
+        println!(
+            "  {horizon:>7}  {standing:>7}  {sessions:>8}  {converged:>9.4}  {error}  \
+             {stopped:>7.4}  {open:>5.4}"
+        );
     }
 
     // The statistic the horizon can answer. Full convergence asks a daily-sigma dislocation to
@@ -248,17 +265,50 @@ fn report(selection: Selection, entries: &[IntradayEntry]) {
     }
 
     if let Some(final_curve) = curves.last() {
-        let expected = final_curve.converged * mean_z
-            - final_curve.stopped * fund::portfolio::screen::STOP_LOSS_WIDENING;
+        // The shares count only the entries still standing at this horizon, so the z-score they are
+        // multiplied by has to be taken over that same cohort and not over every entry opened.
+        let standing = standing_at(entries, final_curve.horizon);
+        match intraday_convergence::mean_entry_z_score(&standing) {
+            Some(mean_z_score) => {
+                let expected = final_curve.converged * mean_z_score
+                    - final_curve.stopped * fund::portfolio::screen::STOP_LOSS_WIDENING;
+                println!(
+                    "\n  expected value at horizon {}: {expected:+.4} sigma per entry, over the \
+                     {} entries standing there (mean entry z {mean_z_score:.3})",
+                    final_curve.horizon,
+                    standing.len()
+                );
+            }
+            None => println!(
+                "\n  expected value at horizon {}: no entry stands there to value",
+                final_curve.horizon
+            ),
+        }
+        let round_trip = pair_round_trip_basis_points(EFFECTIVE_SPREAD_BASIS_POINTS);
         println!(
-            "\n  expected value at horizon {}: {expected:+.4} sigma per entry",
-            final_curve.horizon
-        );
-        println!(
-            "  round-trip cost is about {EFFECTIVE_SPREAD_BASIS_POINTS:.0} basis points; a sigma \
-             is worth that only if the fitted spread is wider than it"
+            "  pair round trip is about {round_trip:.0} basis points \
+             ({EFFECTIVE_SPREAD_BASIS_POINTS:.0} bp single-name effective spread over \
+             {PAIR_ROUND_TRIP_CROSSINGS:.0} crossings); a sigma is worth that only if the fitted \
+             spread is wider than it"
         );
     }
+}
+
+/// What a pair round trip costs, in basis points, given one name's effective spread.
+///
+/// An effective spread is the full width and a crossing pays half of it, so four crossings come to
+/// twice the single-name figure.
+fn pair_round_trip_basis_points(single_name_effective_spread: f64) -> f64 {
+    single_name_effective_spread * PAIR_ROUND_TRIP_CROSSINGS / 2.0
+}
+
+/// The entries a horizon's shares are computed over, which is what those shares may be priced with.
+fn standing_at(entries: &[IntradayEntry], horizon: usize) -> Vec<IntradayEntry> {
+    entries
+        .iter()
+        .filter(|entry| state_at(entry.resolution, entry.observed, horizon).is_some())
+        .cloned()
+        .collect()
 }
 
 #[cfg(test)]
@@ -278,6 +328,58 @@ mod tests {
         let parameters = Parameters::parse(&arguments(&["2026-08-20", "30", "50"])).unwrap();
         assert_eq!(parameters.lookback_days, 30);
         assert_eq!(parameters.universe, 50);
+    }
+
+    use fund::laboratory::convergence::{Observed, Resolution};
+
+    fn entry_with(long: &str, entry_z_score: f64, resolution: Resolution) -> IntradayEntry {
+        IntradayEntry {
+            session: SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 6, 1).unwrap()),
+            entry_bar: 0,
+            long: long.to_string(),
+            short: "SHORT".to_string(),
+            entry_z_score,
+            final_z_score: None,
+            resolution,
+            observed: Observed::default(),
+        }
+    }
+
+    /// The shares at a horizon are over the entries still standing there, so the z-score they are
+    /// priced with has to be over the same cohort. Taken over every entry opened, an entry never
+    /// observed at that horizon lends its z-score to a share it is no part of.
+    #[test]
+    fn test_the_value_at_a_horizon_prices_only_the_entries_standing_there() {
+        let entries = vec![
+            entry_with("RESOLVED", 2.0, Resolution::Converged(2)),
+            // Never priced at any horizon, so it stands nowhere.
+            entry_with("TRUNCATED", 4.0, Resolution::Unresolved),
+        ];
+
+        let standing = standing_at(&entries, 20);
+
+        assert_eq!(standing.len(), 1, "only one entry was seen that far");
+        assert_eq!(standing[0].long, "RESOLVED");
+        assert!(
+            (intraday_convergence::mean_entry_z_score(&standing).unwrap() - 2.0).abs() < 1e-12,
+            "over every entry opened it would have been 3.0"
+        );
+        assert!(
+            standing_at(&entries, 1).is_empty(),
+            "and a horizon before either was seen values nothing"
+        );
+    }
+
+    /// A pair round trip is four crossings and Roll's estimator prices one name's spread, so the
+    /// hurdle is twice the single-name figure rather than the figure itself.
+    #[test]
+    fn test_a_pair_round_trip_costs_four_crossings() {
+        assert!(
+            (pair_round_trip_basis_points(10.0) - 20.0).abs() < 1e-12,
+            "ten basis points a name is twenty for the pair, got {}",
+            pair_round_trip_basis_points(10.0)
+        );
+        assert!((pair_round_trip_basis_points(6.0) - 12.0).abs() < 1e-12);
     }
 
     /// One ticker makes no pairs, so a universe of one would measure nothing and report it as a

--- a/src/bin/laboratory_regime.rs
+++ b/src/bin/laboratory_regime.rs
@@ -195,20 +195,28 @@ async fn run(
         for (name, state) in &states {
             // Both series cut with the same range, or a lag would pair a reading against the state
             // of a session outside the stretch being measured.
-            for (segment, range) in regime::segments(panel.sessions()) {
-                let state = &state[range.clone()];
-                let readings = &readings[range];
-                let record = laboratory::RegimeMeasured {
-                    predictor: evaluation.predictor.clone(),
-                    statistic: STATISTIC.to_string(),
-                    state: name.to_string(),
-                    segment: segment.to_string(),
-                    sessions: readings.iter().flatten().count(),
-                    associations: LAGS
-                        .iter()
-                        .filter_map(|lag| stability::association(state, readings, *lag))
-                        .collect(),
-                };
+            let mut segments: Vec<laboratory::RegimeMeasured> = regime::segments(panel.sessions())
+                .into_iter()
+                .map(|(segment, range)| {
+                    let state = &state[range.clone()];
+                    let readings = &readings[range];
+                    laboratory::RegimeMeasured {
+                        predictor: evaluation.predictor.clone(),
+                        statistic: STATISTIC.to_string(),
+                        state: name.to_string(),
+                        segment: segment.to_string(),
+                        sessions: readings.iter().flatten().count(),
+                        associations: LAGS
+                            .iter()
+                            .filter_map(|lag| stability::association(state, readings, *lag))
+                            .collect(),
+                        half_differences: Vec::new(),
+                    }
+                })
+                .collect();
+            attach_half_differences(&mut segments);
+
+            for record in segments {
                 info!(
                     predictor = record.predictor,
                     state = record.state,
@@ -243,10 +251,42 @@ async fn run(
     Ok(measured)
 }
 
+/// Records the gap between the two halves on the whole-window record of one state.
+///
+/// The split-sample check is the difference against its own error: two halves pointing the same way
+/// can still be far apart, and two pointing opposite ways can be one standard error from agreeing.
+fn attach_half_differences(segments: &mut [laboratory::RegimeMeasured]) {
+    let association_at = |segment: &str, lag: usize| {
+        segments
+            .iter()
+            .find(|record| record.segment == segment)
+            .and_then(|record| {
+                record
+                    .associations
+                    .iter()
+                    .find(|association| association.lag == lag)
+            })
+            .copied()
+    };
+    let differences: Vec<laboratory::HalfDifference> = LAGS
+        .iter()
+        .filter_map(|lag| {
+            laboratory::HalfDifference::between(
+                association_at(FIRST_HALF, *lag).as_ref(),
+                association_at(SECOND_HALF, *lag).as_ref(),
+            )
+        })
+        .collect();
+
+    if let Some(whole) = segments.iter_mut().find(|record| record.segment == WHOLE) {
+        whole.half_differences = differences;
+    }
+}
+
 /// One block per forecast, one row per state and lag, one column per stretch of the window.
 ///
-/// The halves sit beside the whole rather than under it, because the question they answer is whether
-/// the whole's figure is one relationship or two unrelated ones that averaged into the look of one.
+/// The halves sit beside the whole rather than under it, and the difference sits beside them:
+/// whether the whole's figure is one relationship or two is a question about that gap and its error.
 fn render(measured: &[laboratory::RegimeMeasured]) -> String {
     let mut rendered = String::new();
     let mut current = "";
@@ -254,14 +294,15 @@ fn render(measured: &[laboratory::RegimeMeasured]) -> String {
         if record.predictor != current {
             current = &record.predictor;
             rendered.push_str(&format!(
-                "\n{} ({})\n{:<24}{:>6}{:>26}{:>26}{:>26}\n",
+                "\n{} ({})\n{:<24}{:>6}{:>26}{:>26}{:>26}{:>26}\n",
                 record.predictor,
                 record.statistic,
                 "state",
                 "lag",
                 "whole",
                 "first half",
-                "second half"
+                "second half",
+                "second minus first"
             ));
         }
         if record.segment != WHOLE {
@@ -269,16 +310,39 @@ fn render(measured: &[laboratory::RegimeMeasured]) -> String {
         }
         for lag in LAGS {
             rendered.push_str(&format!(
-                "{:<24}{:>6}{:>26}{:>26}{:>26}\n",
+                "{:<24}{:>6}{:>26}{:>26}{:>26}{:>26}\n",
                 record.state,
                 lag,
                 correlation(measured, record, WHOLE, *lag),
                 correlation(measured, record, FIRST_HALF, *lag),
                 correlation(measured, record, SECOND_HALF, *lag),
+                half_difference(record, *lag),
             ));
         }
     }
     rendered
+}
+
+/// The gap between the halves with its error, or why there is none.
+fn half_difference(record: &laboratory::RegimeMeasured, lag: usize) -> String {
+    record
+        .half_differences
+        .iter()
+        .find(|difference| difference.lag == lag)
+        .map_or_else(
+            || "unmeasurable".to_string(),
+            |difference| {
+                let errors = if difference.standard_error > 0.0 {
+                    difference.difference / difference.standard_error
+                } else {
+                    f64::NAN
+                };
+                format!(
+                    "{:+.4} ± {:.4} ({errors:+.2})",
+                    difference.difference, difference.standard_error
+                )
+            },
+        )
 }
 
 /// One association with its error, or why there is none.
@@ -367,7 +431,58 @@ mod tests {
                 standard_error: 0.0448,
                 pairs: 499,
             }],
+            half_differences: Vec::new(),
         }
+    }
+
+    /// The split-sample check is the gap between the halves against its own error. Printing the
+    /// halves side by side and nothing else reduces it to eyeballing whether both point the same
+    /// way, which two halves a quarter apart can do.
+    #[test]
+    fn test_the_difference_between_the_halves_is_computed_and_rendered() {
+        let mut segments = vec![
+            measurement("breadth", WHOLE, 0.1494, 1),
+            measurement("breadth", FIRST_HALF, 0.2000, 1),
+            measurement("breadth", SECOND_HALF, 0.5000, 1),
+        ];
+        // A round error apiece, so the quadrature sum is a number to check by hand.
+        for segment in &mut segments[1..] {
+            segment.associations[0].standard_error = 0.03;
+        }
+
+        attach_half_differences(&mut segments);
+
+        let gaps = &segments[0].half_differences;
+        assert_eq!(gaps.len(), 1, "one lag was measured: {gaps:?}");
+        assert!((gaps[0].difference - 0.3).abs() < 1e-12, "{gaps:?}");
+        assert!(
+            (gaps[0].standard_error - 0.042_426_407).abs() < 1e-9,
+            "{gaps:?}"
+        );
+        assert!(
+            segments[1].half_differences.is_empty() && segments[2].half_differences.is_empty(),
+            "the gap belongs to the figure it splits, not to each half"
+        );
+
+        let rendered = render(&segments);
+        assert!(rendered.contains("second minus first"), "{rendered}");
+        assert!(rendered.contains("+0.3000 ± 0.0424 (+7.07)"), "{rendered}");
+    }
+
+    /// A half that could not be measured leaves no difference, and rendering a zero there would
+    /// read as two halves that agreed.
+    #[test]
+    fn test_a_missing_half_leaves_no_difference_rather_than_a_zero() {
+        let mut segments = vec![
+            measurement("breadth", WHOLE, 0.1494, 1),
+            measurement("breadth", FIRST_HALF, 0.2000, 1),
+        ];
+
+        attach_half_differences(&mut segments);
+
+        assert!(segments[0].half_differences.is_empty());
+        let rendered = render(&segments);
+        assert!(!rendered.contains("+0.0000"), "{rendered}");
     }
 
     /// The whole and its halves belong in one row, because the question they answer together is

--- a/src/bin/laboratory_tide.rs
+++ b/src/bin/laboratory_tide.rs
@@ -1,12 +1,15 @@
-//! Trains one model and scores it against the baselines, over the same sessions.
+//! Trains several models and scores them against the baselines, over one universe of names.
 //!
 //! Publishes nothing: the question is what the model orders, not what it should trade.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use burn::module::AutodiffModule;
 use burn::tensor::backend::Backend;
 use chrono::Utc;
+use polars::prelude::*;
+use rand::seq::SliceRandom;
+use rand::{rngs::StdRng, SeedableRng};
 use tracing::{error, info, warn};
 
 use fund::common::log::init_tracing;
@@ -19,12 +22,16 @@ use fund::laboratory::predictor::{
 };
 use fund::laboratory::{dataset, forecast};
 use fund::models::tide::configuration::ModelParameters;
-use fund::models::tide::data::{input_feature_size, DatasetKind, Target, TrainingFraction};
+use fund::models::tide::data::{
+    input_feature_size, DatasetKind, FeatureMappings, Target, TrainingDataset, TrainingFraction,
+};
 use fund::models::tide::model::TiDEModel;
 use fund::models::tide::train::{train, TrainBackend, TrainConfiguration};
+use fund::models::tide::TideError;
 
-const USAGE: &str = "Usage: laboratory_tide [LOOKBACK_DAYS] [EPOCHS] [SEED] [TARGET]\n\
-                     TARGET is raw (default) or demeaned";
+const USAGE: &str =
+    "Usage: laboratory_tide [LOOKBACK_DAYS] [EPOCHS] [SEED] [TARGET] [SEED_COUNT]\n\
+     TARGET is raw (default) or demeaned";
 
 const INPUT_LENGTH: usize = 35;
 const OUTPUT_LENGTH: usize = 1;
@@ -42,52 +49,78 @@ const RANDOM_SEED: u64 = 0x5EED;
 
 /// Seeds the weight initialiser, so two runs of one configuration produce one model.
 ///
-/// `train` already seeds its own batch shuffle; the weights went through the backend's global
-/// generator, and two runs of the same configuration scored 0.008 apart — a whole standard error.
-/// Settable, because one seed measures one model and the question is about the architecture.
+/// `train` already seeds its own batch shuffle; the weights go through the backend's global
+/// generator, and initialisation alone moves the reported coefficient by more than the tradeable
+/// threshold. This names the first of [`Parameters::seed_count`] consecutive seeds.
 const DEFAULT_TRAINING_SEED: i64 = 0x7A1D;
+
+/// How many seeds one invocation trains, so the run reports a spread rather than a point.
+///
+/// Each seed costs a full fit of both arms, so this is the smallest count that has a spread at all
+/// plus one. A single seed reports a number with no error bar on the thing that is being varied.
+const DEFAULT_SEED_COUNT: i64 = 3;
+
+/// Mixed into the training seed to draw the permutation, so the null's shuffle and the null model's
+/// weights are not the same draw.
+const PERMUTATION_SEED: u64 = 0x9E37_79B9_7F4A_7C15;
+
+/// Below this the seeds produced one model rather than several.
+///
+/// A tight spread is a warning and never a quality signal: it means initialisation did not reach the
+/// weights, so the single number the run reports has no error bar behind it after all.
+const SEED_DISPERSION_FLOOR: f64 = 1e-9;
 
 struct Parameters {
     lookback_days: i64,
     epochs: usize,
     seed: u64,
     target: Target,
+    seed_count: usize,
 }
 
 impl Parameters {
     fn parse(arguments: &[String]) -> Result<Self, String> {
-        let (lookback_days, epochs, seed) = match arguments {
-            [] => (DEFAULT_LOOKBACK_DAYS, DEFAULT_EPOCHS, DEFAULT_TRAINING_SEED),
+        let (lookback_days, epochs, seed, seed_count) = match arguments {
+            [] => (
+                DEFAULT_LOOKBACK_DAYS,
+                DEFAULT_EPOCHS,
+                DEFAULT_TRAINING_SEED,
+                DEFAULT_SEED_COUNT,
+            ),
             [lookback] => (
                 positive(lookback, "LOOKBACK_DAYS")?,
                 DEFAULT_EPOCHS,
                 DEFAULT_TRAINING_SEED,
+                DEFAULT_SEED_COUNT,
             ),
             [lookback, epochs] => (
                 positive(lookback, "LOOKBACK_DAYS")?,
                 positive(epochs, "EPOCHS")?,
                 DEFAULT_TRAINING_SEED,
+                DEFAULT_SEED_COUNT,
             ),
-            [lookback, epochs, seed] => (
+            [lookback, epochs, seed] | [lookback, epochs, seed, _] => (
                 positive(lookback, "LOOKBACK_DAYS")?,
                 positive(epochs, "EPOCHS")?,
                 positive(seed, "SEED")?,
+                DEFAULT_SEED_COUNT,
             ),
-            [lookback, epochs, seed, _] => (
+            [lookback, epochs, seed, _, seed_count] => (
                 positive(lookback, "LOOKBACK_DAYS")?,
                 positive(epochs, "EPOCHS")?,
                 positive(seed, "SEED")?,
+                positive(seed_count, "SEED_COUNT")?,
             ),
             _ => return Err(format!("Too many arguments\n{USAGE}")),
         };
         let target = match arguments {
-            [_, _, _, target] => match target.trim() {
+            [_, _, _, target] | [_, _, _, target, _] => match target.trim() {
                 "raw" => Target::Raw,
                 "demeaned" => Target::CrossSectionallyDemeaned,
                 other => {
                     return Err(format!(
                         "TARGET must be raw or demeaned, got {other:?}\n{USAGE}"
-                    ))
+                    ));
                 }
             },
             _ => Target::Raw,
@@ -98,6 +131,9 @@ impl Parameters {
                 .map_err(|_| format!("EPOCHS is larger than this platform can index\n{USAGE}"))?,
             seed: seed as u64,
             target,
+            seed_count: usize::try_from(seed_count).map_err(|_| {
+                format!("SEED_COUNT is larger than this platform can index\n{USAGE}")
+            })?,
         })
     }
 }
@@ -131,8 +167,8 @@ async fn main() {
     };
 
     let code = match run(&parameters).await {
-        Ok(scored) => {
-            println!("{}", render(&scored));
+        Ok(report) => {
+            println!("{}", render(&report));
             0
         }
         Err(error) => {
@@ -146,9 +182,39 @@ async fn main() {
     std::process::exit(code);
 }
 
-async fn run(
-    parameters: &Parameters,
-) -> Result<Vec<laboratory::ForecastScored>, Box<dyn std::error::Error>> {
+/// The cross-section every arm in one run was measured over.
+///
+/// Reported beside the scores because the windowing emits samples only for names with a contiguous
+/// window, so a baseline read over the whole panel would differ from the model in two respects at
+/// once and neither could be blamed for the gap.
+#[derive(Debug, Clone, Copy)]
+struct Universe {
+    tickers: usize,
+    sessions: usize,
+}
+
+/// How far one statistic moved across seeds that differ in nothing else.
+///
+/// `standard_deviation` is `None` for a single seed, which measures no spread rather than a spread of
+/// zero. A spread far below the per-session standard error is a warning, not a stable architecture.
+#[derive(Debug, Clone)]
+struct SeedDispersion {
+    arm: String,
+    seeds: usize,
+    mean: f64,
+    standard_deviation: Option<f64>,
+    minimum: f64,
+    maximum: f64,
+}
+
+/// What one invocation produced: the universe, every arm's score, and the spread across seeds.
+struct Report {
+    universe: Universe,
+    records: Vec<laboratory::ForecastScored>,
+    dispersions: Vec<SeedDispersion>,
+}
+
+async fn run(parameters: &Parameters) -> Result<Report, Box<dyn std::error::Error>> {
     let bucket = std::env::var("AWS_S3_ARCHIVE_BUCKET_NAME")
         .map_err(|_| "AWS_S3_ARCHIVE_BUCKET_NAME must be set (the shared data/** archive)")?;
     let s3_client = fund::common::aws::s3_client().await;
@@ -170,9 +236,10 @@ async fn run(
         epochs = parameters.epochs,
         seed = parameters.seed,
         target = format!("{:?}", parameters.target),
+        seed_count = parameters.seed_count,
         %session,
         %run_id,
-        "Training a model to score it"
+        "Training models to score them"
     );
 
     let training_fraction = TrainingFraction::new(TRAINING_FRACTION)?;
@@ -221,18 +288,6 @@ async fn run(
     let input_size = input_feature_size(INPUT_LENGTH, OUTPUT_LENGTH);
     let model_parameters = ModelParameters::new(input_size, INPUT_LENGTH, OUTPUT_LENGTH);
     let device = <TrainBackend as Backend>::Device::default();
-    // Before the weights are drawn, not after.
-    <TrainBackend as Backend>::seed(parameters.seed);
-    let model = TiDEModel::<TrainBackend>::new(
-        &device,
-        input_size,
-        model_parameters.hidden_size(),
-        model_parameters.encoder_layer_count(),
-        model_parameters.decoder_layer_count(),
-        model_parameters.output_length(),
-        model_parameters.quantiles().len(),
-        model_parameters.dropout_rate(),
-    );
 
     // Through the validated constructor rather than by assigning a field, as the trainer does: an
     // epoch count of zero would otherwise run no epochs and score an untrained model.
@@ -244,45 +299,65 @@ async fn run(
         defaults.early_stopping_patience(),
         defaults.min_delta(),
     )?;
-    let started = tokio::time::Instant::now();
-    let (best_model, losses) = train(
-        model,
-        &training_data,
-        Some(&validation_data),
-        &model_parameters,
-        &configuration,
-        &device,
-    );
-    info!(
-        epochs = losses.len(),
-        final_train_loss = losses.last().copied().unwrap_or_default(),
-        seconds = started.elapsed().as_secs(),
-        "Training complete"
-    );
 
-    // Named for the arm, so two runs over one window are distinguishable in the journal.
-    let scored_model = forecast::score(
-        match parameters.target {
-            Target::Raw => "tide",
-            Target::CrossSectionallyDemeaned => "tide_demeaned",
-        },
-        &best_model.valid(),
-        &validation_data,
-        &model_parameters,
-        &prepared.fit.scaler,
-    )?;
+    let arm = match parameters.target {
+        Target::Raw => "tide",
+        Target::CrossSectionallyDemeaned => "tide_demeaned",
+    };
+    let null_arm = format!("{arm}_permuted");
 
-    // The sessions the model was actually measured over. Every baseline is then cut to the same
-    // set, because comparing a forecast scored on fifty sessions against one scored on five hundred
-    // compares two stretches of calendar rather than two forecasts.
-    let measured: BTreeSet<i64> = validation_data
+    let mut model_evaluations: Vec<Evaluation> = Vec::with_capacity(parameters.seed_count);
+    let mut null_evaluations: Vec<Evaluation> = Vec::with_capacity(parameters.seed_count);
+    for offset in 0..parameters.seed_count {
+        let seed = parameters.seed.wrapping_add(offset as u64);
+
+        model_evaluations.push(fit_and_score(
+            &arm_name(arm, seed),
+            seed,
+            &training_data,
+            &validation_data,
+            &model_parameters,
+            &configuration,
+            &device,
+            &prepared.fit.scaler,
+        )?);
+
+        // The identical pipeline over a target that cannot be forecast, so whatever it still scores
+        // is what fitting and scoring manufacture. Both splits are permuted: a model fitted on noise
+        // and scored against real outcomes measures something else again.
+        let permutation_seed = seed ^ PERMUTATION_SEED;
+        let permuted_training = permute_targets(&training_data, permutation_seed)?;
+        let permuted_validation = permute_targets(&validation_data, permutation_seed ^ 1)?;
+        null_evaluations.push(fit_and_score(
+            &arm_name(&null_arm, seed),
+            seed,
+            &permuted_training,
+            &permuted_validation,
+            &model_parameters,
+            &configuration,
+            &device,
+            &prepared.fit.scaler,
+        )?);
+    }
+
+    // The sessions and the names the model was actually measured over. Every baseline is cut to
+    // both: comparing a forecast scored on fifty sessions against one scored on five hundred
+    // compares two stretches of calendar, and one scored over every listed name against one scored
+    // over the names that had a contiguous window compares two universes.
+    let measured_sessions: BTreeSet<i64> = validation_data
         .forecast_sessions()
         .iter()
         .copied()
         .collect();
+    let universe_tickers = measured_tickers(&validation_data, &prepared.fit.mappings)?;
+    let universe = Universe {
+        tickers: universe_tickers.len(),
+        sessions: measured_sessions.len(),
+    };
     info!(
-        sessions = measured.len(),
-        "Scored the model over its validation window"
+        tickers = universe.tickers,
+        sessions = universe.sessions,
+        "Scored the models over their validation universe"
     );
 
     // A second read of the same window, because `build` consumed the first into the fit. The
@@ -300,7 +375,9 @@ async fn run(
         )
         .into());
     }
-    let panel = Panel::from_frame(&returns.returns)?;
+    // Cut by name before the panel is built, so every session of a measured name's history survives
+    // — momentum needs twenty sessions of it, and cutting by session as well would starve it.
+    let panel = Panel::from_frame(&restrict_to_tickers(&returns.returns, &universe_tickers)?)?;
     let baselines: Vec<Box<dyn Predictor>> = vec![
         Box::new(CrossSectionalMean),
         Box::new(Persistence),
@@ -310,14 +387,16 @@ async fn run(
         Box::new(RandomRanking { seed: RANDOM_SEED }),
     ];
 
-    let mut scored = vec![scored_model];
+    let mut scored: Vec<Evaluation> = Vec::new();
+    scored.extend(model_evaluations.iter().cloned());
+    scored.extend(null_evaluations.iter().cloned());
     for baseline in &baselines {
         // Evaluated over the whole panel and cut afterwards, so each baseline still reads the
-        // history before its first measured session — momentum needs twenty sessions of it.
+        // history before its first measured session.
         scored.push(restrict(
             evaluate(baseline.as_ref(), &panel),
             &panel,
-            &measured,
+            &measured_sessions,
         ));
     }
 
@@ -327,6 +406,7 @@ async fn run(
         info!(
             predictor = record.predictor,
             sessions = record.sessions,
+            universe = universe.tickers,
             information_coefficient = record
                 .information_coefficient
                 .map(|distribution| distribution.mean),
@@ -344,7 +424,213 @@ async fn run(
         records.push(record);
     }
 
-    Ok(records)
+    let dispersions: Vec<SeedDispersion> = [
+        dispersion(arm, &model_evaluations),
+        dispersion(&null_arm, &null_evaluations),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    for spread in &dispersions {
+        match spread.standard_deviation {
+            Some(standard_deviation) if standard_deviation < SEED_DISPERSION_FLOOR => warn!(
+                arm = spread.arm,
+                seeds = spread.seeds,
+                standard_deviation,
+                "Seeds that differ produced one model; initialisation is not reaching the weights"
+            ),
+            Some(standard_deviation) => info!(
+                arm = spread.arm,
+                seeds = spread.seeds,
+                mean = spread.mean,
+                standard_deviation,
+                "Information coefficient across seeds"
+            ),
+            None => info!(
+                arm = spread.arm,
+                seeds = spread.seeds,
+                "One seed measures one model, so this run has no spread to report"
+            ),
+        }
+    }
+
+    Ok(Report {
+        universe,
+        records,
+        dispersions,
+    })
+}
+
+/// Seeds the backend, trains one model, and scores the ordering it produces.
+///
+/// The seed is set immediately before the weights are drawn rather than after, which is the only
+/// point at which it reaches them.
+#[allow(clippy::too_many_arguments)]
+fn fit_and_score(
+    name: &str,
+    seed: u64,
+    training_data: &TrainingDataset,
+    validation_data: &TrainingDataset,
+    model_parameters: &ModelParameters,
+    configuration: &TrainConfiguration,
+    device: &<TrainBackend as Backend>::Device,
+    scaler: &fund::models::tide::data::Scaler,
+) -> Result<Evaluation, Box<dyn std::error::Error>> {
+    <TrainBackend as Backend>::seed(seed);
+    let model = TiDEModel::<TrainBackend>::new(
+        device,
+        model_parameters.input_size(),
+        model_parameters.hidden_size(),
+        model_parameters.encoder_layer_count(),
+        model_parameters.decoder_layer_count(),
+        model_parameters.output_length(),
+        model_parameters.quantiles().len(),
+        model_parameters.dropout_rate(),
+    );
+
+    let started = tokio::time::Instant::now();
+    let (best_model, losses) = train(
+        model,
+        training_data,
+        Some(validation_data),
+        model_parameters,
+        configuration,
+        device,
+    );
+    info!(
+        arm = name,
+        seed,
+        epochs = losses.len(),
+        final_train_loss = losses.last().copied().unwrap_or_default(),
+        seconds = started.elapsed().as_secs(),
+        "Training complete"
+    );
+
+    Ok(forecast::score(
+        name,
+        &best_model.valid(),
+        validation_data,
+        model_parameters,
+        scaler,
+    )?)
+}
+
+/// The name a scored forecast is journaled under.
+///
+/// The seed is part of the name because [`laboratory::ForecastScored`] carries no seed field, and two
+/// records differing only by initialisation would otherwise be indistinguishable in the journal.
+fn arm_name(base: &str, seed: u64) -> String {
+    format!("{base}_seed_{seed}")
+}
+
+/// The same samples with each session's targets dealt out among the names in that session.
+///
+/// Shuffling inside the session leaves the feature panel and the return distribution alone and breaks
+/// only the pairing, so whatever the pipeline still scores over it is what the pipeline manufactures.
+fn permute_targets(dataset: &TrainingDataset, seed: u64) -> Result<TrainingDataset, TideError> {
+    let targets = dataset.targets().ok_or_else(|| {
+        TideError::Data("a permutation null needs the targets it is permuting".to_string())
+    })?;
+    let steps = targets.shape()[1];
+    let mut permuted = targets.clone();
+    let mut generator = StdRng::seed_from_u64(seed);
+
+    let mut by_session: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
+    for (sample, session) in dataset.forecast_sessions().iter().enumerate() {
+        by_session.entry(*session).or_default().push(sample);
+    }
+    for samples in by_session.values() {
+        let mut shuffled = samples.clone();
+        shuffled.shuffle(&mut generator);
+        for (source, destination) in samples.iter().zip(&shuffled) {
+            for step in 0..steps {
+                permuted[[*destination, step, 0]] = targets[[*source, step, 0]];
+            }
+        }
+    }
+
+    TrainingDataset::new(
+        dataset.past_continuous().clone(),
+        dataset.past_categorical().clone(),
+        dataset.future_categorical().clone(),
+        dataset.static_categorical().clone(),
+        Some(permuted),
+        dataset.forecast_sessions().to_vec(),
+    )
+}
+
+/// The names the model's samples exist for, decoded through the mappings the fit produced.
+fn measured_tickers(
+    dataset: &TrainingDataset,
+    mappings: &FeatureMappings,
+) -> Result<BTreeSet<String>, Box<dyn std::error::Error>> {
+    let mapping = mappings.get("ticker").ok_or(
+        "the fitted mappings carry no `ticker` column, so the model's names cannot be read",
+    )?;
+    let names: HashMap<i32, &str> = mapping
+        .iter()
+        .map(|(name, id)| (*id, name.as_str()))
+        .collect();
+
+    let encoded = dataset.static_categorical();
+    let mut tickers = BTreeSet::new();
+    for sample in 0..dataset.len() {
+        let id = encoded[[sample, 0, 0]];
+        let name = names.get(&id).ok_or_else(|| {
+            format!("sample {sample} carries encoded ticker {id}, which the mapping does not name")
+        })?;
+        tickers.insert((*name).to_string());
+    }
+    Ok(tickers)
+}
+
+/// Cuts the returns frame to the names the model was measured on, keeping their whole history.
+fn restrict_to_tickers(
+    frame: &DataFrame,
+    tickers: &BTreeSet<String>,
+) -> Result<DataFrame, PolarsError> {
+    let names: Vec<String> = tickers.iter().cloned().collect();
+    let measured = Series::new("measured_ticker".into(), &names);
+    frame
+        .clone()
+        .lazy()
+        .filter(col("ticker").is_in(lit(measured), false))
+        .collect()
+}
+
+/// The spread of the information coefficient across seeds that differ in nothing else.
+///
+/// Returns `None` for an arm whose seeds all abstained, because an unmeasurable statistic has no
+/// spread; a single seed yields a `standard_deviation` of `None` for the same reason.
+fn dispersion(arm: &str, evaluations: &[Evaluation]) -> Option<SeedDispersion> {
+    let observed: Vec<f64> = evaluations
+        .iter()
+        .filter_map(|evaluation| evaluation.information_coefficient)
+        .map(|distribution| distribution.mean)
+        .filter(|value| value.is_finite())
+        .collect();
+    if observed.is_empty() {
+        return None;
+    }
+
+    let seeds = observed.len();
+    let mean = observed.iter().sum::<f64>() / seeds as f64;
+    let standard_deviation = (seeds > 1).then(|| {
+        (observed
+            .iter()
+            .map(|value| (value - mean).powi(2))
+            .sum::<f64>()
+            / (seeds - 1) as f64)
+            .sqrt()
+    });
+    Some(SeedDispersion {
+        arm: arm.to_string(),
+        seeds,
+        mean,
+        standard_deviation,
+        minimum: observed.iter().copied().fold(f64::INFINITY, f64::min),
+        maximum: observed.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+    })
 }
 
 /// Keeps only the sessions in `measured`, then re-summarizes what is left.
@@ -372,20 +658,43 @@ fn restrict(evaluation: Evaluation, panel: &Panel, measured: &BTreeSet<i64>) -> 
     }
 }
 
-fn render(scored: &[laboratory::ForecastScored]) -> String {
+fn render(report: &Report) -> String {
     let mut rendered = format!(
-        "{:<22}{:>10}{:>30}{:>30}{:>30}\n",
-        "predictor", "sessions", "information_coefficient", "decile_spread", "directional_accuracy"
+        "universe: {} names over {} sessions, every arm cut to both\n",
+        report.universe.tickers, report.universe.sessions
     );
-    for record in scored {
+    rendered.push_str(&format!(
+        "{:<36}{:>10}{:>30}{:>30}{:>30}\n",
+        "predictor", "sessions", "information_coefficient", "decile_spread", "directional_accuracy"
+    ));
+    for record in &report.records {
         rendered.push_str(&format!(
-            "{:<22}{:>10}{:>30}{:>30}{:>30}\n",
+            "{:<36}{:>10}{:>30}{:>30}{:>30}\n",
             record.predictor,
             record.sessions,
             distribution(record.information_coefficient),
             distribution(record.decile_spread),
             distribution(record.directional_accuracy),
         ));
+    }
+
+    if !report.dispersions.is_empty() {
+        rendered.push_str(
+            "\ninformation coefficient across seeds — a tight spread is a warning, not a result\n",
+        );
+        for spread in &report.dispersions {
+            rendered.push_str(&format!(
+                "{:<36}{:>10}{:>16.6}{:>16}{:>16.6}{:>16.6}\n",
+                spread.arm,
+                spread.seeds,
+                spread.mean,
+                spread
+                    .standard_deviation
+                    .map_or_else(|| "unmeasurable".to_string(), |value| format!("{value:.6}")),
+                spread.minimum,
+                spread.maximum,
+            ));
+        }
     }
     rendered
 }
@@ -406,8 +715,113 @@ fn distribution(value: Option<Distribution>) -> String {
 mod tests {
     use super::*;
 
+    const DAY: i64 = 86_400_000;
+
     fn arguments(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
+    }
+
+    /// An evaluation carrying one information coefficient and nothing else, which is all
+    /// [`dispersion`] reads.
+    fn evaluation_scoring(information_coefficient: f64) -> Evaluation {
+        Evaluation {
+            predictor: "tide".to_string(),
+            sessions: Vec::new(),
+            information_coefficient: Some(Distribution {
+                mean: information_coefficient,
+                standard_error: 0.0,
+                sessions: 2,
+            }),
+            decile_spread: None,
+            directional_accuracy: None,
+        }
+    }
+
+    /// Samples whose only content is their target and the session they forecast.
+    fn dataset_of(sessions: &[i64], values: &[f32]) -> TrainingDataset {
+        let samples = values.len();
+        let mut targets = ndarray::Array3::<f32>::zeros((samples, 1, 1));
+        for (sample, value) in values.iter().enumerate() {
+            targets[[sample, 0, 0]] = *value;
+        }
+        TrainingDataset::new(
+            ndarray::Array3::zeros((samples, 2, 7)),
+            ndarray::Array3::zeros((samples, 2, 5)),
+            ndarray::Array3::zeros((samples, 1, 5)),
+            ndarray::Array3::zeros((samples, 1, 3)),
+            Some(targets),
+            sessions.to_vec(),
+        )
+        .unwrap()
+    }
+
+    fn targets_of(dataset: &TrainingDataset) -> Vec<f32> {
+        let targets = dataset.targets().unwrap();
+        (0..dataset.len())
+            .map(|sample| targets[[sample, 0, 0]])
+            .collect()
+    }
+
+    /// The null must be the same panel with the pairing broken, not a different panel. A target that
+    /// crossed a session would put a return in a cross-section it never belonged to, and the arm
+    /// would then differ from the treatment in two respects.
+    #[test]
+    fn test_the_permutation_leaves_every_session_holding_its_own_returns() {
+        let sessions: Vec<i64> = (0..12).map(|_| 0).chain((0..12).map(|_| DAY)).collect();
+        let values: Vec<f32> = (0..12)
+            .map(|name| name as f32)
+            .chain((0..12).map(|name| 100.0 + name as f32))
+            .collect();
+
+        let permuted = permute_targets(&dataset_of(&sessions, &values), 0x51D).unwrap();
+        assert_eq!(permuted.forecast_sessions(), sessions.as_slice());
+
+        let permuted_targets = targets_of(&permuted);
+        let mut first = permuted_targets[..12].to_vec();
+        let mut second = permuted_targets[12..].to_vec();
+        first.sort_by(|left, right| left.partial_cmp(right).unwrap());
+        second.sort_by(|left, right| left.partial_cmp(right).unwrap());
+
+        assert_eq!(first, (0..12).map(|name| name as f32).collect::<Vec<f32>>());
+        assert_eq!(
+            second,
+            (0..12)
+                .map(|name| 100.0 + name as f32)
+                .collect::<Vec<f32>>()
+        );
+    }
+
+    /// A null that left the pairing intact would fit and score the treatment a second time and
+    /// report it as the floor the treatment must clear.
+    #[test]
+    fn test_the_permutation_moves_the_targets_it_was_given() {
+        let sessions: Vec<i64> = (0..12).map(|_| 0).collect();
+        let values: Vec<f32> = (0..12).map(|name| name as f32).collect();
+        let dataset = dataset_of(&sessions, &values);
+
+        let permuted = permute_targets(&dataset, 0x51D).unwrap();
+
+        assert_ne!(
+            targets_of(&permuted),
+            targets_of(&dataset),
+            "the shuffle returned the order it was given"
+        );
+    }
+
+    /// A dataset with no outcomes cannot have them permuted, and inventing zeros would score the
+    /// null against a target nobody realized.
+    #[test]
+    fn test_a_dataset_without_targets_cannot_be_permuted() {
+        let bare = TrainingDataset::new(
+            ndarray::Array3::zeros((4, 2, 7)),
+            ndarray::Array3::zeros((4, 2, 5)),
+            ndarray::Array3::zeros((4, 1, 5)),
+            ndarray::Array3::zeros((4, 1, 3)),
+            None,
+            vec![0; 4],
+        )
+        .unwrap();
+        assert!(permute_targets(&bare, 1).is_err());
     }
 
     #[test]
@@ -416,6 +830,7 @@ mod tests {
         assert_eq!(parameters.lookback_days, 365);
         assert_eq!(parameters.epochs, 5);
         assert_eq!(parameters.seed, DEFAULT_TRAINING_SEED as u64);
+        assert_eq!(parameters.seed_count, 3);
 
         let parameters = Parameters::parse(&arguments(&["400", "2"])).unwrap();
         assert_eq!(parameters.lookback_days, 400);
@@ -425,6 +840,89 @@ mod tests {
         let parameters = Parameters::parse(&arguments(&["400", "2", "9"])).unwrap();
         assert_eq!(parameters.seed, 9);
         assert_eq!(parameters.target, Target::Raw);
+
+        let parameters = Parameters::parse(&arguments(&["400", "2", "9", "raw", "7"])).unwrap();
+        assert_eq!(parameters.seed_count, 7);
+    }
+
+    /// A run that trains one seed reports a coefficient with no error bar on the thing it varied,
+    /// which is the reading two runs of one configuration disagreed about.
+    #[test]
+    fn test_the_seed_count_is_read_and_refused_like_the_others() {
+        assert_eq!(
+            Parameters::parse(&arguments(&["400", "2", "9", "demeaned", "5"]))
+                .unwrap()
+                .seed_count,
+            5
+        );
+        assert!(Parameters::parse(&arguments(&["400", "2", "9", "raw", "0"])).is_err());
+        assert!(Parameters::parse(&arguments(&["400", "2", "9", "raw", "x"])).is_err());
+        assert!(Parameters::parse(&arguments(&["400", "2", "9", "raw", "1", "1"])).is_err());
+    }
+
+    /// The two arms must be distinguishable in a journal record that carries no seed field.
+    #[test]
+    fn test_each_seed_is_journaled_under_its_own_name() {
+        assert_eq!(arm_name("tide", 31_261), "tide_seed_31261");
+        assert_ne!(arm_name("tide", 31_261), arm_name("tide", 31_262));
+        assert_ne!(arm_name("tide", 31_261), arm_name("tide_permuted", 31_261));
+    }
+
+    /// A spread of zero and no spread at all are different claims, and only one of them is a fact
+    /// about the architecture.
+    #[test]
+    fn test_one_seed_measures_no_spread_rather_than_a_spread_of_zero() {
+        let single = dispersion("tide", &[evaluation_scoring(0.02)]).unwrap();
+        assert_eq!(single.seeds, 1);
+        assert_eq!(single.mean, 0.02);
+        assert_eq!(single.standard_deviation, None);
+
+        let identical = dispersion(
+            "tide",
+            &[evaluation_scoring(0.02), evaluation_scoring(0.02)],
+        )
+        .unwrap();
+        assert_eq!(identical.standard_deviation, Some(0.0));
+        assert!(
+            identical.standard_deviation.unwrap() < SEED_DISPERSION_FLOOR,
+            "two seeds landing on one number is what the floor exists to catch"
+        );
+    }
+
+    /// The spread must be the sample standard deviation of the per-seed means, pinned to a literal
+    /// rather than to the arithmetic under test.
+    #[test]
+    fn test_the_spread_across_seeds_is_the_sample_standard_deviation() {
+        let spread = dispersion(
+            "tide",
+            &[
+                evaluation_scoring(0.01),
+                evaluation_scoring(0.02),
+                evaluation_scoring(0.03),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(spread.seeds, 3);
+        assert!((spread.mean - 0.02).abs() < 1e-12);
+        // Deviations of -0.01, 0, +0.01: variance 0.0002 / 2 = 0.0001, so the deviation is 0.01.
+        assert!(
+            (spread.standard_deviation.unwrap() - 0.01).abs() < 1e-12,
+            "got {:?}",
+            spread.standard_deviation
+        );
+        assert_eq!(spread.minimum, 0.01);
+        assert_eq!(spread.maximum, 0.03);
+    }
+
+    /// An arm whose seeds all abstained has no spread, and reporting one would assert a reading
+    /// nobody took.
+    #[test]
+    fn test_an_arm_that_never_ranked_reports_no_spread() {
+        let mut silent = evaluation_scoring(0.0);
+        silent.information_coefficient = None;
+        assert!(dispersion("tide", &[silent]).is_none());
+        assert!(dispersion("tide", &[]).is_none());
     }
 
     /// The argument that selects the arm, so a regression here would silently compare one target

--- a/src/bin/laboratory_tide.rs
+++ b/src/bin/laboratory_tide.rs
@@ -24,6 +24,7 @@ use fund::laboratory::{dataset, forecast};
 use fund::models::tide::configuration::ModelParameters;
 use fund::models::tide::data::{
     input_feature_size, DatasetKind, FeatureMappings, Target, TrainingDataset, TrainingFraction,
+    STATIC_CATEGORICAL_COLUMNS,
 };
 use fund::models::tide::model::TiDEModel;
 use fund::models::tide::train::{train, TrainBackend, TrainConfiguration};
@@ -340,16 +341,15 @@ async fn run(parameters: &Parameters) -> Result<Report, Box<dyn std::error::Erro
         )?);
     }
 
-    // The sessions and the names the model was actually measured over. Every baseline is cut to
-    // both: comparing a forecast scored on fifty sessions against one scored on five hundred
-    // compares two stretches of calendar, and one scored over every listed name against one scored
-    // over the names that had a contiguous window compares two universes.
-    let measured_sessions: BTreeSet<i64> = validation_data
-        .forecast_sessions()
-        .iter()
-        .copied()
-        .collect();
-    let universe_tickers = measured_tickers(&validation_data, &prepared.fit.mappings)?;
+    // The exact cells the model was measured over. Every baseline is cut to the same ones: a
+    // forecast scored on fifty sessions against one scored on five hundred compares two stretches of
+    // calendar, and a name scored on every session against one scored only where its window was
+    // contiguous compares two universes — in which case the difference reported as model quality is
+    // partly a difference in population.
+    let measured = measured_pairs(&validation_data, &prepared.fit.mappings)?;
+    let measured_sessions: BTreeSet<i64> = measured.iter().map(|(session, _)| *session).collect();
+    let universe_tickers: BTreeSet<String> =
+        measured.iter().map(|(_, ticker)| ticker.clone()).collect();
     let universe = Universe {
         tickers: universe_tickers.len(),
         sessions: measured_sessions.len(),
@@ -376,8 +376,10 @@ async fn run(parameters: &Parameters) -> Result<Report, Box<dyn std::error::Erro
         .into());
     }
     // Cut by name before the panel is built, so every session of a measured name's history survives
-    // — momentum needs twenty sessions of it, and cutting by session as well would starve it.
-    let panel = Panel::from_frame(&restrict_to_tickers(&returns.returns, &universe_tickers)?)?;
+    // — momentum needs twenty sessions of it, and cutting by session as well would starve it. The
+    // mask then holds the grading to the model's own cells without touching that history.
+    let panel = Panel::from_frame(&restrict_to_tickers(&returns.returns, &universe_tickers)?)?
+        .scoring_restricted_to(&measured);
     let baselines: Vec<Box<dyn Predictor>> = vec![
         Box::new(CrossSectionalMean),
         Box::new(Persistence),
@@ -559,11 +561,14 @@ fn permute_targets(dataset: &TrainingDataset, seed: u64) -> Result<TrainingDatas
     )
 }
 
-/// The names the model's samples exist for, decoded through the mappings the fit produced.
-fn measured_tickers(
+/// The `(session, ticker)` cells the model's samples exist for, decoded through the fit's mappings.
+///
+/// Pairs rather than names: windowing drops a name from the sessions its history is not contiguous
+/// over, so the set of names it was measured on does not say which sessions each was measured in.
+fn measured_pairs(
     dataset: &TrainingDataset,
     mappings: &FeatureMappings,
-) -> Result<BTreeSet<String>, Box<dyn std::error::Error>> {
+) -> Result<BTreeSet<(i64, String)>, Box<dyn std::error::Error>> {
     let mapping = mappings.get("ticker").ok_or(
         "the fitted mappings carry no `ticker` column, so the model's names cannot be read",
     )?;
@@ -571,17 +576,24 @@ fn measured_tickers(
         .iter()
         .map(|(name, id)| (*id, name.as_str()))
         .collect();
+    // Derived rather than assumed to be zero: reordering the constant would otherwise decode a
+    // sector code through the ticker mapping and build a plausible, wrong universe.
+    let column = STATIC_CATEGORICAL_COLUMNS
+        .iter()
+        .position(|name| *name == "ticker")
+        .ok_or("the static categorical columns carry no `ticker`, so a sample names no symbol")?;
 
     let encoded = dataset.static_categorical();
-    let mut tickers = BTreeSet::new();
+    let sessions = dataset.forecast_sessions();
+    let mut pairs = BTreeSet::new();
     for sample in 0..dataset.len() {
-        let id = encoded[[sample, 0, 0]];
+        let id = encoded[[sample, 0, column]];
         let name = names.get(&id).ok_or_else(|| {
             format!("sample {sample} carries encoded ticker {id}, which the mapping does not name")
         })?;
-        tickers.insert((*name).to_string());
+        pairs.insert((sessions[sample], (*name).to_string()));
     }
-    Ok(tickers)
+    Ok(pairs)
 }
 
 /// Cuts the returns frame to the names the model was measured on, keeping their whole history.

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -388,9 +388,9 @@ impl QuoteAction {
 
 /// What a trade pass does with the sessions it is given.
 ///
-/// `repair` exists now that Alpaca serves prints per name. The whole-market actions still read a
-/// flat file, which is the only affordable route to five years; a repair reaches one name, and is
-/// also the only route that reaches past Massive's five-year window at all.
+/// The whole-market actions read a flat file, which is the only affordable route to five years;
+/// `repair` reaches one name through Alpaca's per-name prints, and is also the only route that
+/// reaches past Massive's five-year window at all.
 #[derive(Debug, Subcommand)]
 enum TradeAction {
     /// Fold every name the daily archive holds into the sampled sessions that have no partition yet.

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -1,16 +1,6 @@
 //! The trainer: repair, load, train, publish. Runs on its own machine with no database.
 //!
-//! It fetches its own bars from Massive and writes its own parquet rather than reading the
-//! application's nightly export, so the only thing crossing between the two VMs is the finished
-//! artifact. The archive it owns is the long-term record of those bars; the application exports
-//! only its own tables.
-//!
-//! Frames are built through [`fund::data::bars::bars_to_dataframe`], shared with the application:
-//! if the two diverged, the model would train on columns the inference path does not produce.
-//!
-//! Nothing here touches a database, and Alpaca is optional — Massive answers bars by date, so there
-//! is no symbol list to build. The trading calendar and the boundary table do need a broker key, and
-//! both warn and carry on without one: a repair that also requests holidays beats no repair.
+//! It fetches its own bars and writes its own parquet; only the finished artifact crosses the VMs.
 
 use burn::module::AutodiffModule;
 use burn::tensor::backend::Backend;
@@ -320,12 +310,22 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let inner_model = best_model.valid();
-    let metrics = evaluate(&inner_model, &validation_dataset, &parameters)?;
+    let report = evaluate(&inner_model, &validation_dataset, &parameters)?;
+    let metrics = report.metrics;
+    // Every figure beside the trivial forecast it has to beat: a CRPS alone quotes no skill, and a
+    // directional accuracy alone is the base rate whenever the median never turns negative.
     info!(
         continuous_ranked_probability_score = metrics.continuous_ranked_probability_score,
+        baseline = report.baseline_name,
+        baseline_continuous_ranked_probability_score =
+            report.baseline.continuous_ranked_probability_score,
+        continuous_ranked_probability_score_skill =
+            report.continuous_ranked_probability_score_skill(),
         directional_accuracy = metrics.directional_accuracy,
+        base_rate = report.baseline.directional_accuracy,
         quantile_coverage = metrics.quantile_coverage,
-        "Evaluation metrics"
+        nominal_coverage = report.nominal_coverage,
+        "Evaluation metrics against the trivial forecast"
     );
 
     let staging = tempfile::tempdir()?;
@@ -380,19 +380,26 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     );
     // Every variant named. A wildcard would send a future `DriftStatus` down the informational path
     // with no compiler error, which is the case where a new signal is most likely to be missed.
+    // The trivial forecast rides along on both arms: the drift baseline is this model's own past, so
+    // a run can hold steady against every prior run while never having beaten a constant.
     match drift.status {
         DriftStatus::DriftDetected => warn!(
             current_continuous_ranked_probability_score =
                 drift.current_continuous_ranked_probability_score,
-            baseline_continuous_ranked_probability_score =
+            prior_runs_continuous_ranked_probability_score =
                 drift.baseline_continuous_ranked_probability_score,
+            trivial_forecast = report.baseline_name,
+            trivial_forecast_continuous_ranked_probability_score =
+                report.baseline.continuous_ranked_probability_score,
             "Model drift detected"
         ),
         DriftStatus::NoDrift | DriftStatus::InsufficientHistory => info!(
             status = ?drift.status,
             current_continuous_ranked_probability_score = drift.current_continuous_ranked_probability_score,
-            baseline_continuous_ranked_probability_score = drift.baseline_continuous_ranked_probability_score,
+            prior_runs_continuous_ranked_probability_score = drift.baseline_continuous_ranked_probability_score,
             prior_runs = prior_continuous_ranked_probability_scores.len(),
+            trivial_forecast = report.baseline_name,
+            trivial_forecast_continuous_ranked_probability_score = report.baseline.continuous_ranked_probability_score,
             message = drift.message,
             "Drift check complete"
         ),
@@ -411,6 +418,13 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         "epochs_run": losses.len(),
         "final_train_loss": losses.last().copied().unwrap_or_default(),
         "metrics": metrics,
+        // The same three metrics for a forecast that knows only the training distribution, so a
+        // later reader can quote skill rather than a raw score it has nothing to compare against.
+        "baseline": {
+            "name": report.baseline_name,
+            "metrics": report.baseline,
+            "nominal_coverage": report.nominal_coverage,
+        },
         "train_samples": train_dataset.len(),
         "validation_samples": validation_dataset.len(),
         // `crps` keys are the published spelling and stay that way; see `EvaluationMetrics`. Renaming
@@ -548,26 +562,11 @@ fn training_configuration() -> Result<TrainConfiguration, Box<dyn std::error::Er
     )?)
 }
 
-/// Reads every available daily partition over the lookback window and concatenates them.
-///
-/// Missing days — holidays and sessions Massive has never answered for — are skipped rather than
-/// treated as errors, which is what lets one unavailable session cost a day of history instead of
-/// the whole run. Stage one has already tried to fill everything else.
-///
-/// Weekends are stepped over rather than requested. Stage one never writes a weekend partition, so
-/// a request for one is a guaranteed 404 — about a hundred of them per run. Skipping them here uses
-/// the same predicate the archive scan does, which is what keeps reader and writer agreeing about
-/// which days the archive can hold at all.
-/// The bar columns training consumes, in the types [`fund::data::bars::bars_to_dataframe`] writes.
-///
-/// Deliberately a subset of what the archive holds: `bar_interval` and `transactions` are written
-/// but never trained on, so projecting them away costs nothing.
 /// CRPS from the most recent prior runs' `run_metadata.json`, newest first.
 ///
 /// Read from the standalone metadata object rather than from inside the artifact tarball, so a
-/// baseline can be built without downloading every prior run. An unreadable run is skipped and the
-/// rest are kept; only an unlistable prefix yields nothing. Either way a drift baseline that cannot
-/// be read is not a reason to fail a training run.
+/// baseline can be built without downloading every prior run. An unreadable run is skipped and an
+/// unlistable prefix yields nothing, because a drift baseline is not a reason to fail a training run.
 async fn fetch_prior_continuous_ranked_probability_scores(
     s3_client: &aws_sdk_s3::Client,
     bucket: &str,

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -501,16 +501,12 @@ impl OrderIntent {
     }
 }
 
-/// Where a submitted order stands, reduced to the three answers a caller acts on.
+/// Where a submitted order stands, collapsed from Alpaca's fifteen statuses to the three answers a
+/// caller acts on: keep waiting, use the fill, or unwind.
 ///
-/// Alpaca publishes fifteen order statuses. Collapsing them here rather than at each call site is
-/// what makes the caller's `match` exhaustive over outcomes it can actually respond to — keep
-/// waiting, use the fill, or unwind — instead of over a string it has to remember the meaning of.
-/// Every variant carries the broker's own status alongside the collapse, because the collapse is
-/// what the caller acts on and the raw status is what explains it afterwards. An order this process
-/// gave up on is recorded as `timed_out`, which is our word; whether Alpaca had it as `pending_new`
-/// or `accepted` at that moment is the difference between never reaching the market and reaching it
-/// with no contra side.
+/// Every variant carries the broker's own status beside the collapse, because the collapse is what
+/// a caller acts on and the raw status is what explains it afterwards. `timed_out` is our word, not
+/// Alpaca's.
 #[derive(Debug, Clone, PartialEq)]
 pub enum OrderState {
     /// Alpaca still has it: accepted, queued, or partially filled. Ask again.
@@ -1309,7 +1305,11 @@ impl TradingClient {
         Ok(outcomes)
     }
 
-    /// Fetches one activity type for a single session date, walking pagination.
+    /// Fetches one activity type stamped `date` by Alpaca's own record clock, walking pagination.
+    ///
+    /// `date` is not the session an activity belongs to. Only a type carrying a real
+    /// `transaction_time` — [`ActivityType::Fill`] — answers this query for the day asked; a
+    /// date-only type is recorded the following morning, so `date=D` returns the row dated `D-1`.
     pub async fn fetch_activities(
         &self,
         activity_type: &ActivityType,
@@ -1451,13 +1451,9 @@ impl TradingClient {
 
     /// Fetches the daily equity curve over an inclusive date range.
     ///
-    /// **Alpaca's own `end` is exclusive**, so the day after it is what gets sent, making this
-    /// signature inclusive and sparing every caller the knowledge. Verified against the paper
-    /// account 2026-08-09: asking through Monday 2026-06-15 stopped at Friday the 12th. Left
-    /// uncompensated it drops the newest session, which is the one most likely to need repair.
-    ///
-    /// Days with a `null` equity are dropped rather than zeroed, since a zero would claim the
-    /// account was worthless rather than unvalued.
+    /// **Alpaca's own `end` is exclusive**, so the day after it is what gets sent and this
+    /// signature is inclusive. Days with a `null` equity are dropped rather than zeroed, since a
+    /// zero would claim the account was worthless rather than unvalued.
     pub async fn fetch_portfolio_history(
         &self,
         start: NaiveDate,
@@ -1517,16 +1513,12 @@ impl TradingClient {
     }
 }
 
-/// Midnight Eastern on a settlement date, as the equivalent UTC instant.
+/// Midnight Eastern on a settlement date, as the equivalent UTC instant, for the activities that
+/// carry a `date` and no time.
 ///
-/// Non-trade activities carry a `date` and no time, but `account_activities.transaction_time` is
-/// `NOT NULL`, so an instant has to be chosen. Eastern midnight is the only choice that round-trips:
-/// consumers recover the session with `SessionDate::at`, which reads the Eastern calendar day, so
-/// midnight UTC would resolve to the *previous* session for the whole Eastern evening and file a
-/// transfer against the wrong day's capital flows.
-///
-/// Duplicates `SessionDate::midnight`, which cannot be called from here: it lives in
-/// `data::calendar`, and that module already depends on this one.
+/// The only choice that round-trips through `SessionDate::at`: midnight UTC resolves to the
+/// *previous* session for the whole Eastern evening. Duplicates `SessionDate::midnight`, which
+/// cannot be borrowed back because `data::calendar` already depends on this module.
 fn eastern_midnight(date: NaiveDate) -> DateTime<Utc> {
     let local_midnight = date
         .and_hms_opt(0, 0, 0)
@@ -2251,9 +2243,9 @@ impl HistoricalTradePayload {
 
 /// Attempts per quote page before the fetch gives up on the whole symbol.
 ///
-/// Four, because the page is the unit that fails: one session of AAPL is 118 pages and a single
-/// dropped connection anywhere in the chain used to cost the name. Bounded rather than generous —
-/// a page that fails four times running is not a blip.
+/// Four, because the page is the unit that fails: one session of AAPL is 118 pages, so a single
+/// dropped connection anywhere in the chain would otherwise cost the whole name. Bounded rather
+/// than generous — a page that fails four times running is not a blip.
 const QUOTES_PAGE_ATTEMPTS: usize = 4;
 
 /// One page and what it took to get it.
@@ -2591,17 +2583,11 @@ impl MarketDataClient {
         )))
     }
 
-    /// Fetches one page, retrying the page itself while the failure is transient.
-    ///
-    /// Retried here rather than by the caller because the caller's unit is the whole symbol: AAPL
-    /// is 118 pages over one session, so restarting it to recover one dropped connection discards
-    /// 117 pages of work and gives the largest names both the highest failure odds and the dearest
-    /// recovery. The token identifies the page, so resuming at it is exact.
     /// One attempt at one page, with every failure mode expressed as the returned error.
     ///
-    /// Separated from the retry loop so there is one place an attempt can fail from. A connection
+    /// Separated from the retry loop so there is one place an attempt can fail from: a connection
     /// reset during `send` is the same transport fault as a body that arrives truncated, and the
-    /// two have to be indistinguishable here or only one of them gets retried.
+    /// two must be indistinguishable here or only one of them gets retried.
     async fn attempt_tick_page<T: serde::de::DeserializeOwned>(
         &self,
         url: &str,
@@ -2622,6 +2608,11 @@ impl MarketDataClient {
             .map_err(ClientError::Request)
     }
 
+    /// Fetches one page, retrying the page itself while the failure is transient.
+    ///
+    /// Retried here rather than by the caller, whose unit is the whole symbol: AAPL is 118 pages
+    /// over one session, so restarting it to recover one dropped connection discards 117 pages of
+    /// work. The token identifies the page, so resuming at it is exact.
     async fn tick_page<T: serde::de::DeserializeOwned>(
         &self,
         url: &str,
@@ -2650,17 +2641,13 @@ impl MarketDataClient {
         Err(last_error.expect("a failed attempt records its error"))
     }
 
-    /// Streams one symbol's quotes over `[start, end)` through `accept`, oldest first.
+    /// Streams one symbol's quotes over `[start, end)` through `accept`, oldest first, refusing
+    /// unusable books so `accept` only ever sees a quote worth weighing.
     ///
-    /// A fold rather than a `Vec` because the volume forbids collecting: AAPL alone printed 846,305
-    /// quotes on 2026-08-20, which is 110MB of JSON, and the archive wants a dozen numbers out of
-    /// it. Each page is dropped once `accept` has seen it, so peak memory is one page.
-    ///
-    /// Ticks arrive in ascending time order, which every time-weighted fold downstream depends on,
-    /// and unusable books are refused here so `accept` only ever sees a quote worth weighing.
-    ///
-    /// `as_of` is the day whose mapping resolves `ticker`, and must be the session being fetched:
-    /// the default is today, which would read a historical window through today's symbol table.
+    /// A fold rather than a `Vec` because the volume forbids collecting: each page is dropped once
+    /// `accept` has seen it, so peak memory is one page. `as_of` is the day whose mapping resolves
+    /// `ticker` and must be the session being fetched — the default is today, which would read a
+    /// historical window through today's symbol table.
     pub async fn fetch_quotes<F>(
         &self,
         ticker: &Ticker,
@@ -2830,13 +2817,9 @@ impl MarketDataClient {
 
     /// Fetches point-in-time snapshots for `tickers`, in bounded chunks.
     ///
-    /// A chunk that fails is logged and skipped; its symbols simply go unpriced. Partial pricing
-    /// narrows the entry set and holds the exits it cannot price, both of which beat pricing
-    /// nothing at all. Only a total failure — every chunk failing — is reported as an error, which
-    /// keeps that report meaningful for the common single-chunk case.
-    ///
-    /// The failed chunk's symbols come back named. Downstream, a symbol Alpaca had no quote for and
-    /// one whose request never completed are the same absence, and they are not the same problem.
+    /// A chunk that fails is skipped and its symbols named in `failed_tickers`, so a symbol Alpaca
+    /// had no quote for stays distinguishable from one whose request never completed. Only a total
+    /// failure — every chunk failing — is reported as an error.
     pub async fn fetch_snapshots(&self, tickers: &[Ticker]) -> Result<SnapshotFetch, ClientError> {
         if tickers.is_empty() {
             return Ok(SnapshotFetch::default());
@@ -4112,7 +4095,7 @@ mod tests {
             .mock("GET", "/v2/stocks/snapshots?symbols=AAPL&feed=sip")
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(FULL_SNAPSHOT)
+            .with_body(SNAPSHOT_PAYLOAD)
             .create_async()
             .await;
 
@@ -4125,26 +4108,27 @@ mod tests {
         mock.assert_async().await;
     }
 
-    const FULL_SNAPSHOT: &str = r#"{
+    /// The two components a snapshot is read for, spelled as Alpaca sends them.
+    const SNAPSHOT_PAYLOAD: &str = r#"{
         "AAPL": {
             "latestTrade": {"t":"2026-06-10T15:59:00Z","p":201.5},
-            "latestQuote": {"t":"2026-06-10T15:59:30Z","bp":201.0,"ap":202.0,"bs":10,"as":12},
-            "minuteBar": {"t":"2026-06-10T15:59:00Z","o":201.1,"h":201.9,"l":201.0,"c":201.5,"v":15000.0,"vw":201.4,"n":120},
-            "dailyBar": {"t":"2026-06-10T04:00:00Z","o":199.0,"h":202.5,"l":198.5,"c":201.5,"v":2500000.0,"vw":200.9,"n":18000},
-            "prevDailyBar": {"t":"2026-06-09T04:00:00Z","o":197.0,"h":199.5,"l":196.5,"c":199.0,"v":2100000.0,"vw":198.2,"n":16000}
+            "latestQuote": {"t":"2026-06-10T15:59:30Z","bp":201.0,"ap":202.0,"bs":10,"as":12}
         }
     }"#;
 
-    /// The whole payload must survive, not just the quote. The previous daily bar in particular is
-    /// a free end-of-day backfill that the earlier quote-only parse discarded.
+    /// Both readings survive the parse, not just the quote.
+    ///
+    /// The bars Alpaca sends beside them are deliberately unparsed: this route prices the current
+    /// moment, and a daily bar belongs to the archive, stamped at the 16:00 Eastern close rather
+    /// than at the 04:00 UTC a snapshot carries.
     #[tokio::test]
-    async fn test_fetch_snapshots_retains_every_component() {
+    async fn test_fetch_snapshots_keeps_the_quote_and_the_trade() {
         let mut server = mockito::Server::new_async().await;
         let mock = server
             .mock("GET", "/v2/stocks/snapshots?symbols=AAPL&feed=iex")
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(FULL_SNAPSHOT)
+            .with_body(SNAPSHOT_PAYLOAD)
             .create_async()
             .await;
 
@@ -4169,7 +4153,7 @@ mod tests {
         let mock = server
             .mock("GET", "/v2/stocks/snapshots?symbols=AAPL&feed=iex")
             .with_status(200)
-            .with_body(FULL_SNAPSHOT)
+            .with_body(SNAPSHOT_PAYLOAD)
             .create_async()
             .await;
 
@@ -4236,7 +4220,7 @@ mod tests {
         let mock = server
             .mock("GET", "/v2/stocks/snapshots?symbols=AAPL&feed=iex")
             .with_status(200)
-            .with_body(FULL_SNAPSHOT)
+            .with_body(SNAPSHOT_PAYLOAD)
             .create_async()
             .await;
 
@@ -4717,9 +4701,9 @@ mod tests {
 
     /// A tape field that is not one character is refused rather than read by its first byte.
     ///
-    /// `"CTA"` used to be accepted as tape `C`, so its conditions were resolved against the UTP
-    /// table while nothing counted the row as malformed. Pinned to `"CTA"` specifically because its
-    /// first byte is a *valid* tape letter, which is the case a length check catches and a
+    /// Read by its first byte, `"CTA"` passes as tape `C` and its conditions resolve against the
+    /// UTP table while nothing counts the row as malformed. Pinned to `"CTA"` specifically because
+    /// its first byte is a *valid* tape letter, which is the case a length check catches and a
     /// `from_letter` check alone does not.
     #[tokio::test]
     async fn test_a_multi_character_tape_is_refused_rather_than_read_by_its_first_letter() {

--- a/src/common/aws.rs
+++ b/src/common/aws.rs
@@ -29,13 +29,9 @@ pub fn date_partitioned_key(prefix: &str, date: chrono::NaiveDate) -> String {
 /// Recover the date from a key built by [`date_partitioned_key`], or `None` if the key does not
 /// have that shape.
 ///
-/// The inverse exists so a `ListObjectsV2` result can become a set of dates, which is what lets the
-/// archive answer "which sessions am I missing" by comparing what is present against what is
-/// expected. Written against the tail of the key rather than the whole of it, so it is indifferent
-/// to the prefix and cannot be broken by one being renamed.
-///
-/// `None` rather than an error: a bucket may hold objects this layout knows nothing about, and a
-/// stray key is something to skip, not something to fail a run over.
+/// Written against the tail of the key rather than the whole of it, so it is indifferent to the
+/// prefix and cannot be broken by one being renamed. `None` rather than an error: a bucket may hold
+/// objects this layout knows nothing about, and a stray key is something to skip.
 pub fn date_from_partitioned_key(key: &str) -> Option<chrono::NaiveDate> {
     let mut segments = key.rsplit('/');
     if segments.next()? != "data.parquet" {

--- a/src/common/database.rs
+++ b/src/common/database.rs
@@ -1,7 +1,6 @@
 //! PostgreSQL connection handling.
 //!
-//! Connecting is fallible at startup rather than optional at runtime: every command arrives
-//! through the database, so there is no degraded mode to fall back to.
+//! Connecting is fallible at startup rather than optional at runtime: there is no degraded mode.
 
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -242,15 +242,10 @@ pub async fn emit_errored(pool: &PgPool, command: Command, error: &str) -> Resul
 /// Finds commands requested during the current Eastern trading date that never reached a terminal
 /// outcome, and which should be re-run.
 ///
-/// This replaces a consumer offset table, and is why the `events` table needs no queue beside it.
-/// A `_requested` row with no terminal outcome is work issued and never finished — what a process
-/// killed mid-handler leaves behind, and equally what a process not running when cron fired leaves
-/// behind. Both want the same response.
-///
-/// [`Recovery::Skip`] commands are found and dropped, so the caller receives only work worth doing.
-///
-/// The window is the Eastern date because that is the boundary the trading day has, and the
-/// additional two-day bound on `created_at` keeps the hypertable from scanning every chunk.
+/// A `_requested` row with no terminal outcome is work issued and never finished, which is why the
+/// `events` table needs no queue or consumer offset beside it; [`Recovery::Skip`] commands are
+/// dropped, so the caller receives only work worth doing. The window is the Eastern trading date,
+/// and the additional two-day bound on `created_at` keeps the hypertable from scanning every chunk.
 pub async fn recover_missed_commands(pool: &PgPool) -> Result<Vec<Command>, EventError> {
     let rows = sqlx::query!(
         r#"

--- a/src/common/flatfiles.rs
+++ b/src/common/flatfiles.rs
@@ -148,13 +148,9 @@ pub enum FlatFileError {
 
 /// Credentials for `files.massive.com`: issued by Massive, spoken in S3's dialect, not AWS's.
 ///
-/// Named `MASSIVE_S3_*` rather than anything containing `AWS` on purpose. This process also holds
-/// real AWS credentials and writes the archive with them, and `aws_config::load_defaults` reads
-/// `AWS_ACCESS_KEY_ID` from the environment — so a name in that family would hand Massive's key to
-/// every genuine AWS call in the same binary.
-///
-/// Deliberately does not derive `Debug`: it holds a secret key, and a derived `Debug` puts that key
-/// into any log line or panic message that formats a struct containing one.
+/// Named `MASSIVE_S3_*` rather than anything containing `AWS` because `aws_config::load_defaults`
+/// reads `AWS_ACCESS_KEY_ID` from the environment, and this process also holds real AWS credentials
+/// it writes the archive with. Deliberately does not derive `Debug`: it holds a secret key.
 #[derive(Clone)]
 pub struct FlatFileCredentials {
     endpoint_url: String,
@@ -275,10 +271,9 @@ impl BarSink for Vec<EquityBar> {
 
 /// One of Massive's flat-file datasets, which is also which parser its rows want.
 ///
-/// An enum rather than the string this used to be, because the value names two things that must
-/// agree — the vendor path a fold reads and the archive prefix its bytes are teed to — and a pair of
-/// strings passed separately can disagree. Both derive from the variant here, so a fold cannot read
-/// trades and file them under quotes.
+/// An enum rather than a string, because the value names two things that must agree — the vendor
+/// path a fold reads and the archive prefix its bytes are teed to. Both derive from the variant
+/// here, so a fold cannot read trades and file them under quotes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RawDataset {
     Quotes,
@@ -449,13 +444,11 @@ impl FlatFileFold {
 
     /// Refuses a file whose rows descend in time within a ticker.
     ///
-    /// The quote fold weighs each tick by the interval to the next, so a descending run weighs every one
-    /// at zero and still produces a summary — a silent wrong answer rather than a failure. Massive
-    /// does not document the row order and it cannot be inspected before paying, so it is asserted.
-    ///
+    /// The quote fold weighs each tick by the interval to the next, so a descending run weighs every
+    /// one at zero and still produces a summary — a silent wrong answer rather than a failure.
     /// The threshold is not a tuning knob: an ascending file inverts only where the SIP itself ties
     /// or reorders, a handful of rows per name, while a descending file inverts every row after the
-    /// first. Nothing real sits between them.
+    /// first.
     fn require_ascending(&self, key: &str) -> Result<(), FlatFileError> {
         let forwards = self.ticks_folded.saturating_sub(self.backwards);
         if self.backwards <= forwards {
@@ -1334,7 +1327,7 @@ async fn try_fetch_one_range(
 /// Presents the ordered chunks as something the gzip decoder can read.
 ///
 /// Blocking by construction: it is handed to `spawn_blocking` alongside the decoder and the parser,
-/// so waiting for the next chunk is the same wait the old single stream did.
+/// so waiting for the next chunk blocks only that thread.
 struct ChunkReader {
     receiver: tokio::sync::mpsc::Receiver<Result<Vec<u8>, FlatFileError>>,
     current: std::io::Cursor<Vec<u8>>,
@@ -2902,8 +2895,8 @@ mod tests {
     }
 
     /// A completion that fails leaves every part open and billing exactly as a failed part upload
-    /// would. This was a real hole: the abort used to hang off the `send_parts` error arm only, so
-    /// the completion path reached the same outcome by a door with no abort behind it.
+    /// would. The completion path reaches that outcome without passing through the `send_parts`
+    /// error arm, so the abort cannot hang off that arm alone.
     #[tokio::test]
     async fn test_a_failed_completion_still_aborts_the_upload() {
         let (directory, path) = staged_object("failed-completion", 4096);

--- a/src/common/journal.rs
+++ b/src/common/journal.rs
@@ -1,7 +1,6 @@
-//! Append-only record of what the application observed before it acted.
-//!
-//! One JSONL file per session on local disk, and the only original this application owns — every
-//! other store is a fold over it. Sealing and shipping it is [`crate::data::export`]'s.
+//! Append-only record of what the application observed before it acted: one JSONL file per session
+//! on local disk, and the only original this application owns — every other store is a fold over
+//! it. Sealing and shipping it is [`crate::data::export`]'s.
 
 use std::path::{Path, PathBuf};
 
@@ -20,7 +19,7 @@ use crate::common::types::{CloseReason, Dataset, PairID, SessionDate, Ticker};
 ///
 /// Readers map old versions forward rather than rewriting files, so this only ever goes up. What
 /// each version held is documented beside the DuckDB view in `tools/duckdb_initialization.sql`.
-pub const SCHEMA_VERSION: u32 = 5;
+pub const SCHEMA_VERSION: u32 = 6;
 
 /// Anything that stops a record reaching the disk.
 #[derive(Debug, thiserror::Error)]
@@ -101,20 +100,20 @@ impl Observation {
 }
 
 /// Why a scheduled command did no work.
+///
+/// The calendar is the only thing that stops a pass today; nothing in the tree detects a halt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SkipReason {
     NotATradingDay,
-    MarketHalted,
 }
 
 impl SkipReason {
-    pub const ALL: [SkipReason; 2] = [SkipReason::NotATradingDay, SkipReason::MarketHalted];
+    pub const ALL: [SkipReason; 1] = [SkipReason::NotATradingDay];
 
     pub fn as_str(self) -> &'static str {
         match self {
             SkipReason::NotATradingDay => "not_a_trading_day",
-            SkipReason::MarketHalted => "market_halted",
         }
     }
 
@@ -431,7 +430,8 @@ impl From<CloseReason> for PairDecision {
 /// An open pair as this pass measured it, whether or not it closed.
 ///
 /// Carries every input to the z-score, which on its own cannot distinguish a price move from a
-/// refit.
+/// refit. The stop is not among them: it is [`crate::portfolio::screen::stop_at`] of
+/// `entry_z_score`, so storing it beside its own input is a second thing that can be wrong.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct OpenPairReading {
     pub pair_id: PairID,
@@ -443,7 +443,8 @@ pub struct OpenPairReading {
     pub spread_standard_deviation: Option<f64>,
     pub z_score: Option<f64>,
     pub entry_z_score: f64,
-    pub stop_at: f64,
+    /// Why the spread model was unavailable, when `decision` is `no_spread_model`.
+    pub spread_model_failure: Option<String>,
     pub entry_session: SessionDate,
     pub minutes_held: i64,
     pub decision: PairDecision,
@@ -456,7 +457,10 @@ pub enum CandidateDecision {
     Opened,
     /// Selected and written into the plan, but the pass ended before it was attempted.
     Planned,
+    /// The ranking never reached it, so nothing was asked of it.
     NotSelected,
+    /// Selected and then refused by the sizer, which is a different fact from not being selected.
+    SizingRefused,
     RiskRefused,
     Unfilled,
     AbandonedAtShutdown,
@@ -482,7 +486,10 @@ pub struct CandidateReading {
     #[serde(with = "crate::common::types::decimal_number_option")]
     pub gross_exposure: Option<Decimal>,
     pub decision: CandidateDecision,
-    /// The risk gate's rendered reason, when `decision` is `risk_refused`.
+    /// The rendered reason the candidate was turned down, and by which stage.
+    ///
+    /// Set for `sizing_refused`, `risk_refused`, and `unfilled`. A `not_selected` candidate has no
+    /// refusal because nothing refused it — the ranking simply did not reach it.
     pub refusal: Option<String>,
 }
 
@@ -643,8 +650,8 @@ pub struct PositionCloseRequested {
 /// The pre-close flattening.
 ///
 /// Written whether or not the flattening succeeded. This is the last fail-safe before positions
-/// carry overnight, and a run that failed at the broker used to leave no trace of having been
-/// attempted at all.
+/// carry overnight, and a run that failed at the broker would otherwise leave no trace of having
+/// been attempted.
 #[derive(Debug, Clone, PartialEq, Default, Serialize)]
 pub struct LiquidationAttempted {
     pub pairs_closed: usize,
@@ -1325,7 +1332,7 @@ mod tests {
         );
         let value: Value = serde_json::to_value(&record).expect("record must serialize");
 
-        assert_eq!(value["schema_version"], Value::Number(5.into()));
+        assert_eq!(value["schema_version"], Value::Number(6.into()));
         assert_eq!(value["event_type"], "account_observed");
         assert_eq!(value["session_date"], "2026-08-11");
         assert_eq!(value["timestamp"], "2026-08-11T20:15:00Z");

--- a/src/common/log.rs
+++ b/src/common/log.rs
@@ -26,12 +26,9 @@ pub fn log_directory() -> std::path::PathBuf {
 /// to a rolling daily file under `FUND_LOG_DIRECTORY`.
 ///
 /// `file_filter` overrides the file layer's level; an uncreatable directory disables file logging
-/// rather than failing.
-///
-/// `Some` means *this call* installed the file layer, and the `WorkerGuard` MUST then be held for
-/// the process lifetime — dropping it tears down the non-blocking writer and buffered lines are
-/// lost. `None` means it did not, either because file logging is off or because `try_init` found a
-/// subscriber already installed, which is what makes repeated calls across tests a no-op.
+/// rather than failing. `Some` means *this call* installed the file layer and the `WorkerGuard` MUST
+/// then be held for the process lifetime, since dropping it tears down the non-blocking writer and
+/// loses buffered lines; `None` means it did not, which is what makes repeated calls a no-op.
 pub fn init_tracing(
     log_file: &str,
     file_filter: Option<&str>,

--- a/src/common/massive.rs
+++ b/src/common/massive.rs
@@ -230,21 +230,11 @@ struct GroupedResponse {
 
 /// Whether a raw symbol is common stock rather than a preferred, warrant, unit, or right.
 ///
-/// Massive encodes share class in the *case* of the symbol: `GSpD` is Goldman Sachs preferred
-/// series D, `BCpC` a preferred, `TpC` another. `Ticker::new` uppercases before validating — which
-/// is right for user input and wrong here, because it collapses `BCpC` onto `BCPC`, the common
-/// stock of an entirely different company. The two then share a primary key of
-/// `(ticker, bar_interval, timestamp)` and the upsert silently keeps whichever arrived last, so a
-/// real mid-cap's bar can be replaced by a thinly traded preferred's.
-///
-/// Measured on one live session: 12,445 symbols, of which 2 collided this way. Small, silent, and
-/// corrupting to exactly the names the strategy would trade — the preferred's volume is a rounding
-/// error against the common's, so the liquidity screen, the correlation, and the model input all
-/// take the wrong number.
-///
-/// Requiring the raw form to already be uppercase drops every one of them. That is not a
-/// workaround: this strategy trades common stock, and a preferred share is not something it should
-/// have been offered in the first place.
+/// Massive encodes share class in the *case* of the symbol — `GSpD` is Goldman Sachs preferred
+/// series D — and `Ticker::new` uppercases, which collapses `BCpC` onto `BCPC`, the common stock of
+/// an entirely different company; they then share the `(ticker, bar_interval, timestamp)` key and
+/// the upsert keeps whichever arrived last. Requiring the raw form to already be uppercase drops
+/// every such symbol, which is what a strategy trading common stock wants.
 fn is_common_stock_symbol(raw: &str) -> bool {
     let trimmed = raw.trim();
     !trimmed.is_empty() && trimmed == trimmed.to_ascii_uppercase()
@@ -336,9 +326,6 @@ impl MassiveClient {
     ///
     /// Prices are raw (`adjusted=false`), so a stored bar means the same thing forever and
     /// [`crate::data::adjust`] restates it at read time.
-    ///
-    /// Asking for the adjustment made every stored bar mean whatever the feed knew the night it was
-    /// written, and nothing revisits an old one.
     pub async fn fetch_grouped_daily(
         &self,
         date: NaiveDate,
@@ -390,11 +377,6 @@ impl MassiveClient {
         Ok(bars)
     }
 
-    /// Fetches every stock split Massive knows about, following the cursor to the last page.
-    ///
-    /// The response covers announced-but-unexecuted splits as well as historical ones, so a caller
-    /// holding the result has the feed's whole current opinion rather than a window of it — which is
-    /// what makes replacing the stored table safe when a split is cancelled and disappears.
     /// Fetches one symbol's bars at an intraday cadence over an inclusive date range.
     ///
     /// **Refuses [`BarInterval::OneDay`].** This route stamps a daily bar at midnight Eastern where
@@ -470,6 +452,11 @@ impl MassiveClient {
         )))
     }
 
+    /// Fetches every stock split Massive knows about, following the cursor to the last page.
+    ///
+    /// The response covers announced-but-unexecuted splits as well as historical ones, so a caller
+    /// holding the result has the feed's whole current opinion rather than a window of it, which is
+    /// what makes replacing the stored table safe when a split is cancelled and disappears.
     pub async fn fetch_splits(&self) -> Result<Vec<EquitySplit>, MassiveError> {
         let mut url = splits_url(&self.credentials.base_url);
         let mut splits: Vec<EquitySplit> = Vec::new();

--- a/src/common/provenance.rs
+++ b/src/common/provenance.rs
@@ -1,7 +1,6 @@
 //! Which vendor and which subscription answer for a dataset.
 //!
-//! Declared in the type system rather than in prose so a new dataset cannot be added without saying
-//! where it comes from, and so "what stops working when a subscription lapses" is a query.
+//! Declared in the type system, so a dataset cannot be added without saying where it comes from.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -8,6 +8,44 @@ use rust_decimal::Decimal;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
+/// Which bound of a [`LiquidityFloor`] a name failed, and the reading that failed it.
+///
+/// A bound can only be moved from the readings it refused, so a refusal that says only "excluded"
+/// cannot be calibrated against anything.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LiquidityRefusal {
+    ClosePrice { observed: f64, minimum: f64 },
+    DollarVolume { observed: f64, minimum: f64 },
+}
+
+impl LiquidityRefusal {
+    /// The stable name this refusal is recorded under.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LiquidityRefusal::ClosePrice { .. } => "close_price",
+            LiquidityRefusal::DollarVolume { .. } => "dollar_volume",
+        }
+    }
+
+    /// The reading and the bound it failed.
+    pub fn detail(&self) -> String {
+        match self {
+            LiquidityRefusal::ClosePrice { observed, minimum } => {
+                format!("close_price={observed:.4} minimum={minimum:.4}")
+            }
+            LiquidityRefusal::DollarVolume { observed, minimum } => {
+                format!("dollar_volume={observed:.2} minimum={minimum:.2}")
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for LiquidityRefusal {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.detail())
+    }
+}
+
 /// The boundary of the modeled and served equity universe: the price and daily notional a name
 /// must clear.
 ///
@@ -24,8 +62,7 @@ impl LiquidityFloor {
     /// The floor every path uses until a caller declares its own.
     ///
     /// Both figures are conventions rather than measurements, and the notional one drifts with the
-    /// market it screens: it admitted 20.6% of priced names in 2022 and 23.0% in 2026, as
-    /// market-wide dollar volume nearly doubled.
+    /// market it screens: it admitted 20.6% of priced names in 2022 and 23.0% in 2026.
     pub const CURRENT: Self = Self {
         minimum_close_price: 10.0,
         minimum_dollar_volume: 50_000_000.0,
@@ -42,11 +79,24 @@ impl LiquidityFloor {
 
     /// Whether a name trading at `close_price` on `dollar_volume` is inside the universe.
     ///
-    /// Both bounds are inclusive, and this is the only place that comparison is written. Every
-    /// screen that reached for the constants separately was free to differ on the boundary, and the
-    /// one that did admitted a name to training and then refused to predict for it.
-    pub fn admits(&self, close_price: f64, dollar_volume: f64) -> bool {
-        close_price >= self.minimum_close_price && dollar_volume >= self.minimum_dollar_volume
+    /// Both bounds are inclusive, and this is the only place that comparison is written. Price is
+    /// tested first, so a name failing both is reported on its price.
+    pub fn admits(&self, close_price: f64, dollar_volume: f64) -> Result<(), LiquidityRefusal> {
+        // The `is_nan` half is load-bearing: a bare `<` admits a reading that fails every
+        // comparison, which is how an unpriceable name reaches a screen that thinks it is liquid.
+        if close_price.is_nan() || close_price < self.minimum_close_price {
+            return Err(LiquidityRefusal::ClosePrice {
+                observed: close_price,
+                minimum: self.minimum_close_price,
+            });
+        }
+        if dollar_volume.is_nan() || dollar_volume < self.minimum_dollar_volume {
+            return Err(LiquidityRefusal::DollarVolume {
+                observed: dollar_volume,
+                minimum: self.minimum_dollar_volume,
+            });
+        }
+        Ok(())
     }
 
     pub fn minimum_close_price(&self) -> f64 {
@@ -73,13 +123,9 @@ impl std::fmt::Display for LiquidityFloor {
 /// Serializes a [`Decimal`] as a JSON number rather than a quoted string.
 ///
 /// `Decimal`'s own `Serialize` writes a string, which a reader has to cast before it can do
-/// arithmetic and which shows its quotes to anyone reading a rendered payload. Used through
-/// `#[serde(with = "...")]` on every field that reaches JSON.
-///
-/// Routes through [`Decimal::as_f64`], which returns an `f64` rather than an `Option`, so there is
-/// no failure to handle. `rust_decimal::serde::float` does the same conversion through `to_f64`
-/// and unwraps it — infallible in that crate today, since `to_f64` is `Some(self.as_f64())`, but
-/// an unwrap in the journal write path is not a thing to inherit from a dependency's internals.
+/// arithmetic; used through `#[serde(with = "...")]` on every field that reaches JSON. Routes
+/// through [`Decimal::as_f64`], which returns an `f64` rather than an `Option`, so there is no
+/// failure to handle and no unwrap in the journal write path.
 pub mod decimal_number {
     use super::Decimal;
     use serde::{de, Deserialize, Deserializer, Serializer};
@@ -329,23 +375,10 @@ impl<'de> Deserialize<'de> for Notional {
 
 /// A trading day, identified by its `America/New_York` calendar date.
 ///
-/// The type exists to make a session and an instant impossible to confuse. Both used to be spelled
-/// `NaiveDate`/`DateTime`, and every timekeeping bug this system has had was that confusion: a
-/// session derived from `Utc::now().date_naive()`, a prediction stamped at UTC midnight, a session
-/// and its label computed from two separate expressions. None of those is expressible here.
-///
-/// There are exactly two ways in. [`SessionDate::at`] converts an instant, which is the only
-/// correct way to answer "what trading day is it now". [`SessionDate::from_date`] takes a date
-/// already expressed in Eastern terms — parsed from a command-line argument, read from a `DATE`
-/// column, or returned by an exchange API that publishes Eastern dates. A `NaiveDate` obtained any
-/// other way, and a UTC date in particular, has no business becoming one of these.
-///
-/// **What it guarantees is the timezone, not tradability.** A `SessionDate` is a calendar date in
-/// the frame the exchange keeps; it is not proof that the market opens that day. Weekends and
-/// holidays are perfectly representable, and [`SessionDate::plus_calendar_days`] will land on them.
-/// Whether a date trades is [`crate::data::calendar::TradingCalendar::is_trading_day`]'s question,
-/// and it is the only thing that can answer it — the calendar is fetched from Alpaca, and a holiday
-/// table in the type system would be a second source that can disagree.
+/// There are exactly two ways in: [`SessionDate::at`] converts an instant, and
+/// [`SessionDate::from_date`] takes a date already expressed in Eastern terms. What it guarantees
+/// is the timezone, not tradability — only
+/// [`crate::data::calendar::TradingCalendar::is_trading_day`] can answer whether a date trades.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
 pub struct SessionDate(NaiveDate);
@@ -621,9 +654,7 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for PairID {
 
 /// The sampling interval of an OHLCV bar.
 ///
-/// Part of the `equity_bars` primary key. Every variant now has a writer:
-/// [`BarInterval::OneMinute`] gained one with the flat-file bar route, which had been the outstanding
-/// case this paragraph used to record.
+/// Part of the `equity_bars` primary key, and every variant has a writer.
 ///
 /// [`BarInterval::as_str`] must match the `bar_interval` CHECK constraint exactly. It is the
 /// snake_case of the variant name, which lets `rename_all` derive the same string for serde so what
@@ -669,8 +700,7 @@ impl BarInterval {
     }
 
     /// Parses the canonical stored form. Returns `None` for anything else, including Alpaca's
-    /// `1Day`/`1Min` timeframe spelling — that vocabulary belonged to a bars endpoint this
-    /// codebase no longer calls, and accepting it here would let it back in unnoticed.
+    /// `1Day`/`1Min` timeframe spelling, which is not a form this table stores.
     pub fn parse(raw: &str) -> Option<Self> {
         BarInterval::ALL
             .into_iter()
@@ -1434,10 +1464,9 @@ mod trade_exclusion_tests {
 
     /// Every recorded exclusion moves its count and its dollars together.
     ///
-    /// The reason the fields are private. Recording a rule used to be two statements at each of
-    /// three call sites, so a fourth rule added later could increment a count and forget its
-    /// dollars — and these columns are the archive's audit trail, so the audit would be the thing
-    /// that was wrong. Pinned to literals rather than to a sum of the inputs.
+    /// The reason the fields are private: a rule recorded as two separate statements can increment
+    /// a count and forget its dollars, and these columns are the archive's audit trail. Pinned to
+    /// literals rather than to a sum of the inputs.
     #[test]
     fn test_a_recorded_exclusion_moves_its_count_and_its_dollars_together() {
         let mut exclusions = TradeExclusions::default();
@@ -1494,8 +1523,10 @@ pub struct TradeSummary {
     dollar_volume: f64,
     /// `None` when no eligible share traded, which an exclusion-only bar is.
     volume_weighted_average_price: Option<f64>,
-    median_trade_size: f64,
-    ninetieth_percentile_trade_size: f64,
+    /// `None` when no eligible print has a size to report, which an exclusion-only bar is.
+    median_trade_size: Option<f64>,
+    /// Measurable exactly when [`TradeSummary::median_trade_size`] is.
+    ninetieth_percentile_trade_size: Option<f64>,
     /// Buys minus sells in shares, signed by the tick rule — a trade above the previous price is a
     /// buy, below is a sell, equal inherits the last non-zero direction.
     signed_volume: f64,
@@ -1516,8 +1547,8 @@ impl TradeSummary {
         trade_count: i64,
         volume: f64,
         dollar_volume: f64,
-        median_trade_size: f64,
-        ninetieth_percentile_trade_size: f64,
+        median_trade_size: Option<f64>,
+        ninetieth_percentile_trade_size: Option<f64>,
         signed_volume: f64,
         exclusions: TradeExclusions,
     ) -> Result<Self, InconsistentRecordError> {
@@ -1545,16 +1576,27 @@ impl TradeSummary {
                 ninetieth_percentile_trade_size,
             ),
         ] {
+            let Some(value) = value else { continue };
             if !value.is_finite() || value < 0.0 {
                 return Err(reject(format!(
                     "{name} {value} is not a non-negative number"
                 )));
             }
         }
-        if median_trade_size > ninetieth_percentile_trade_size {
-            return Err(reject(format!(
-                "median trade size {median_trade_size} exceeds the ninetieth percentile {ninetieth_percentile_trade_size}"
-            )));
+        // Both are drawn from the same eligible prints, so a bar that could measure one could
+        // measure the other; a disagreement means the two were folded over different populations.
+        match (median_trade_size, ninetieth_percentile_trade_size) {
+            (Some(median), Some(ninetieth)) if median > ninetieth => {
+                return Err(reject(format!(
+                    "median trade size {median} exceeds the ninetieth percentile {ninetieth}"
+                )));
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                return Err(reject(
+                    "one trade size percentile is measured and the other is not".to_string(),
+                ));
+            }
+            (Some(_), Some(_)) | (None, None) => {}
         }
         if trade_count < 0 {
             return Err(reject(format!("trade count {trade_count} is negative")));
@@ -1617,11 +1659,11 @@ impl TradeSummary {
         self.volume_weighted_average_price
     }
 
-    pub fn median_trade_size(&self) -> f64 {
+    pub fn median_trade_size(&self) -> Option<f64> {
         self.median_trade_size
     }
 
-    pub fn ninetieth_percentile_trade_size(&self) -> f64 {
+    pub fn ninetieth_percentile_trade_size(&self) -> Option<f64> {
         self.ninetieth_percentile_trade_size
     }
 
@@ -2031,23 +2073,74 @@ mod tests {
     fn test_a_floor_admits_a_name_sitting_exactly_on_it() {
         let floor = LiquidityFloor::new(10.0, 50_000_000.0).unwrap();
 
-        assert!(floor.admits(10.0, 50_000_000.0));
-        assert!(!floor.admits(9.99, 50_000_000.0));
-        assert!(!floor.admits(10.0, 49_999_999.0));
+        assert_eq!(floor.admits(10.0, 50_000_000.0), Ok(()));
+        assert_eq!(
+            floor.admits(9.99, 50_000_000.0),
+            Err(LiquidityRefusal::ClosePrice {
+                observed: 9.99,
+                minimum: 10.0,
+            })
+        );
+        assert_eq!(
+            floor.admits(10.0, 49_999_999.0),
+            Err(LiquidityRefusal::DollarVolume {
+                observed: 49_999_999.0,
+                minimum: 50_000_000.0,
+            })
+        );
     }
 
     /// The two bounds are independent, which is what makes an expensive thin name and a cheap heavy
-    /// one each excluded for their own reason.
+    /// one each excluded for their own reason — and the refusal is what says which.
     #[test]
-    fn test_each_bound_rejects_on_its_own() {
+    fn test_each_bound_rejects_on_its_own_and_names_itself() {
         let floor = LiquidityFloor::new(10.0, 50_000_000.0).unwrap();
 
-        assert!(!floor.admits(500.0, 30_000_000.0), "expensive but untraded");
-        assert!(
-            !floor.admits(2.0, 900_000_000.0),
-            "heavily traded but cheap"
+        assert_eq!(
+            floor
+                .admits(500.0, 30_000_000.0)
+                .expect_err("expensive but untraded")
+                .as_str(),
+            "dollar_volume"
         );
-        assert!(floor.admits(290.0, 261_000_000.0));
+        assert_eq!(
+            floor
+                .admits(2.0, 900_000_000.0)
+                .expect_err("heavily traded but cheap")
+                .as_str(),
+            "close_price"
+        );
+        assert_eq!(floor.admits(290.0, 261_000_000.0), Ok(()));
+
+        // The whole string: the detail is aggregated out of the journal, so the format is contract.
+        assert_eq!(
+            floor
+                .admits(2.0, 900_000_000.0)
+                .expect_err("a cheap name reports its price")
+                .detail(),
+            "close_price=2.0000 minimum=10.0000"
+        );
+    }
+
+    /// A reading that is not a number fails every comparison, so a bare `<` would admit it.
+    #[test]
+    fn test_a_floor_refuses_a_reading_that_is_not_a_number() {
+        let floor = LiquidityFloor::new(10.0, 50_000_000.0).unwrap();
+
+        assert_eq!(
+            floor
+                .admits(f64::NAN, 900_000_000.0)
+                .expect_err("an unpriceable name must be refused")
+                .as_str(),
+            "close_price"
+        );
+        assert_eq!(
+            floor
+                .admits(290.0, f64::NAN)
+                .expect_err("an unmeasurable notional must be refused")
+                .as_str(),
+            "dollar_volume"
+        );
     }
 
     #[test]
@@ -2367,9 +2460,8 @@ mod tests {
         }
     }
 
-    /// Neither Alpaca's timeframe spelling nor either pre-rename stored form is accepted. The last
-    /// two matter most: `1day` was the stored value before this vocabulary changed, and silently
-    /// parsing it would let a stale writer put unreadable rows in the table.
+    /// Neither Alpaca's timeframe spelling nor any near-miss of the stored form is accepted;
+    /// silently parsing one would let a stale writer put unreadable rows in the table.
     #[test]
     fn test_bar_interval_parse_rejects_foreign_spellings() {
         assert!(BarInterval::parse("1Day").is_none());

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -1,7 +1,6 @@
 //! The dashboard: a read-only page describing what the fund is doing.
 //!
-//! Its own process, connecting as `dashboard_reader` — SELECT on six tables and nothing else. A
-//! poller refreshes state on a fixed interval, a listener appends events, and handlers never query.
+//! Its own process, connecting as `dashboard_reader`: SELECT on six tables, and handlers never query.
 
 pub mod cache;
 pub mod database;

--- a/src/dashboard/cache.rs
+++ b/src/dashboard/cache.rs
@@ -1,7 +1,6 @@
 //! Shared in-memory state for the dashboard, and the two tasks that keep it current.
 //!
-//! A failed poll leaves the previous state and records the error rather than blanking the page —
-//! stale numbers with a visible "last updated" beat no numbers.
+//! A failed poll leaves the previous state and records the error rather than blanking the page.
 
 use std::collections::VecDeque;
 use std::sync::Arc;

--- a/src/dashboard/database.rs
+++ b/src/dashboard/database.rs
@@ -1,7 +1,6 @@
 //! Read-only queries behind the dashboard, and the aggregations computed from them.
 //!
-//! Raw `sqlx::query` rather than the macros, so the dashboard adds no `.sqlx` cache entries. The
-//! aggregations are pure functions over rows they were handed, testable without a database.
+//! Raw `sqlx::query` rather than the macros, so the dashboard adds no `.sqlx` cache entries.
 
 use chrono::{DateTime, Datelike, NaiveDate, Utc};
 use rust_decimal::Decimal;
@@ -116,16 +115,11 @@ async fn fetch_account_snapshot_history(
 
 /// Fetches the sessions in which capital moved into or out of the account, within a session range.
 ///
-/// Bounded to the snapshot history the dashboard displays, because a transfer outside it cannot
-/// change any published figure: every baseline [`compute_period_returns`] measures from comes out of
-/// that same history. Bounding also keeps the scan off the whole table —
-/// `idx_account_activities_transaction_time` covers this predicate, and there is no index on
-/// `activity_type`.
-///
-/// Timestamps come back raw and become sessions through [`SessionDate::at`], rather than being
-/// converted in SQL: `(transaction_time AT TIME ZONE 'America/New_York')::date` would hide the column
-/// behind an expression and defeat that index, which is the same reasoning
-/// [`SessionDate::bounds`] documents for itself.
+/// Bounded to the snapshot history the dashboard displays, because every baseline
+/// [`compute_period_returns`] measures from comes out of that same history, and because
+/// `idx_account_activities_transaction_time` covers this predicate where nothing indexes
+/// `activity_type`. Timestamps come back raw and become sessions through [`SessionDate::at`]:
+/// converting in SQL would hide the column behind an expression and defeat that index.
 async fn fetch_transfer_sessions(
     pool: &PgPool,
     first: SessionDate,

--- a/src/dashboard/html.rs
+++ b/src/dashboard/html.rs
@@ -29,14 +29,10 @@ pub fn render_html(state: &DashboardState) -> String {
 
 /// Formats an instant for display: Eastern wall clock, with the zone stated.
 ///
-/// Every timestamp on this page goes through here, so the page cannot mix zones. Eastern rather
-/// than UTC because that is the timezone the trading day has — rendered in UTC, the page disagreed
-/// with the session it was describing for the last four or five hours of every evening, which is
-/// exactly when an operator is checking whether the post-close jobs ran and exactly when the UTC
-/// date has already rolled over to tomorrow.
-///
-/// Elapsed times — [`format_age`], holding durations — are differences between two instants and
-/// carry no zone, so they do not come through here.
+/// Every timestamp on this page goes through here, so the page cannot mix zones, and Eastern rather
+/// than UTC because that is the timezone the trading day has. Elapsed times — [`format_age`],
+/// holding durations — are differences between two instants and carry no zone, so they do not come
+/// through here.
 fn eastern_stamp(instant: DateTime<Utc>, format: &str) -> String {
     format!(
         "{} ET",
@@ -667,7 +663,7 @@ mod tests {
     /// The fixture instant is 20:00 UTC, which is 16:00 Eastern, so the two cannot be confused: a
     /// regression to UTC brings the 20:00 back and the assertion fails rather than passing on a
     /// shared substring. The closed pair at 19:00 UTC and the event at 19:55 UTC are checked for
-    /// the same reason — they are the two columns that used to render with no zone at all.
+    /// the same reason.
     #[test]
     fn test_every_timestamp_renders_in_eastern_and_says_so() {
         let html = render_html_at(&populated_state(), now());

--- a/src/data/adjust.rs
+++ b/src/data/adjust.rs
@@ -114,14 +114,11 @@ impl SplitTable {
 
     /// The factor putting a bar of `ticker` on `session` onto `as_of`'s share basis.
     ///
-    /// Splits are applied when they execute strictly after the bar and no later than `as_of`. The
-    /// lower bound is exclusive because a split executes at the open, so the bar stamped that day
-    /// already reflects it. The upper bound is what keeps an *announced* split out: the table
-    /// carries them months ahead, and applying one would restate today's history onto a basis the
-    /// market has not moved to, leaving it incomparable with the live quote it gets screened against.
-    ///
-    /// A composition that leaves the representable range falls back to
-    /// [`AdjustmentFactor::IDENTITY`] — the same answer an unknown ticker gets.
+    /// Splits are applied when they execute strictly after the bar and no later than `as_of`: a
+    /// split executes at the open, so the bar stamped that day already reflects it, and the upper
+    /// bound keeps an *announced* split from restating history onto a basis the market has not
+    /// moved to. A composition that leaves the representable range falls back to
+    /// [`AdjustmentFactor::IDENTITY`], the same answer an unknown ticker gets.
     pub fn factor_at(
         &self,
         ticker: &str,
@@ -302,6 +299,7 @@ mod tests {
     use super::*;
     use crate::common::types::{EquitySplit, Ticker};
     use crate::data::splits::splits_to_dataframe;
+    use chrono::TimeZone;
 
     fn session(value: &str) -> SessionDate {
         SessionDate::from_date(value.parse().expect("a valid session date"))
@@ -426,11 +424,43 @@ mod tests {
         );
     }
 
+    /// The instant ingestion stamps a daily bar at, which is the 16:00 Eastern close.
+    ///
+    /// Not `midnight()`: that sits exactly on the lower edge of the session's `bounds()`, a place
+    /// no real bar is written, so a fixture using it would not exercise the conversion at all.
+    fn session_close(session_date: &str) -> i64 {
+        let local_close = session(session_date)
+            .date()
+            .and_hms_opt(16, 0, 0)
+            .expect("16:00 is a valid wall-clock time");
+        chrono_tz::America::New_York
+            .from_local_datetime(&local_close)
+            .earliest()
+            .expect("16:00 Eastern is unambiguous")
+            .timestamp_millis()
+    }
+
+    /// The bar fixture is stamped where ingestion stamps one, strictly inside the session.
+    ///
+    /// `midnight()` sits exactly on the lower edge of `bounds()`, so a fixture using it agrees with
+    /// the fold by accident rather than by describing a bar the archive could hold.
+    #[test]
+    fn test_a_bar_fixture_is_stamped_at_the_session_close() {
+        let (start, end) = session("2026-06-26").bounds();
+        let stamp =
+            DateTime::from_timestamp_millis(session_close("2026-06-26")).expect("a real instant");
+        assert!(
+            stamp > start && stamp < end,
+            "{stamp} is not inside the session"
+        );
+        assert_eq!(stamp.to_rfc3339(), "2026-06-26T20:00:00+00:00");
+    }
+
     fn bars(ticker: &str, session_date: &str, close: f64, volume: i64) -> DataFrame {
         df![
             "ticker" => [ticker],
             "bar_interval" => ["1Day"],
-            "timestamp" => [session(session_date).midnight().timestamp_millis()],
+            "timestamp" => [session_close(session_date)],
             "open_price" => [close],
             "high_price" => [close],
             "low_price" => [close],

--- a/src/data/archive.rs
+++ b/src/data/archive.rs
@@ -55,15 +55,9 @@ pub const DETAILS_ARCHIVE_KEY: &str = "data/derived/equity/details/details.csv";
 
 /// S3 key for the stock splits the bars are adjusted against.
 ///
-/// Read by [`crate::data::adjust::SplitTableCache`] at read time and by the trainer before it
-/// builds a dataset, so both see the same basis.
-///
-/// One object rather than a partition per session, unlike the bars beside it. A split belongs to
-/// its execution date, but the feed revises and cancels announced ones, so a per-date layout would
-/// leave a cancelled split sitting in a partition nothing revisits.
-///
-/// Under `corporate_actions/` rather than a directory of its own, because spinoffs and symbol
-/// changes are the same kind of fact read the same way and belong beside it as sibling files.
+/// One object rather than a partition per session, unlike the bars beside it: the feed revises and
+/// cancels announced splits, so a per-date layout would leave a cancelled one sitting in a
+/// partition nothing revisits.
 pub const SPLITS_ARCHIVE_KEY: &str = "data/derived/equity/corporate_actions/splits.parquet";
 
 /// Object holding every date a symbol's price series may not be read across.
@@ -72,19 +66,12 @@ pub const SPLITS_ARCHIVE_KEY: &str = "data/derived/equity/corporate_actions/spli
 /// purposes: a split says how to restate a price across a date, a boundary says not to.
 pub const BOUNDARIES_ARCHIVE_KEY: &str = "data/derived/equity/corporate_actions/boundaries.parquet";
 
-/// Trailing sessions re-fetched even when a partition already exists.
+/// Trailing sessions re-fetched even when a partition already exists, so a bar restated after the
+/// close reaches [`merge_partitions`] rather than being skipped as a day already held.
 ///
-/// Gap-filling alone never revisits a day it has, but a later response can *correct* an earlier one
-/// — a bar restated after the close, a symbol that arrived late. That is what [`merge_partitions`]
-/// and its last-write-wins strategy are for, and without a deliberate overlap they would have
-/// nothing to do. Kept separate from the gap scan because the two answer different questions, and
-/// the single fixed lookback that used to serve both could not do either well.
-///
-/// Counted in sessions, and it has to be taken from `expected` rather than measured backwards from
-/// `end` in calendar days. The two disagree across a weekend: a Monday run with a two-*day* floor
-/// lands on Saturday, so only Monday is above it and the preceding Friday is never revisited. The
-/// trainer runs weekdays, which made that every Monday, on the session a weekend gives the most
-/// time to be restated.
+/// Counted in sessions and taken from `expected`, never measured backwards from `end` in calendar
+/// days: a Monday run with a two-*day* floor lands on Saturday, leaving the preceding Friday — the
+/// session a weekend gives the most time to be restated — never revisited.
 const CORRECTION_WINDOW_SESSIONS: usize = 2;
 
 /// Sessions fetched before their partitions are written and the buffer released.
@@ -611,20 +598,12 @@ fn stampable_prefixes() -> Vec<StampablePrefix> {
     let mut found = Vec::new();
     for dataset in DerivedDataset::ALL {
         match dataset {
-            DerivedDataset::Bars | DerivedDataset::Quotes | DerivedDataset::Trades => {
-                let build: fn(BarInterval) -> String = match dataset {
-                    DerivedDataset::Bars => bar_archive_prefix,
-                    DerivedDataset::Quotes => quote_archive_prefix,
-                    _ => trade_archive_prefix,
-                };
-                for interval in BarInterval::ALL {
-                    found.push(StampablePrefix {
-                        dataset: dataset.as_str().to_string(),
-                        interval: Some(interval),
-                        prefix: build(interval),
-                        object: "data.parquet",
-                    });
-                }
+            DerivedDataset::Bars => found.extend(session_partitions(dataset, bar_archive_prefix)),
+            DerivedDataset::Quotes => {
+                found.extend(session_partitions(dataset, quote_archive_prefix))
+            }
+            DerivedDataset::Trades => {
+                found.extend(session_partitions(dataset, trade_archive_prefix))
             }
             // One object, not a partition tree, so the prefix is its parent and the object its name.
             DerivedDataset::Splits => found.push(whole_table(dataset, SPLITS_ARCHIVE_KEY)),
@@ -646,6 +625,22 @@ fn stampable_prefixes() -> Vec<StampablePrefix> {
     found
 }
 
+/// One session-partitioned prefix per cadence, which `build` names.
+fn session_partitions(
+    dataset: DerivedDataset,
+    build: fn(BarInterval) -> String,
+) -> Vec<StampablePrefix> {
+    BarInterval::ALL
+        .into_iter()
+        .map(|interval| StampablePrefix {
+            dataset: dataset.as_str().to_string(),
+            interval: Some(interval),
+            prefix: build(interval),
+            object: "data.parquet",
+        })
+        .collect()
+}
+
 /// A whole-table object described as a prefix and a filename, so the sweep can list it like any other.
 fn whole_table(dataset: DerivedDataset, key: &'static str) -> StampablePrefix {
     let (prefix, object) = key
@@ -660,7 +655,9 @@ fn whole_table(dataset: DerivedDataset, key: &'static str) -> StampablePrefix {
 }
 
 /// The session a partition or raw key belongs to, whatever its object is called.
-fn session_from_key(key: &str, object: &str) -> Option<NaiveDate> {
+///
+/// The partition path is written in Eastern terms, so this is the boundary the wrap happens at.
+fn session_from_key(key: &str, object: &str) -> Option<SessionDate> {
     let mut segments = key.rsplit('/');
     if segments.next()? != object {
         return None;
@@ -668,7 +665,7 @@ fn session_from_key(key: &str, object: &str) -> Option<NaiveDate> {
     let day: u32 = segments.next()?.strip_prefix("day=")?.parse().ok()?;
     let month: u32 = segments.next()?.strip_prefix("month=")?.parse().ok()?;
     let year: i32 = segments.next()?.strip_prefix("year=")?.parse().ok()?;
-    NaiveDate::from_ymd_opt(year, month, day)
+    NaiveDate::from_ymd_opt(year, month, day).map(SessionDate::from_date)
 }
 
 /// Every partition key under `prefix`, with whether it already carries a sidecar.
@@ -821,20 +818,11 @@ pub async fn sweep_partition_provenance(
 
 /// Fetches and writes every session in `[window_start, window_end]` the archive is missing.
 ///
-/// **A set difference, not a lookback**, so a missed night, a week of downtime, and an empty bucket
-/// are one case where a fixed lookback repairs only the first. Expected means "worth requesting"
-/// rather than "the market traded", since the trainer holds no broker credentials to consult a
-/// calendar with: a holiday is requested, answered with nothing, and requested again, at a cost of
-/// roughly ten empty requests a year that [`PassSummary`] reports rather than hides.
-///
-/// Idempotent: a second pass over an unchanged window requests only the correction window and
-/// writes the same rows back. Safe to interrupt, because partitions are written as each chunk
-/// completes and no state outside the bucket records progress — an interrupted seed keeps
-/// everything it had already written, and the next pass sees the rest as gaps.
-///
-/// Safe to run concurrently with another pass over the same bucket, which the trainer's nightly
-/// repair and an operator's seed can be. Each partition is written under a precondition on what was
-/// read, so a racing writer is detected rather than overwritten; see [`write_partition`].
+/// **A set difference, not a lookback**, so a missed night, a week of downtime and an empty bucket
+/// are one case. Expected means "worth requesting" rather than "the market traded", so a holiday is
+/// requested, answered with nothing, and requested again. Idempotent, safe to interrupt, and safe
+/// to run concurrently over the same bucket — [`write_partition`] writes under a precondition on
+/// what it read, so a racing writer is rejected rather than overwritten.
 pub async fn archive_missing_sessions(
     s3_client: &S3Client,
     massive: &MassiveClient,
@@ -1150,7 +1138,7 @@ impl std::fmt::Display for Scope {
 /// The sessions a pass touches, which [`SessionSelection`] decides.
 ///
 /// Split out from the S3 listing so the rule is testable without a bucket. Seeding and repairing
-/// want opposite sets, and getting that backwards is the defect #1102 was written for.
+/// want opposite sets.
 fn sessions_for(
     selection: SessionSelection,
     offered: &[SessionDate],
@@ -1767,14 +1755,11 @@ struct Universe {
 
 /// Merges `fetched` into the partition for `session` and writes it back, conditional on what it read.
 ///
-/// The read-merge-write is a compare-and-swap. S3 returns the object's `ETag` on read, and the write
-/// carries `If-Match` on it -- or `If-None-Match: *` when the partition did not exist -- so a pass
-/// that raced another one is rejected with `412` instead of silently discarding the other's rows.
-/// The whole cycle is retried against the now-current object, which is why the merge is redone
-/// rather than the buffer resent.
-///
-/// This matters more than it would have before bars left the nightly export: `data/` is now their
-/// only copy, so a lost write has no second source to recover from.
+/// The read-merge-write is a compare-and-swap on the object's `ETag`: the write carries `If-Match`
+/// on it -- or `If-None-Match: *` when the partition did not exist -- so a pass that raced another
+/// is rejected with `412` instead of silently discarding the other's rows. The whole cycle is
+/// retried against the now-current object, which is why the merge is redone rather than the buffer
+/// resent.
 async fn write_partition(
     s3_client: &S3Client,
     bucket: &str,
@@ -1999,14 +1984,8 @@ impl std::fmt::Display for QuoteSource<'_> {
 
 /// Folds the quoted book across `sessions`, per `scope`, taking its ticks from `source`.
 ///
-/// Session-major rather than ticker-major, unlike the intraday bar pass: a quote request is already
-/// bounded to one session's hours, so there is nothing to gain by holding a chunk of them. That is
-/// also why the never-create rule costs nothing here: a session-major pass never fetches outside the
-/// sessions it selected, while a bar chunk spans a range and needs [`writable_session`] at the write.
-///
-/// Regular hours only, taken from the calendar so an early close is 3.5 hours rather than 6.5. The
+/// Regular hours only, taken from the calendar so an early close is 3.5 hours rather than 6.5: the
 /// overnight book is an order of magnitude wider and would swamp any session mean it entered.
-///
 /// `sessions` must already be calendar-filtered, which the returned summary assumes when it reports
 /// a session that answered with nothing as a fault rather than as a holiday.
 pub async fn archive_quote_sessions(
@@ -3057,9 +3036,8 @@ async fn archive_bar_flat_file_session(
         return Ok(());
     }
 
-    // Through `write_partitions` rather than `write_partition`, for one session at a time. The
-    // plural form is where contention and write faults are carried instead of ending the pass --
-    // the #1106 behaviour, and a third hand-written copy of those arms could drift from it.
+    // Through `write_partitions` rather than `write_partition`, for one session at a time: the
+    // plural form is where contention and write faults are carried instead of ending the pass.
     write_partitions(
         s3_client,
         bucket,
@@ -3274,13 +3252,9 @@ pub async fn archive_details(
 
 /// Reads one archived partition, distinguishing a missing object from a failed request.
 ///
-/// `Ok(None)` means the partition genuinely does not exist yet. Every other failure propagates: a
-/// credential error, a throttle, or a network fault silently treated as "missing" would shorten the
-/// training window without any signal, and the model would just be slightly worse for reasons
-/// nothing recorded.
-///
-/// For readers that only want the data. A writer wants [`read_partition_with_etag`], because the
-/// ETag is what makes its write conditional on the version it merged from.
+/// `Ok(None)` means the partition genuinely does not exist yet; every other failure propagates,
+/// because a throttle silently treated as "missing" would shorten the training window with no
+/// signal. A writer wants [`read_partition_with_etag`], whose ETag makes its write conditional.
 pub async fn read_partition(
     s3_client: &S3Client,
     bucket: &str,
@@ -3856,13 +3830,11 @@ mod tests {
         fold.finish()
     }
 
-    /// A partition records the route that actually built it, not the route trades used to have.
+    /// A partition records the route that actually built it, not a hard-coded one.
     ///
-    /// `write_trade_partitions` hard-coded the flat-file provenance behind a comment reading "trades
-    /// have one route and no repair path". Adding the Alpaca per-name route made that false, and an
-    /// `equity-trades repair` would have filed Alpaca rows as Massive — hiding the provider seam in
-    /// the one record kept to expose it. `TradeSource::provenance()` existed throughout and was
-    /// never called.
+    /// Trades have two routes, the flat-file fold and the Alpaca per-name repair, so provenance has
+    /// to come from [`TradeSource::provenance`]: filing an `equity-trades repair` under Massive
+    /// would hide the provider seam in the one record kept to expose it.
     #[tokio::test]
     async fn test_a_trade_partition_is_attributed_to_the_route_that_built_it() {
         let bodies: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
@@ -4059,8 +4031,8 @@ mod tests {
 
     /// A record that does not parse is left for the sweep rather than retried against.
     ///
-    /// An `Absent` precondition cannot replace an object that is really there, so the old lenient
-    /// read spent every attempt on writes that could only 409, then warned about losing a race.
+    /// An `Absent` precondition cannot replace an object that is really there, so a lenient read
+    /// spends every attempt on writes that can only 409, then warns about losing a race.
     #[tokio::test]
     async fn test_a_sidecar_that_does_not_parse_is_left_for_the_sweep() {
         let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
@@ -4148,9 +4120,8 @@ mod tests {
 
     /// One session's write failing must cost that session and no other.
     ///
-    /// The regression test #1106 could not have: before it, any non-contention error returned from
-    /// `write_partitions`, so a single transient fault discarded every session after it — which is
-    /// what ended a five-hour whole-market pass four fifths of the way through.
+    /// A non-contention error returned from `write_partitions` would discard every session after
+    /// it, which on a five-hour whole-market pass costs whatever is left of the run.
     #[tokio::test]
     async fn test_a_failed_partition_write_costs_only_its_own_session() {
         let doomed = session(2026, 9, 3);

--- a/src/data/attribution.rs
+++ b/src/data/attribution.rs
@@ -1,16 +1,14 @@
 //! Recovers which route built each archived object, from pass logs and from declared configuration.
 //!
-//! Logs are one source among two, not a special case; they are simply the only record of the quote
-//! archive's two routes.
+//! Logs are one source among two, and the only record of the quote archive's two routes.
 
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use chrono::NaiveDate;
 use serde::Deserialize;
 
 use crate::common::provenance::{AlpacaPlan, MassivePlan, MassiveTransport, Provenance};
-use crate::common::types::BarInterval;
+use crate::common::types::{BarInterval, SessionDate};
 
 /// What one log line attests to: a dataset, optionally one cadence of it, and a session.
 ///
@@ -18,7 +16,7 @@ use crate::common::types::BarInterval;
 /// both do — and `Some` where it does not. **One-minute bars are the case that forces this**: they
 /// come from a flat file while the five-minute and daily partitions for the same session come from
 /// Massive's REST route, so a key without a cadence would attribute all three to the flat file.
-pub type Attribution = BTreeMap<(String, Option<BarInterval>, NaiveDate), Vec<Provenance>>;
+pub type Attribution = BTreeMap<(String, Option<BarInterval>, SessionDate), Vec<Provenance>>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum AttributionError {
@@ -77,12 +75,12 @@ pub fn routes_from_logs(directory: &Path) -> Result<Attribution, AttributionErro
 }
 
 /// What one log line says, where it says anything.
-fn attribute(fields: &Fields) -> Option<(String, Option<BarInterval>, NaiveDate, Provenance)> {
+fn attribute(fields: &Fields) -> Option<(String, Option<BarInterval>, SessionDate, Provenance)> {
     match fields.message.as_str() {
         // The quote pass names its route in the line itself, which is the only reason the two
         // sources are separable at all.
         "Folding a session's quoted book" => {
-            let date = fields.session.as_deref()?.parse().ok()?;
+            let date = SessionDate::from_date(fields.session.as_deref()?.parse().ok()?);
             let route = match fields.source.as_deref()? {
                 "per-name" => Provenance::alpaca(AlpacaPlan::AlgoTraderPlus),
                 "whole-session" => {
@@ -108,7 +106,7 @@ fn attribute(fields: &Fields) -> Option<(String, Option<BarInterval>, NaiveDate,
 }
 
 /// Splits `us_stocks_sip/trades_v1/2023/06/2023-06-14.csv.gz` into our dataset name and its date.
-fn vendor_key_parts(key: &str) -> Option<(String, Option<BarInterval>, NaiveDate)> {
+fn vendor_key_parts(key: &str) -> Option<(String, Option<BarInterval>, SessionDate)> {
     let mut segments = key.split('/');
     segments.next()?;
     // `minute_aggs_v1` attests to the one-minute cadence and to nothing else; the other two folds
@@ -120,7 +118,7 @@ fn vendor_key_parts(key: &str) -> Option<(String, Option<BarInterval>, NaiveDate
         _ => return None,
     };
     let file = key.rsplit('/').next()?;
-    let date = file.split('.').next()?.parse().ok()?;
+    let date = SessionDate::from_date(file.split('.').next()?.parse().ok()?);
     Some((dataset.to_string(), interval, date))
 }
 
@@ -189,12 +187,14 @@ fn log_files(directory: &Path) -> Result<Vec<std::path::PathBuf>, AttributionErr
 mod tests {
     use super::*;
 
+    use chrono::NaiveDate;
+
     fn write(directory: &Path, name: &str, lines: &[&str]) {
         std::fs::write(directory.join(name), lines.join("\n")).expect("the fixture writes");
     }
 
-    fn session(year: i32, month: u32, day: u32) -> NaiveDate {
-        NaiveDate::from_ymd_opt(year, month, day).expect("a real date")
+    fn session(year: i32, month: u32, day: u32) -> SessionDate {
+        SessionDate::from_date(NaiveDate::from_ymd_opt(year, month, day).expect("a real date"))
     }
 
     #[test]

--- a/src/data/bars.rs
+++ b/src/data/bars.rs
@@ -328,18 +328,10 @@ pub async fn load_bars_dataframe(
 /// Loads a trailing window of closes per ticker, aligned across tickers by session and restated
 /// onto `as_of`'s share basis.
 ///
-/// Every series has the same length and position `i` is the same session across all of them.
-/// Tickers missing any session are dropped rather than gap-filled — this is why it is not a
-/// `GROUP BY ticker`: two equal-length series covering different dates correlate different days,
-/// and nothing downstream carries a sign that it happened.
-///
-/// Both bounds on `timestamp` are expressed against the column directly rather than wrapped in an
-/// expression, so hypertable chunk exclusion applies. The upper one is what keeps the window and
-/// `as_of` the same day: without it the most recent sessions in the table are taken whatever
-/// `as_of` says, and a replay would load today's closes and restate them onto a past date.
-///
-/// Adjusting per row while the timestamps are still in hand is why the returned shape needs no
-/// dates: it drops them, and a caller adjusting afterwards would have nothing to key the factor on.
+/// Every series has the same length and position `i` is the same session across all of them;
+/// tickers missing any session are dropped rather than gap-filled. Both `timestamp` bounds are
+/// expressed against the column directly so hypertable chunk exclusion applies, and the upper one
+/// is what keeps the window on `as_of`'s day rather than the table's most recent sessions.
 pub async fn load_aligned_closes(
     pool: &PgPool,
     bar_interval: BarInterval,

--- a/src/data/boundaries.rs
+++ b/src/data/boundaries.rs
@@ -1,7 +1,6 @@
 //! The dates a symbol's price series may not be read across.
 //!
-//! One S3 object, refreshed over a date range and merged with what is stored. Applied at read time
-//! by [`crate::data::truncate`].
+//! One S3 object, merged with what is stored, applied at read time by [`crate::data::truncate`].
 
 use chrono::{DateTime, Utc};
 use polars::prelude::*;
@@ -60,13 +59,11 @@ pub fn boundaries_to_dataframe(
 
 /// Merges a stored boundary table with one fetched over `start..=end`.
 ///
-/// Unlike [`crate::data::splits::merge_splits`], which replaces the row set outright because that
-/// feed answers with its whole history, this one answers only for a range — so stored rows the
-/// refresh could not have re-reported survive, and absence within it means cancelled.
-///
-/// The range is matched on `process_date`, never on `date`. Alpaca filters a request by when it
-/// processed an action, while the boundary is stamped with when the price moved, and those differ
-/// by years: filtering survivors on the wrong one leaves a cancelled action archived forever.
+/// The fetch answers only for a range, unlike [`crate::data::splits::merge_splits`], so stored rows
+/// the refresh could not have re-reported survive and absence within the range means cancelled.
+/// The range is matched on `process_date`, never on `date`: Alpaca filters a request by when it
+/// processed an action while the boundary is stamped with when the price moved, and those differ by
+/// years.
 pub fn merge_boundaries(
     existing: DataFrame,
     fetched: DataFrame,

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -42,14 +42,10 @@ impl<T: Clone> DailyCache<T> {
 
     /// Today's value, rebuilding it when the cache is cold or was filled on an earlier date.
     ///
-    /// `worth_caching` decides whether the rebuilt value is stored, and the answer is not always
-    /// yes. An empty universe or an empty close history is a failed read, and storing one would
-    /// answer "nothing is there" for the rest of the Eastern date; an empty splits table is a real
-    /// answer that should be kept.
-    ///
-    /// A rebuild that finds the slot written since it started discards its own result rather than
-    /// storing it. Otherwise an [`DailyCache::invalidate`] landing mid-rebuild would be undone by
-    /// the rebuild it was meant to invalidate, pinning the superseded value until the date rolls.
+    /// `worth_caching` decides whether the rebuilt value is stored: an empty universe or an empty
+    /// close history is a failed read, while an empty splits table is a real answer. A rebuild that
+    /// finds the slot written since it started discards its own result, so an
+    /// [`DailyCache::invalidate`] landing mid-rebuild is not undone by the rebuild it invalidated.
     pub async fn get<Error, Rebuild, Rebuilding>(
         &self,
         today: SessionDate,

--- a/src/data/cadence.rs
+++ b/src/data/cadence.rs
@@ -1,7 +1,6 @@
 //! Cross-cadence agreement over the summaries the archive already holds.
 //!
-//! Verifies rather than re-emits: the cadences are folded separately, so sum-back is a cross-pass
-//! claim that re-deriving both sides would hide.
+//! Verifies rather than re-emits: re-deriving both sides would hide the cross-pass claim.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -563,13 +562,9 @@ impl CadenceAgreement {
 
     /// Whether every reconstructed column agreed on every row both cadences hold.
     ///
-    /// Says nothing about the rows only one of them holds, which `one_sided` reports separately and
-    /// which no comparison can speak for.
-    ///
-    /// **A comparison that matched nothing has not agreed** — it failed to run. The join key is
-    /// `(ticker, bucket)`, so a fold that bucketed to the wrong stamp shares no row with the stored
-    /// partition and every column then agrees over an empty population. Requiring a population is
-    /// what keeps that from reading as a pass.
+    /// Says nothing about the rows only one of them holds, which `one_sided` reports separately.
+    /// **A comparison that matched nothing has not agreed** — the join key is `(ticker, bucket)`,
+    /// so a fold bucketed to the wrong stamp agrees over an empty population.
     pub fn agrees(&self) -> bool {
         self.compared > 0 && self.disagreements() == 0
     }
@@ -737,8 +732,25 @@ mod tests {
         SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 8, day).expect("a real date"))
     }
 
-    /// The instant the archive stamps a session row at, which no intraday bucket lands on.
-    const SESSION_STAMP: i64 = 1_755_720_000_000;
+    /// 2026-08-20T20:00Z, the 16:00 Eastern close of [`session`] and where the archive stamps a
+    /// session row -- an instant no intraday bucket of that session lands on.
+    const SESSION_STAMP: i64 = 1_787_256_000_000;
+
+    /// The session fixtures are stamped inside the session they name.
+    ///
+    /// The join key is taken off the stored row, so a stamp from the wrong year compares green
+    /// while describing a partition that could not exist. Nothing else here would catch it.
+    #[test]
+    fn test_the_session_stamp_falls_within_the_session_it_names() {
+        let (start, end) = session().bounds();
+        let stamp = chrono::DateTime::from_timestamp_millis(SESSION_STAMP).expect("a real instant");
+        assert!(
+            stamp >= start && stamp < end,
+            "{stamp} is outside {}",
+            session()
+        );
+        assert_eq!(stamp.to_rfc3339(), "2026-08-20T20:00:00+00:00");
+    }
 
     /// A quote frame carrying only what a comparison reads.
     ///

--- a/src/data/calendar.rs
+++ b/src/data/calendar.rs
@@ -56,13 +56,10 @@ pub struct TradingCalendar {
 impl TradingCalendar {
     /// Builds a calendar from published days.
     ///
-    /// This is the boundary where a date Alpaca sent over the wire becomes a [`SessionDate`].
-    /// [`CalendarDay`] stays on `NaiveDate` because it is what the transport parsed; everything
-    /// above this line deals in sessions.
-    ///
-    /// The result answers `false` to [`TradingCalendar::covers`] for every range: what it was
-    /// fetched for cannot be recovered from what came back. Use [`TradingCalendar::covering`] where
-    /// a caller needs to prove the horizon spans a window.
+    /// This is the boundary where a date Alpaca sent over the wire becomes a [`SessionDate`];
+    /// [`CalendarDay`] stays on `NaiveDate` because it is what the transport parsed. The result
+    /// answers `false` to [`TradingCalendar::covers`] for every range, so use
+    /// [`TradingCalendar::covering`] where a caller needs to prove the horizon spans a window.
     pub fn from_days(days: Vec<CalendarDay>) -> Self {
         Self {
             days: Self::index(days),
@@ -152,10 +149,9 @@ impl TradingCalendar {
     /// Minutes remaining until today's close, or `None` when today does not trade or has already
     /// closed.
     ///
-    /// The entry path uses this to refuse opening a pair it cannot plausibly exit before the bell,
-    /// which is the one piece of the old end-of-day feasibility check worth keeping. Reading the
-    /// close from the published calendar rather than assuming 16:00 is what makes it correct on a
-    /// half-day.
+    /// The entry path uses this to refuse opening a pair it cannot plausibly exit before the bell.
+    /// Reading the close from the published calendar rather than assuming 16:00 is what makes it
+    /// correct on a half-day.
     pub fn minutes_until_close(&self, instant: DateTime<Utc>) -> Option<i64> {
         let session = self.session(SessionDate::at(instant))?;
         let now = eastern_time(instant);

--- a/src/data/conditions.rs
+++ b/src/data/conditions.rs
@@ -92,13 +92,9 @@ pub fn volume_eligibility(identifiers: &[u32]) -> Eligibility {
 
 /// The marker a SIP spells "no condition applies" with, which is not a condition.
 ///
-/// Tape-dependent like every other spelling here: CTA writes a space and UTP an at-sign. The
-/// provider's reference table has no row for either, because Massive says the same thing by sending
-/// no conditions at all while Alpaca states it on nearly every print.
-///
-/// Counting it unknown reported the whole tape as unreadable — measured on 2026-08-20, 688,578 of
-/// AAPL's 688,608 prints and 573,781 of SPY's 573,791. Fixing only the at-sign left SPY unchanged,
-/// which is what identified the tape as the axis rather than the character.
+/// Tape-dependent like every other spelling here: CTA writes a space and UTP an at-sign, and the
+/// provider's reference table has a row for neither. Counting it unknown reports nearly every print
+/// on the tape as unreadable, so both spellings must be recognized rather than one.
 fn regular_sale_on(tape: Tape) -> u8 {
     match tape {
         Tape::ConsolidatedTapeAssociation => b' ',
@@ -393,23 +389,32 @@ mod tests {
         ));
     }
 
-    /// Both providers reach the same verdict on the same trade.
+    /// Both providers reach the same verdict on the same trade, and it is the verdict named here.
     ///
     /// The point of the whole module: a bulk fold reading Massive identifiers and a nightly fold
-    /// reading Alpaca characters must not disagree about whether a print is volume.
+    /// reading Alpaca characters must not disagree about whether a print is volume. Each pair
+    /// carries its own literal expectation, so both paths regressing to `Eligible` together fails.
     #[test]
     fn test_the_two_provider_spellings_agree_on_eligibility() {
         let tape = Tape::ConsolidatedTapeAssociation;
-        for (identifiers, characters) in [
-            (vec![37u32], b"I".to_vec()),
-            (vec![16], b"Q".to_vec()),
-            (vec![15], b"M".to_vec()),
-            (vec![14], b"F".to_vec()),
+        for (identifiers, characters, expected) in [
+            // Odd Lot Trade, which is real volume.
+            (vec![37u32], b"I".to_vec(), Eligibility::Eligible),
+            // Market Center Official Open and Close, which are the auctions.
+            (vec![16], b"Q".to_vec(), Eligibility::Ineligible),
+            (vec![15], b"M".to_vec(), Eligibility::Ineligible),
+            // Intermarket Sweep, which is an ordinary print.
+            (vec![14], b"F".to_vec(), Eligibility::Eligible),
         ] {
             assert_eq!(
                 volume_eligibility(&identifiers),
+                expected,
+                "{identifiers:?} must be {expected:?}"
+            );
+            assert_eq!(
                 volume_eligibility_from_characters(&characters, tape),
-                "{identifiers:?} and {characters:?} must agree"
+                expected,
+                "{characters:?} must be {expected:?}"
             );
         }
     }

--- a/src/data/splits.rs
+++ b/src/data/splits.rs
@@ -1,7 +1,6 @@
-//! The stock splits the bar archive is adjusted against, read by [`crate::data::adjust`].
-//!
-//! One S3 object rather than a partition per session: a split belongs to its execution date, but
-//! the feed revises and cancels announced ones, so only the whole table is ever authoritative.
+//! The stock splits the bar archive is adjusted against, read by [`crate::data::adjust`]. One S3
+//! object rather than a partition per session: the feed revises and cancels announced splits, so
+//! only the whole table is ever authoritative.
 
 use chrono::{DateTime, Utc};
 use polars::prelude::*;
@@ -46,13 +45,9 @@ pub fn splits_to_dataframe(
 /// Merges a stored splits table with a freshly fetched one.
 ///
 /// The fetched rows are the row set: a split the feed no longer reports has been cancelled, and
-/// keeping it would adjust prices across a split that never happened. Only `first_seen` survives
-/// from the stored copy, taking the earlier of the two so a row keeps the date we first saw it
-/// rather than the date of the latest fetch.
-///
-/// An empty fetch is the exception, and keeps the stored table. Replacing means an upstream answering
-/// success with nothing would erase every corporate action we hold, and the feed has never held
-/// nothing — it goes back to 1978.
+/// only `first_seen` survives from the stored copy, taking the earlier of the two so a row keeps
+/// the date it was first seen. An empty fetch is the exception and keeps the stored table, so an
+/// upstream answering success with nothing cannot erase every corporate action we hold.
 pub fn merge_splits(existing: DataFrame, fetched: DataFrame) -> Result<DataFrame, PolarsError> {
     if fetched.height() == 0 {
         return Ok(existing);

--- a/src/data/trades.rs
+++ b/src/data/trades.rs
@@ -105,9 +105,8 @@ impl TradeAccumulator {
             self.trade_count,
             self.volume,
             self.dollar_volume,
-            // Zero on an exclusion-only bar, where no eligible print has a size to report.
-            quantile(&self.sizes, 0.5).unwrap_or(0.0),
-            quantile(&self.sizes, UPPER_QUANTILE).unwrap_or(0.0),
+            quantile(&self.sizes, 0.5),
+            quantile(&self.sizes, UPPER_QUANTILE),
             self.signed_volume,
             self.exclusions,
         );
@@ -532,19 +531,19 @@ pub fn summaries_to_dataframe(summaries: &[TradeSummary]) -> Result<DataFrame, P
                 .map(TradeSummary::volume_weighted_average_price)
                 .collect::<Vec<Option<f64>>>(),
         ),
-        column(
-            "median_trade_size",
+        Column::new(
+            "median_trade_size".into(),
             summaries
                 .iter()
                 .map(TradeSummary::median_trade_size)
-                .collect(),
+                .collect::<Vec<Option<f64>>>(),
         ),
-        column(
-            "ninetieth_percentile_trade_size",
+        Column::new(
+            "ninetieth_percentile_trade_size".into(),
             summaries
                 .iter()
                 .map(TradeSummary::ninetieth_percentile_trade_size)
-                .collect(),
+                .collect::<Vec<Option<f64>>>(),
         ),
         column(
             "signed_volume",

--- a/src/data/truncate.rs
+++ b/src/data/truncate.rs
@@ -465,8 +465,8 @@ mod tests {
     }
 
     /// Each step moves the date floor strictly forward over a finite table, so the walk terminates
-    /// on its own and needs no length bound. Nine links is past the fixed limit this used to carry,
-    /// which stopped one short and returned a symbol the company had already left.
+    /// on its own and needs no length bound. Nine links is longer than any fixed bound would allow,
+    /// and a walk that stopped one short would return a symbol the company had already left.
     #[test]
     fn test_a_chain_longer_than_the_old_bound_reaches_its_end() {
         let rows = [

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -5,6 +5,7 @@
 use std::collections::HashSet;
 
 use chrono::{DateTime, Utc};
+use polars::prelude::*;
 use sqlx::PgPool;
 use tracing::info;
 
@@ -12,14 +13,14 @@ use uuid::Uuid;
 
 use crate::common::alpaca::{ClientError, TradableAssets, TradingClient};
 use crate::common::journal::{Journal, Observation, UniverseRefreshed};
-use crate::common::types::{BarInterval, LiquidityFloor, SessionDate, Ticker};
+use crate::common::types::{BarInterval, LiquidityFloor, LiquidityRefusal, SessionDate, Ticker};
 use crate::data::cache::DailyCache;
 
 /// Trailing window over which liquidity is averaged.
 ///
 /// Long enough that a single quiet week does not evict a normally liquid name, short enough to
 /// notice one that has genuinely dried up.
-const LIQUIDITY_LOOKBACK_DAYS: i64 = 30;
+pub const LIQUIDITY_LOOKBACK_DAYS: i64 = 30;
 
 /// Errors building the universe.
 #[derive(Debug, thiserror::Error)]
@@ -51,11 +52,51 @@ impl LiquidityRow {
         }
     }
 
-    /// Whether this ticker clears `floor`, screening price on the window's minimum rather than its
-    /// average, which is the stricter of the two.
-    fn is_liquid(&self, floor: LiquidityFloor) -> bool {
+    /// Whether this ticker clears `floor`, and which bound it failed if not.
+    fn admission(&self, floor: LiquidityFloor) -> Result<(), LiquidityRefusal> {
         floor.admits(self.minimum_close_price, self.average_dollar_volume)
     }
+}
+
+/// Screens a bar frame down to the tickers that clear `floor` over the window it holds.
+///
+/// The one expression of liquidity in dataframe terms, and the same pair of statistics
+/// [`load_liquidity`] reads in SQL: `MIN(close_price)` against the price bound and
+/// `MEAN(close_price * volume)` against the notional bound, per ticker. A screen that computes a
+/// different pair makes the traded, predicted and trained populations three different sets.
+///
+/// `bars` must carry `ticker`, `close_price`, and `volume`.
+pub fn filter_liquid_bars(bars: DataFrame, floor: LiquidityFloor) -> PolarsResult<DataFrame> {
+    let liquid_tickers = bars
+        .clone()
+        .lazy()
+        .group_by([col("ticker")])
+        .agg([
+            col("close_price")
+                .cast(DataType::Float64)
+                .min()
+                .alias("minimum_close_price"),
+            // The product per session and then the mean, because the mean of a product is not the
+            // product of the means once price and volume move together.
+            (col("close_price").cast(DataType::Float64) * col("volume").cast(DataType::Float64))
+                .mean()
+                .alias("average_dollar_volume"),
+        ])
+        .filter(
+            col("minimum_close_price")
+                .gt_eq(lit(floor.minimum_close_price()))
+                .and(col("average_dollar_volume").gt_eq(lit(floor.minimum_dollar_volume()))),
+        )
+        .select([col("ticker")]);
+
+    bars.lazy()
+        .join(
+            liquid_tickers,
+            [col("ticker")],
+            [col("ticker")],
+            JoinArgs::new(JoinType::Semi),
+        )
+        .collect()
 }
 
 /// The symbols eligible to trade today, and which of them can be shorted.
@@ -85,7 +126,7 @@ impl Universe {
         let mut shortable = HashSet::new();
 
         for row in liquidity {
-            if !row.is_liquid(floor) {
+            if row.admission(floor).is_err() {
                 continue;
             }
             if !assets.is_tradable(&row.ticker) {
@@ -257,7 +298,7 @@ impl UniverseCache {
                                 alpaca_shortable: assets.shortable_count(),
                                 liquid: liquidity
                                     .iter()
-                                    .filter(|row| row.is_liquid(self.floor))
+                                    .filter(|row| row.admission(self.floor).is_ok())
                                     .count(),
                                 universe_size: universe.len(),
                                 admitted,
@@ -402,6 +443,82 @@ mod tests {
     fn test_empty_inputs_produce_an_empty_universe() {
         assert!(Universe::build(&assets(), &[], floor()).is_empty());
         assert!(Universe::build(&TradableAssets::default(), &[liquid("AAPL")], floor()).is_empty());
+    }
+
+    /// Two sessions of one ticker, so the minimum and the mean differ.
+    fn bars(rows: &[(&str, f64, i64)]) -> DataFrame {
+        let tickers: Vec<&str> = rows.iter().map(|(ticker, _, _)| *ticker).collect();
+        let close_prices: Vec<f64> = rows.iter().map(|(_, close, _)| *close).collect();
+        let volumes: Vec<i64> = rows.iter().map(|(_, _, volume)| *volume).collect();
+        DataFrame::new(vec![
+            Column::new("ticker".into(), tickers),
+            Column::new("close_price".into(), close_prices),
+            Column::new("volume".into(), volumes),
+        ])
+        .expect("the fixture frame must build")
+    }
+
+    fn surviving_tickers(frame: &DataFrame) -> Vec<String> {
+        let mut names: Vec<String> = frame
+            .column("ticker")
+            .unwrap()
+            .str()
+            .unwrap()
+            .into_no_null_iter()
+            .map(str::to_string)
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+    }
+
+    /// The dataframe screen and [`LiquidityFloor::admits`] have to agree at the boundary, or the
+    /// traded population and the trained one differ by the names sitting exactly on the floor.
+    #[test]
+    fn test_the_dataframe_screen_matches_the_floor_at_the_boundary() {
+        // 10.00 close and 50,000,000 notional: on the bound in both, which both admit.
+        let frame = bars(&[("EDGE", 10.0, 5_000_000), ("EDGE", 10.0, 5_000_000)]);
+        assert_eq!(floor().admits(10.0, 50_000_000.0), Ok(()));
+        assert_eq!(
+            surviving_tickers(&filter_liquid_bars(frame, floor()).unwrap()),
+            vec!["EDGE".to_string()]
+        );
+
+        let under = bars(&[("EDGE", 9.99, 5_000_000), ("EDGE", 9.99, 5_000_000)]);
+        assert!(filter_liquid_bars(under, floor()).unwrap().is_empty());
+    }
+
+    /// Price on the window minimum and notional on the window average, which is the definition the
+    /// universe query already reads. A screen that averaged the price instead would admit a name
+    /// that spent half the window below the floor.
+    #[test]
+    fn test_the_dataframe_screen_takes_the_minimum_price_and_the_average_notional() {
+        // Mean close 55, minimum close 5: the minimum is what binds, so this is refused.
+        let dipped = bars(&[("DIPS", 105.0, 1_000_000), ("DIPS", 5.0, 20_000_000)]);
+        assert!(filter_liquid_bars(dipped, floor()).unwrap().is_empty());
+
+        // One quiet session against one heavy one: the average carries it, which the price
+        // treatment deliberately does not do.
+        let quiet = bars(&[("FLOW", 100.0, 10_000), ("FLOW", 100.0, 2_000_000)]);
+        assert_eq!(
+            surviving_tickers(&filter_liquid_bars(quiet, floor()).unwrap()),
+            vec!["FLOW".to_string()]
+        );
+    }
+
+    /// Every bar of an admitted ticker survives, and none of a refused one: the screen is per
+    /// ticker, not per session, so a name's quiet days travel with its busy ones.
+    #[test]
+    fn test_the_dataframe_screen_keeps_or_drops_a_ticker_whole() {
+        let frame = bars(&[
+            ("KEEP", 100.0, 1_000_000),
+            ("KEEP", 100.0, 1_000_000),
+            ("DROP", 100.0, 1),
+            ("DROP", 100.0, 1),
+        ]);
+        let filtered = filter_liquid_bars(frame, floor()).unwrap();
+        assert_eq!(filtered.height(), 2);
+        assert_eq!(surviving_tickers(&filtered), vec!["KEEP".to_string()]);
     }
 
     #[tokio::test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -765,13 +765,10 @@ async fn handle_market_data_sync(
 
 /// Chained from a completed market data sync: seal the journal, export to S3, then purge.
 ///
-/// The order is fixed and the purge is conditional on the *database* export being clean. Purging
-/// after a partial export deletes rows that never reached S3, and nothing afterwards can tell that
-/// it happened.
-///
-/// The journal seals independently and does not gate the purge. It holds different data written
-/// by a different path, and letting a failure there hold PostgreSQL rows would couple two things
-/// whose only relationship is that they run on the same schedule.
+/// The order is fixed and the purge is conditional on the *database* export being clean, because
+/// purging after a partial export deletes rows that never reached S3 and nothing afterwards can
+/// tell. The journal seals independently and does not gate the purge; it holds different data
+/// written by a different path.
 async fn handle_database_export(
     state: &ServiceState,
     correlation_id: Uuid,
@@ -943,18 +940,10 @@ async fn previous_session_gaps(
 
 /// How many trading sessions the artifact skipped, when its run identifier can be read as a date.
 ///
-/// Zero is the healthy answer, and calendar days cannot express that. The trainer publishes after
-/// one session's close for the *next* session, so a healthy artifact is always dated at least one
-/// calendar day back — one midweek, three across a weekend, four across a long one. Counting days
-/// reported every one of those as stale; counting the sessions strictly between the artifact's date
-/// and today reports none of them, and still reports a genuinely skipped night.
-///
-/// Bounded by the calendar's horizon, so an artifact older than [`HORIZON_DAYS_BACKWARD`] undercounts.
-/// That only understates a number already past the threshold, so the warning still fires.
-///
-/// `None` rather than a guess when the run identifier is not date-prefixed. The trainer names runs
-/// `YYYY-MM-DD-HH-MM-SS-mmm`, but a hand-uploaded artifact need not, and reporting staleness
-/// computed from an unparsed prefix would be worse than reporting none.
+/// Sessions strictly between the artifact's date and today, not calendar days: the trainer
+/// publishes after one close for the *next* session, so a healthy artifact is always dated at least
+/// one calendar day back and zero is the healthy answer. Bounded by [`HORIZON_DAYS_BACKWARD`], so
+/// an older artifact undercounts a number already past the threshold; `None` if not date-prefixed.
 ///
 /// [`HORIZON_DAYS_BACKWARD`]: crate::data::calendar
 fn artifact_staleness_sessions(
@@ -1036,10 +1025,10 @@ mod tests {
             completion_outcome(&json!({ "pairs_opened": ["AAAA-BBBB"] })),
             CommandOutcome::Completed
         );
-        // The second documented skip, which the handlers use when the exchange halts.
+        // A reason no handler emits is warned about and recorded as completed, never panicked on.
         assert_eq!(
-            completion_outcome(&json!({ "skipped": "market_halted" })),
-            CommandOutcome::Skipped(SkipReason::MarketHalted)
+            completion_outcome(&json!({ "skipped": "no_such_reason" })),
+            CommandOutcome::Completed
         );
     }
 

--- a/src/laboratory/convergence.rs
+++ b/src/laboratory/convergence.rs
@@ -12,8 +12,8 @@ use crate::common::types::CloseReason;
 use crate::models::tide::TideError;
 use crate::portfolio::evaluate::exit_reason;
 use crate::portfolio::screen::{
-    logarithmic_returns, pearson_correlation, worst_session_move, SpreadModel, CORRELATION_MAXIMUM,
-    CORRELATION_MINIMUM, CORRELATION_WINDOW_SESSIONS, ENTRY_Z_SCORE, ENTRY_Z_SCORE_CAP,
+    admits_correlation, admits_entry_z_score, logarithmic_returns, pearson_correlation,
+    worst_session_move, SpreadModel, CORRELATION_WINDOW_SESSIONS,
     MAXIMUM_SESSION_LOGARITHMIC_RETURN,
 };
 
@@ -239,19 +239,11 @@ pub struct Entry {
     pub observed: Observed,
 }
 
-impl Entry {
-    /// Where this entry stands at `horizon`, or `None` if it could not be read there.
-    /// The pair this entry contributes to a curve, without its identity.
-    fn state(&self) -> (Resolution, Observed) {
-        (self.resolution, self.observed)
-    }
-}
-
 /// Where one entry stands at `horizon`, or `None` where it was never priced there.
 ///
 /// An entry that resolved before `horizon` keeps its resolution: the question each horizon asks is
 /// what has become of the cohort by then, not what is happening at that instant.
-fn state_at(resolution: Resolution, observed: Observed, horizon: usize) -> Option<Resolution> {
+pub fn state_at(resolution: Resolution, observed: Observed, horizon: usize) -> Option<Resolution> {
     match resolution {
         Resolution::Converged(step) | Resolution::Stopped(step) if step <= horizon => {
             Some(resolution)
@@ -263,8 +255,11 @@ fn state_at(resolution: Resolution, observed: Observed, horizon: usize) -> Optio
 
 /// Where a cohort of entries stands at one horizon.
 ///
-/// The three shares are of `entries`, which counts only the entries followed this far — an entry
-/// the archive ran out under leaves the denominator rather than counting as still open.
+/// The three shares are means over sessions of each session's own share, and
+/// `converged_standard_error` is that mean's error across sessions — entries within a session are
+/// pairs drawn from one universe sharing legs, so an error over entries would divide by far more
+/// than the information present. `entries` counts only the entries followed this far, so one the
+/// archive ran out under leaves the denominator rather than counting as still open.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Curve {
     pub horizon: usize,
@@ -272,6 +267,10 @@ pub struct Curve {
     pub stopped: f64,
     pub open: f64,
     pub entries: usize,
+    /// Sessions contributing an entry still standing at this horizon.
+    pub sessions: usize,
+    /// Absent under two sessions, which give no spread between sessions to take an error from.
+    pub converged_standard_error: Option<f64>,
 }
 
 /// Every entry `session` admits under `selection`, each followed forward until it resolves.
@@ -307,9 +306,7 @@ pub fn entries_at(
                         &logarithmic_returns(&second_window),
                     );
                     match correlation {
-                        Some(correlation)
-                            if (CORRELATION_MINIMUM..=CORRELATION_MAXIMUM)
-                                .contains(&correlation) => {}
+                        Some(correlation) if admits_correlation(correlation) => {}
                         Some(_) | None => continue,
                     }
                 }
@@ -344,13 +341,13 @@ pub fn entries_at(
                 ),
             ];
             for (long, long_window, long_price, short, short_window, short_price) in orientations {
-                let Some(model) = SpreadModel::fit(long_window, short_window) else {
+                let Ok(model) = SpreadModel::fit(long_window, short_window) else {
                     continue;
                 };
                 let Some(entry_z_score) = model.z_score(long_price, short_price) else {
                     continue;
                 };
-                if !(ENTRY_Z_SCORE..=ENTRY_Z_SCORE_CAP).contains(&entry_z_score) {
+                if !admits_entry_z_score(entry_z_score) {
                     continue;
                 }
                 entries.push(follow(closes, &model, long, short, session, entry_z_score));
@@ -470,39 +467,82 @@ pub fn without_reentry(mut entries: Vec<Entry>) -> Vec<Entry> {
 
 /// Where a cohort stands at each horizon from one to [`HORIZONS`].
 pub fn curves(entries: &[Entry]) -> Vec<Curve> {
-    curves_of(&entries.iter().map(Entry::state).collect::<Vec<_>>())
+    curves_of(
+        &entries
+            .iter()
+            .map(|entry| (entry.session, entry.resolution, entry.observed))
+            .collect::<Vec<_>>(),
+    )
 }
 
-/// The same curve over any entries carrying a resolution and what they were priced at.
+/// The same curve over any entries carrying the session they opened in and what became of them.
 ///
-/// Shared with the intraday measurement, whose horizons are bars rather than sessions: the shape of
-/// the question is identical and only the unit of the horizon differs.
-pub fn curves_of(states: &[(Resolution, Observed)]) -> Vec<Curve> {
+/// Shared with the intraday measurement, whose horizons are bars rather than sessions and whose
+/// session key is a calendar date: the shape of the question is identical and only the units differ.
+pub fn curves_of<Session: Ord + Copy>(states: &[(Session, Resolution, Observed)]) -> Vec<Curve> {
     (1..=HORIZONS)
         .map(|horizon| {
-            let standing: Vec<Resolution> = states
-                .iter()
-                .filter_map(|(resolution, observed)| state_at(*resolution, *observed, horizon))
-                .collect();
-            let share = |count: usize| {
-                if standing.is_empty() {
+            let mut by_session: BTreeMap<Session, Vec<Resolution>> = BTreeMap::new();
+            let mut standing = 0_usize;
+            for (session, resolution, observed) in states {
+                let Some(state) = state_at(*resolution, *observed, horizon) else {
+                    continue;
+                };
+                by_session.entry(*session).or_default().push(state);
+                standing += 1;
+            }
+
+            let session_share = |matching: fn(&Resolution) -> bool| -> Vec<f64> {
+                by_session
+                    .values()
+                    .map(|states| {
+                        states.iter().filter(|state| matching(state)).count() as f64
+                            / states.len() as f64
+                    })
+                    .collect()
+            };
+            let converged = session_share(|state| matches!(state, Resolution::Converged(_)));
+            let mean = |shares: &[f64]| {
+                if shares.is_empty() {
                     0.0
                 } else {
-                    count as f64 / standing.len() as f64
+                    shares.iter().sum::<f64>() / shares.len() as f64
                 }
             };
-            let count = |matching: fn(&Resolution) -> bool| {
-                standing.iter().filter(|state| matching(state)).count()
-            };
+
             Curve {
                 horizon,
-                converged: share(count(|state| matches!(state, Resolution::Converged(_)))),
-                stopped: share(count(|state| matches!(state, Resolution::Stopped(_)))),
-                open: share(count(|state| matches!(state, Resolution::Unresolved))),
-                entries: standing.len(),
+                converged: mean(&converged),
+                stopped: mean(&session_share(|state| {
+                    matches!(state, Resolution::Stopped(_))
+                })),
+                open: mean(&session_share(|state| {
+                    matches!(state, Resolution::Unresolved)
+                })),
+                entries: standing,
+                sessions: by_session.len(),
+                converged_standard_error: standard_error(&converged),
             }
         })
         .collect()
+}
+
+/// Standard error of a mean over sessions, or `None` under two of them.
+///
+/// One session gives no spread between sessions to take an error from, and reporting zero there
+/// would make a single day read as infinitely significant.
+fn standard_error(session_shares: &[f64]) -> Option<f64> {
+    if session_shares.len() < 2 {
+        return None;
+    }
+    let sessions = session_shares.len() as f64;
+    let mean = session_shares.iter().sum::<f64>() / sessions;
+    let variance = session_shares
+        .iter()
+        .map(|share| (share - mean).powi(2))
+        .sum::<f64>()
+        / (sessions - 1.0);
+    Some((variance / sessions).sqrt())
 }
 
 /// The average z-score entries were opened at, which is what a convergence is worth.
@@ -729,14 +769,12 @@ mod tests {
     }
 
     /// The window the spread is measured against must end before the session being judged, or it
-    /// contains the observation and inflates its own dispersion by exactly the move being scored.
+    /// contains the observation and inflates its own dispersion by the move being scored.
     ///
-    /// Read at the cap rather than at the entry threshold, because that is where the difference
-    /// bites. A window of sixty admitting one point `d` deviations out reports it at roughly
-    /// `d / sqrt(1 + d² / 61)`, which stays above two for every `d` above two — so an entry fires
-    /// either way and only the *upper* bound separates them. At five and a half deviations the
-    /// honest reading is past [`ENTRY_Z_SCORE_CAP`] and refused, and the contaminated one is 4.4
-    /// and admitted: the guard against unadjusted corporate actions stops working silently.
+    /// Read at the cap rather than at the entry threshold: a contaminated window still reports a
+    /// large move as above two, so an entry fires either way and only the upper bound separates
+    /// them — at five and a half deviations the honest reading is refused and the contaminated one
+    /// is admitted at 4.4.
     #[test]
     fn test_the_fit_window_ends_before_the_session_it_judges() {
         let beyond_the_cap = |session: usize| match session {
@@ -885,6 +923,48 @@ mod tests {
             let total = curve.converged + curve.stopped + curve.open;
             assert!((total - 1.0).abs() < 1e-12, "{curve:?}");
         }
+    }
+
+    /// One session gives no spread between sessions to take an error from, and a zero there would
+    /// make a single day read as infinitely significant.
+    #[test]
+    fn test_a_single_session_carries_no_standard_error() {
+        let curves = curves(&[
+            entry(Resolution::Converged(1), 1),
+            entry(Resolution::Stopped(1), 1),
+        ]);
+
+        assert_eq!(curves[0].sessions, 1, "both entries opened at session ten");
+        assert_eq!(curves[0].converged_standard_error, None);
+        assert!((curves[0].converged - 0.5).abs() < 1e-12);
+    }
+
+    /// Entries within a session are pairs from one universe sharing legs, so the shares are means
+    /// over sessions and the error is taken across them. Weighted by entries the busy session would
+    /// carry the whole reading.
+    #[test]
+    fn test_the_shares_weight_sessions_and_not_entries() {
+        let at = |session: usize, resolution: Resolution, observed: usize| {
+            let mut entry = entry(resolution, observed);
+            entry.session = session;
+            entry
+        };
+        let mut entries = vec![at(1, Resolution::Converged(1), 1)];
+        // Ten entries in one session, none of which converged.
+        entries.extend((0..10).map(|_| at(2, Resolution::Stopped(1), 1)));
+
+        let curves = curves(&entries);
+
+        assert_eq!(curves[0].entries, 11);
+        assert_eq!(curves[0].sessions, 2);
+        // Session shares are 1.0 and 0.0, so the mean is a half; weighted by entries it would be
+        // about 0.09.
+        assert!((curves[0].converged - 0.5).abs() < 1e-12, "{:?}", curves[0]);
+        assert!(
+            (curves[0].converged_standard_error.unwrap() - 0.5).abs() < 1e-12,
+            "{:?}",
+            curves[0]
+        );
     }
 
     /// The median is over the entries that converged and not over every entry: an unresolved entry

--- a/src/laboratory/export.rs
+++ b/src/laboratory/export.rs
@@ -1,4 +1,4 @@
-//! Ships sealed laboratory journal days to S3, one object per experiment type per UTC date.
+//! Ships sealed laboratory journal days to S3, one object per experiment type per session.
 //!
 //! Triggered explicitly: the laboratory has no scheduled pass to hang this off.
 
@@ -7,13 +7,14 @@ use std::path::Path;
 
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client as S3Client;
-use chrono::{DateTime, NaiveDate};
+use chrono::DateTime;
 use polars::prelude::*;
 use serde_json::Value;
 use tracing::{info, warn};
 
 use crate::common::aws::date_partitioned_key;
-use crate::laboratory::journal::{date_from_file_name, file_name, Journal};
+use crate::common::types::SessionDate;
+use crate::laboratory::journal::{file_name, session_from_file_name, Journal};
 
 /// S3 prefix the laboratory writes under.
 ///
@@ -29,8 +30,8 @@ pub const RETENTION_DAYS: i64 = 7;
 /// What one export run shipped, and what it could not.
 #[derive(Debug, Default, PartialEq)]
 pub struct ExportSummary {
-    /// `(experiment_type, date, rows)` for each object written.
-    pub written: Vec<(String, NaiveDate, usize)>,
+    /// `(experiment_type, session, rows)` for each object written.
+    pub written: Vec<(String, SessionDate, usize)>,
     pub failed: Vec<String>,
     pub files_deleted: usize,
     /// Lines the Parquet does not hold, which keep their file from being deleted.
@@ -39,18 +40,18 @@ pub struct ExportSummary {
 
 /// Writes every sealed day to S3, then deletes the local files that have aged out.
 ///
-/// A day is sealed once `today` has moved past it. The key is derived from the record, so a repeat
-/// run overwrites byte-identically and a failed run repairs itself.
+/// A session is sealed once `today` has moved past it. The key is derived from the record, so a
+/// repeat run overwrites byte-identically and a failed run repairs itself.
 pub async fn export_journals(
     journal: &Journal,
     s3_client: &S3Client,
     bucket: &str,
-    today: NaiveDate,
+    today: SessionDate,
 ) -> ExportSummary {
     let mut summary = ExportSummary::default();
 
-    let dates = match sealed_dates(journal.directory(), today) {
-        Ok(dates) => dates,
+    let sessions = match sealed_sessions(journal.directory(), today) {
+        Ok(sessions) => sessions,
         Err(error) => {
             summary.failed.push(format!(
                 "could not list {}: {error}",
@@ -60,12 +61,12 @@ pub async fn export_journals(
         }
     };
 
-    let mut shipped: Vec<NaiveDate> = Vec::new();
-    for date in dates {
+    let mut shipped: Vec<SessionDate> = Vec::new();
+    for session in sessions {
         // Held only for the read, so a long upload does not block an experiment mid-run.
         let frames = {
             let _sealed = journal.seal().await;
-            read_day(&journal.directory().join(file_name(date)))
+            read_day(&journal.directory().join(file_name(session)))
         };
         let (frames, unparsable) = match frames {
             Ok(read) => read,
@@ -85,11 +86,11 @@ pub async fn export_journals(
                 continue;
             }
             let prefix = format!("{EXPERIMENT_PREFIX}/experiment_type={experiment_type}");
-            let key = date_partitioned_key(&prefix, date);
+            let key = date_partitioned_key(&prefix, session.date());
             match write_frame(s3_client, bucket, &key, &mut frame).await {
                 Ok(()) => summary
                     .written
-                    .push((experiment_type, date, frame.height())),
+                    .push((experiment_type, session, frame.height())),
                 Err(error) => {
                     summary.failed.push(error);
                     day_written = false;
@@ -99,7 +100,7 @@ pub async fn export_journals(
         // A file with unparsable lines is kept whole: those lines reach no object, and deleting the
         // file would destroy the only copy of them.
         if day_written && unparsable == 0 {
-            shipped.push(date);
+            shipped.push(session);
         }
     }
 
@@ -107,23 +108,26 @@ pub async fn export_journals(
     summary
 }
 
-/// Every UTC date in the directory that `today` has moved past.
-fn sealed_dates(directory: &Path, today: NaiveDate) -> Result<Vec<NaiveDate>, std::io::Error> {
-    let mut dates = Vec::new();
+/// Every session in the directory that `today` has moved past.
+fn sealed_sessions(
+    directory: &Path,
+    today: SessionDate,
+) -> Result<Vec<SessionDate>, std::io::Error> {
+    let mut sessions = Vec::new();
     for entry in std::fs::read_dir(directory)? {
         let Some(name) = entry?.file_name().to_str().map(str::to_string) else {
             continue;
         };
-        let Some(date) = date_from_file_name(&name) else {
+        let Some(session) = session_from_file_name(&name) else {
             continue;
         };
-        if date >= today {
+        if session >= today {
             continue;
         }
-        dates.push(date);
+        sessions.push(session);
     }
-    dates.sort_unstable();
-    Ok(dates)
+    sessions.sort_unstable();
+    Ok(sessions)
 }
 
 /// One day's records as a frame per experiment type, keyed by that type.
@@ -237,14 +241,14 @@ async fn write_frame(
 }
 
 /// Deletes shipped files older than the retention window.
-fn delete_aged_out(directory: &Path, shipped: &[NaiveDate], today: NaiveDate) -> usize {
-    let oldest_kept = today - chrono::Duration::days(RETENTION_DAYS);
+fn delete_aged_out(directory: &Path, shipped: &[SessionDate], today: SessionDate) -> usize {
+    let oldest_kept = today.plus_calendar_days(-RETENTION_DAYS);
     let mut deleted = 0usize;
-    for date in shipped {
-        if *date >= oldest_kept {
+    for session in shipped {
+        if *session >= oldest_kept {
             continue;
         }
-        let path = directory.join(file_name(*date));
+        let path = directory.join(file_name(*session));
         match std::fs::remove_file(&path) {
             Ok(()) => deleted += 1,
             Err(error) => warn!(path = %path.display(), %error, "Could not delete a shipped file"),
@@ -267,7 +271,7 @@ mod tests {
             DateTime::from_timestamp_millis(milliseconds).unwrap(),
             Observation::DatasetBuilt(DatasetBuilt {
                 fingerprint: DatasetFingerprint {
-                    session: SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 8, 17).unwrap()),
+                    session: session(2026, 8, 17),
                     lookback_days: 365,
                     rows: 10,
                     tickers: 2,
@@ -281,20 +285,24 @@ mod tests {
         )
     }
 
-    fn write_day(directory: &Path, date: NaiveDate, lines: &[String]) {
-        std::fs::write(directory.join(file_name(date)), lines.join("\n") + "\n").unwrap();
+    fn session(year: i32, month: u32, day: u32) -> SessionDate {
+        SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(year, month, day).unwrap())
+    }
+
+    fn write_day(directory: &Path, session: SessionDate, lines: &[String]) {
+        std::fs::write(directory.join(file_name(session)), lines.join("\n") + "\n").unwrap();
     }
 
     #[test]
     fn test_today_is_not_yet_sealed() {
         let directory = tempfile::tempdir().unwrap();
-        let today = NaiveDate::from_ymd_opt(2026, 8, 18).unwrap();
-        let yesterday = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        let today = session(2026, 8, 18);
+        let yesterday = session(2026, 8, 17);
         for date in [today, yesterday] {
             write_day(directory.path(), date, &[]);
         }
 
-        let sealed = sealed_dates(directory.path(), today).unwrap();
+        let sealed = sealed_sessions(directory.path(), today).unwrap();
 
         assert_eq!(
             sealed,
@@ -308,7 +316,7 @@ mod tests {
     #[test]
     fn test_a_day_groups_into_one_frame_per_experiment_type() {
         let directory = tempfile::tempdir().unwrap();
-        let date = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        let date = session(2026, 8, 17);
         let run_id = Uuid::new_v4();
 
         let mut lines: Vec<String> = (0..2)
@@ -349,10 +357,10 @@ mod tests {
     #[test]
     fn test_only_files_older_than_the_retention_window_are_deleted() {
         let directory = tempfile::tempdir().unwrap();
-        let today = NaiveDate::from_ymd_opt(2026, 8, 18).unwrap();
-        let too_old = NaiveDate::from_ymd_opt(2026, 8, 10).unwrap();
-        let exactly_at_the_edge = NaiveDate::from_ymd_opt(2026, 8, 11).unwrap();
-        let recent = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        let today = session(2026, 8, 18);
+        let too_old = session(2026, 8, 10);
+        let exactly_at_the_edge = session(2026, 8, 11);
+        let recent = session(2026, 8, 17);
         for date in [too_old, exactly_at_the_edge, recent] {
             write_day(directory.path(), date, &[]);
         }
@@ -377,7 +385,7 @@ mod tests {
     #[test]
     fn test_a_type_whose_records_were_all_rejected_yields_an_empty_frame() {
         let directory = tempfile::tempdir().unwrap();
-        let date = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        let date = session(2026, 8, 17);
         // A well-formed experiment_type over an envelope missing run_id: grouped, then rejected.
         let mut broken: serde_json::Value =
             serde_json::from_str(&serde_json::to_string(&record(Uuid::new_v4(), 1)).unwrap())
@@ -394,7 +402,7 @@ mod tests {
     #[test]
     fn test_a_line_without_an_experiment_type_is_counted_not_filed() {
         let directory = tempfile::tempdir().unwrap();
-        let date = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        let date = session(2026, 8, 17);
         write_day(
             directory.path(),
             date,
@@ -415,7 +423,7 @@ mod tests {
     /// not be the one this produces.
     #[test]
     fn test_the_key_does_not_collide_with_the_application_journal() {
-        let date = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        let date = session(2026, 8, 17).date();
         let laboratory = date_partitioned_key(
             &format!("{EXPERIMENT_PREFIX}/experiment_type=dataset_built"),
             date,

--- a/src/laboratory/forecast.rs
+++ b/src/laboratory/forecast.rs
@@ -90,9 +90,9 @@ fn measure(
         let (scores, realized) = by_session
             .entry(dataset.forecast_sessions()[sample])
             .or_default();
-        scores.push(scaler.inverse_transform_value(TARGET_COLUMN, scaled));
+        scores.push(scaler.inverse_transform_value(TARGET_COLUMN, scaled)?);
         realized
-            .push(scaler.inverse_transform_value(TARGET_COLUMN, targets[[sample, 0, 0]] as f64));
+            .push(scaler.inverse_transform_value(TARGET_COLUMN, targets[[sample, 0, 0]] as f64)?);
     }
 
     let sessions: Vec<metrics::SessionMetrics> = by_session

--- a/src/laboratory/information.rs
+++ b/src/laboratory/information.rs
@@ -21,18 +21,29 @@ pub const NAMES_PER_CELL: usize = 1;
 
 /// What one session's cross-section says about a feature.
 ///
-/// Both figures are reported because their difference is the answer and their gap is the reason:
 /// `null_bits` is the bias a hundred-cell table carries at this sample size, and it is not small.
+/// `target_entropy` is the ceiling: mutual information cannot exceed it, so two targets compared in
+/// raw bits are being compared by their ceilings.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 pub struct SessionInformation {
     pub bits: f64,
     pub null_bits: f64,
+    /// Entropy of the binned target, in bits.
+    pub target_entropy: f64,
 }
 
 impl SessionInformation {
     /// Bits above what an unrelated feature scores on the same cross-section.
     pub fn excess(&self) -> f64 {
         self.bits - self.null_bits
+    }
+
+    /// Excess bits as a share of what the target itself carries, or `None` where it carries nothing.
+    ///
+    /// The comparable figure: a target cut into two bins caps every feature at one bit and one cut
+    /// into ten caps them at 3.32, so the raw excess ranks the cuts and not the features.
+    pub fn excess_share(&self) -> Option<f64> {
+        (self.target_entropy > 0.0).then(|| self.excess() / self.target_entropy)
     }
 }
 
@@ -180,6 +191,30 @@ pub fn mutual_information(feature: &[usize], target: &[usize]) -> Option<f64> {
     Some(bits)
 }
 
+/// Shannon entropy of a binned variable, in bits.
+///
+/// The ceiling on what any feature can say about it, which is what makes a share of it comparable
+/// across targets where a raw bit count is not.
+pub fn entropy(bins: &[usize]) -> Option<f64> {
+    if bins.is_empty() {
+        return None;
+    }
+    let total = bins.len() as f64;
+    let mut counts: std::collections::BTreeMap<usize, f64> = std::collections::BTreeMap::new();
+    for bin in bins {
+        *counts.entry(*bin).or_default() += 1.0;
+    }
+    Some(
+        counts
+            .into_values()
+            .map(|count| {
+                let share = count / total;
+                -share * share.log2()
+            })
+            .sum(),
+    )
+}
+
 /// Measures one session's cross-section, and the same cross-section with the feature shuffled.
 ///
 /// Shuffling breaks the association while leaving both marginals alone, so what it scores is
@@ -208,8 +243,13 @@ pub fn measure_session(
     let mut shuffled = feature_bins;
     shuffled.shuffle(&mut StdRng::seed_from_u64(seed));
     let null_bits = mutual_information(&shuffled, &target_bins)?;
+    let target_entropy = entropy(&target_bins)?;
 
-    Some(SessionInformation { bits, null_bits })
+    Some(SessionInformation {
+        bits,
+        null_bits,
+        target_entropy,
+    })
 }
 
 /// One session's cross-section: a feature read before the session, and what it forecasts.
@@ -342,6 +382,68 @@ mod tests {
         );
         // The shuffled copy of a perfect association is worth the bias and nothing more.
         assert!(measured.null_bits < 0.1, "{measured:?}");
+    }
+
+    /// Mutual information is capped by the target's own entropy, so a comparison in raw bits is a
+    /// comparison of caps. A perfect association reaches exactly one, which is the top of the scale.
+    #[test]
+    fn test_excess_is_reported_as_a_share_of_what_the_target_carries() {
+        let (feature, target) = paired(1000, |index| index as f64);
+        let measured = measure_session(&feature, &target, DEFAULT_BINS, 1).unwrap();
+
+        assert!(
+            (measured.target_entropy - 10.0_f64.log2()).abs() < 1e-9,
+            "ten equal bins carry log2(10): {measured:?}"
+        );
+        let share = measured
+            .excess_share()
+            .expect("the target carries something");
+        assert!(
+            share > 0.95,
+            "a perfect association takes nearly all: {share}"
+        );
+        assert!(
+            share <= 1.0 + 1e-9,
+            "and cannot exceed the ceiling: {share}"
+        );
+    }
+
+    /// The same relationship measured against a coarser target scores fewer raw bits and the same
+    /// share, which is the whole reason the share is the reported figure.
+    #[test]
+    fn test_a_coarser_target_lowers_the_bits_and_not_the_share() {
+        let (feature, target) = paired(1000, |index| index as f64);
+
+        let ten = measure_session(&feature, &target, 10, 1).unwrap();
+        let two = measure_session(&feature, &target, 2, 1).unwrap();
+
+        assert!(
+            (two.target_entropy - 1.0).abs() < 1e-9,
+            "two equal bins carry one bit: {two:?}"
+        );
+        assert!(
+            two.excess() < ten.excess() - 1.0,
+            "the coarser cut scores far fewer raw bits: {two:?} {ten:?}"
+        );
+        let (coarse, fine) = (two.excess_share().unwrap(), ten.excess_share().unwrap());
+        assert!(
+            (coarse - fine).abs() < 0.05,
+            "and the same share of its own ceiling: {coarse} {fine}"
+        );
+    }
+
+    /// A target every name shares carries nothing, and dividing by that ceiling is unmeasurable
+    /// rather than infinite or zero.
+    #[test]
+    fn test_a_target_carrying_nothing_has_no_share_to_report() {
+        let measured = SessionInformation {
+            bits: 0.0,
+            null_bits: 0.0,
+            target_entropy: 0.0,
+        };
+        assert_eq!(measured.excess_share(), None);
+        assert_eq!(entropy(&[]), None);
+        assert_eq!(entropy(&[3, 3, 3]), Some(0.0));
     }
 
     /// Reversing the target is still a perfect association: mutual information counts shared
@@ -554,9 +656,9 @@ mod tests {
         );
     }
 
-    /// The market's own move is a constant across a session, and the bins are cut by rank, so it
-    /// is already absent from every figure here. Measured before this was understood: an outcome
-    /// that demeaned the target returned bit-identical numbers, because it could not do otherwise.
+    /// The market's own move is a constant across a session, and the bins are cut by rank, so it is
+    /// already absent from every figure here — an outcome that demeaned the target could only
+    /// return bit-identical numbers.
     #[test]
     fn test_the_sessions_own_move_is_already_out_of_the_measurement() {
         let (feature, target) = paired(1000, |index| ((index * 37) % 1000) as f64);
@@ -604,9 +706,8 @@ mod tests {
         );
     }
 
-    /// The defect this replaced: a nominal column cut into ten quantiles merges its groups by
-    /// nothing but their numbering, and the data has thirteen sectors and a hundred and fifty-one
-    /// industries.
+    /// A nominal column cut into ten quantiles merges its groups by nothing but their numbering,
+    /// and the data has thirteen sectors and a hundred and fifty-one industries.
     #[test]
     fn test_more_groups_than_bins_stay_apart() {
         let values: Vec<usize> = (0..40).map(|index| index % 20).collect();

--- a/src/laboratory/intraday.rs
+++ b/src/laboratory/intraday.rs
@@ -308,10 +308,37 @@ pub struct BounceReading {
     pub lag_two: Option<f64>,
     /// Median Roll effective spread, as a fraction of price, over the name-sessions that admit one.
     pub roll_spread: Option<f64>,
-    /// Name-sessions clearing [`MINIMUM_RETURNS`].
+    /// Name-sessions clearing [`MINIMUM_RETURNS`], which is the denominator of every share here.
     pub measured: usize,
     /// Share of those whose first-order coefficient is negative.
     pub share_negative: f64,
+    /// Of `measured`, how many admitted a lag-two estimate.
+    pub lag_two_measured: usize,
+    /// Of `measured`, how many had the negative autocovariance Roll's estimator needs.
+    pub roll_spread_measured: usize,
+}
+
+impl BounceReading {
+    /// Share of measured name-sessions where lag two could not be estimated.
+    ///
+    /// Reported beside `lag_two` because an estimator defined on a twentieth of the population must
+    /// not read the same as one defined on all of it.
+    pub fn lag_two_undefined_share(&self) -> f64 {
+        undefined_share(self.lag_two_measured, self.measured)
+    }
+
+    /// Share of measured name-sessions where Roll's estimator had nothing to say.
+    pub fn roll_spread_undefined_share(&self) -> f64 {
+        undefined_share(self.roll_spread_measured, self.measured)
+    }
+}
+
+/// The share of `total` an estimator was not defined on, or zero where nothing was measured.
+fn undefined_share(defined: usize, total: usize) -> f64 {
+    if total == 0 {
+        return 0.0;
+    }
+    (total.saturating_sub(defined)) as f64 / total as f64
 }
 
 /// Measures bid-ask bounce over per-session returns.
@@ -356,6 +383,8 @@ pub fn bounce(sessions: &[SessionReturns]) -> Option<BounceReading> {
         roll_spread: median(&mut spreads),
         measured,
         share_negative: negative as f64 / measured as f64,
+        lag_two_measured: lag_two.len(),
+        roll_spread_measured: spreads.len(),
     })
 }
 
@@ -635,10 +664,9 @@ mod tests {
         }
     }
 
-    /// **The defect this module shipped with.** A missing interior bar used to be bridged: the
-    /// closes on either side were differenced and the result counted as one five-minute return.
-    /// Every adjacency-dependent statistic here — autocorrelation, Roll, the predictors — then read
-    /// a ten-minute move as a five-minute one.
+    /// A missing interior bar must not be bridged. Differencing the closes on either side counts a
+    /// ten-minute move as a five-minute return, and every adjacency-dependent statistic here —
+    /// autocorrelation, Roll, the predictors — then reads the wrong distance.
     #[test]
     fn test_a_missing_bar_leaves_a_hole_rather_than_a_longer_return() {
         let bars = frame(&[
@@ -852,26 +880,64 @@ mod tests {
     }
 
     /// The conclusion rests on lag-2 being small, so "measured and small" must stay distinguishable
-    /// from "never measured" — a substituted zero collapses the two.
+    /// from "never measured" — a substituted zero collapses the two, and the undefined share is
+    /// what says which of the two the figure is.
     #[test]
     fn test_an_unmeasured_lag_two_is_absent_rather_than_zero() {
         let mut by_ticker = BTreeMap::new();
-        // Long enough to qualify and to admit lag one, but flat after the first move, so the
-        // variance is carried entirely by pairs lag two cannot form.
-        let mut returns = vec![Some(0.0); 40];
-        returns[0] = Some(0.01);
+        // Present in adjacent couples separated by two empty slots, so every lag-one pair forms and
+        // no lag-two pair can.
+        let mut returns = vec![None; 80];
+        for couple in 0..20 {
+            returns[couple * 4] = Some(0.01);
+            returns[couple * 4 + 1] = Some(-0.01);
+        }
         by_ticker.insert("AAA".to_string(), returns);
         let sessions = vec![SessionReturns {
             session: session_of(2026, 6, 1),
             by_ticker,
         }];
 
-        if let Some(reading) = bounce(&sessions) {
-            assert!(
-                reading.lag_two.is_none() || reading.lag_two.is_some_and(f64::is_finite),
-                "lag two is either a real measurement or absent, never a stand-in zero"
-            );
-        }
+        let reading = bounce(&sessions).expect("forty returns clear the minimum and admit lag one");
+
+        assert_eq!(reading.measured, 1);
+        assert!(
+            (reading.lag_one + 1.0).abs() < 1e-12,
+            "the couples alternate, so lag one is -1: {}",
+            reading.lag_one
+        );
+        assert_eq!(
+            reading.lag_two, None,
+            "no lag-two pair forms, and that is not a zero"
+        );
+        assert_eq!(reading.lag_two_measured, 0);
+        assert!((reading.lag_two_undefined_share() - 1.0).abs() < 1e-12);
+    }
+
+    /// An estimator defined on part of the population must not read like one defined on all of it,
+    /// so the share it was undefined on travels with the figure.
+    #[test]
+    fn test_the_undefined_share_travels_with_each_estimate() {
+        let mut by_ticker = BTreeMap::new();
+        // Alternating returns admit both lag two and Roll's negative autocovariance.
+        by_ticker.insert("AAA".to_string(), alternating(40, 0.01));
+        // A steady climb admits lag two and refuses Roll.
+        by_ticker.insert(
+            "BBB".to_string(),
+            (0..40).map(|index| Some(0.001 * index as f64)).collect(),
+        );
+        let sessions = vec![SessionReturns {
+            session: session_of(2026, 6, 1),
+            by_ticker,
+        }];
+
+        let reading = bounce(&sessions).expect("two qualifying names");
+
+        assert_eq!(reading.measured, 2);
+        assert_eq!(reading.lag_two_measured, 2);
+        assert_eq!(reading.roll_spread_measured, 1);
+        assert!((reading.lag_two_undefined_share() - 0.0).abs() < 1e-12);
+        assert!((reading.roll_spread_undefined_share() - 0.5).abs() < 1e-12);
     }
 
     /// A name that traded four times in a session carries almost no information about its own

--- a/src/laboratory/intraday_convergence.rs
+++ b/src/laboratory/intraday_convergence.rs
@@ -117,7 +117,7 @@ pub fn entries_in_session(
             ];
             for (long, long_window, long_prices, short, short_window, short_prices) in orientations
             {
-                let Some(model) = SpreadModel::fit(long_window, short_window) else {
+                let Ok(model) = SpreadModel::fit(long_window, short_window) else {
                     continue;
                 };
                 let Some(entry) = follow(&model, session, long, long_prices, short, short_prices)

--- a/src/laboratory/intraday_convergence.rs
+++ b/src/laboratory/intraday_convergence.rs
@@ -202,10 +202,24 @@ fn follow(
     })
 }
 
-/// The average z-score entries were opened at, which is what a convergence would be worth.
+/// Mean over sessions of each session's own mean entry z-score, which is what a convergence is worth.
+///
+/// Weighted per session rather than per entry so it multiplies against the session-weighted shares
+/// in [`crate::laboratory::convergence::Curve`]; the two weightings describe different populations
+/// and their product is not an expected value under either.
 pub fn mean_entry_z_score(entries: &[IntradayEntry]) -> Option<f64> {
-    (!entries.is_empty()).then(|| {
-        entries.iter().map(|entry| entry.entry_z_score).sum::<f64>() / entries.len() as f64
+    let mut by_session: BTreeMap<SessionDate, Vec<f64>> = BTreeMap::new();
+    for entry in entries {
+        by_session
+            .entry(entry.session)
+            .or_default()
+            .push(entry.entry_z_score);
+    }
+    (!by_session.is_empty()).then(|| {
+        let session_means = by_session
+            .values()
+            .map(|scores| scores.iter().sum::<f64>() / scores.len() as f64);
+        session_means.sum::<f64>() / by_session.len() as f64
     })
 }
 
@@ -279,6 +293,38 @@ mod tests {
 
     fn session_of(year: i32, month: u32, day: u32) -> SessionDate {
         SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(year, month, day).unwrap())
+    }
+
+    fn entry_on(session: SessionDate, entry_z_score: f64) -> IntradayEntry {
+        IntradayEntry {
+            session,
+            entry_bar: 0,
+            long: "LONG".to_string(),
+            short: "SHORT".to_string(),
+            entry_z_score,
+            final_z_score: None,
+            resolution: Resolution::Unresolved,
+            observed: Observed::default(),
+        }
+    }
+
+    /// The mean is over sessions, matching the shares it is multiplied by.
+    ///
+    /// A busy session would otherwise carry the average, so the product of an entry-weighted mean
+    /// and a session-weighted share describes no population at all.
+    #[test]
+    fn test_the_mean_entry_score_weights_sessions_not_entries() {
+        let first = session_of(2026, 6, 1);
+        let second = session_of(2026, 6, 2);
+        let entries = vec![
+            entry_on(first, 2.0),
+            entry_on(second, 3.0),
+            entry_on(second, 3.0),
+            entry_on(second, 3.0),
+        ];
+
+        // Session means are 2.0 and 3.0, so the answer is 2.5; over entries it would be 2.75.
+        assert_eq!(mean_entry_z_score(&entries), Some(2.5));
     }
 
     /// A pair whose spread sits at `dislocation` standard deviations at `at_bar`, and returns to

--- a/src/laboratory/journal.rs
+++ b/src/laboratory/journal.rs
@@ -1,6 +1,6 @@
 //! The laboratory's own append-only record of what it ran.
 //!
-//! Keyed by run and rolled on the UTC date: an experiment happens at an instant, not on a session.
+//! Keyed by run and rolled on the Eastern session the run's instant falls in.
 
 use std::path::{Path, PathBuf};
 
@@ -10,6 +10,7 @@ use tokio::io::AsyncWriteExt;
 use tracing::{debug, error};
 use uuid::Uuid;
 
+use crate::common::types::SessionDate;
 use crate::laboratory::convergence::Curve;
 use crate::laboratory::dataset::DatasetFingerprint;
 use crate::laboratory::metrics::Distribution;
@@ -105,6 +106,44 @@ pub struct RegimeMeasured {
     pub segment: String,
     pub sessions: usize,
     pub associations: Vec<Association>,
+    /// How far apart the two halves landed, recorded only on the whole-window record.
+    ///
+    /// Empty on a half's own record: the comparison qualifies the figure it is a split of, and
+    /// repeating it on each half would journal one comparison three times.
+    pub half_differences: Vec<HalfDifference>,
+}
+
+/// The gap between the two halves of the window, at one lag.
+///
+/// The split-sample check is this number against its error, not two figures that happen to point
+/// the same way.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct HalfDifference {
+    pub lag: usize,
+    /// The second half's association minus the first's.
+    pub difference: f64,
+    /// The halves are disjoint stretches, so their errors add in quadrature.
+    pub standard_error: f64,
+}
+
+impl HalfDifference {
+    /// The gap between two associations at the same lag, or `None` where either is missing.
+    pub fn between(
+        first_half: Option<&Association>,
+        second_half: Option<&Association>,
+    ) -> Option<Self> {
+        let (first_half, second_half) = (first_half?, second_half?);
+        if first_half.lag != second_half.lag {
+            return None;
+        }
+        Some(Self {
+            lag: first_half.lag,
+            difference: second_half.correlation - first_half.correlation,
+            standard_error: (first_half.standard_error.powi(2)
+                + second_half.standard_error.powi(2))
+            .sqrt(),
+        })
+    }
 }
 
 /// Whether one forecast's per-session readings carry into the sessions after them.
@@ -123,8 +162,9 @@ pub struct StabilityMeasured {
 
 /// How much one feature says about the session it precedes.
 ///
-/// `excess_bits` is the answer and the other two are why it should be believed: the raw estimate is
-/// biased upward at this sample size, and `null_bits` is that bias measured on the same rows.
+/// `excess_share` is the answer and the rest are why it should be believed: the raw estimate is
+/// biased upward at this sample size, `null_bits` is that bias measured on the same rows, and
+/// `target_entropy_bits` is the ceiling that makes two targets comparable at all.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct FeatureTriaged {
     pub feature: String,
@@ -132,6 +172,10 @@ pub struct FeatureTriaged {
     pub bits: Option<Distribution>,
     pub null_bits: Option<Distribution>,
     pub excess_bits: Option<Distribution>,
+    /// What the target itself carries, which caps anything a feature can say about it.
+    pub target_entropy_bits: Option<Distribution>,
+    /// `excess_bits` as a share of that ceiling, which is the only figure comparable across targets.
+    pub excess_share: Option<Distribution>,
 }
 
 /// One frame prepared for an experiment to read.
@@ -197,19 +241,19 @@ impl Record {
     }
 }
 
-/// The file the writer currently holds open, and the UTC date it belongs to.
-struct OpenDate {
-    date: NaiveDate,
+/// The file the writer currently holds open, and the session it belongs to.
+struct OpenSession {
+    session: SessionDate,
     file: tokio::fs::File,
 }
 
-/// Appends records to the current UTC date's file.
+/// Appends records to the current session's file.
 ///
-/// The date comes from the record rather than from construction, so the file rolls at UTC midnight
-/// whatever the process was doing at the time.
+/// The session comes from the record's own instant rather than from construction, so the file rolls
+/// at Eastern midnight whatever the process was doing at the time.
 pub struct Journal {
     directory: PathBuf,
-    open_date: tokio::sync::Mutex<Option<OpenDate>>,
+    open_session: tokio::sync::Mutex<Option<OpenSession>>,
 }
 
 impl Journal {
@@ -222,7 +266,7 @@ impl Journal {
         })?;
         Ok(Self {
             directory,
-            open_date: tokio::sync::Mutex::new(None),
+            open_session: tokio::sync::Mutex::new(None),
         })
     }
 
@@ -241,18 +285,18 @@ impl Journal {
     pub async fn append(&self, record: &Record) -> Result<(), JournalError> {
         let mut line = serde_json::to_vec(record)?;
         line.push(b'\n');
-        let date = record.timestamp.date_naive();
+        let session = SessionDate::at(record.timestamp);
 
-        let mut open_date = self.open_date.lock().await;
-        let open = match open_date.as_mut() {
-            Some(open) if open.date == date => open,
+        let mut open_session = self.open_session.lock().await;
+        let open = match open_session.as_mut() {
+            Some(open) if open.session == session => open,
             _ => {
                 let file = tokio::fs::OpenOptions::new()
                     .create(true)
                     .append(true)
-                    .open(self.directory.join(file_name(date)))
+                    .open(self.directory.join(file_name(session)))
                     .await?;
-                open_date.insert(OpenDate { date, file })
+                open_session.insert(OpenSession { session, file })
             }
         };
 
@@ -282,30 +326,32 @@ impl Journal {
 
     /// Blocks appends for as long as the returned guard is held.
     pub async fn seal(&self) -> JournalGuard<'_> {
-        let mut open_date = self.open_date.lock().await;
-        *open_date = None;
+        let mut open_session = self.open_session.lock().await;
+        *open_session = None;
         JournalGuard {
-            _appends_blocked: open_date,
+            _appends_blocked: open_session,
         }
     }
 }
 
 /// Proof that no append can run while it is alive.
 pub struct JournalGuard<'a> {
-    _appends_blocked: tokio::sync::MutexGuard<'a, Option<OpenDate>>,
+    _appends_blocked: tokio::sync::MutexGuard<'a, Option<OpenSession>>,
 }
 
-/// The file one UTC date's records are written to.
-pub fn file_name(date: NaiveDate) -> String {
-    format!("laboratory-{date}.jsonl")
+/// The file one session's records are written to.
+pub fn file_name(session_date: SessionDate) -> String {
+    format!("laboratory-{}.jsonl", session_date.date())
 }
 
-/// Recovers the UTC date from a name built by [`file_name`], or `None` if it does not have that
-/// shape.
-pub fn date_from_file_name(name: &str) -> Option<NaiveDate> {
-    name.strip_prefix("laboratory-")
-        .and_then(|rest| rest.strip_suffix(".jsonl"))
-        .and_then(|date| NaiveDate::parse_from_str(date, "%Y-%m-%d").ok())
+/// Recovers the session from a name built by [`file_name`], or `None` for anything else.
+///
+/// Accepted only if it is exactly what the writer would have produced: `%Y-%m-%d` also parses
+/// `2026-8-11`, and admitting both spellings would let one session reach the export twice.
+pub fn session_from_file_name(name: &str) -> Option<SessionDate> {
+    let date = name.strip_prefix("laboratory-")?.strip_suffix(".jsonl")?;
+    let session_date = SessionDate::from_date(NaiveDate::parse_from_str(date, "%Y-%m-%d").ok()?);
+    (file_name(session_date) == name).then_some(session_date)
 }
 
 #[cfg(test)]
@@ -360,6 +406,8 @@ mod tests {
             bits: None,
             null_bits: None,
             excess_bits: None,
+            target_entropy_bits: None,
+            excess_share: None,
         });
         let value: serde_json::Value = serde_json::to_value(&triaged).unwrap();
 
@@ -396,6 +444,7 @@ mod tests {
             segment: "whole".to_string(),
             sessions: 499,
             associations: Vec::new(),
+            half_differences: Vec::new(),
         });
         let value: serde_json::Value = serde_json::to_value(&regime).unwrap();
 
@@ -466,10 +515,15 @@ mod tests {
     }
 
     #[test]
-    fn test_file_names_round_trip_through_their_date() {
-        let date = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
-        assert_eq!(file_name(date), "laboratory-2026-08-17.jsonl");
-        assert_eq!(date_from_file_name(&file_name(date)), Some(date));
+    fn test_file_names_round_trip_through_their_session() {
+        let session = SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 8, 17).unwrap());
+        assert_eq!(file_name(session), "laboratory-2026-08-17.jsonl");
+        assert_eq!(session_from_file_name(&file_name(session)), Some(session));
+        assert_eq!(
+            session_from_file_name("laboratory-2026-8-17.jsonl"),
+            None,
+            "one session must not reach the export under two spellings"
+        );
     }
 
     /// `experiment_type()` restates what `rename_all` generates for the variant. Left unpinned, a
@@ -489,8 +543,39 @@ mod tests {
     /// laboratory file would file an instant under a trading day.
     #[test]
     fn test_an_application_journal_file_name_is_not_a_laboratory_one() {
-        assert_eq!(date_from_file_name("fund-2026-08-17.jsonl"), None);
-        assert_eq!(date_from_file_name("laboratory-2026-08-17.txt"), None);
+        assert_eq!(session_from_file_name("fund-2026-08-17.jsonl"), None);
+        assert_eq!(session_from_file_name("laboratory-2026-08-17.txt"), None);
+    }
+
+    /// Two halves pointing the same way is not agreement, and only the gap and its own error can
+    /// say whether they differ. The halves are disjoint, so the errors add in quadrature.
+    #[test]
+    fn test_the_gap_between_two_halves_carries_its_own_error() {
+        let half = |correlation: f64, standard_error: f64| Association {
+            lag: 1,
+            correlation,
+            standard_error,
+            pairs: 250,
+        };
+        let first = half(0.20, 0.03);
+        let second = half(0.50, 0.04);
+
+        let gap = HalfDifference::between(Some(&first), Some(&second)).unwrap();
+
+        assert_eq!(gap.lag, 1);
+        assert!((gap.difference - 0.30).abs() < 1e-12, "{gap:?}");
+        assert!((gap.standard_error - 0.05).abs() < 1e-12, "{gap:?}");
+        assert_eq!(
+            HalfDifference::between(Some(&first), None),
+            None,
+            "a half that could not be measured leaves no gap to report"
+        );
+        let other_lag = half(0.50, 0.04);
+        assert_eq!(
+            HalfDifference::between(Some(&Association { lag: 0, ..first }), Some(&other_lag)),
+            None,
+            "two lags are two questions"
+        );
     }
 
     /// The envelope is what the export partitions and joins on, so every field of it must survive
@@ -520,25 +605,39 @@ mod tests {
         );
     }
 
+    /// An evening run straddles UTC midnight and no session boundary, and the export partitions on
+    /// this name into a bucket whose every other prefix is Eastern-session-partitioned.
     #[tokio::test]
-    async fn test_records_roll_into_the_file_for_their_utc_date() {
+    async fn test_records_roll_on_the_eastern_session_and_not_the_utc_date() {
         let directory = tempfile::tempdir().unwrap();
         let journal = Journal::new(directory.path()).unwrap();
         let run_id = Uuid::new_v4();
 
-        let first = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
-        let second = NaiveDate::from_ymd_opt(2026, 8, 18).unwrap();
+        let seventeenth = NaiveDate::from_ymd_opt(2026, 8, 17).unwrap();
+        let eighteenth = NaiveDate::from_ymd_opt(2026, 8, 18).unwrap();
 
-        // 23:30 on the 17th and 00:30 on the 18th: an hour apart, either side of UTC midnight.
-        for (date, hour, minute) in [(first, 23, 30), (second, 0, 30)] {
-            let timestamp = date.and_hms_opt(hour, minute, 0).unwrap().and_utc();
+        // 23:30 and 00:30 UTC are an hour apart and both fall on the evening of the 17th Eastern;
+        // 05:00 UTC on the 18th is the small hours of the 18th.
+        for (date, hour) in [(seventeenth, 23), (eighteenth, 0), (eighteenth, 5)] {
+            let timestamp = date.and_hms_opt(hour, 30, 0).unwrap().and_utc();
             journal
                 .append(&Record::new(run_id, timestamp, observation()))
                 .await
                 .unwrap();
         }
 
-        assert!(directory.path().join(file_name(first)).exists());
-        assert!(directory.path().join(file_name(second)).exists());
+        let session_file = |date: NaiveDate| {
+            directory
+                .path()
+                .join(file_name(SessionDate::from_date(date)))
+        };
+        let lines = |date: NaiveDate| std::fs::read_to_string(session_file(date)).unwrap();
+
+        assert_eq!(
+            lines(seventeenth).lines().count(),
+            2,
+            "the evening pair belongs to one session"
+        );
+        assert_eq!(lines(eighteenth).lines().count(), 1);
     }
 }

--- a/src/laboratory/journal.rs
+++ b/src/laboratory/journal.rs
@@ -339,9 +339,17 @@ pub struct JournalGuard<'a> {
     _appends_blocked: tokio::sync::MutexGuard<'a, Option<OpenSession>>,
 }
 
+/// Prefix naming files whose date is an Eastern session.
+///
+/// Distinct from the `laboratory-` files an earlier build wrote, whose date was the UTC day. The two
+/// disagree either side of 20:00 Eastern, and nothing in a file says which rule named it, so the
+/// generations are told apart by name rather than by inspection. Legacy files are inert: they are
+/// never appended to, exported, or deleted, and can be removed by hand.
+const SESSION_FILE_PREFIX: &str = "laboratory-session-";
+
 /// The file one session's records are written to.
 pub fn file_name(session_date: SessionDate) -> String {
-    format!("laboratory-{}.jsonl", session_date.date())
+    format!("{SESSION_FILE_PREFIX}{}.jsonl", session_date.date())
 }
 
 /// Recovers the session from a name built by [`file_name`], or `None` for anything else.
@@ -349,7 +357,9 @@ pub fn file_name(session_date: SessionDate) -> String {
 /// Accepted only if it is exactly what the writer would have produced: `%Y-%m-%d` also parses
 /// `2026-8-11`, and admitting both spellings would let one session reach the export twice.
 pub fn session_from_file_name(name: &str) -> Option<SessionDate> {
-    let date = name.strip_prefix("laboratory-")?.strip_suffix(".jsonl")?;
+    let date = name
+        .strip_prefix(SESSION_FILE_PREFIX)?
+        .strip_suffix(".jsonl")?;
     let session_date = SessionDate::from_date(NaiveDate::parse_from_str(date, "%Y-%m-%d").ok()?);
     (file_name(session_date) == name).then_some(session_date)
 }
@@ -517,13 +527,22 @@ mod tests {
     #[test]
     fn test_file_names_round_trip_through_their_session() {
         let session = SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 8, 17).unwrap());
-        assert_eq!(file_name(session), "laboratory-2026-08-17.jsonl");
+        assert_eq!(file_name(session), "laboratory-session-2026-08-17.jsonl");
         assert_eq!(session_from_file_name(&file_name(session)), Some(session));
         assert_eq!(
-            session_from_file_name("laboratory-2026-8-17.jsonl"),
+            session_from_file_name("laboratory-session-2026-8-17.jsonl"),
             None,
             "one session must not reach the export under two spellings"
         );
+    }
+
+    /// A file the previous build wrote names a UTC day, and nothing inside it says so.
+    ///
+    /// Read as a session it would ship records either side of 20:00 Eastern to the wrong partition
+    /// and then delete the only local copy, so it must not be recognised at all.
+    #[test]
+    fn test_a_legacy_utc_dated_file_is_not_read_as_a_session() {
+        assert_eq!(session_from_file_name("laboratory-2026-08-17.jsonl"), None);
     }
 
     /// `experiment_type()` restates what `rename_all` generates for the variant. Left unpinned, a

--- a/src/laboratory/predictor.rs
+++ b/src/laboratory/predictor.rs
@@ -28,6 +28,10 @@ pub struct Panel {
     tickers: Vec<String>,
     /// `returns[session][ticker]`, absent where that name did not trade that session.
     returns: Vec<Vec<Option<f64>>>,
+    /// `scored[session][ticker]`, or `None` to score the whole cross-section.
+    ///
+    /// Read only when grading; the history a predictor sees is always the full grid.
+    scored: Option<Vec<Vec<bool>>>,
 }
 
 impl Panel {
@@ -104,7 +108,35 @@ impl Panel {
             sessions: session_axis,
             tickers: ticker_axis,
             returns: grid,
+            scored: None,
         })
+    }
+
+    /// Restricts what [`evaluate`] scores to the given `(session, ticker)` pairs.
+    ///
+    /// The mask governs the cross-section a predictor is graded on and never
+    /// [`Panel::history_before`], so a name held out of one session still supplies the past that
+    /// `Momentum` reads. A pair naming a session or name outside the panel is ignored.
+    pub fn scoring_restricted_to(mut self, pairs: &BTreeSet<(i64, String)>) -> Self {
+        let mut scored = vec![vec![false; self.tickers.len()]; self.sessions.len()];
+        for (session, ticker) in pairs {
+            let (Some(index), Some(name)) = (
+                self.sessions.iter().position(|it| it == session),
+                self.tickers.iter().position(|it| it == ticker),
+            ) else {
+                continue;
+            };
+            scored[index][name] = true;
+        }
+        self.scored = Some(scored);
+        self
+    }
+
+    /// Whether the name at `ticker` is part of the cross-section scored in the session at `index`.
+    fn is_scored(&self, index: usize, ticker: usize) -> bool {
+        self.scored
+            .as_ref()
+            .is_none_or(|scored| scored[index][ticker])
     }
 
     pub fn sessions(&self) -> usize {
@@ -340,7 +372,9 @@ pub fn evaluate(predictor: &dyn Predictor, panel: &Panel) -> Evaluation {
         let (scores, outcomes): (Vec<f64>, Vec<f64>) = scored
             .iter()
             .zip(realized)
-            .filter_map(|(score, outcome)| score.zip(*outcome))
+            .enumerate()
+            .filter(|(ticker, _)| panel.is_scored(index, *ticker))
+            .filter_map(|(_, (score, outcome))| score.zip(*outcome))
             .unzip();
         let mut measured = metrics::measure_session(&scores, &outcomes);
         if !predictor.scores_are_returns() {
@@ -391,6 +425,46 @@ mod tests {
 
     fn panel() -> Panel {
         Panel::from_frame(&panel_frame()).unwrap()
+    }
+
+    /// A masked cell leaves the scored cross-section and stays in the history.
+    ///
+    /// Both halves matter: dropping it from the grading is the point, and dropping it from the past
+    /// as well would starve `Momentum` of the sessions it needs and change the very scores the mask
+    /// exists to make comparable.
+    #[test]
+    fn test_a_masked_cell_is_not_scored_but_is_still_history() {
+        let every_pair: BTreeSet<(i64, String)> = (0..4)
+            .flat_map(|session| {
+                ["AAA", "BBB", "CCC"]
+                    .iter()
+                    .map(move |ticker| (session * DAY, (*ticker).to_string()))
+            })
+            .collect();
+        let mut held_out = every_pair.clone();
+        held_out.remove(&(3 * DAY, "BBB".to_string()));
+
+        let whole = panel().scoring_restricted_to(&every_pair);
+        let masked = panel().scoring_restricted_to(&held_out);
+
+        // Session 3 has three names; holding one out leaves two to grade.
+        assert!(whole.is_scored(3, 1));
+        assert!(!masked.is_scored(3, 1));
+
+        // The held-out name is unchanged as an observation, and the sessions before it are intact,
+        // so a predictor reading history sees exactly what it saw before.
+        assert_eq!(masked.return_of(3, 1), Some(3.1));
+        assert_eq!(masked.history_before(3).sessions(), 3);
+        assert_eq!(masked.returns_at(3), whole.returns_at(3));
+    }
+
+    /// An unmasked panel scores its whole cross-section, so the mask is opt-in.
+    #[test]
+    fn test_a_panel_without_a_mask_scores_every_name() {
+        let panel = panel();
+        for ticker in 0..panel.tickers() {
+            assert!(panel.is_scored(2, ticker));
+        }
     }
 
     #[test]
@@ -699,6 +773,39 @@ mod tests {
                 .directional_accuracy
                 .is_some(),
             "a score in return units does have a sign to be right about"
+        );
+    }
+
+    /// Masking a name out of a session changes what that session scores.
+    ///
+    /// `CCC` has no session-2 return, so persistence already declines to score it in session 3 and
+    /// masking it would prove nothing; `BBB` is scored, and holding it out leaves one name, which is
+    /// too few to correlate. That the reading disappears is the mask reaching `evaluate` rather than
+    /// merely being stored on the panel.
+    #[test]
+    fn test_the_mask_changes_the_cross_section_evaluate_scores() {
+        let panel = panel();
+        let unmasked = evaluate(&Persistence, &panel);
+        assert_eq!(
+            unmasked.sessions[3].information_coefficient,
+            Some(1.0),
+            "AAA and BBB both carry a prior, so the session has two names to rank"
+        );
+
+        let held_out: BTreeSet<(i64, String)> = (0..4)
+            .flat_map(|session| {
+                ["AAA", "BBB", "CCC"]
+                    .iter()
+                    .map(move |ticker| (session * DAY, (*ticker).to_string()))
+            })
+            .filter(|(session, ticker)| !(*session == 3 * DAY && ticker == "BBB"))
+            .collect();
+        let masked = evaluate(&Persistence, &panel.scoring_restricted_to(&held_out));
+
+        assert_eq!(masked.sessions[3].information_coefficient, None);
+        assert_eq!(
+            masked.sessions[1], unmasked.sessions[1],
+            "a session the mask does not touch is scored exactly as before"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 //! Fund platform: a statistical arbitrage service driven entirely by scheduled events.
-//!
 //! One process, woken by pg_cron, running the commands in [`common::events::Command`]. It flattens
 //! the book before every close, and treats Alpaca as the source of truth for what it holds.
-//!
 
 pub mod common;
 pub mod dashboard;

--- a/src/models/tide/artifact.rs
+++ b/src/models/tide/artifact.rs
@@ -38,14 +38,10 @@ pub struct ModelState {
 impl ModelState {
     /// Constructs a `ModelState` from a fully loaded artifact.
     ///
-    /// The column lists the artifact was fitted with are not carried here. They are checked against
-    /// this build's constants inside [`crate::models::tide::data::Scaler::load`] and then dropped:
-    /// verifying them is what they were for, nothing read them afterwards, and keeping a copy that
-    /// is provably equal to the constants invited a future caller to trust the copy.
-    ///
-    /// The artifact key and load instant are not carried either, on the same reasoning. The
-    /// pre-open handler resolves the key itself and derives staleness from `run_id` against the
-    /// trading calendar, and both reach the journal through `predictions_generated`.
+    /// The artifact's own column lists are checked against this build's constants inside
+    /// [`crate::models::tide::data::Scaler::load`] and then dropped, because a copy provably equal to
+    /// the constants only invites a caller to trust the copy. The artifact key and the load instant
+    /// are dropped on the same reasoning: the pre-open handler resolves both for itself.
     pub fn new(
         model: TiDEModel<NdArray>,
         parameters: ModelParameters,
@@ -91,9 +87,8 @@ impl ModelState {
 }
 
 /// `ModelState` must stay `Send + Sync` — the prediction handler holds a `&ModelState` across an
-/// await inside a future that `JoinSet::spawn` requires to be `Send`. That used to be asserted with
-/// `unsafe impl`; it is now a property the compiler derives from the `Mutex` around the model, and
-/// this is what makes the difference visible. Removing the mutex fails here rather than in
+/// await inside a future that `JoinSet::spawn` requires to be `Send`. The compiler derives that
+/// from the `Mutex` around the model, so removing the mutex fails here rather than in
 /// `bin/fund.rs`, several call layers from the cause.
 #[allow(dead_code)]
 fn model_state_is_send_and_sync() {
@@ -352,16 +347,20 @@ fn extract_tar_gz(tar_path: &Path, destination: &Path) -> Result<(), ArtifactErr
     Ok(())
 }
 
-fn load_model_from_directory(dir: &Path, artifact_key: &str) -> Result<ModelState, ArtifactError> {
-    let parameters_path = dir.join("tide_parameters.json");
+/// Loads the four files an extracted artifact holds into one servable model.
+fn load_model_from_directory(
+    directory: &Path,
+    artifact_key: &str,
+) -> Result<ModelState, ArtifactError> {
+    let parameters_path = directory.join("tide_parameters.json");
     let parameters = crate::models::tide::configuration::ModelParameters::load(&parameters_path)
         .map_err(|error| ArtifactError::ModelLoad(error.to_string()))?;
 
-    let scaler_path = dir.join("tide_data_scaler.json");
+    let scaler_path = directory.join("tide_data_scaler.json");
     let scaler = crate::models::tide::data::Scaler::load(&scaler_path)
         .map_err(|error| ArtifactError::ModelLoad(error.to_string()))?;
 
-    let mappings_path = dir.join("tide_data_mappings.json");
+    let mappings_path = directory.join("tide_data_mappings.json");
     let mappings_content = std::fs::read_to_string(&mappings_path)
         .map_err(|error| ArtifactError::ModelLoad(error.to_string()))?;
     let mappings: crate::models::tide::data::FeatureMappings =
@@ -370,7 +369,7 @@ fn load_model_from_directory(dir: &Path, artifact_key: &str) -> Result<ModelStat
 
     let quantile_count = parameters.quantiles().len();
     let model = crate::models::tide::model::TiDEModel::load(
-        dir,
+        directory,
         parameters.input_size(),
         parameters.hidden_size(),
         parameters.encoder_layer_count(),

--- a/src/models/tide/batch.rs
+++ b/src/models/tide/batch.rs
@@ -1,7 +1,6 @@
 //! Windowed ndarray datasets into Burn tensors.
 //!
-//! Training and inference both flatten through here, so the feature ordering cannot drift between
-//! them.
+//! Training and inference both flatten through here, so the feature ordering cannot drift.
 
 use burn::prelude::*;
 
@@ -11,13 +10,9 @@ use crate::models::tide::data::TrainingDataset;
 /// Checks that a dataset can produce the input the loaded weights were trained to consume.
 ///
 /// [`build_input_tensor`] derives its width from the *dataset's* shapes and never consults the
-/// parameters, so a dataset built from a different feature set reshapes cleanly and then fails
-/// inside the first linear layer — a burn panic about tensor dimensions, on the pre-open inference
-/// path, naming neither the artifact nor the column set.
-///
-/// Called once per dataset rather than inside the batch loop: the invariant is a property of
-/// `(dataset, parameters)`, not of a chunk, and the inference path would otherwise re-check it for
-/// every batch of 4096.
+/// parameters, so a mismatched feature set reshapes cleanly and then fails inside the first linear
+/// layer, as a burn panic naming neither the artifact nor the column set. Called once per dataset
+/// rather than inside the batch loop, since the invariant is a property of `(dataset, parameters)`.
 pub fn validate_input_shape(
     dataset: &TrainingDataset,
     parameters: &ModelParameters,

--- a/src/models/tide/configuration.rs
+++ b/src/models/tide/configuration.rs
@@ -110,22 +110,11 @@ impl ModelParameters {
 
     /// Rejects a quantile list the rest of the pipeline cannot consume.
     ///
-    /// Three consumers read this list and each responds to a bad one differently: `quantile_loss`
-    /// pairs it positionally with tensor slices, `evaluate`'s index helpers unwrap a `partial_cmp`
-    /// and so **panic on a non-finite value**, and the prediction path sizes its output by the
-    /// count. Validating once here is what lets all three treat `quantiles()` as trustworthy
-    /// instead of each inventing its own guard.
-    ///
-    /// **The served set is fixed, because the storage columns are.** `equity_predictions` has
-    /// `quantile_10`, `quantile_50`, and `quantile_90`, and `generate_predictions` sorts the model's
-    /// output and assigns it to those three positionally. An artifact trained on `[0.1, 0.3, 0.9]`
-    /// is internally coherent and would load, predict, and store its 30th percentile under
-    /// `quantile_50` — which `EquityPrediction::expected_return` then returns as the model's median
-    /// view, with nothing anywhere to notice. Being usable is not the same as being the thing the
-    /// schema says it is.
-    ///
-    /// Order is still not required: positions are located rather than assumed, so an artifact may
-    /// list the three any way round.
+    /// Three consumers treat `quantiles()` as trustworthy rather than guarding themselves, and
+    /// `evaluate`'s index helpers panic outright on a non-finite value. The served set is fixed at
+    /// the three `equity_predictions` stores, because `generate_predictions` sorts the model's
+    /// output and assigns it to `quantile_10`, `quantile_50`, and `quantile_90` positionally; order
+    /// within the list is not required, only membership.
     fn validate_quantiles(&self) -> Result<(), String> {
         if self.quantiles.is_empty() {
             return Err("the quantile list is empty, so the model predicts nothing".to_string());

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -304,7 +304,7 @@ pub(crate) const CATEGORICAL_COLUMNS: &[&str] = &[
     "year",
 ];
 
-pub(crate) const STATIC_CATEGORICAL_COLUMNS: &[&str] = &["ticker", "sector", "industry"];
+pub const STATIC_CATEGORICAL_COLUMNS: &[&str] = &["ticker", "sector", "industry"];
 
 /// The model target is the future window of `daily_return`, which is the last
 /// continuous column. Fitting and windowing index into this position.

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -1,7 +1,6 @@
 //! Feature engineering, scaling, categorical encoding, and windowing.
 //!
-//! Training fits the scaler and mappings here; inference reuses the ones stored in the artifact.
-//! Both paths run the same functions, so a change to any of them changes both.
+//! Training fits the scaler and mappings; inference reuses the artifact's, through these same functions.
 
 use std::collections::HashMap;
 
@@ -17,23 +16,10 @@ pub type FeatureMappings = HashMap<String, CategoryMapping>;
 
 /// Per-column standardization statistics, fitted during training and reloaded at inference.
 ///
-/// **Holding one is proof that every column it carries can be scaled.** [`Scaler::new`] checks that
-/// each mean is finite, each standard deviation is finite and strictly positive, and that the two
-/// maps name the same columns — so no column is half-described and no call site re-checks.
-///
-/// It is deliberately *not* proof that a particular column is present, because a scaler over one
-/// column is a legitimate value: the unscale path asks only for `daily_return`. Covering every
-/// entry in `CONTINUOUS_COLUMNS` is a property of an *artifact*, not of the type, and
-/// [`Scaler::load`] is where it is enforced.
-///
-/// That guarantee is the point of the type rather than decoration. This value crosses a machine
-/// boundary as a JSON file, and the failure it prevents is silent: a scaler that degrades to the
-/// identity produces predictions on the wrong scale, the service reports a successful load, and
-/// nothing downstream can distinguish them from good ones — the only remaining validation is
-/// `EquityPrediction::new`'s quantile ordering, which wrong-scale values satisfy perfectly well.
-///
-/// Deliberately not `Deserialize`: deriving it would reintroduce a path into the type that skips
-/// the constructor, which is the hole this closes.
+/// Holding one is proof that every column it carries can be scaled, not that any particular column
+/// is present — covering [`CONTINUOUS_COLUMNS`] is a property of an artifact and [`Scaler::load`]
+/// enforces it. Deliberately not `Deserialize`, which would be a way into the type past the
+/// constructor.
 #[derive(Debug, Clone)]
 pub struct Scaler {
     means: HashMap<String, f64>,
@@ -95,15 +81,9 @@ impl Scaler {
 
     /// Reads a scaler from a training artifact, rejecting anything it cannot verify.
     ///
-    /// **Every branch here refuses rather than defaults.** The previous version replaced an
-    /// unparsable `means` entry with `0.0`, an unparsable `standard_deviations` entry with `1.0`,
-    /// and a missing object with an empty map — which is exactly identity scaling, reported as a
-    /// successful load.
-    ///
-    /// The column lists the artifact was fitted with are checked against this build's constants and
-    /// then dropped. Checking them is the whole of their value: an artifact fitted on a different
-    /// column set would otherwise load without complaint and scale a different set than the weights
-    /// were trained on. Carrying them further served nothing — no caller read them.
+    /// Every branch refuses rather than defaults, because a scaler degraded to the identity loads
+    /// successfully and produces predictions nothing downstream can tell from good ones. The column
+    /// lists are checked against this build's constants and then dropped; no caller reads them.
     pub fn load(path: &std::path::Path) -> Result<Self, TideError> {
         let display = path.display();
         let content = std::fs::read_to_string(path)?;
@@ -179,15 +159,19 @@ impl Scaler {
         })
     }
 
-    /// The mean and deviation for `column`, falling back to the identity pair.
+    /// The mean and deviation for `column`.
     ///
-    /// The fallback is reachable only for a column outside `CONTINUOUS_COLUMNS` — [`Scaler::load`]
-    /// rejects an artifact missing any of those.
-    fn statistics_for(&self, column: &str) -> (f64, f64) {
-        (
-            self.means.get(column).copied().unwrap_or(0.0),
-            self.standard_deviations.get(column).copied().unwrap_or(1.0),
-        )
+    /// A column the scaler was not fitted over is an error rather than the identity pair, which
+    /// would be indistinguishable downstream from a correct scaling.
+    fn statistics_for(&self, column: &str) -> Result<(f64, f64), TideError> {
+        // One lookup would answer both, since `Scaler::new` has already made the maps name the same
+        // columns; both are read so a scaler reaching here another way still cannot half-scale.
+        match (self.means.get(column), self.standard_deviations.get(column)) {
+            (Some(mean), Some(standard_deviation)) => Ok((*mean, *standard_deviation)),
+            _ => Err(TideError::Artifact(format!(
+                "the scaler was not fitted over `{column}`, so it cannot be scaled"
+            ))),
+        }
     }
 
     /// Standardizes a value into the units the model was trained in.
@@ -196,15 +180,15 @@ impl Scaler {
     /// trains on the forward image and every prediction is read back through the inverse, so the
     /// two must compose to the identity. Drift between them leaves predictions on the wrong scale,
     /// which every ordering check downstream still accepts.
-    pub fn transform_value(&self, column: &str, value: f64) -> f64 {
-        let (mean, standard_deviation) = self.statistics_for(column);
-        (value - mean) / standard_deviation
+    pub fn transform_value(&self, column: &str, value: f64) -> Result<f64, TideError> {
+        let (mean, standard_deviation) = self.statistics_for(column)?;
+        Ok((value - mean) / standard_deviation)
     }
 
     /// Maps a scaled value back to its original units.
-    pub fn inverse_transform_value(&self, column: &str, value: f64) -> f64 {
-        let (mean, standard_deviation) = self.statistics_for(column);
-        value * standard_deviation + mean
+    pub fn inverse_transform_value(&self, column: &str, value: f64) -> Result<f64, TideError> {
+        let (mean, standard_deviation) = self.statistics_for(column)?;
+        Ok(value * standard_deviation + mean)
     }
 }
 
@@ -337,15 +321,9 @@ pub fn input_feature_size(input_length: usize, output_length: usize) -> usize {
 
 /// The fraction of the observed time range that goes to **training**; the remainder validates.
 ///
-/// Named for the side it measures rather than for the split it defines. "Validation split" is
-/// ambiguous across the field — some libraries mean the held-out fraction by it — and a type whose
-/// name reads backwards is worse than a bare `f64`, because `TrainingFraction::new(0.2)` looks
-/// deliberate. At 0.2 this trains on a fifth of the window and every guard still passes.
-///
-/// Strictly between 0 and 1. At either endpoint one side of the split is empty, and an empty side
-/// is not an error anywhere downstream — [`window_frame`] simply yields no windows, training runs
-/// on nothing or validates against nothing, and the run reports a loss computed over zero rows.
-/// Rejecting the endpoint here is the only place that failure is still legible.
+/// Named for the side it measures, because "validation split" is read both ways across the field and
+/// `TrainingFraction::new(0.2)` looks deliberate either way. Strictly between 0 and 1: at an endpoint
+/// one side is empty, which no downstream step treats as an error.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TrainingFraction(f64);
 
@@ -459,19 +437,9 @@ impl Data {
 /// The timestamp at or before which a row belongs to the training side of the split:
 /// `min + (max - min) * training_fraction`.
 ///
-/// Shared with [`crate::models::tide::fit::fit`], which fits the scaler on the rows this selects
-/// while [`Data::split_by_timestamp`] later selects the rows the model trains on. The two must name
-/// the same instant — statistics fitted over a window other than the one they scale are the
-/// look-ahead this function exists to prevent — so the arithmetic lives here once rather than at
-/// both call sites.
-///
-/// A `TrainingFraction` is strictly between 0 and 1, so the cutoff never falls below the minimum
-/// timestamp: the training side is non-empty for any non-empty frame.
-///
-/// The span is measured with `checked_sub` because a column carrying timestamps at both ends of
-/// `i64` wraps it negative in a release build, which puts the cutoff below every row and empties the
-/// training side — surfacing as `fit_scaler` reporting no rows to fit on, which blames the cutoff
-/// for a corrupt column.
+/// Shared with [`crate::models::tide::fit::fit`], which fits the scaler over the rows this selects
+/// while [`Data::split_by_timestamp`] selects the rows the model trains on; statistics fitted over
+/// any other window are look-ahead, so the arithmetic lives here once rather than at both sites.
 pub(crate) fn training_cutoff(
     data: &DataFrame,
     training_fraction: TrainingFraction,
@@ -506,10 +474,6 @@ pub(crate) fn split_at_cutoff(
     Ok((train, validation))
 }
 
-/// Core windowing over a single (already preprocessed) frame.
-///
-/// `predict_mode` keeps only the final window per ticker; `with_targets`
-/// additionally extracts the future `daily_return` window as the target.
 /// Maps every session the frame holds to its position in the sorted set of them.
 ///
 /// Adjacency is therefore relative to the sessions this frame contains, not to a trading calendar:
@@ -749,20 +713,10 @@ fn window_frame(
 /// Append one row per ticker carrying `target_session`, so the windowing has a future step to spend
 /// that is not a real bar.
 ///
-/// [`window_frame`] splits one contiguous block of `input_length + output_length` rows into a past
-/// and a future half. Without this the newest bar is spent as the future calendar step, which both
-/// feeds the model the wrong session's calendar and pushes the most recent close out of the past
-/// window — so a pre-open run forecasts the session that already closed.
-///
-/// The appended row is the ticker's own last bar with `timestamp` moved to the target session.
-/// Copying it rather than inventing values means `close_price` equals the previous close, so the
-/// engineered `daily_return` is `0.0` and survives [`clean_data`]'s non-finite filter, and sector
-/// and industry carry over. None of those prices reach the model: the future half consumes only
-/// [`CATEGORICAL_COLUMNS`], and the extra row shifts the window so the past half lands on real bars.
-/// Calendar fields are left to [`engineer_features`] so only one place derives them.
-///
-/// Tickers already holding a bar at or after the target session are skipped, so a late run cannot
-/// duplicate a real row.
+/// Without this the newest bar is spent as [`window_frame`]'s future calendar step, so a pre-open run
+/// forecasts the session that already closed. The appended row copies the ticker's own last bar, so
+/// the engineered `daily_return` is `0.0` and survives [`clean_data`] while none of its prices reach
+/// the model; a ticker already holding a bar at or after the target session is skipped.
 pub(crate) fn append_forecast_session_rows(
     data: DataFrame,
     target_session: SessionDate,
@@ -869,11 +823,8 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, TideError>
     for (index, &timestamp_milliseconds) in timestamp_values.iter().enumerate() {
         let instant = chrono::DateTime::from_timestamp_millis(timestamp_milliseconds)
             .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap());
-        // Through `SessionDate`, not `date_naive()`. These are the covariates describing the
-        // trading day a bar belongs to, so they must come from the Eastern date. Reading the UTC
-        // date agreed only because a daily bar is stamped at Eastern midnight, which lands in the
-        // morning of the same UTC day -- a coincidence of the offset's sign that would reverse if
-        // the stamp ever moved later in the session.
+        // Through `SessionDate`, not `date_naive()`: these covariates name the trading day a bar
+        // belongs to, and a bar stamped at the 16:00 Eastern close only happens to share a UTC date.
         let date = SessionDate::at(instant).date();
 
         // Monday = 1 .. Sunday = 7, per polars `dt.weekday()`.
@@ -1039,8 +990,12 @@ pub(crate) fn apply_scaling(data: DataFrame, scaler: &Scaler) -> Result<DataFram
             .cast(&DataType::Float64)?
             .f64()?
             .into_no_null_iter()
-            .map(|value| scaler.transform_value(column_name, value) as f32)
-            .collect();
+            .map(|value| {
+                scaler
+                    .transform_value(column_name, value)
+                    .map(|it| it as f32)
+            })
+            .collect::<Result<_, _>>()?;
 
         result.with_column(Column::new((*column_name).into(), values))?;
     }
@@ -1112,18 +1067,9 @@ pub(crate) fn encode_categoricals(
 
 /// Rejects a column carrying nulls before its values are read positionally.
 ///
-/// `into_no_null_iter` does not skip nulls and does not check for them: it reads the raw value
-/// sitting in the null slot, which is whatever the buffer happens to hold — `0.0` in practice, but
-/// that is an implementation detail rather than a guarantee. The count therefore matches the frame
-/// and nothing fails, so a null `close_price` is scaled and fed to the model as though someone had
-/// observed it.
-///
-/// **A silent wrong value, not a crash.** Checking the extracted length instead would be inert,
-/// because the length is never wrong. The null count is the only thing that carries the
-/// information.
-///
-/// The same family of trap produced a real bug fixed in #1035, where a null `sector` put later rows
-/// on the wrong ticker.
+/// `into_no_null_iter` neither skips nulls nor checks for them: it reads whatever the buffer holds in
+/// the null slot, so the extracted length always matches the frame and a null reaches the model as an
+/// observation. The null count is the only thing that carries the information.
 fn reject_null_column(column: &Column, column_name: &str) -> Result<(), TideError> {
     let nulls = column.null_count();
     if nulls > 0 {
@@ -1251,9 +1197,9 @@ mod scaler_boundary_tests {
         assert!(error.contains("non-string"), "got: {error}");
     }
 
-    /// The headline case. A missing object used to yield an empty map, every lookup then fell back
-    /// to mean 0.0 and deviation 1.0, and scaling became the identity — reported as a successful
-    /// load, producing predictions on the wrong scale that nothing downstream can detect.
+    /// The headline case: without this, a missing object yields an empty map, every lookup falls
+    /// back to mean 0.0 and deviation 1.0, and scaling becomes the identity — a successful load
+    /// producing predictions on a wrong scale that nothing downstream can detect.
     #[test]
     fn test_load_refuses_a_missing_statistics_object_rather_than_scaling_by_identity() {
         for field in ["means", "standard_deviations"] {
@@ -1267,8 +1213,8 @@ mod scaler_boundary_tests {
         }
     }
 
-    /// Same failure by a different route: an entry that is present but not a number used to be
-    /// silently replaced with the identity value for its field.
+    /// Same failure by a different route: an entry present but not a number, which must be refused
+    /// rather than replaced with the identity value for its field.
     #[test]
     fn test_load_refuses_a_non_numeric_entry() {
         let mut artifact = well_formed_artifact();
@@ -1374,56 +1320,76 @@ mod tests {
 
     fn return_scaler() -> Scaler {
         Scaler::new(
-            HashMap::from([("daily_return".to_string(), 0.001)]),
-            HashMap::from([("daily_return".to_string(), 0.02)]),
+            HashMap::from([(TARGET_COLUMN.to_string(), 0.001)]),
+            HashMap::from([(TARGET_COLUMN.to_string(), 0.02)]),
         )
         .expect("the fixture statistics must be usable")
     }
 
     #[test]
     fn test_scaler_inverse_transform() {
-        let result = return_scaler().inverse_transform_value("daily_return", 1.0);
+        let result = return_scaler()
+            .inverse_transform_value(TARGET_COLUMN, 1.0)
+            .unwrap();
         assert!((result - 0.021).abs() < 1e-10);
     }
 
-    /// The two halves must compose to the identity in both directions. They are the reason the
-    /// forward transform moved onto `Scaler`: written separately, one can change without the other
-    /// and the only symptom is predictions on the wrong scale, which every downstream check
-    /// accepts. An unknown column falls through to the identity pair and must round-trip too.
+    /// The two halves must compose to the identity in both directions.
+    ///
+    /// Written separately, one can change without the other and the only symptom is predictions on
+    /// the wrong scale, which every downstream check accepts.
     #[test]
     fn test_scaling_and_unscaling_are_inverses() {
         let scaler = return_scaler();
         for value in [-0.05_f64, 0.0, 1e-9, 0.037, 12.5] {
-            let there_and_back = scaler.inverse_transform_value(
-                "daily_return",
-                scaler.transform_value("daily_return", value),
-            );
+            let there_and_back = scaler
+                .inverse_transform_value(
+                    TARGET_COLUMN,
+                    scaler.transform_value(TARGET_COLUMN, value).unwrap(),
+                )
+                .unwrap();
             assert!(
                 (there_and_back - value).abs() < 1e-12,
                 "forward then inverse moved {value} to {there_and_back}"
             );
 
-            let scaled = scaler.transform_value("daily_return", value);
-            let back_and_there = scaler.transform_value(
-                "daily_return",
-                scaler.inverse_transform_value("daily_return", scaled),
-            );
+            let scaled = scaler.transform_value(TARGET_COLUMN, value).unwrap();
+            let back_and_there = scaler
+                .transform_value(
+                    TARGET_COLUMN,
+                    scaler
+                        .inverse_transform_value(TARGET_COLUMN, scaled)
+                        .unwrap(),
+                )
+                .unwrap();
             assert!(
                 (back_and_there - scaled).abs() < 1e-12,
                 "inverse then forward moved {scaled} to {back_and_there}"
             );
-
-            assert_eq!(
-                scaler.transform_value("not_a_column", value),
-                value,
-                "an unknown column is the identity forward"
-            );
-            assert_eq!(
-                scaler.inverse_transform_value("not_a_column", value),
-                value,
-                "and the identity back"
-            );
         }
+    }
+
+    /// A column the scaler was never fitted over must stop the run rather than scale by the identity.
+    ///
+    /// The identity pair is indistinguishable downstream from a correct scaling: a renamed column
+    /// would have served every prediction unscaled, past `EquityPrediction`'s ordering check and
+    /// into the book, with nothing reporting it.
+    #[test]
+    fn test_an_unknown_column_cannot_be_scaled() {
+        let error = return_scaler()
+            .transform_value("not_a_column", 0.037)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("not_a_column"), "{error}");
+    }
+
+    #[test]
+    fn test_an_unknown_column_cannot_be_unscaled_either() {
+        let error = return_scaler()
+            .inverse_transform_value("not_a_column", 0.037)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("not_a_column"), "{error}");
     }
 
     #[test]
@@ -1718,17 +1684,12 @@ mod tests {
         assert!(TrainingFraction::new(0.8).is_ok());
     }
 
-    /// A validation split can yield no windows at all while the training split yields plenty, and
-    /// nothing in this module treats that as an error — `window_frame` just returns an empty
-    /// dataset.
+    /// A validation split can yield no windows while the training split yields plenty, and nothing
+    /// here treats that as an error.
     ///
-    /// This is the condition `bin/tide_model_trainer.rs` refuses before training, and it pins why
-    /// that guard has to exist. Downstream, an empty validation set is silent in three places at
-    /// once: early stopping falls back to the training loss, [`crate::models::tide::evaluate`]
-    /// short-circuits to zeroed metrics, and the trainer publishes `crps: 0.0` — the best score
-    /// achievable — into the drift baseline that every later run is measured against.
-    ///
-    /// The guard itself is not exercised here; it lives in `run()`, which fetches from S3.
+    /// It is what `bin/tide_model_trainer.rs` refuses before training: downstream, early stopping
+    /// falls back to the training loss and [`crate::models::tide::evaluate`] short-circuits to zeroed
+    /// metrics, so a run that validated on nothing publishes the best score achievable.
     #[test]
     fn test_a_validation_split_can_produce_no_windows_while_training_produces_many() {
         // 11 rows split at 0.8 leaves 2 validation rows, and a window needs input + output = 4.
@@ -1752,9 +1713,8 @@ mod tests {
         );
     }
 
-    /// The predict variant carries no split, so inference cannot pass one that does nothing — which
-    /// is what the `0.8` at the old predict call site was. This is a compile-time property; the
-    /// assertion here records that predicting reads the whole frame rather than a split of it.
+    /// The predict variant carries no split, so inference cannot pass one that does nothing. That is
+    /// a compile-time property; the assertion here records that predicting reads the whole frame.
     #[test]
     fn test_predict_windows_the_whole_frame_rather_than_a_split() {
         let frame = make_encoded_frame(1, 10);
@@ -1953,10 +1913,21 @@ mod tests {
         assert_eq!(dataset.past_continuous.shape()[0], 9);
     }
 
+    /// Two names over two consecutive sessions, stamped the way ingestion stamps a daily bar.
     fn raw_two_ticker_frame() -> DataFrame {
+        let first = SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 6, 1).unwrap());
+        let second = first.plus_calendar_days(1);
         DataFrame::new(vec![
             Column::new("ticker".into(), vec!["BBB", "AAA", "BBB", "AAA"]),
-            Column::new("timestamp".into(), vec![0_i64, 0, 86_400_000, 86_400_000]),
+            Column::new(
+                "timestamp".into(),
+                vec![
+                    session_close(first),
+                    session_close(first),
+                    session_close(second),
+                    session_close(second),
+                ],
+            ),
             Column::new("open_price".into(), vec![1.0_f64; 4]),
             Column::new("high_price".into(), vec![1.0_f64; 4]),
             Column::new("low_price".into(), vec![1.0_f64; 4]),
@@ -2046,6 +2017,19 @@ mod tests {
         }
     }
 
+    /// The instant a daily bar carries: the 16:00 Eastern close, which is where the grouped route
+    /// [`crate::common::massive::MassiveClient::fetch_grouped_daily`] stamps it. A fixture built at
+    /// Eastern midnight sits on the edge of the session's own bounds, which ingestion never produces.
+    fn session_close(session: SessionDate) -> i64 {
+        use chrono::TimeZone;
+        chrono_tz::America::New_York
+            .from_local_datetime(&session.date().and_hms_opt(16, 0, 0).unwrap())
+            .earliest()
+            .unwrap()
+            .with_timezone(&chrono::Utc)
+            .timestamp_millis()
+    }
+
     /// Raw (pre-engineering) frame with string tickers and one bar per consecutive day.
     ///
     /// `close_price` is `100 + row`, so a window's contents identify which rows produced them.
@@ -2061,7 +2045,7 @@ mod tests {
                 let date =
                     SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 6, 1).unwrap())
                         .plus_calendar_days(row as i64);
-                timestamp.push(date.midnight().timestamp_millis());
+                timestamp.push(session_close(date));
                 close.push(100.0 + row as f64);
             }
         }
@@ -2314,15 +2298,11 @@ mod tests {
 
     #[test]
     fn test_engineer_features_day_of_week_is_monday_based_one_to_seven() {
-        // Monday = 1 .. Sunday = 7.
-        //
-        // Stamped at Eastern midnight, which is how a daily bar actually arrives. Built at UTC
-        // midnight instead — as this fixture was — every date reads as the previous Eastern day,
-        // and the assertion below became [7, 6]. The fixture, not the feature, was wrong.
+        // Monday = 1 .. Sunday = 7, stamped at the session close the way ingestion writes a bar.
         let session = |year, month, day| {
-            SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(year, month, day).unwrap())
-                .midnight()
-                .timestamp_millis()
+            session_close(SessionDate::from_date(
+                chrono::NaiveDate::from_ymd_opt(year, month, day).unwrap(),
+            ))
         };
         let monday = session(2026, 6, 8);
         let sunday = session(2026, 6, 14);
@@ -2341,6 +2321,15 @@ mod tests {
         ])
         .unwrap();
 
+        // The precondition, pinned so the fixture cannot drift back to an instant ingestion never
+        // produces: a June session closes at 16:00 in New York, which is 20:00 UTC.
+        assert_eq!(
+            monday,
+            chrono::DateTime::parse_from_rfc3339("2026-06-08T20:00:00Z")
+                .unwrap()
+                .timestamp_millis()
+        );
+
         let engineered = engineer_features(frame).unwrap();
         let day_of_week: Vec<i32> = engineered
             .column("day_of_week")
@@ -2354,12 +2343,9 @@ mod tests {
 
     /// The covariates must come from the Eastern date, on an instant where Eastern and UTC disagree.
     ///
-    /// The fixture above cannot prove this. A daily bar is stamped at Eastern midnight, which is
-    /// 04:00 or 05:00 the *same* UTC day, so `date_naive()` and `SessionDate::at` return the same
-    /// date for it and the assertion holds under either implementation.
-    ///
-    /// 01:00Z on 10 June is 21:00 on 9 June in New York — Wednesday in UTC, Tuesday in Eastern.
-    /// Reading the UTC date here yields 3; the session's own weekday is 2.
+    /// The fixture above cannot prove this: a bar stamped at the 16:00 Eastern close is 20:00 or
+    /// 21:00 the *same* UTC day, so both readings return that date. 01:00Z on 10 June is 21:00 on
+    /// 9 June in New York, where reading the UTC date yields 3 and the session's own weekday is 2.
     #[test]
     fn test_engineer_features_reads_the_eastern_date_where_the_two_disagree() {
         let late_evening = chrono::DateTime::parse_from_rfc3339("2026-06-10T01:00:00Z")

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -1,7 +1,6 @@
-//! Evaluation metrics for a trained TiDE model, computed on the validation set in scaled space.
-//!
-//! CRPS here sums pinball loss with a non-strict split where [`crate::models::tide::loss`]
-//! averages with a strict one — deliberately different, not a bug to reconcile.
+//! Evaluation metrics for a trained TiDE model, on the validation set in scaled space. CRPS here
+//! sums pinball loss with a non-strict split where [`crate::models::tide::loss`] averages with a
+//! strict one — deliberately different, not a bug to reconcile.
 
 use burn::backend::NdArray;
 
@@ -13,17 +12,23 @@ use crate::models::tide::TideError;
 
 const EVALUATION_BATCH_SIZE: usize = 4096;
 
+/// The trivial forecast every score here is read against: the scaler's own mean at every quantile.
+///
+/// Zero in scaled space, so it is the constant forecast that has learned the training distribution
+/// and nothing else. Named wherever the scores are reported, because a raw CRPS quotes no skill.
+pub const BASELINE_NAME: &str = "scaler_mean";
+
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 pub struct EvaluationMetrics {
     /// Serialized as `crps`, deliberately, even though the field is spelled out.
     ///
-    /// This value is written into each run's `run_metadata.json` in S3 and read back out of
-    /// *previous* runs' metadata by the trainer's drift check. Every artifact already published
-    /// spells the key `crps`, so renaming it would make the drift baseline read `None` for every
-    /// historical run — and with `DRIFT_MINIMUM_RUNS` at three, that suppresses drift reporting
-    /// entirely until three new runs accumulate, silently.
+    /// Every artifact already published spells the key that way and the trainer's drift check reads
+    /// it back out of them, so renaming it would make the baseline read `None` for every historical
+    /// run and suppress drift reporting rather than fail.
     #[serde(rename = "crps")]
     pub continuous_ranked_probability_score: f64,
+    /// Measured in scaled space, so it counts the target landing on the same side of the scaler's
+    /// mean as the median quantile — not the same side of zero return.
     pub directional_accuracy: f64,
     pub quantile_coverage: f64,
 }
@@ -35,6 +40,39 @@ impl EvaluationMetrics {
             directional_accuracy: 0.0,
             quantile_coverage: 0.0,
         }
+    }
+}
+
+/// What one model scored, beside what the same metrics say about a forecast that knows nothing.
+///
+/// `baseline.directional_accuracy` is the base rate — the share of targets at or above the scaler
+/// mean — which is exactly what a model whose median never turns negative scores, so the model's own
+/// figure means nothing read apart from it.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct EvaluationReport {
+    pub metrics: EvaluationMetrics,
+    pub baseline: EvaluationMetrics,
+    pub baseline_name: &'static str,
+    /// The span between the outermost quantiles, which is the coverage a calibrated model reaches.
+    /// `None` where the artifact emits no quantiles, because then there is no interval to calibrate.
+    pub nominal_coverage: Option<f64>,
+}
+
+impl EvaluationReport {
+    /// A report over a dataset that yielded no rows to score.
+    fn empty() -> Self {
+        Self {
+            metrics: EvaluationMetrics::zero(),
+            baseline: EvaluationMetrics::zero(),
+            baseline_name: BASELINE_NAME,
+            nominal_coverage: None,
+        }
+    }
+
+    /// How far the model beat [`BASELINE_NAME`]; CRPS is a loss, so positive is the model winning.
+    pub fn continuous_ranked_probability_score_skill(&self) -> f64 {
+        self.baseline.continuous_ranked_probability_score
+            - self.metrics.continuous_ranked_probability_score
     }
 }
 
@@ -61,10 +99,9 @@ impl QuantileIndices {
 
 /// Running totals behind the three metrics.
 ///
-/// This exists so the tests can reach the arithmetic without running the network. They used to
-/// assert against their own copy of the loop below, which meant a change to the pinball split, the
-/// median selection, or the coverage bounds left every one of them green — a suite that named the
-/// thing it could not detect a regression in. One implementation, two callers.
+/// Exists so the tests can reach the arithmetic without running the network: one implementation and
+/// two callers, so a change to the pinball split, the median selection, or the coverage bounds
+/// cannot leave a test green by asserting against its own copy of the loop.
 #[derive(Debug, Default, Clone, Copy)]
 struct MetricAccumulator {
     pinball_sum: f64,
@@ -87,6 +124,8 @@ impl MetricAccumulator {
             };
         }
 
+        // Scaled space: this asks whether the target sits above the scaler's mean, not above zero
+        // return, so it is only readable beside the same count for the constant-mean forecast.
         if (row[indices.median] >= 0.0) == (target >= 0.0) {
             self.directional_matches += 1;
         }
@@ -112,24 +151,27 @@ impl MetricAccumulator {
     }
 }
 
-/// Run the (inner, non-autodiff) model over the validation dataset and compute
-/// the metrics. Returns zeros for an empty or target-less dataset.
+/// Runs the (inner, non-autodiff) model over the validation dataset and scores it against
+/// [`BASELINE_NAME`] over the same rows.
+///
+/// Returns zeros for an empty or target-less dataset, which is why the trainer refuses an empty
+/// validation split before it gets here: zeroed metrics are the best score achievable.
 pub fn evaluate(
     model: &TiDEModel<NdArray>,
     dataset: &TrainingDataset,
     parameters: &ModelParameters,
-) -> Result<EvaluationMetrics, TideError> {
+) -> Result<EvaluationReport, TideError> {
     let sample_count = dataset.len();
     let targets = match dataset.targets() {
         Some(targets) if sample_count > 0 => targets,
-        _ => return Ok(EvaluationMetrics::zero()),
+        _ => return Ok(EvaluationReport::empty()),
     };
 
     let output_length = parameters.output_length();
     let quantiles = parameters.quantiles();
     let quantile_count = quantiles.len();
     if quantile_count == 0 {
-        return Ok(EvaluationMetrics::zero());
+        return Ok(EvaluationReport::empty());
     }
 
     crate::models::tide::batch::validate_input_shape(dataset, parameters)
@@ -175,6 +217,9 @@ pub fn evaluate(
     }
 
     let mut accumulator = MetricAccumulator::default();
+    let mut baseline_accumulator = MetricAccumulator::default();
+    // The trivial forecast, through the same arithmetic: every quantile at the scaler's own mean.
+    let baseline_row = vec![0.0; quantile_count];
     // Reused across rows: the model emits `f32` and the metrics are computed in `f64`, so each row
     // is widened once into this buffer rather than allocating one per horizon step.
     let mut row = Vec::with_capacity(quantile_count);
@@ -188,11 +233,18 @@ pub fn evaluate(
                     .iter()
                     .map(|&prediction| prediction as f64),
             );
-            accumulator.add_row(&row, targets[[sample, step, 0]] as f64, quantiles, indices);
+            let target = targets[[sample, step, 0]] as f64;
+            accumulator.add_row(&row, target, quantiles, indices);
+            baseline_accumulator.add_row(&baseline_row, target, quantiles, indices);
         }
     }
 
-    Ok(accumulator.finish())
+    Ok(EvaluationReport {
+        metrics: accumulator.finish(),
+        baseline: baseline_accumulator.finish(),
+        baseline_name: BASELINE_NAME,
+        nominal_coverage: Some(quantiles[indices.upper] - quantiles[indices.lower]),
+    })
 }
 
 fn argmin(values: &[f64]) -> usize {
@@ -234,11 +286,9 @@ mod tests {
     use crate::models::tide::data::TrainingDataset;
     use crate::models::tide::model::TiDEModel;
 
-    /// The serialized key is the contract with every artifact already in the bucket, and the Rust
-    /// field name no longer matches it. Nothing else would notice if the `serde(rename)` were
-    /// dropped: the trainer would keep writing metadata, the drift check would keep reading
-    /// `metrics.crps`, and it would find nothing there — reporting `InsufficientHistory` rather
-    /// than an error, which is indistinguishable from a genuinely young bucket.
+    /// The serialized key is the contract with every artifact already in the bucket, and nothing
+    /// else would notice the `serde(rename)` being dropped: the drift check would read
+    /// `metrics.crps`, find nothing, and report `InsufficientHistory` rather than an error.
     #[test]
     fn test_metrics_serialize_under_the_published_crps_key() {
         let metrics = EvaluationMetrics {
@@ -326,15 +376,10 @@ mod tests {
 
     /// Runs `predictions` and `targets` through `MetricAccumulator`, the same type `evaluate` uses.
     ///
-    /// This deliberately reimplements nothing: it lays out the fixture and hands each row to the
-    /// production accumulator. Every assertion below therefore fails if the pinball split, the
-    /// median selection, or the coverage bounds change in the shipped code.
-    ///
-    /// The two length assertions are the point of the helper as much as the accumulator call is.
-    /// Every metric here is a mean, so a fixture with more prediction rows than targets would zip
-    /// short, divide by a smaller row count, and produce a plausible number for a table nobody
-    /// wrote — the failure this whole change exists to remove, reintroduced in the fixture instead
-    /// of the code.
+    /// Reimplements nothing, so every assertion below fails if the pinball split, the median
+    /// selection, or the coverage bounds change. The two length assertions matter as much as the
+    /// accumulator call: every metric is a mean, and a fixture that zipped short would divide by a
+    /// smaller row count and produce a plausible number for a table nobody wrote.
     fn metrics_from(
         predictions: &[[f64; 3]],
         targets: &[f64],
@@ -361,9 +406,8 @@ mod tests {
     }
 
     /// The quantile list is whatever training wrote, so the three positions are found rather than
-    /// assumed. The old test helper hardcoded 0, 1, and 2, which is why it could not have caught
-    /// this: an artifact listing its quantiles in any other order would have had its coverage
-    /// measured between the wrong two bounds.
+    /// assumed: an artifact listing its quantiles in any other order would otherwise have its
+    /// coverage measured between the wrong two bounds.
     #[test]
     fn test_quantile_indices_are_located_not_assumed() {
         let indices = QuantileIndices::locate(&[0.9, 0.1, 0.5]);
@@ -500,6 +544,28 @@ mod tests {
         .unwrap()
     }
 
+    /// `make_tiny_dataset` with the targets set, because every metric here is a mean and a fixture
+    /// whose targets never vary makes each one structurally `count / rows` — true of any
+    /// implementation, so nothing asserted over it can fail. Inputs stay zero, so the forward pass
+    /// returns the same row for every sample and only the targets move.
+    fn dataset_with_targets(values: &[f32]) -> TrainingDataset {
+        let mut dataset = make_tiny_dataset(values.len(), true);
+        let mut targets = ndarray::Array3::<f32>::zeros((values.len(), 1, 1));
+        for (sample, value) in values.iter().enumerate() {
+            targets[[sample, 0, 0]] = *value;
+        }
+        dataset = TrainingDataset::new(
+            dataset.past_continuous().clone(),
+            dataset.past_categorical().clone(),
+            dataset.future_categorical().clone(),
+            dataset.static_categorical().clone(),
+            Some(targets),
+            dataset.forecast_sessions().to_vec(),
+        )
+        .unwrap();
+        dataset
+    }
+
     /// Build a TiDEModel that matches `make_tiny_dataset`: input_size=32,
     /// output_length=1, quantile_count=3.
     fn make_tiny_model() -> TiDEModel<NdArray> {
@@ -518,10 +584,14 @@ mod tests {
         let model = make_tiny_model();
         let dataset = make_tiny_dataset(0, true);
         let parameters = make_tiny_parameters();
-        let metrics = evaluate(&model, &dataset, &parameters).unwrap();
-        assert_eq!(metrics.continuous_ranked_probability_score, 0.0);
-        assert_eq!(metrics.directional_accuracy, 0.0);
-        assert_eq!(metrics.quantile_coverage, 0.0);
+        let report = evaluate(&model, &dataset, &parameters).unwrap();
+        assert_eq!(report.metrics.continuous_ranked_probability_score, 0.0);
+        assert_eq!(report.metrics.directional_accuracy, 0.0);
+        assert_eq!(report.metrics.quantile_coverage, 0.0);
+        assert_eq!(
+            report.nominal_coverage, None,
+            "no rows scored means no interval was calibrated, which is not a coverage of zero"
+        );
     }
 
     #[test]
@@ -530,10 +600,10 @@ mod tests {
         let model = make_tiny_model();
         let dataset = make_tiny_dataset(4, false);
         let parameters = make_tiny_parameters();
-        let metrics = evaluate(&model, &dataset, &parameters).unwrap();
-        assert_eq!(metrics.continuous_ranked_probability_score, 0.0);
-        assert_eq!(metrics.directional_accuracy, 0.0);
-        assert_eq!(metrics.quantile_coverage, 0.0);
+        let report = evaluate(&model, &dataset, &parameters).unwrap();
+        assert_eq!(report.metrics.continuous_ranked_probability_score, 0.0);
+        assert_eq!(report.metrics.directional_accuracy, 0.0);
+        assert_eq!(report.metrics.quantile_coverage, 0.0);
     }
 
     #[test]
@@ -543,37 +613,134 @@ mod tests {
         let dataset = make_tiny_dataset(4, true);
         // Use a model whose quantile list is empty.
         let parameters = ModelParameters::for_tests(32, 8, 1, 1, 1, 2, 0.0, vec![], 0.5);
-        let metrics = evaluate(&model, &dataset, &parameters).unwrap();
-        assert_eq!(metrics.continuous_ranked_probability_score, 0.0);
-        assert_eq!(metrics.directional_accuracy, 0.0);
-        assert_eq!(metrics.quantile_coverage, 0.0);
+        let report = evaluate(&model, &dataset, &parameters).unwrap();
+        assert_eq!(report.metrics.continuous_ranked_probability_score, 0.0);
+        assert_eq!(report.metrics.directional_accuracy, 0.0);
+        assert_eq!(report.metrics.quantile_coverage, 0.0);
     }
 
+    /// The trivial forecast is the constant zero, so its CRPS is `1.5 * mean|target|` — 1.5 being
+    /// 0.1 + 0.5 + 0.9 — which is zero exactly where the forecast is right and rises with the error.
+    ///
+    /// Every number below is a literal worked from that identity rather than from the quantile list
+    /// the code reads, and each one moves with the fixture, which the all-zeros dataset this replaced
+    /// could not: over constant targets every metric is `count / rows` for any implementation at all.
     #[test]
-    fn test_evaluate_with_samples_returns_valid_metrics() {
-        // Run the full inference path: sample_count > 0, targets present, quantiles non-empty.
-        // The model is randomly initialized so we only assert the metric ranges, not values.
+    fn test_the_reported_baseline_is_zero_when_right_and_monotone_in_its_error() {
         let model = make_tiny_model();
-        let dataset = make_tiny_dataset(3, true);
         let parameters = make_tiny_parameters();
-        let metrics = evaluate(&model, &dataset, &parameters).unwrap();
-        // continuous_ranked_probability_score is a sum of non-negative pinball losses so it must be >= 0.
-        assert!(
-            metrics.continuous_ranked_probability_score >= 0.0,
-            "crps={}",
-            metrics.continuous_ranked_probability_score
+
+        let exact = evaluate(&model, &dataset_with_targets(&[0.0, 0.0, 0.0]), &parameters).unwrap();
+        assert_eq!(
+            exact.baseline.continuous_ranked_probability_score, 0.0,
+            "a forecast that is the outcome must cost nothing"
         );
-        // directional_accuracy is a fraction in [0,1].
+
+        let near = evaluate(
+            &model,
+            &dataset_with_targets(&[0.0, 1.0, -1.0]),
+            &parameters,
+        )
+        .unwrap();
+        let far = evaluate(
+            &model,
+            &dataset_with_targets(&[0.0, 2.0, -2.0]),
+            &parameters,
+        )
+        .unwrap();
         assert!(
-            (0.0..=1.0).contains(&metrics.directional_accuracy),
-            "directional_accuracy={}",
-            metrics.directional_accuracy
+            (near.baseline.continuous_ranked_probability_score - 1.0).abs() < 1e-9,
+            "1.5 * (0 + 1 + 1) / 3, got {}",
+            near.baseline.continuous_ranked_probability_score
         );
-        // quantile_coverage is a fraction in [0,1].
         assert!(
-            (0.0..=1.0).contains(&metrics.quantile_coverage),
-            "quantile_coverage={}",
-            metrics.quantile_coverage
+            (far.baseline.continuous_ranked_probability_score - 2.0).abs() < 1e-9,
+            "1.5 * (0 + 2 + 2) / 3, got {}",
+            far.baseline.continuous_ranked_probability_score
+        );
+
+        assert_eq!(near.baseline_name, "scaler_mean");
+        assert!(
+            (near.nominal_coverage.unwrap() - 0.8).abs() < 1e-9,
+            "the outermost quantiles span 0.9 - 0.1, got {:?}",
+            near.nominal_coverage
+        );
+    }
+
+    /// The base rate is what a median that never turns negative scores, so directional accuracy
+    /// cannot be read without it — and it is a fact about the targets, not about the model.
+    #[test]
+    fn test_the_base_rate_is_reported_beside_directional_accuracy() {
+        let model = make_tiny_model();
+        let parameters = make_tiny_parameters();
+
+        let report = evaluate(
+            &model,
+            &dataset_with_targets(&[0.0, 1.0, -1.0]),
+            &parameters,
+        )
+        .unwrap();
+        assert!(
+            (report.baseline.directional_accuracy - 2.0 / 3.0).abs() < 1e-9,
+            "two of the three targets sit at or above the scaler mean, got {}",
+            report.baseline.directional_accuracy
+        );
+
+        let every_target_below = evaluate(
+            &model,
+            &dataset_with_targets(&[-1.0, -2.0, -3.0]),
+            &parameters,
+        )
+        .unwrap();
+        assert_eq!(
+            every_target_below.baseline.directional_accuracy, 0.0,
+            "no target above the mean is a base rate of zero, whatever the model scored"
+        );
+        // Pins the figure to the constant forecast rather than to whatever the network emitted: the
+        // model's own accuracy over these targets is 0.0 too whenever its median happens to be
+        // non-negative, and only the loss separates the two.
+        assert!(
+            (every_target_below
+                .baseline
+                .continuous_ranked_probability_score
+                - 3.0)
+                .abs()
+                < 1e-9,
+            "1.5 * (1 + 2 + 3) / 3, got {}",
+            every_target_below
+                .baseline
+                .continuous_ranked_probability_score
+        );
+    }
+
+    /// The same inputs give the same forward pass, so moving the targets away from it is the only
+    /// thing that can change the model's own CRPS — and it must cost more, not less.
+    #[test]
+    fn test_the_model_score_rises_as_the_targets_move_away_from_it() {
+        let model = make_tiny_model();
+        let parameters = make_tiny_parameters();
+
+        let near = evaluate(&model, &dataset_with_targets(&[0.0, 0.0, 0.0]), &parameters).unwrap();
+        let far = evaluate(
+            &model,
+            &dataset_with_targets(&[100.0, 100.0, 100.0]),
+            &parameters,
+        )
+        .unwrap();
+
+        assert!(
+            far.metrics.continuous_ranked_probability_score
+                > near.metrics.continuous_ranked_probability_score,
+            "{} against {}",
+            far.metrics.continuous_ranked_probability_score,
+            near.metrics.continuous_ranked_probability_score
+        );
+        // Targets all zero, so the trivial forecast is exactly right and nothing can beat it: a
+        // skill reported above zero there would mean the difference is signed the wrong way round.
+        assert!(
+            near.continuous_ranked_probability_score_skill() <= 0.0,
+            "skill against a baseline that scored 0.0 was {}",
+            near.continuous_ranked_probability_score_skill()
         );
     }
 

--- a/src/models/tide/fit.rs
+++ b/src/models/tide/fit.rs
@@ -1,5 +1,4 @@
-//! Fit the scaler and categorical mappings from training data, and serialize the artifact JSON
-//! files the inference path loads.
+//! Fits the scaler and categorical mappings, and writes the artifact JSON the inference path loads.
 //!
 //! Categoricals encode over sorted-unique values, so the mapping is deterministic across runs.
 
@@ -9,6 +8,7 @@ use std::path::Path;
 use polars::prelude::*;
 
 use crate::common::types::LiquidityFloor;
+use crate::data::universe::filter_liquid_bars;
 use crate::models::tide::configuration::ModelParameters;
 use crate::models::tide::data::{
     apply_scaling, clean_data, demean_target, encode_categoricals, engineer_features,
@@ -27,22 +27,10 @@ pub struct FitResult {
 
 /// Fit preprocessing on a raw consolidated frame (bars joined with categories).
 ///
-/// The scaler is fitted on the rows at or before `training_fraction`'s cutoff and then applied to
-/// the whole frame, so the validation rows are standardized by statistics that never saw them.
-/// Fitting over every row instead put the validation period's own volatility in the divisor of the
-/// `daily_return` target — and [`crate::models::tide::evaluate`] scores in scaled units, so the
-/// reported CRPS was denominated in a scale the held-out data had helped set.
-///
-/// The **mappings are fitted over the whole frame**, and that asymmetry is deliberate. A mapping is
-/// a vocabulary, not a statistic: it carries which symbols, sectors, and industries exist, and
-/// nothing about their returns. Restricting it to the training rows would instead be actively
-/// harmful, because [`encode_categoricals`] drops rows whose static value it cannot map — every
-/// instrument first listed (or first clearing the liquidity floors) after the cutoff would vanish
-/// from the validation split, and, since these mappings ship in the artifact as the inference
-/// vocabulary, could not be predicted at all until it had traded the full pre-cutoff window.
-///
-/// `target` selects what the model learns to predict. Demeaning happens after cleaning and before
-/// the scaler is fitted, so the statistics describe the label the model is actually given.
+/// The scaler is fitted only on the rows at or before `training_fraction`'s cutoff, after any
+/// demeaning of `target`, so validation rows are standardized by statistics that never saw them.
+/// The categorical mappings are fitted over the whole frame instead, because they are a vocabulary
+/// rather than a statistic and [`encode_categoricals`] drops rows whose static value it cannot map.
 pub fn fit(
     raw: DataFrame,
     training_fraction: TrainingFraction,
@@ -136,48 +124,35 @@ fn build_mapping(data: &DataFrame, column: &str) -> Result<CategoryMapping, Tide
         .collect())
 }
 
-/// Row-level training filter: thresholds are inclusive, and tickers containing lowercase letters
-/// are dropped — they are distinct instruments that would collide with the uppercase ticker after
+/// The training filter: the shared liquidity screen, plus a drop of tickers containing lowercase
+/// letters — they are distinct instruments that would collide with the uppercase ticker after
 /// cleaning.
+///
+/// Liquidity is delegated to [`filter_liquid_bars`] rather than tested per row, so the population
+/// the model is fitted on is the population the universe trades: a per-session test admits a
+/// name's good days and refuses its quiet ones, which is not a set the screen can ever produce.
 pub fn filter_training_bars(
     data: DataFrame,
     floor: LiquidityFloor,
 ) -> Result<DataFrame, TideError> {
-    let close_prices = data.column("close_price")?.cast(&DataType::Float64)?;
-    let close_prices = close_prices.f64()?;
-    let volumes = data.column("volume")?.cast(&DataType::Float64)?;
-    let volumes = volumes.f64()?;
     let tickers = data.column("ticker")?.str()?;
-
-    let mask: BooleanChunked = close_prices
+    let mask: BooleanChunked = tickers
         .into_iter()
-        .zip(volumes)
-        .zip(tickers)
-        .map(|((close_price, volume), ticker)| {
-            close_price
-                .zip(volume)
-                .is_some_and(|(price, shares)| floor.admits(price, price * shares))
-                && ticker
-                    .is_some_and(|value| !value.chars().any(|character| character.is_lowercase()))
+        .map(|ticker| {
+            ticker.is_some_and(|value| !value.chars().any(|character| character.is_lowercase()))
         })
         .collect();
 
-    let filtered = data.filter(&mask)?;
-    Ok(filtered)
+    Ok(filter_liquid_bars(data.filter(&mask)?, floor)?)
 }
 
-/// Write the three artifact JSON files (scaler, mappings, parameters) the
-/// inference loader reads, into `directory`.
+/// Write the three artifact JSON files (scaler, mappings, parameters) the inference loader reads,
+/// into `directory`.
 ///
-/// Each file is serialized to a temporary name and renamed into place, and every rename happens
-/// after every serialization. A reader therefore never sees a half-written file, and the window in
-/// which the three could disagree shrinks from "between two writes" — which spans serializing a
-/// scaler over every continuous column — to three consecutive renames.
-///
-/// This is a narrowed window rather than an atomic set, and the distinction is worth stating: POSIX
-/// gives atomicity per rename, not across three. Closing it completely would mean staging a
-/// directory and renaming that. The mixed-artifact failure this guards against is a crash *during*
-/// the writes, which is where essentially all of the wall clock is.
+/// Each file is serialized to a temporary name and every rename happens after every serialization,
+/// so a reader never sees a half-written file and the window in which the three could disagree is
+/// three consecutive renames. That is a narrowed window rather than an atomic set: POSIX gives
+/// atomicity per rename, not across three.
 pub fn write_artifact_json(
     directory: &Path,
     scaler: &Scaler,
@@ -336,8 +311,8 @@ mod tests {
         }
     }
 
-    /// The leak this module was changed to close: the scaler used to be fitted over every cleaned
-    /// row, so the held-out period set the scale its own predictions were later measured on.
+    /// The leak this closes: a scaler fitted over every cleaned row lets the held-out period set the
+    /// scale its own predictions are later measured on.
     #[test]
     fn test_the_scaler_is_fitted_only_on_rows_at_or_before_the_training_cutoff() {
         let result = fit(scale_shifted_frame(), training_fraction(), Target::Raw).unwrap();
@@ -436,20 +411,24 @@ mod tests {
         );
     }
 
+    /// The screen keeps or drops a ticker whole, on the window's minimum close and average
+    /// notional — the same summary the universe query reads. A per-row test would admit a name's
+    /// good sessions and refuse its quiet ones, which is not a population the screen can produce.
     #[test]
-    fn test_filter_training_bars_is_row_level_and_inclusive() {
-        // The filter is per row, so a ticker with one qualifying row and one penny row keeps
-        // only the qualifying row. Rows exactly at the threshold are kept.
+    fn test_filter_training_bars_screens_a_ticker_whole() {
         let data = DataFrame::new(vec![
-            Column::new("ticker".into(), vec!["AAA", "AAA", "BBB"]),
-            Column::new("timestamp".into(), vec![0_i64, 86_400_000, 0]),
-            Column::new("close_price".into(), vec![0.5_f64, 1.0, 250.0]),
-            Column::new("volume".into(), vec![100_000.0_f64, 100_000.0, 200.0]),
+            Column::new("ticker".into(), vec!["DIPS", "DIPS", "KEEP", "KEEP"]),
+            Column::new("timestamp".into(), vec![0_i64, 86_400_000, 0, 86_400_000]),
+            Column::new("close_price".into(), vec![0.5_f64, 250.0, 1.0, 250.0]),
+            Column::new(
+                "volume".into(),
+                vec![100_000.0_f64, 100_000.0, 100_000.0, 100_000.0],
+            ),
         ])
         .unwrap();
 
         let filtered = filter_training_bars(data, floor(1.0, 100_000.0)).unwrap();
-        assert_eq!(filtered.height(), 1);
+
         let tickers: Vec<&str> = filtered
             .column("ticker")
             .unwrap()
@@ -457,15 +436,9 @@ mod tests {
             .unwrap()
             .into_no_null_iter()
             .collect();
-        assert_eq!(tickers, vec!["AAA"]);
-        let close: Vec<f64> = filtered
-            .column("close_price")
-            .unwrap()
-            .f64()
-            .unwrap()
-            .into_no_null_iter()
-            .collect();
-        assert_eq!(close, vec![1.0]);
+        // DIPS dipped to 0.50 once, so the minimum refuses it and both its rows go. KEEP sits
+        // exactly on the price bound and both its rows stay, threshold row included.
+        assert_eq!(tickers, vec!["KEEP", "KEEP"]);
     }
 
     /// The second threshold is notional, not share count. HIGH trades 200 shares at $250 and is

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -200,8 +200,17 @@ pub fn filter_equity_bars(
     let Some(newest_timestamp) = newest_timestamp else {
         return Ok(data);
     };
-    let window_start =
-        newest_timestamp - universe::LIQUIDITY_LOOKBACK_DAYS * 24 * 60 * 60 * 1_000 + 1;
+    // Eastern calendar days rather than a multiple of 24 hours, and inclusive at the lower edge,
+    // because that is what `universe::load_liquidity` asks Postgres for.
+    let newest_instant = DateTime::from_timestamp_millis(newest_timestamp).ok_or_else(|| {
+        PredictionError::DataConsolidation(format!(
+            "bar timestamp {newest_timestamp} is not an instant"
+        ))
+    })?;
+    let window_start = SessionDate::at(newest_instant)
+        .plus_calendar_days(-universe::LIQUIDITY_LOOKBACK_DAYS)
+        .midnight()
+        .timestamp_millis();
 
     let window = data
         .clone()
@@ -764,6 +773,76 @@ mod tests {
         let result = filter_equity_bars(data, floor(10.0, 50_000_000.0)).unwrap();
 
         assert_eq!(result.height(), 0);
+    }
+
+    /// The window's own lower edge is inside it, matching `load_liquidity`'s `timestamp >= $2`.
+    ///
+    /// An exclusive bound here and an inclusive one in SQL disagree on exactly one session, which is
+    /// the session most likely to decide a marginal name.
+    #[test]
+    fn test_a_bar_exactly_on_the_window_edge_is_inside_it() {
+        let newest = SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 6, 30).unwrap());
+        let edge = newest
+            .plus_calendar_days(-universe::LIQUIDITY_LOOKBACK_DAYS)
+            .midnight()
+            .timestamp_millis();
+        let data = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["EDGE", "EDGE"]),
+            // The older bar sits on the edge and carries all the notional; drop it and the name
+            // averages below the floor.
+            Column::new(
+                "timestamp".into(),
+                vec![edge, newest.midnight().timestamp_millis()],
+            ),
+            Column::new("close_price".into(), vec![50.0, 50.0]),
+            Column::new("volume".into(), vec![4_000_000i64, 0]),
+        ])
+        .unwrap();
+
+        let result = filter_equity_bars(data, floor(10.0, 50_000_000.0)).unwrap();
+
+        assert_eq!(result.height(), 2);
+    }
+
+    /// The window is 30 Eastern calendar days, not 30 multiples of 24 hours.
+    ///
+    /// A window ending after the March transition opens an hour later in UTC than a fixed offset
+    /// does, so a fixed offset reaches back into a session the universe has already stopped counting
+    /// and can admit a name on liquidity that is outside the window.
+    #[test]
+    fn test_the_window_counts_calendar_days_across_a_daylight_saving_transition() {
+        // 2026-03-08 is the spring transition; a window ending 2026-03-20 spans it.
+        let newest = SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 3, 20).unwrap());
+        let oldest = newest.plus_calendar_days(-universe::LIQUIDITY_LOOKBACK_DAYS);
+        let fixed_offset_start =
+            newest.midnight().timestamp_millis() - universe::LIQUIDITY_LOOKBACK_DAYS * 86_400_000;
+
+        assert_eq!(
+            oldest.midnight().timestamp_millis() - fixed_offset_start,
+            3_600_000,
+            "the calendar bound must open an hour after the fixed-offset one across the transition"
+        );
+
+        // All of the name's notional sits in that one disputed hour, so whether it clears the floor
+        // is exactly the question of which bound is used.
+        let data = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["SPRUNG", "SPRUNG"]),
+            Column::new(
+                "timestamp".into(),
+                vec![fixed_offset_start, newest.midnight().timestamp_millis()],
+            ),
+            Column::new("close_price".into(), vec![50.0, 50.0]),
+            Column::new("volume".into(), vec![4_000_000i64, 0]),
+        ])
+        .unwrap();
+
+        let result = filter_equity_bars(data, floor(10.0, 50_000_000.0)).unwrap();
+
+        assert_eq!(
+            result.height(),
+            0,
+            "a bar an hour outside the calendar window must not admit the name"
+        );
     }
 
     #[test]

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -1,10 +1,6 @@
 //! Running the TiDE model: from stored market history to rows in `equity_predictions`.
-//!
-//! The [`crate::common::types::LiquidityFloor`] is passed in and the artifact does not record the
-//! one it was fitted against, so an artifact older than the current floor is served under a screen
-//! it never saw. [`filter_to_trained_tickers`] is what bounds that: it intersects against the
-//! artifact's own vocabulary, so a stale floor narrows the served set rather than handing the
-//! scaler a name it never trained on.
+//! The artifact does not record the [`crate::common::types::LiquidityFloor`] it was fitted against,
+//! so [`filter_to_trained_tickers`] intersects the served set against its own vocabulary instead.
 
 use burn::backend::NdArray;
 use chrono::{DateTime, Utc};
@@ -14,9 +10,10 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::common::types::{EquityPrediction, LiquidityFloor, SessionDate, Ticker};
+use crate::data::universe;
 
 use crate::models::tide::artifact::ModelState;
-use crate::models::tide::data::{Data, DatasetKind};
+use crate::models::tide::data::{Data, DatasetKind, TARGET_COLUMN};
 
 #[derive(Debug, thiserror::Error)]
 pub enum PredictionError {
@@ -112,12 +109,9 @@ pub fn consolidate_data(
 /// Collapses repeated `(ticker, timestamp)` bars, keeping the highest-volume row of each pair.
 ///
 /// A provider that serves two instruments under one symbol yields two bars for one session, and
-/// keeping whichever arrived last picked the wrong series for BCPC and OP on every day of a
-/// two-year archive. Volume separates them where price cannot: the two TPC series opened fifty
-/// cents apart, while their volumes differed five-fold.
-///
-/// Every collapse is logged, because a silent tie-break is how the wrong instrument trained for two
-/// years without anything recording that a choice had been made.
+/// volume separates them where price cannot: the two TPC series opened fifty cents apart while their
+/// volumes differed five-fold. Every collapse is logged, because a silent tie-break leaves nothing
+/// recording that a choice between two instruments was made at all.
 fn resolve_duplicate_bars(bars: DataFrame) -> Result<DataFrame, PredictionError> {
     let before = bars.height();
 
@@ -183,48 +177,53 @@ fn duplicated_tickers(bars: &DataFrame) -> Result<Vec<String>, PredictionError> 
     Ok(names)
 }
 
-/// Drops tickers whose trailing averages fall below `floor`.
+/// Drops tickers that do not clear `floor` over the same window the traded universe screens.
 ///
-/// Screens the *average* close where [`crate::data::universe::LiquidityRow`] screens the window's
-/// minimum, which is the stricter test, so every name the universe admits still reaches this one.
-/// Both bounds are inclusive, as in [`LiquidityFloor::admits`] — polars needs the thresholds as
-/// expressions, so this is one of the two screens that cannot call it and has a boundary test
-/// instead.
+/// The frame carries a longer history than the screen reads, because the features need it and the
+/// universe does not: the statistics are taken over the trailing
+/// [`universe::LIQUIDITY_LOOKBACK_DAYS`], so the predicted set is the traded set rather than a
+/// superset of it. Screening the whole frame would let a name that has since dried up keep a
+/// prediction on the strength of history the universe has already stopped counting.
 pub fn filter_equity_bars(
     data: DataFrame,
     floor: LiquidityFloor,
 ) -> Result<DataFrame, PredictionError> {
     let before_count = data.height();
+    let consolidation = |error: PolarsError| PredictionError::DataConsolidation(error.to_string());
 
-    let valid_tickers = data
+    let newest_timestamp = data
+        .column("timestamp")
+        .map_err(consolidation)?
+        .i64()
+        .map_err(consolidation)?
+        .max();
+    let Some(newest_timestamp) = newest_timestamp else {
+        return Ok(data);
+    };
+    let window_start =
+        newest_timestamp - universe::LIQUIDITY_LOOKBACK_DAYS * 24 * 60 * 60 * 1_000 + 1;
+
+    let window = data
         .clone()
         .lazy()
-        .group_by([col("ticker")])
-        .agg([
-            col("close_price").mean().alias("average_close_price"),
-            (col("close_price") * col("volume").cast(DataType::Float64))
-                .mean()
-                .alias("average_dollar_volume"),
-        ])
-        .filter(
-            col("average_close_price")
-                .gt_eq(lit(floor.minimum_close_price()))
-                .and(col("average_dollar_volume").gt_eq(lit(floor.minimum_dollar_volume()))),
-        )
-        .select([col("ticker")])
+        .filter(col("timestamp").gt_eq(lit(window_start)))
         .collect()
-        .map_err(|error| PredictionError::DataConsolidation(error.to_string()))?;
+        .map_err(consolidation)?;
+    let liquid = universe::filter_liquid_bars(window, floor).map_err(consolidation)?;
 
     let filtered = data
         .lazy()
         .join(
-            valid_tickers.lazy(),
+            liquid
+                .lazy()
+                .select([col("ticker")])
+                .unique(None, UniqueKeepStrategy::Any),
             [col("ticker")],
             [col("ticker")],
             JoinArgs::new(JoinType::Semi),
         )
         .collect()
-        .map_err(|error| PredictionError::DataConsolidation(error.to_string()))?;
+        .map_err(consolidation)?;
 
     info!(
         before = before_count,
@@ -280,19 +279,21 @@ pub fn filter_to_trained_tickers(
     Ok(filtered)
 }
 
-/// Inverse-scale the predicted `daily_return` quantiles and sort them monotonic.
+/// Inverse-scale the predicted target quantiles and sort them monotonic.
 ///
+/// Named through [`TARGET_COLUMN`] rather than spelled out, so a rename reaches the scaler lookup
+/// too — a literal that drifted from the constant would leave every served prediction unscaled.
 /// Quantile crossing is routine in quantile regression; sorting is the standard remedy.
 pub(crate) fn unscale_and_sort_quantiles(
     scaled_quantiles: &[f64],
     scaler: &crate::models::tide::data::Scaler,
-) -> Vec<f64> {
+) -> Result<Vec<f64>, crate::models::tide::TideError> {
     let mut unscaled: Vec<f64> = scaled_quantiles
         .iter()
-        .map(|value| scaler.inverse_transform_value("daily_return", *value))
-        .collect();
+        .map(|value| scaler.inverse_transform_value(TARGET_COLUMN, *value))
+        .collect::<Result<_, _>>()?;
     unscaled.sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
-    unscaled
+    Ok(unscaled)
 }
 
 /// Timestamp for horizon step `step`, where step 0 is the Eastern session `now` falls in.
@@ -396,9 +397,8 @@ pub fn generate_predictions(
     let mut results = Vec::with_capacity(sample_count);
     for sample_index in 0..sample_count {
         let ticker_id = dataset.static_categorical()[[sample_index, 0, 0]];
-        // Reported rather than defaulted. This used to fall back to the literal string "UNKNOWN",
-        // which is a valid ticker format -- so an unmappable id was stored as a prediction for a
-        // symbol called UNKNOWN rather than failing.
+        // Reported rather than defaulted: any placeholder string here is a valid ticker format, so
+        // an unmappable id would be stored as a prediction for a symbol of that name.
         let raw_ticker = reverse_ticker_map.get(&ticker_id).ok_or_else(|| {
             PredictionError::Postprocessing(format!(
                 "sample {sample_index} carries encoded ticker {ticker_id}, which the artifact's \
@@ -421,7 +421,8 @@ pub fn generate_predictions(
             let scaled: Vec<f64> = (0..quantile_count)
                 .map(|quantile| predictions_data[base_index + quantile] as f64)
                 .collect();
-            let quantiles = unscale_and_sort_quantiles(&scaled, model_state.scaler());
+            let quantiles = unscale_and_sort_quantiles(&scaled, model_state.scaler())
+                .map_err(|error| PredictionError::Postprocessing(error.to_string()))?;
 
             results.push(
                 EquityPrediction::new(
@@ -531,13 +532,10 @@ pub async fn insert_predictions(
 
 /// Loads the most recent prediction per ticker within a half-open instant range.
 ///
-/// The range is the current session's Eastern day, so a pass on a morning when the pre-open
-/// inference failed reads nothing rather than reading yesterday's prediction as though it were
-/// today's. A stale artifact is acceptable and logged; a stale *prediction* silently presented as
-/// current is not, because nothing downstream carries the timestamp far enough to notice.
-///
-/// `DISTINCT ON` rather than a group-by join: the table's primary key is `(ticker, timestamp)`, so
-/// the newest row per ticker is a single ordered scan of the day's chunk.
+/// The range is the current session's Eastern day, so a morning when the pre-open inference failed
+/// reads nothing rather than yesterday's prediction presented as today's — nothing downstream carries
+/// the timestamp far enough to notice. `DISTINCT ON` rather than a group-by join, because the primary
+/// key is `(ticker, timestamp)` and the newest row per ticker is one ordered scan of the day's chunk.
 pub async fn load_predictions_between(
     pool: &PgPool,
     start: chrono::DateTime<chrono::Utc>,
@@ -615,7 +613,7 @@ mod tests {
             .expect("test floor must be valid")
     }
 
-    /// A scaler over `daily_return` alone, which is all `unscale_and_sort_quantiles` reads.
+    /// A scaler over the target column alone, which is all `unscale_and_sort_quantiles` reads.
     ///
     /// Built through the validated constructor, so a future tightening of the `Scaler` contract
     /// fails here once rather than in five separate fixtures.
@@ -624,8 +622,8 @@ mod tests {
         standard_deviation: f64,
     ) -> crate::models::tide::data::Scaler {
         crate::models::tide::data::Scaler::new(
-            std::collections::HashMap::from([("daily_return".to_string(), mean)]),
-            std::collections::HashMap::from([("daily_return".to_string(), standard_deviation)]),
+            std::collections::HashMap::from([(TARGET_COLUMN.to_string(), mean)]),
+            std::collections::HashMap::from([(TARGET_COLUMN.to_string(), standard_deviation)]),
         )
         .expect("test scaler statistics must be usable")
     }
@@ -708,13 +706,13 @@ mod tests {
     /// exactly $10.00 was admitted to the universe, trained on, and dropped at inference.
     #[test]
     fn test_filter_equity_bars_keeps_a_ticker_exactly_at_both_thresholds() {
-        // Two bars either side of each threshold, so the averages land on it exactly rather than
-        // near it: (8 + 12)/2 = 10.00 and ($40M + $60M)/2 = $50,000,000.
+        // The lowest close sits on the price bound and the mean notional on the notional bound:
+        // min(10, 12) = 10.00, and ($40M + $60M)/2 = $50,000,000.
         let data = DataFrame::new(vec![
             Column::new("ticker".into(), vec!["EDGE", "EDGE"]),
             Column::new("timestamp".into(), vec![1000i64, 2000]),
-            Column::new("close_price".into(), vec![8.0, 12.0]),
-            Column::new("volume".into(), vec![5_000_000i64, 5_000_000]),
+            Column::new("close_price".into(), vec![10.0, 12.0]),
+            Column::new("volume".into(), vec![4_000_000i64, 5_000_000]),
         ])
         .unwrap();
 
@@ -725,6 +723,47 @@ mod tests {
             2,
             "a ticker sitting exactly on both thresholds must survive inference filtering"
         );
+    }
+
+    /// The screened quantity is the window's *minimum* close, which is what the traded universe
+    /// reads. An average admits a name that spent half the window untradeable.
+    #[test]
+    fn test_a_name_whose_close_only_averages_above_the_floor_is_refused() {
+        let data = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["DIPPER", "DIPPER"]),
+            Column::new("timestamp".into(), vec![1000i64, 2000]),
+            // Mean 10.00, minimum 4.00.
+            Column::new("close_price".into(), vec![4.0, 16.0]),
+            Column::new("volume".into(), vec![20_000_000i64, 20_000_000]),
+        ])
+        .unwrap();
+
+        let result = filter_equity_bars(data, floor(10.0, 50_000_000.0)).unwrap();
+
+        assert_eq!(result.height(), 0);
+    }
+
+    /// The window is the traded universe's, not the whole frame the features need, so liquidity
+    /// that predates the window cannot keep a name that has since dried up.
+    #[test]
+    fn test_liquidity_older_than_the_window_does_not_admit_a_name() {
+        let day = 24 * 60 * 60 * 1_000i64;
+        let newest = 1_000 * day;
+        let data = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["FADED", "FADED"]),
+            Column::new(
+                "timestamp".into(),
+                // One bar inside the 30-day window, one 60 days before it.
+                vec![newest - 60 * day, newest],
+            ),
+            Column::new("close_price".into(), vec![50.0, 50.0]),
+            Column::new("volume".into(), vec![10_000_000i64, 100]),
+        ])
+        .unwrap();
+
+        let result = filter_equity_bars(data, floor(10.0, 50_000_000.0)).unwrap();
+
+        assert_eq!(result.height(), 0);
     }
 
     #[test]
@@ -807,7 +846,7 @@ mod tests {
         let scaler = daily_return_scaler(0.0, 1.0);
 
         // Crossed raw quantiles (q10 > q50) must come back monotonic.
-        let sorted = unscale_and_sort_quantiles(&[0.05, 0.02, 0.03], &scaler);
+        let sorted = unscale_and_sort_quantiles(&[0.05, 0.02, 0.03], &scaler).unwrap();
         assert_eq!(sorted, vec![0.02, 0.03, 0.05]);
     }
 
@@ -815,8 +854,8 @@ mod tests {
     fn test_predictions_are_visible_to_the_same_session_evaluation() {
         // The 09:00 Eastern run exists to feed the same session's evaluation passes, which select
         // rows with `eastern_day_bounds`. A stamp built at UTC midnight falls in the *previous*
-        // Eastern day's window -- 20:00 the day before, under EDT -- so the prediction written this
-        // morning is never the one read this afternoon.
+        // Eastern day's window -- 20:00 or 19:00 the day before in New York -- so the prediction
+        // written this morning is never the one read this afternoon.
         use crate::common::types::SessionDate;
 
         for day in [
@@ -1084,7 +1123,7 @@ mod tests {
         let scaler = daily_return_scaler(0.0, 1.0);
 
         // Already-sorted quantiles must come back unchanged.
-        let result = unscale_and_sort_quantiles(&[0.01, 0.02, 0.03], &scaler);
+        let result = unscale_and_sort_quantiles(&[0.01, 0.02, 0.03], &scaler).unwrap();
         assert_eq!(result, vec![0.01, 0.02, 0.03]);
     }
 
@@ -1093,7 +1132,7 @@ mod tests {
         // inverse_transform = value * std + mean
         let scaler = daily_return_scaler(0.005, 0.01);
 
-        let result = unscale_and_sort_quantiles(&[-1.0, 0.0, 1.0], &scaler);
+        let result = unscale_and_sort_quantiles(&[-1.0, 0.0, 1.0], &scaler).unwrap();
         // -1.0 * 0.01 + 0.005 = -0.005, 0.0 * 0.01 + 0.005 = 0.005, 1.0 * 0.01 + 0.005 = 0.015
         assert!((result[0] - (-0.005)).abs() < 1e-12);
         assert!((result[1] - 0.005).abs() < 1e-12);
@@ -1284,7 +1323,7 @@ mod tests {
     fn test_unscale_and_sort_quantiles_single_element() {
         let scaler = daily_return_scaler(0.0, 1.0);
 
-        let result = unscale_and_sort_quantiles(&[0.05], &scaler);
+        let result = unscale_and_sort_quantiles(&[0.05], &scaler).unwrap();
         assert_eq!(result.len(), 1);
         assert!((result[0] - 0.05).abs() < 1e-12);
     }
@@ -1293,7 +1332,7 @@ mod tests {
     fn test_unscale_and_sort_quantiles_empty_input() {
         let scaler = daily_return_scaler(0.0, 1.0);
 
-        let result = unscale_and_sort_quantiles(&[], &scaler);
+        let result = unscale_and_sort_quantiles(&[], &scaler).unwrap();
         assert!(result.is_empty());
     }
 }

--- a/src/models/tide/train.rs
+++ b/src/models/tide/train.rs
@@ -1,7 +1,6 @@
 //! TiDE training loop on the `Autodiff<NdArray>` backend.
 //!
-//! Hand-rolled rather than `burn-train`'s `Learner`. The best checkpoint is restored from memory
-//! rather than round-tripped to disk.
+//! Hand-rolled rather than `burn-train`'s `Learner`; the best checkpoint is restored from memory.
 
 use burn::backend::{Autodiff, NdArray};
 use burn::module::AutodiffModule;
@@ -165,15 +164,12 @@ pub(crate) struct EpochDecision {
     pub(crate) stop: bool,
 }
 
-/// Train the model, returning the best-checkpoint model and the per-epoch
-/// training loss history.
+/// Train the model, returning the best-checkpoint model and the per-epoch training loss history.
 ///
-/// `validation_dataset` drives early stopping. When it is `None` or empty, the **training** loss is
-/// used as the stopping metric instead — which makes early stopping measure fit rather than
-/// generalization, so it will happily run to the epoch limit on a model that has memorized the
-/// window. The caller is expected to reject an empty validation split rather than rely on this;
-/// `bin/tide_model_trainer.rs` does. The fallback exists so a deliberately validation-free run
-/// (the overfitting tests below) still terminates, not as a supported production path.
+/// `validation_dataset` drives early stopping; when it is `None` or empty the **training** loss is
+/// used instead, which measures fit rather than generalization and will run to the epoch limit on a
+/// model that has memorized the window. The caller is expected to reject an empty validation split
+/// rather than rely on that fallback, which exists so a validation-free test run still terminates.
 pub fn train(
     mut model: TiDEModel<TrainBackend>,
     train_dataset: &TrainingDataset,

--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -1,7 +1,6 @@
 //! The strategy: which pairs to hold, how large, and when to let them go.
 //!
-//! [`execute`] is the only module that sends an order and [`evaluate`] is the pass driving it;
-//! [`account`] is the post-close half that writes back what Alpaca says actually happened.
+//! [`evaluate`] drives the pass, [`execute`] sends every order, [`account`] writes back the fills.
 
 pub mod account;
 pub mod evaluate;

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -1,7 +1,6 @@
-//! The post-close account sync: what Alpaca says actually happened.
-//!
-//! Balances land in `account_snapshots`, activities in `account_activities` keyed by Alpaca's own
-//! identifier, and then the fills — and only the fills — are attributed back to their pairs.
+//! The post-close account sync: what Alpaca says actually happened. Balances land in
+//! `account_snapshots`, activities in `account_activities` keyed by Alpaca's own identifier, and
+//! then the fills — and only the fills — are attributed back to their pairs.
 
 use std::collections::{HashMap, HashSet};
 
@@ -390,15 +389,11 @@ fn position_reading(position: &Position) -> PositionReading {
 
 /// The previous trading session, when it has no snapshot of its own.
 ///
-/// A sync that failed at 16:15 leaves a hole nothing else notices, and the equity series is what a
-/// time-weighted return will eventually be folded from — a fold cannot chain across a missing
-/// session, and by the time one is discovered it may be months old.
-/// `/v2/account/portfolio/history` can refill it.
-///
-/// Asking the calendar for the previous session, rather than testing a date against
-/// [`TradingCalendar::is_trading_day`], is deliberate: it only ever returns days it actually holds,
-/// so a date beyond the fetched horizon cannot pass for a holiday. `None` means either no gap or no
-/// calendar reaching back that far, and neither is worth failing the sync over.
+/// A sync that failed at 16:15 leaves a hole nothing else notices, and a time-weighted return
+/// cannot chain across a missing session; `/v2/account/portfolio/history` can refill it. Asking the
+/// calendar for the previous session, rather than testing a date against
+/// [`TradingCalendar::is_trading_day`], means a date beyond the fetched horizon cannot pass for a
+/// holiday, and `None` means either no gap or no calendar reaching back that far.
 async fn missing_previous_snapshot(
     pool: &PgPool,
     calendar: &TradingCalendar,
@@ -445,13 +440,10 @@ pub struct Attribution {
 /// Attributes fills to the pairs whose legs and window they fall inside.
 ///
 /// A fill belongs to a pair when its symbol is one of the pair's legs and its timestamp is within
-/// the pair's open window. Profit and loss is the sum of the signed cash flows: a buy is negative,
-/// a sell positive, so a pair that opened and closed cleanly sums to what it made.
-///
-/// A fill matching more than one pair is counted against **none** of them and reported as
-/// unattributed. That means the same symbol traded in two overlapping pairs, which
-/// [`crate::portfolio::screen::select_disjoint`] is supposed to prevent — so splitting the fill
-/// would produce two plausible numbers and hide an upstream bug.
+/// the pair's open window; profit and loss is the sum of the signed cash flows, a buy negative and
+/// a sell positive. A fill matching more than one pair is counted against **none** of them and
+/// reported as unattributed, because that means an upstream bug in
+/// [`crate::portfolio::screen::select_disjoint`] rather than something to split.
 pub fn attribute(closed: &[ClosedPair], activities: &[AccountActivity]) -> Attribution {
     let mut realized: HashMap<Uuid, Decimal> = closed
         .iter()

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -1,7 +1,6 @@
 //! The five-minute pass, and the pre-close liquidation that backs it up.
 //!
-//! Each half is observe, decide, apply, with the decision a pure function of its reading; see
-//! [`evaluate_pass`] for the two properties that arrangement exists to protect.
+//! Each half is observe, decide, apply, with the decision a pure function of its reading.
 
 use std::collections::{HashMap, HashSet};
 
@@ -38,8 +37,8 @@ use crate::portfolio::execute::{
 use crate::portfolio::pairs::{self, OpenPair, PairsError};
 use crate::portfolio::risk::{RiskBlock, RiskGate};
 use crate::portfolio::screen::{
-    self, ScreenInput, SpreadModel, CONVERGENCE_Z_SCORE, CORRELATION_WINDOW_SESSIONS,
-    STOP_LOSS_WIDENING,
+    self, ExitModelFailure, ScreenInput, SpreadModel, CONVERGENCE_Z_SCORE,
+    CORRELATION_WINDOW_SESSIONS,
 };
 use crate::portfolio::size::{self, SizedPair, SizingParameters};
 
@@ -108,7 +107,8 @@ pub struct ClosedRecord {
 pub struct ExitReading {
     pub open_pairs: Vec<OpenPair>,
     pub prices: HashMap<Ticker, CheckedPrice>,
-    pub models: HashMap<PairID, SpreadModel>,
+    /// One entry per open pair, carrying why the model is missing when it is.
+    pub models: HashMap<PairID, Result<SpreadModel, ExitModelFailure>>,
     pub session: SessionDate,
     pub now: DateTime<Utc>,
 }
@@ -244,15 +244,9 @@ pub struct EvaluationSummary {
 
 /// Decides whether an open pair should be closed at this spread reading.
 ///
-/// The spread is `ln(short) - hedge_ratio * ln(long)` and entry is always above
-/// [`crate::portfolio::screen::ENTRY_Z_SCORE`], so convergence is a fall back through zero. There is
-/// no sign handling here because the orientation invariant already removed it.
-///
-/// The stop is measured from `entry_z_score` rather than from a fixed line. An absolute stop cannot
-/// be right for every pair at once: it silently forbids entries above itself, and the screen has no
-/// matching upper bound, so pairs were opened already past it and closed on the next pass having
-/// never moved. Convergence stays absolute, because crossing the mean is the move the position was
-/// taken to capture regardless of where it started.
+/// Entry is always positive, so convergence is a fall back through zero and no sign handling is
+/// needed. The stop is measured from `entry_z_score` because an absolute one silently forbids
+/// entries above itself; convergence stays absolute, since crossing the mean is the move captured.
 pub fn exit_reason(z_score: f64, entry_z_score: f64) -> Option<CloseReason> {
     if !z_score.is_finite() || !entry_z_score.is_finite() {
         return None;
@@ -260,7 +254,7 @@ pub fn exit_reason(z_score: f64, entry_z_score: f64) -> Option<CloseReason> {
     if z_score <= CONVERGENCE_Z_SCORE {
         return Some(CloseReason::Convergence);
     }
-    if z_score >= entry_z_score + STOP_LOSS_WIDENING {
+    if z_score >= screen::stop_at(entry_z_score) {
         return Some(CloseReason::StopLoss);
     }
     None
@@ -741,8 +735,8 @@ async fn observe_candidates(
 /// Scores, selects, sizes, and admits. Pure, and the round's whole decision.
 ///
 /// Every scored candidate is seeded as `not_selected` and relabelled as it survives each stage —
-/// `risk_refused` if the gate turned it down, `planned` if it cleared — so a candidate that fell out
-/// at selection is recorded as precisely as one that was approved.
+/// `sizing_refused`, `risk_refused`, or `planned` — so a candidate that fell out at selection is
+/// recorded as precisely as one that was approved.
 pub fn decide_entries(
     account: &AccountReading,
     reading: &CandidatesReading,
@@ -756,14 +750,19 @@ pub fn decide_entries(
         &reading.held,
         &reading.screened.sectors,
     );
-    let sized = size::size_pairs(&selected, account.account.equity(), sizing);
+    let (sized, sizing_refusals) = size::size_pairs(&selected, account.account.equity(), sizing);
     let (approved, refusals) = gate.admit_all(&sized);
 
     let mut plan = EntryPlan {
         candidates_screened: candidates.len(),
-        refusals: refusals
+        refusals: sizing_refusals
             .iter()
-            .map(|refusal| format!("{}: {}", refusal.block.as_str(), refusal.block))
+            .map(|refused| format!("{}: {}", refused.refusal.as_str(), refused.refusal))
+            .chain(
+                refusals
+                    .iter()
+                    .map(|refusal| format!("{}: {}", refusal.block.as_str(), refusal.block)),
+            )
             .collect(),
         candidates: candidates
             .iter()
@@ -796,6 +795,14 @@ pub fn decide_entries(
             candidate.long_notional = Some(pair.long_notional().value());
             candidate.short_quantity = Some(Decimal::from(pair.short_shares().get()));
             candidate.gross_exposure = Some(pair.gross_exposure());
+        }
+    }
+    // A candidate the sizer turned down is not one the ranking never reached, and only the cause
+    // separates them once both are absent from the plan.
+    for refused in &sizing_refusals {
+        if let Some(candidate) = plan.candidates.get_mut(refused.pair_id.as_str()) {
+            candidate.decision = CandidateDecision::SizingRefused;
+            candidate.refusal = Some(format!("{}: {}", refused.refusal.as_str(), refused.refusal));
         }
     }
     for refusal in &refusals {
@@ -1044,7 +1051,7 @@ pub fn decide_exits(reading: &ExitReading) -> ExitPlan {
             spread_standard_deviation: None,
             z_score: None,
             entry_z_score: pair.entry_z_score(),
-            stop_at: pair.entry_z_score() + screen::STOP_LOSS_WIDENING,
+            spread_model_failure: None,
             entry_session: SessionDate::at(pair.opened_at()),
             minutes_held: pair.minutes_held(reading.now),
             decision: PairDecision::Held,
@@ -1060,11 +1067,27 @@ pub fn decide_exits(reading: &ExitReading) -> ExitPlan {
             plan.readings.push(open_pair_reading);
             continue;
         };
-        let Some(model) = reading.models.get(pair.pair_id()) else {
-            warn!(pair_id = %pair.pair_id(), "Open pair has no rebuildable spread model");
-            open_pair_reading.decision = PairDecision::NoSpreadModel;
-            plan.readings.push(open_pair_reading);
-            continue;
+        let model = match reading.models.get(pair.pair_id()) {
+            Some(Ok(model)) => model,
+            // The cause travels with the refusal: a leg whose history went missing and a spread
+            // that will not fit are held identically and fixed differently.
+            Some(Err(failure)) => {
+                warn!(
+                    pair_id = %pair.pair_id(),
+                    failure = failure.as_str(),
+                    "Open pair has no rebuildable spread model"
+                );
+                open_pair_reading.decision = PairDecision::NoSpreadModel;
+                open_pair_reading.spread_model_failure = Some(failure.detail());
+                plan.readings.push(open_pair_reading);
+                continue;
+            }
+            None => {
+                warn!(pair_id = %pair.pair_id(), "Open pair was never offered to the model builder");
+                open_pair_reading.decision = PairDecision::NoSpreadModel;
+                plan.readings.push(open_pair_reading);
+                continue;
+            }
         };
 
         open_pair_reading.model_hedge_ratio = Some(model.hedge_ratio());
@@ -1082,14 +1105,13 @@ pub fn decide_exits(reading: &ExitReading) -> ExitPlan {
         //
         // A z-score on its own is unfalsifiable: a pair recorded at entry z 6.09 and read at 1.25
         // five minutes later is indistinguishable from a price move, a refitted distribution, and a
-        // bug, and the exit path previously logged only its decision. These five fields are what
-        // separate those cases, and the pass that does not close anything is the one that needs
-        // them most.
+        // bug. These five fields separate those cases, and the pass that closes nothing needs them
+        // most.
         debug!(
             pair_id = %pair.pair_id(),
             z_score,
             entry_z_score = pair.entry_z_score(),
-            stop_at = pair.entry_z_score() + screen::STOP_LOSS_WIDENING,
+            stop_at = screen::stop_at(pair.entry_z_score()),
             spread_mean = model.mean(),
             spread_standard_deviation = model.standard_deviation(),
             hedge_ratio = model.hedge_ratio(),
@@ -1442,6 +1464,29 @@ mod tests {
     use super::*;
     use crate::portfolio::screen::ENTRY_Z_SCORE;
 
+    /// The live long-leg price the exit fixture reads.
+    const FIXTURE_LONG_PRICE: f64 = 100.0;
+
+    /// Two cointegrated series whose hedge ratio is far from one.
+    ///
+    /// Both legs move, which is what keeps the hedge ratio in the algebra: against a constant long
+    /// leg `ln(short) - hedge_ratio * ln(long)` differs from `ln(short)` by a constant, the z-score
+    /// is invariant to the ratio, and no test can see it. Such a pair also cannot arise from the
+    /// entry path, since ordinary least squares refuses a constant predictor.
+    fn exit_fixture_series() -> (Vec<f64>, Vec<f64>) {
+        let long_closes: Vec<f64> = (0..CORRELATION_WINDOW_SESSIONS)
+            .map(|index| 100.0 * (1.0 + 0.010 * (index as f64 * 0.7).sin()))
+            .collect();
+        let short_closes: Vec<f64> = (0..CORRELATION_WINDOW_SESSIONS)
+            .map(|index| {
+                50.0 * (1.0
+                    + 0.020 * (index as f64 * 0.7).sin()
+                    + 0.004 * (index as f64 * 1.9 + 1.0).sin())
+            })
+            .collect();
+        (long_closes, short_closes)
+    }
+
     /// One open pair, its spread model, and prices placing the spread at `z_at_close`.
     fn exit_reading_for(z_at_close: f64, priced: bool) -> ExitReading {
         exit_reading_with(z_at_close, priced, true, 0)
@@ -1460,24 +1505,25 @@ mod tests {
         let short = Ticker::new("BBBB").unwrap();
         let pair_id = PairID::new(long.clone(), short.clone());
 
-        // Only the short leg moves: wiggling both proportionally holds `ln(short) - ln(long)`
-        // constant, and a spread with no dispersion is the fixture that makes a test assert nothing.
-        let long_closes: Vec<f64> = vec![100.0; CORRELATION_WINDOW_SESSIONS];
-        let short_closes: Vec<f64> = (0..CORRELATION_WINDOW_SESSIONS)
-            .map(|index| if index % 2 == 0 { 50.0 } else { 51.0 })
-            .collect();
-        let model = SpreadModel::with_hedge_ratio(1.0, &long_closes, &short_closes)
-            .expect("the fixture series must fit");
+        let (long_closes, short_closes) = exit_fixture_series();
+        // Fitted rather than assumed, so the stored ratio is the one the entry path would have
+        // produced for this pair and the exit measures the spread the entry was taken on.
+        let model =
+            SpreadModel::fit(&long_closes, &short_closes).expect("the fixture series must fit");
+        let hedge_ratio = model.hedge_ratio();
 
-        // Solve for the short price that puts the spread at the requested z.
-        let short_price =
-            (model.mean() + z_at_close * model.standard_deviation() + 100.0_f64.ln()).exp();
+        // Solve for the short price that puts the spread at the requested z. The hedge ratio is in
+        // the solve, so a model that ignored it would land the reading somewhere else entirely.
+        let short_price = (model.mean()
+            + z_at_close * model.standard_deviation()
+            + hedge_ratio * FIXTURE_LONG_PRICE.ln())
+        .exp();
 
         let mut prices = HashMap::new();
         if priced {
             prices.insert(
                 long.clone(),
-                CheckedPrice::for_test(100.0, PriceSource::LastTrade),
+                CheckedPrice::for_test(FIXTURE_LONG_PRICE, PriceSource::LastTrade),
             );
             prices.insert(
                 short.clone(),
@@ -1488,7 +1534,12 @@ mod tests {
         let opened_at = DateTime::from_timestamp(1_770_000_000, 0).unwrap();
         let mut models = HashMap::new();
         if modelled {
-            models.insert(pair_id.clone(), model);
+            models.insert(pair_id.clone(), Ok(model));
+        } else {
+            models.insert(
+                pair_id.clone(),
+                Err(screen::ExitModelFailure::MissingCloseHistory),
+            );
         }
 
         let read_at = opened_at + chrono::Duration::days(sessions_later);
@@ -1496,7 +1547,7 @@ mod tests {
             open_pairs: vec![OpenPair::new(
                 uuid::Uuid::nil(),
                 pair_id,
-                1.0,
+                hedge_ratio,
                 ENTRY_Z_SCORE,
                 opened_at,
             )],
@@ -1505,6 +1556,38 @@ mod tests {
             session: SessionDate::at(read_at),
             now: read_at,
         }
+    }
+
+    /// The fixture's hedge ratio has to participate in the z-score, or every exit test below is
+    /// blind to it. Both halves are load-bearing: a ratio near one would be indistinguishable from
+    /// the degenerate case, and a z-score unmoved by a change in the ratio would prove it cancels.
+    #[test]
+    fn test_the_exit_fixture_hedge_ratio_participates_in_the_reading() {
+        let reading = exit_reading_for(-1.0, true);
+        let stored = reading.open_pairs[0].hedge_ratio();
+        assert!(
+            (stored - 1.0).abs() > 0.5,
+            "the fitted ratio must be far from one, got {stored}"
+        );
+
+        let (long_closes, short_closes) = exit_fixture_series();
+        let long_price = FIXTURE_LONG_PRICE;
+        let short_price = reading.prices[&Ticker::new("BBBB").unwrap()].price();
+
+        let fitted = SpreadModel::fit(&long_closes, &short_closes).expect("the fixture must fit");
+        let shifted = SpreadModel::with_hedge_ratio(stored + 0.5, &long_closes, &short_closes)
+            .expect("a shifted ratio must still fit");
+
+        let fitted_z = fitted
+            .z_score(long_price, short_price)
+            .expect("the fitted model must read");
+        let shifted_z = shifted
+            .z_score(long_price, short_price)
+            .expect("the shifted model must read");
+        assert!(
+            (fitted_z - shifted_z).abs() > 0.1,
+            "changing the hedge ratio must move the reading; got {fitted_z} and {shifted_z}"
+        );
     }
 
     /// The point of the split: the exit decision is a pure function of a value, so it runs with no
@@ -1557,7 +1640,9 @@ mod tests {
     /// would silently apply the session-local stop to an overnight pair.
     #[test]
     fn test_a_pair_from_an_earlier_session_is_scored_on_convergence_alone() {
-        let widened = ENTRY_Z_SCORE + STOP_LOSS_WIDENING + 1.0;
+        // 2.0 entry plus the 1.5 widening plus a margin, as literals: an expectation derived
+        // from the constant under test moves with it and can never fail.
+        let widened = 4.5;
 
         let same_session = decide_exits(&exit_reading_with(widened, true, true, 0));
         assert_eq!(
@@ -1575,13 +1660,18 @@ mod tests {
         assert_eq!(overnight.readings[0].decision, PairDecision::Held);
     }
 
-    /// A pair whose spread model could not be rebuilt is held and named, never closed.
+    /// A pair whose spread model could not be rebuilt is held and named, never closed — and the
+    /// record carries which of the six ways it failed, since each is fixed differently.
     #[test]
     fn test_a_pair_without_a_spread_model_is_held_and_named() {
         let plan = decide_exits(&exit_reading_with(-1.0, true, false, 0));
 
         assert!(plan.closes.is_empty());
         assert_eq!(plan.readings[0].decision, PairDecision::NoSpreadModel);
+        assert_eq!(
+            plan.readings[0].spread_model_failure.as_deref(),
+            Some("missing_close_history")
+        );
         assert_eq!(
             plan.unpriced, 0,
             "it was priced; what it lacked was the model"
@@ -1593,7 +1683,11 @@ mod tests {
     #[test]
     fn test_the_exit_thresholds_bracket_the_entry_threshold() {
         const _: () = assert!(CONVERGENCE_Z_SCORE < ENTRY_Z_SCORE);
-        const _: () = assert!(STOP_LOSS_WIDENING > 0.0);
+        assert_eq!(
+            screen::stop_at(2.0),
+            3.5,
+            "the stop sits above the entry it measures from"
+        );
         assert_eq!(exit_reason(ENTRY_Z_SCORE, ENTRY_Z_SCORE), None);
     }
 
@@ -1605,11 +1699,9 @@ mod tests {
 
     #[test]
     fn test_a_spread_widening_past_the_stop_is_a_stop_loss() {
+        // 2.5 entry plus a 1.5 widening, spelled out rather than derived from the constant.
         let entry = 2.5;
-        assert_eq!(
-            exit_reason(entry + STOP_LOSS_WIDENING, entry),
-            Some(CloseReason::StopLoss)
-        );
+        assert_eq!(exit_reason(4.0, entry), Some(CloseReason::StopLoss));
         assert_eq!(exit_reason(entry + 3.0, entry), Some(CloseReason::StopLoss));
     }
 
@@ -1617,7 +1709,7 @@ mod tests {
     #[test]
     fn test_a_spread_inside_the_band_is_held() {
         assert_eq!(exit_reason(1.0, 2.5), None);
-        assert_eq!(exit_reason(2.5 + STOP_LOSS_WIDENING - 0.01, 2.5), None);
+        assert_eq!(exit_reason(3.99, 2.5), None);
     }
 
     /// The whole point of measuring from entry: a wide entry gets the same room as a narrow one.
@@ -1656,7 +1748,7 @@ mod tests {
     #[test]
     fn test_the_cross_session_rule_differs_from_the_session_local_rule() {
         let entry = 2.0;
-        let widened = entry + STOP_LOSS_WIDENING;
+        let widened = 3.5;
         assert_eq!(exit_reason(widened, entry), Some(CloseReason::StopLoss));
         assert_eq!(convergence_only(widened), None);
     }

--- a/src/portfolio/execute.rs
+++ b/src/portfolio/execute.rs
@@ -1,7 +1,6 @@
 //! Order submission and fill confirmation. The only module that sends an order.
 //!
-//! Opening a pair is two orders that must both work or neither hold; see [`open_pair`] for the
-//! ordering that makes the common failure free to recover from.
+//! Opening a pair is two orders that must both work or neither hold; see [`open_pair`].
 
 use std::time::Duration;
 

--- a/src/portfolio/pairs.rs
+++ b/src/portfolio/pairs.rs
@@ -1,7 +1,6 @@
 //! `equity_pairs` persistence: which long belongs with which short, and why.
 //!
-//! Alpaca holds the authoritative position, quantity, and fill; this stores only what it cannot
-//! answer. Not a position ledger, and never to be trusted over Alpaca.
+//! Alpaca holds the authoritative position, quantity, and fill; this is not a position ledger.
 
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;

--- a/src/portfolio/risk.rs
+++ b/src/portfolio/risk.rs
@@ -1,7 +1,6 @@
 //! The risk gate: every condition here only ever stops an *entry*.
 //!
-//! Nothing can block an exit. The book is flat overnight without exception, so a gate that could
-//! refuse to close a position would be a way to carry one.
+//! Nothing can block an exit: the book is flat overnight without exception.
 
 use rust_decimal::Decimal;
 use tracing::{info, warn};
@@ -284,7 +283,7 @@ mod tests {
     use super::*;
     use crate::common::types::{Dollars, PairID, Ticker};
     use crate::portfolio::screen::PairCandidate;
-    use crate::portfolio::size::size_pair;
+    use crate::portfolio::size::{size_pair, size_pairs};
 
     fn account(equity: i64, long: i64, short: i64) -> AccountSnapshot {
         AccountSnapshot::new(
@@ -473,6 +472,84 @@ mod tests {
         // rather than left looking as though the screen dropped it.
         assert_eq!(refusals[0].pair_id.as_str(), "CCCC-DDDD");
         assert_eq!(refusals[1].pair_id.as_str(), "EEEE-FFFF");
+    }
+
+    /// The nth distinct pair of symbols. `Ticker` admits letters only, so the index is spelled.
+    fn candidate_for_index(index: usize) -> PairCandidate {
+        let letter = (b'A' + index as u8) as char;
+        PairCandidate::new(
+            PairID::new(
+                Ticker::new(&format!("L{letter}{letter}{letter}")).unwrap(),
+                Ticker::new(&format!("S{letter}{letter}{letter}")).unwrap(),
+            ),
+            1.0,
+            2.5,
+            0.02,
+            100.0,
+            100.0,
+        )
+        .expect("the test candidate must be constructible")
+    }
+
+    /// The per-leg budget and the gross cap are two halves of one calibration, and only their
+    /// composition shows it: a full ten-pair book lands exactly on the cap, admitted by a strict
+    /// `>` and nothing else. Neither module can state this alone.
+    #[test]
+    fn test_a_full_book_of_sized_pairs_lands_exactly_on_the_gross_cap() {
+        let parameters = SizingParameters::new(10, 1.0).unwrap();
+        let equity = Decimal::from(100_000);
+        let candidates: Vec<PairCandidate> = (0..10).map(candidate_for_index).collect();
+
+        let (sized, refusals) = size_pairs(&candidates, equity, &parameters);
+        assert_eq!(sized.len(), 10, "every candidate sizes at this budget");
+        assert!(refusals.is_empty());
+        // 5,000 a leg, a 100-dollar short rounding to 50 whole shares: 10,000 gross a pair.
+        assert_eq!(sized[0].gross_exposure(), Decimal::from(10_000));
+
+        let mut gate = RiskGate::new(
+            &account(100_000, 0, 0),
+            Some(equity),
+            0,
+            Some(120),
+            parameters,
+            true,
+        );
+        assert_eq!(gate.gross_exposure_cap(), Decimal::from(100_000));
+
+        let (approved, blocked) = gate.admit_all(&sized);
+        assert_eq!(approved.len(), 10, "a full book fits the cap exactly");
+        assert!(blocked.is_empty());
+    }
+
+    /// There is no headroom whatsoever: one dollar of exposure already on the account is enough to
+    /// refuse the tenth pair, which is what "lands exactly on the cap" costs.
+    #[test]
+    fn test_a_dollar_of_prior_exposure_refuses_the_last_pair_of_a_full_book() {
+        let parameters = SizingParameters::new(10, 1.0).unwrap();
+        let equity = Decimal::from(100_000);
+        let candidates: Vec<PairCandidate> = (0..10).map(candidate_for_index).collect();
+        let (sized, _) = size_pairs(&candidates, equity, &parameters);
+
+        let mut gate = RiskGate::new(
+            &account(100_000, 1, 0),
+            Some(equity),
+            0,
+            Some(120),
+            parameters,
+            true,
+        );
+        let (approved, blocked) = gate.admit_all(&sized);
+
+        assert_eq!(approved.len(), 9);
+        assert_eq!(blocked.len(), 1);
+        assert_eq!(blocked[0].pair_id.as_str(), "LJJJ-SJJJ");
+        assert_eq!(
+            blocked[0].block,
+            RiskBlock::GrossExposure {
+                projected: Decimal::from(100_001),
+                cap: Decimal::from(100_000),
+            }
+        );
     }
 
     #[test]

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -1,7 +1,6 @@
 //! Pair selection: which two symbols, which way round, and how strong the signal.
 //!
-//! Quadratic in the eligible universe, so the cheap tests come first: the confidence floor shrinks
-//! the input, and a pair with no shortable leg is skipped before its correlation is computed.
+//! Quadratic in the eligible universe, so the cheap tests come first.
 
 use std::collections::{HashMap, HashSet};
 
@@ -15,14 +14,9 @@ pub const CORRELATION_WINDOW_SESSIONS: usize = 60;
 
 /// Correlation band a pair's log returns must fall inside.
 ///
-/// The floor rejects pairs with nothing to mean-revert to. The ceiling rejects pairs so alike the
-/// spread is mostly microstructure noise — two share classes of one issuer — where a two-sigma move
-/// is inside the bid-ask spread.
-///
-/// **The band is on signed correlation, not magnitude.** An anti-correlated pair fits a negative
-/// hedge ratio, turning `ln(short) - hedge_ratio * ln(long)` into a sum that hedges nothing, and
-/// sizing is dollar-neutral regardless — so admitting one is a directional bet wearing a
-/// market-neutral name.
+/// The band is on signed correlation, not magnitude: an anti-correlated pair fits a negative hedge
+/// ratio, turning `ln(short) - hedge_ratio * ln(long)` into a sum that hedges nothing while sizing
+/// stays dollar-neutral. Read it through [`admits_correlation`] rather than spelling it out.
 pub const CORRELATION_MINIMUM: f64 = 0.5;
 pub const CORRELATION_MAXIMUM: f64 = 0.95;
 
@@ -31,28 +25,20 @@ pub const ENTRY_Z_SCORE: f64 = 2.0;
 
 /// Spread z-score at which an open pair has converged and is closed at a profit.
 ///
-/// Zero, not a band around zero: the spread is entered above `ENTRY_Z_SCORE` and closed when it
+/// Zero, not a band around zero: the spread is entered above [`ENTRY_Z_SCORE`] and closed when it
 /// crosses back through its own mean, which is the move the position was taken to capture.
 pub const CONVERGENCE_Z_SCORE: f64 = 0.0;
 
-/// How much further a spread must widen *beyond its own entry* before the pair is stopped out.
+/// How much further a spread must widen beyond its own entry before the pair is stopped out.
 ///
-/// Relative rather than absolute, because an absolute line cannot be right for every pair at once:
-/// with entry admitting anything at or above [`ENTRY_Z_SCORE`], a pair entered above the old fixed
-/// stop of 4.0 was already closable the moment it opened, and three of the first ten pairs opened in
-/// production were stopped on the next pass without the spread ever moving against them. Measuring
-/// from entry is what makes the stop describe adverse movement rather than absolute position.
-///
-/// Expressed in z units, so it is already normalized per pair: one unit is one standard deviation of
-/// *that* pair's own spread.
+/// Expressed in z units, so it is already normalized per pair: one unit is one standard deviation
+/// of *that* pair's own spread. Read it through [`stop_at`] rather than adding it at a call site.
 pub const STOP_LOSS_WIDENING: f64 = 1.5;
 
 /// Upper bound on the entry z-score.
 ///
-/// A data-quality guard, not a strategy rule. Mean reversion is the premise of the whole position,
-/// and a spread this far out is more often an unadjusted corporate action or a regime break than an
-/// opportunity — neither of which reverts. Rejections are counted so the rate is visible rather than
-/// inferred.
+/// A data-quality guard, not a strategy rule: a spread this far out is more often an unadjusted
+/// corporate action or a regime break than an opportunity, and neither reverts.
 pub const ENTRY_Z_SCORE_CAP: f64 = 5.0;
 
 /// Minimum model confidence for a ticker to be eligible for either leg.
@@ -60,18 +46,9 @@ pub const CONFIDENCE_FLOOR: f64 = 0.5;
 
 /// Legs the book may hold in one sector at once.
 ///
-/// This is the constraint the different-sector rule was reaching for, applied where it belongs. A
-/// reservoir of same-sector spreads ranks by the same industry factor at the top, so ten selected
-/// pairs can be one bet held ten times. That is a property of the *selection across the book*, not
-/// of any individual candidate — a single same-sector pair is a perfectly good trade, and is in
-/// fact the classic one.
-///
-/// Counted in legs rather than pairs so held and candidate positions measure the same way from a
-/// flat ticker set, and because a same-sector pair genuinely sits entirely inside one sector while
-/// a cross-sector pair only half does. Against a ten-pair book, six legs is a little under a third
-/// of the twenty on offer: enough for three same-sector pairs in one industry, not enough for the
-/// book to become an industry bet. Note it is absolute, so lowering
-/// [`crate::portfolio::size::MAXIMUM_CONCURRENT_PAIRS`] far enough would make it inert.
+/// A property of the selection across the book rather than of any candidate: a reservoir of
+/// same-sector spreads ranks by the same industry factor at the top, so ten selected pairs can be
+/// one bet held ten times. Counted in legs so held and candidate positions measure the same way.
 pub const MAXIMUM_LEGS_PER_SECTOR: usize = 6;
 
 /// Tickers needed before a screen can produce anything.
@@ -79,9 +56,8 @@ const MINIMUM_ELIGIBLE_TICKERS: usize = 2;
 
 /// Observations needed before a spread distribution can be fitted at all.
 ///
-/// Two, because the sample standard deviation removes one degree of freedom. Deliberately a separate
-/// constant from [`MINIMUM_ELIGIBLE_TICKERS`] despite sharing its value: the two are unrelated
-/// quantities, and a change to the ticker threshold must not silently move the statistical floor.
+/// Two, because the sample standard deviation removes one degree of freedom. Separate from
+/// [`MINIMUM_ELIGIBLE_TICKERS`] despite sharing its value: the two are unrelated quantities.
 const MINIMUM_SPREAD_OBSERVATIONS: usize = 2;
 
 /// Largest single-session log return a fit window may contain and still be screened.
@@ -89,9 +65,31 @@ const MINIMUM_SPREAD_OBSERVATIONS: usize = 2;
 /// A window holding a larger move is not one distribution, so the hedge ratio fitted across it does
 /// not hedge. The cause is deliberately not consulted: a split artifact and a real collapse damage
 /// the fit identically, and only one of them is fixable by re-fetching.
-///
-/// Provisional, on the same terms as [`crate::common::alpaca::MAXIMUM_QUOTE_AGE_SECONDS`].
 pub const MAXIMUM_SESSION_LOGARITHMIC_RETURN: f64 = 0.40;
+
+/// Whether `z_score` is inside the entry admission band `[ENTRY_Z_SCORE, ENTRY_Z_SCORE_CAP]`.
+///
+/// The single expression of the band. A caller spelling the comparison out itself is free to differ
+/// on a boundary, and a study that differs from the screen is a study of another strategy.
+pub fn admits_entry_z_score(z_score: f64) -> bool {
+    (ENTRY_Z_SCORE..=ENTRY_Z_SCORE_CAP).contains(&z_score)
+}
+
+/// Whether `correlation` is inside `[CORRELATION_MINIMUM, CORRELATION_MAXIMUM]`.
+///
+/// The single expression of the band, on the same terms as [`admits_entry_z_score`]. Signed, so an
+/// anti-correlated pair is refused rather than mirrored.
+pub fn admits_correlation(correlation: f64) -> bool {
+    (CORRELATION_MINIMUM..=CORRELATION_MAXIMUM).contains(&correlation)
+}
+
+/// The z-score at which a pair entered at `entry_z_score` is stopped out.
+///
+/// The single expression of the stop. It is relative because an absolute line silently forbids
+/// entries above itself, closing a pair on the same reading that opened it.
+pub fn stop_at(entry_z_score: f64) -> f64 {
+    entry_z_score + STOP_LOSS_WIDENING
+}
 
 /// Why a symbol could not be screened.
 ///
@@ -232,13 +230,71 @@ impl ScreenInput {
     }
 }
 
+/// Why a spread distribution could not be fitted.
+///
+/// Carried out of the fit rather than collapsed into `None`, so an open pair held without a signal
+/// says which of the six causes it was and — where the cause is a number — what that number was.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SpreadFitFailure {
+    /// The two close series do not describe the same sessions.
+    MisalignedSeries {
+        long_sessions: usize,
+        short_sessions: usize,
+    },
+    /// Fewer observations than a distribution can be drawn from.
+    WindowTooShort { sessions: usize, minimum: usize },
+    /// A close with no logarithm: non-positive, or not a number.
+    UnusableClose,
+    /// The long leg's log price does not move, so no slope exists to hedge with.
+    HedgeRatioUnfittable,
+    /// The hedge ratio handed in is not a usable number.
+    HedgeRatioUnusable { hedge_ratio: f64 },
+    /// The spread does not move, which makes every z-score infinite.
+    NoDispersion { standard_deviation: f64 },
+}
+
+impl SpreadFitFailure {
+    /// The stable name this failure is recorded under.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SpreadFitFailure::MisalignedSeries { .. } => "misaligned_series",
+            SpreadFitFailure::WindowTooShort { .. } => "window_too_short",
+            SpreadFitFailure::UnusableClose => "unusable_close",
+            SpreadFitFailure::HedgeRatioUnfittable => "hedge_ratio_unfittable",
+            SpreadFitFailure::HedgeRatioUnusable { .. } => "hedge_ratio_unusable",
+            SpreadFitFailure::NoDispersion { .. } => "no_dispersion",
+        }
+    }
+
+    /// The numbers behind the failure, for the ones that have any.
+    pub fn detail(&self) -> Option<String> {
+        match self {
+            SpreadFitFailure::MisalignedSeries {
+                long_sessions,
+                short_sessions,
+            } => Some(format!(
+                "long_sessions={long_sessions} short_sessions={short_sessions}"
+            )),
+            SpreadFitFailure::WindowTooShort { sessions, minimum } => {
+                Some(format!("sessions={sessions} minimum={minimum}"))
+            }
+            SpreadFitFailure::UnusableClose | SpreadFitFailure::HedgeRatioUnfittable => None,
+            SpreadFitFailure::HedgeRatioUnusable { hedge_ratio } => {
+                Some(format!("hedge_ratio={hedge_ratio}"))
+            }
+            SpreadFitFailure::NoDispersion { standard_deviation } => {
+                Some(format!("standard_deviation={standard_deviation:e}"))
+            }
+        }
+    }
+}
+
 /// The log-price spread of an oriented pair, and the distribution it is measured against.
 ///
 /// The spread is `ln(short) - hedge_ratio * ln(long)`, with `hedge_ratio` the ordinary least
-/// squares slope of the short leg's log price on the long leg's. One consequence is worth stating
-/// because everything downstream leans on it: a pair is opened only when the short leg is the
-/// expensive one, so **an entry z-score is always positive**, convergence is a fall toward zero,
-/// and a stop is a rise away from it. No call site has to reason about which sign means what.
+/// squares slope of the short leg's log price on the long leg's. A pair is opened only when the
+/// short leg is the expensive one, so an entry z-score is always positive and no call site
+/// downstream has to reason about which sign means what.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SpreadModel {
     hedge_ratio: f64,
@@ -248,37 +304,33 @@ pub struct SpreadModel {
 
 impl SpreadModel {
     /// Fits both the hedge ratio and the distribution from aligned close histories.
-    ///
-    /// Returns `None` when the series are unusable: different lengths, too short, or a spread with
-    /// no dispersion. A zero standard deviation is the degenerate case that matters — it makes
-    /// every z-score infinite, so every pair looks like a screaming entry.
-    pub fn fit(long_closes: &[f64], short_closes: &[f64]) -> Option<Self> {
+    pub fn fit(long_closes: &[f64], short_closes: &[f64]) -> Result<Self, SpreadFitFailure> {
         let (long_logs, short_logs) = aligned_logs(long_closes, short_closes)?;
-        let hedge_ratio = ordinary_least_squares_slope(&long_logs, &short_logs)?;
+        let hedge_ratio = ordinary_least_squares_slope(&long_logs, &short_logs)
+            .ok_or(SpreadFitFailure::HedgeRatioUnfittable)?;
         Self::build(hedge_ratio, &long_logs, &short_logs)
     }
 
     /// Rebuilds the distribution around a hedge ratio that was already decided.
     ///
     /// This is the exit path. Refitting here would measure a different spread from the one the
-    /// entry was taken on, judging the position against a line it was never above.
-    ///
-    /// The window length is enforced for the same reason: [`SpreadModel::fit`] is only ever called
-    /// with exactly `CORRELATION_WINDOW_SESSIONS` closes, so a shorter series draws its mean and
-    /// standard deviation from a different sample and can cross a threshold for a spread that has
-    /// not moved.
+    /// entry was taken on, and a series shorter than the window would draw its mean and deviation
+    /// from a different sample, crossing a threshold for a spread that has not moved.
     pub fn with_hedge_ratio(
         hedge_ratio: f64,
         long_closes: &[f64],
         short_closes: &[f64],
-    ) -> Option<Self> {
+    ) -> Result<Self, SpreadFitFailure> {
         if !hedge_ratio.is_finite() {
-            return None;
+            return Err(SpreadFitFailure::HedgeRatioUnusable { hedge_ratio });
         }
-        if long_closes.len() < CORRELATION_WINDOW_SESSIONS
-            || short_closes.len() < CORRELATION_WINDOW_SESSIONS
-        {
-            return None;
+        for sessions in [long_closes.len(), short_closes.len()] {
+            if sessions < CORRELATION_WINDOW_SESSIONS {
+                return Err(SpreadFitFailure::WindowTooShort {
+                    sessions,
+                    minimum: CORRELATION_WINDOW_SESSIONS,
+                });
+            }
         }
         let long_window = &long_closes[long_closes.len() - CORRELATION_WINDOW_SESSIONS..];
         let short_window = &short_closes[short_closes.len() - CORRELATION_WINDOW_SESSIONS..];
@@ -287,9 +339,13 @@ impl SpreadModel {
         Self::build(hedge_ratio, &long_logs, &short_logs)
     }
 
-    fn build(hedge_ratio: f64, long_logs: &[f64], short_logs: &[f64]) -> Option<Self> {
+    fn build(
+        hedge_ratio: f64,
+        long_logs: &[f64],
+        short_logs: &[f64],
+    ) -> Result<Self, SpreadFitFailure> {
         if !hedge_ratio.is_finite() {
-            return None;
+            return Err(SpreadFitFailure::HedgeRatioUnusable { hedge_ratio });
         }
         let spread: Vec<f64> = short_logs
             .iter()
@@ -297,12 +353,19 @@ impl SpreadModel {
             .map(|(short, long)| short - hedge_ratio * long)
             .collect();
 
-        let mean = mean(&spread)?;
-        let standard_deviation = standard_deviation(&spread, mean)?;
+        // `aligned_logs` already refused a short or non-finite series, so anything unreadable here
+        // is a spread with no dispersion by another name.
+        let mean = mean(&spread).ok_or(SpreadFitFailure::NoDispersion {
+            standard_deviation: f64::NAN,
+        })?;
+        let standard_deviation =
+            standard_deviation(&spread, mean).ok_or(SpreadFitFailure::NoDispersion {
+                standard_deviation: f64::NAN,
+            })?;
         if standard_deviation <= f64::EPSILON {
-            return None;
+            return Err(SpreadFitFailure::NoDispersion { standard_deviation });
         }
-        Some(Self {
+        Ok(Self {
             hedge_ratio,
             mean,
             standard_deviation,
@@ -327,11 +390,9 @@ impl SpreadModel {
 
     /// Standardizes a live observation of the spread against the fitted distribution.
     ///
-    /// The observation is a pair of current prices and is deliberately not part of the distribution
-    /// it is measured against — the window is closed daily bars, the observation is intraday. A
-    /// z-score taken against a distribution containing the point being scored is bounded by the
-    /// sample size and cannot exceed the threshold it is compared to, which is the failure recorded
-    /// in `dual_path_signal_agreement`.
+    /// The observation is deliberately not part of the distribution it is measured against — the
+    /// window is closed daily bars, the observation is intraday. A z-score taken against a
+    /// distribution containing the scored point is bounded by the sample size.
     pub fn z_score(&self, long_price: f64, short_price: f64) -> Option<f64> {
         if !long_price.is_finite() || long_price <= 0.0 {
             return None;
@@ -342,6 +403,65 @@ impl SpreadModel {
         let spread = short_price.ln() - self.hedge_ratio * long_price.ln();
         let z_score = (spread - self.mean) / self.standard_deviation;
         z_score.is_finite().then_some(z_score)
+    }
+}
+
+/// Why a candidate could not describe a position worth taking.
+///
+/// Carried out of [`PairCandidate::new`] rather than collapsed into `None`, so the five refusals
+/// stay five facts and each reports the number that produced it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CandidateRejection {
+    HedgeRatioUnusable {
+        hedge_ratio: f64,
+    },
+    /// The legs are oriented the wrong way round: the short leg is the cheap one.
+    EntryZScoreNotPositive {
+        entry_z_score: f64,
+    },
+    /// The model expects the short leg to out-return the long, contradicting the orientation.
+    SignalStrengthNotPositive {
+        signal_strength: f64,
+    },
+    LongPriceUnusable {
+        long_price: f64,
+    },
+    ShortPriceUnusable {
+        short_price: f64,
+    },
+}
+
+impl CandidateRejection {
+    /// The stable name this rejection is recorded under.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CandidateRejection::HedgeRatioUnusable { .. } => "hedge_ratio_unusable",
+            CandidateRejection::EntryZScoreNotPositive { .. } => "entry_z_score_not_positive",
+            CandidateRejection::SignalStrengthNotPositive { .. } => "signal_strength_not_positive",
+            CandidateRejection::LongPriceUnusable { .. } => "long_price_unusable",
+            CandidateRejection::ShortPriceUnusable { .. } => "short_price_unusable",
+        }
+    }
+
+    /// The number behind the rejection. Every variant has one.
+    pub fn detail(&self) -> String {
+        match self {
+            CandidateRejection::HedgeRatioUnusable { hedge_ratio } => {
+                format!("hedge_ratio={hedge_ratio}")
+            }
+            CandidateRejection::EntryZScoreNotPositive { entry_z_score } => {
+                format!("entry_z_score={entry_z_score}")
+            }
+            CandidateRejection::SignalStrengthNotPositive { signal_strength } => {
+                format!("signal_strength={signal_strength}")
+            }
+            CandidateRejection::LongPriceUnusable { long_price } => {
+                format!("long_price={long_price}")
+            }
+            CandidateRejection::ShortPriceUnusable { short_price } => {
+                format!("short_price={short_price}")
+            }
+        }
     }
 }
 
@@ -369,23 +489,23 @@ impl PairCandidate {
         signal_strength: f64,
         long_price: f64,
         short_price: f64,
-    ) -> Option<Self> {
+    ) -> Result<Self, CandidateRejection> {
         if !hedge_ratio.is_finite() {
-            return None;
+            return Err(CandidateRejection::HedgeRatioUnusable { hedge_ratio });
         }
         if !entry_z_score.is_finite() || entry_z_score <= 0.0 {
-            return None;
+            return Err(CandidateRejection::EntryZScoreNotPositive { entry_z_score });
         }
         if !signal_strength.is_finite() || signal_strength <= 0.0 {
-            return None;
+            return Err(CandidateRejection::SignalStrengthNotPositive { signal_strength });
         }
         if !long_price.is_finite() || long_price <= 0.0 {
-            return None;
+            return Err(CandidateRejection::LongPriceUnusable { long_price });
         }
         if !short_price.is_finite() || short_price <= 0.0 {
-            return None;
+            return Err(CandidateRejection::ShortPriceUnusable { short_price });
         }
-        Some(Self {
+        Ok(Self {
             pair_id,
             hedge_ratio,
             entry_z_score,
@@ -437,27 +557,72 @@ impl PairCandidate {
     }
 }
 
+/// Why one orientation of a pair did not become a candidate.
+///
+/// Every exit from [`orient_one`] is a variant here, so a pair that produced nothing says which
+/// test it failed rather than only that it failed one.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OrientationRejection {
+    /// The leg that would be sold cannot be borrowed.
+    ShortLegNotShortable,
+    SpreadUnfitted(SpreadFitFailure),
+    /// The live prices do not standardize against the fitted distribution.
+    SpreadUnreadable,
+    EntryBelowThreshold {
+        z_score: f64,
+        threshold: f64,
+    },
+    EntryBeyondCap {
+        z_score: f64,
+        cap: f64,
+    },
+    /// The model expects the short leg to out-return the long.
+    ModelDisagrees {
+        signal_strength: f64,
+    },
+    Candidate(CandidateRejection),
+}
+
+impl OrientationRejection {
+    /// The stable name this rejection is counted under.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OrientationRejection::ShortLegNotShortable => "short_leg_not_shortable",
+            OrientationRejection::SpreadUnfitted(failure) => failure.as_str(),
+            OrientationRejection::SpreadUnreadable => "spread_unreadable",
+            OrientationRejection::EntryBelowThreshold { .. } => "entry_below_threshold",
+            OrientationRejection::EntryBeyondCap { .. } => "entry_beyond_cap",
+            OrientationRejection::ModelDisagrees { .. } => "model_disagrees",
+            OrientationRejection::Candidate(rejection) => rejection.as_str(),
+        }
+    }
+
+    /// The numbers behind the rejection, for the ones that have any.
+    pub fn detail(&self) -> Option<String> {
+        match self {
+            OrientationRejection::ShortLegNotShortable | OrientationRejection::SpreadUnreadable => {
+                None
+            }
+            OrientationRejection::SpreadUnfitted(failure) => failure.detail(),
+            OrientationRejection::EntryBelowThreshold { z_score, threshold } => {
+                Some(format!("z_score={z_score:.4} threshold={threshold:.4}"))
+            }
+            OrientationRejection::EntryBeyondCap { z_score, cap } => {
+                Some(format!("z_score={z_score:.4} cap={cap:.4}"))
+            }
+            OrientationRejection::ModelDisagrees { signal_strength } => {
+                Some(format!("signal_strength={signal_strength:.6}"))
+            }
+            OrientationRejection::Candidate(rejection) => Some(rejection.detail()),
+        }
+    }
+}
+
 /// Screens every combination and returns the candidates worth opening, best first.
 ///
-/// A pair survives four tests, in increasing order of cost:
-///
-/// 1. Both legs clear the confidence floor and at least one is shortable.
-/// 2. Their log returns correlate *positively*, within `[CORRELATION_MINIMUM, CORRELATION_MAXIMUM]`.
-/// 3. The spread, oriented so the short leg is the expensive one, is at or above `ENTRY_Z_SCORE`.
-/// 4. The model agrees with that orientation — it expects the long leg to out-return the short.
-///
-/// Test four is the model doing more than gating eligibility: without it a pair can open whose
-/// spread says buy A and sell B while the prediction says the opposite.
-///
-/// **Sector is not tested here.** A same-sector spread is the canonical statistical arbitrage
-/// trade — two companies facing the same demand, the same input costs, and the same regulator,
-/// whose relative price has something to mean-revert toward — and refusing those removes exactly
-/// the pairs most likely to cointegrate, which is the property the whole strategy rests on. The
-/// real concern was never the pair but the book, so it is answered in [`select_disjoint`] by
-/// [`MAXIMUM_LEGS_PER_SECTOR`].
-///
-/// No disjointness constraint is applied — the returned list is the full reservoir and pairs may
-/// share tickers. [`select_disjoint`] is the cheap second half.
+/// Sector is not tested here: a same-sector spread is the canonical statistical arbitrage trade, so
+/// concentration is bounded across the book in [`select_disjoint`] instead. No disjointness applies
+/// either — the returned list is the full reservoir and pairs may share tickers.
 pub fn score_candidates(inputs: &[ScreenInput]) -> Vec<PairCandidate> {
     let eligible: Vec<&ScreenInput> = inputs
         .iter()
@@ -474,6 +639,9 @@ pub fn score_candidates(inputs: &[ScreenInput]) -> Vec<PairCandidate> {
     }
 
     let mut candidates: Vec<PairCandidate> = Vec::new();
+    // Tallied rather than logged per pair: the loop is quadratic in the universe, so a line each
+    // would be millions of them.
+    let mut rejections: HashMap<&'static str, usize> = HashMap::new();
     for first_index in 0..eligible.len() {
         for second_index in (first_index + 1)..eligible.len() {
             let first = eligible[first_index];
@@ -481,6 +649,7 @@ pub fn score_candidates(inputs: &[ScreenInput]) -> Vec<PairCandidate> {
 
             // At least one leg has to be shortable or there is no orientation to take.
             if !first.is_shortable && !second.is_shortable {
+                *rejections.entry("no_shortable_leg").or_default() += 1;
                 continue;
             }
 
@@ -489,14 +658,38 @@ pub fn score_candidates(inputs: &[ScreenInput]) -> Vec<PairCandidate> {
                 &logarithmic_returns(second.window()),
             );
             let Some(correlation) = correlation else {
+                *rejections.entry("correlation_unreadable").or_default() += 1;
                 continue;
             };
-            if !(CORRELATION_MINIMUM..=CORRELATION_MAXIMUM).contains(&correlation) {
+            if !admits_correlation(correlation) {
+                *rejections.entry("correlation_outside_band").or_default() += 1;
                 continue;
             }
 
-            if let Some(candidate) = orient(first, second) {
-                candidates.push(candidate);
+            match orient(first, second) {
+                Ok(candidate) => candidates.push(candidate),
+                Err(orientations) => {
+                    for rejection in orientations {
+                        *rejections.entry(rejection.as_str()).or_default() += 1;
+                        // The cap is the one rejection whose reading is worth seeing per pair: it
+                        // is how an unadjusted corporate action announces itself.
+                        match rejection {
+                            OrientationRejection::EntryBeyondCap { z_score, cap } => debug!(
+                                first = %first.ticker,
+                                second = %second.ticker,
+                                z_score,
+                                cap,
+                                "Rejected a candidate whose entry spread is beyond the cap"
+                            ),
+                            OrientationRejection::ShortLegNotShortable
+                            | OrientationRejection::SpreadUnfitted(_)
+                            | OrientationRejection::SpreadUnreadable
+                            | OrientationRejection::EntryBelowThreshold { .. }
+                            | OrientationRejection::ModelDisagrees { .. }
+                            | OrientationRejection::Candidate(_) => {}
+                        }
+                    }
+                }
             }
         }
     }
@@ -508,9 +701,12 @@ pub fn score_candidates(inputs: &[ScreenInput]) -> Vec<PairCandidate> {
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
+    let mut tally: Vec<(&str, usize)> = rejections.into_iter().collect();
+    tally.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
     debug!(
         eligible = eligible.len(),
         candidates = candidates.len(),
+        rejections = ?tally,
         "Pair screen complete"
     );
     candidates
@@ -519,71 +715,76 @@ pub fn score_candidates(inputs: &[ScreenInput]) -> Vec<PairCandidate> {
 /// Decides which leg is long and which is short, and applies the entry and agreement tests.
 ///
 /// Both orientations are tried because ordinary least squares is not symmetric: the slope of `a` on
-/// `b` is not the reciprocal of the slope of `b` on `a`, so the spread has to be fitted in the
-/// orientation it will be held in rather than negated from the other one.
-fn orient(first: &ScreenInput, second: &ScreenInput) -> Option<PairCandidate> {
+/// `b` is not the reciprocal of the slope of `b` on `a`. On refusal both causes are returned, in
+/// the order tried, because a pair that fails one test each way failed for two different reasons.
+fn orient(
+    first: &ScreenInput,
+    second: &ScreenInput,
+) -> Result<PairCandidate, [OrientationRejection; 2]> {
     // `first` short, `second` long; then the reverse. At most one can clear a positive entry
     // threshold, since the two spreads move in opposite directions.
-    for (long, short) in [(second, first), (first, second)] {
-        if !short.is_shortable {
-            continue;
-        }
-        let Some(model) = SpreadModel::fit(long.window(), short.window()) else {
-            continue;
-        };
-        let Some(z_score) = model.z_score(long.price, short.price) else {
-            continue;
-        };
-        if z_score < ENTRY_Z_SCORE {
-            continue;
-        }
-        // Bounded above as well as below. Mean reversion is the premise of the position, and a
-        // spread this stretched is more often an unadjusted corporate action or a regime break than
-        // an opportunity.
-        if z_score > ENTRY_Z_SCORE_CAP {
-            debug!(
-                long = %long.ticker,
-                short = %short.ticker,
-                z_score,
-                cap = ENTRY_Z_SCORE_CAP,
-                "Rejected a candidate whose entry spread is beyond the cap"
-            );
-            continue;
-        }
+    let forward = match orient_one(second, first) {
+        Ok(candidate) => return Ok(candidate),
+        Err(rejection) => rejection,
+    };
+    let reverse = match orient_one(first, second) {
+        Ok(candidate) => return Ok(candidate),
+        Err(rejection) => rejection,
+    };
+    Err([forward, reverse])
+}
 
-        // The model has to agree that the cheap leg is the one to own. `PairCandidate::new`
-        // enforces this too; checking here as well keeps the loop from silently falling through to
-        // the other orientation on a rejection that is about the model rather than the spread.
-        let signal_strength = long.expected_return - short.expected_return;
-        if signal_strength <= 0.0 {
-            continue;
-        }
-
-        return PairCandidate::new(
-            PairID::new(long.ticker.clone(), short.ticker.clone()),
-            model.hedge_ratio(),
-            z_score,
-            signal_strength,
-            long.price,
-            short.price,
-        );
+/// Applies every entry test to one fixed orientation.
+fn orient_one(
+    long: &ScreenInput,
+    short: &ScreenInput,
+) -> Result<PairCandidate, OrientationRejection> {
+    if !short.is_shortable {
+        return Err(OrientationRejection::ShortLegNotShortable);
     }
-    None
+    let model = SpreadModel::fit(long.window(), short.window())
+        .map_err(OrientationRejection::SpreadUnfitted)?;
+    let z_score = model
+        .z_score(long.price, short.price)
+        .ok_or(OrientationRejection::SpreadUnreadable)?;
+    if !admits_entry_z_score(z_score) {
+        return Err(if z_score < ENTRY_Z_SCORE {
+            OrientationRejection::EntryBelowThreshold {
+                z_score,
+                threshold: ENTRY_Z_SCORE,
+            }
+        } else {
+            OrientationRejection::EntryBeyondCap {
+                z_score,
+                cap: ENTRY_Z_SCORE_CAP,
+            }
+        });
+    }
+
+    // The model has to agree that the cheap leg is the one to own. Checked here as well as in
+    // `PairCandidate::new` so the caller can tell a model disagreement from a spread rejection.
+    let signal_strength = long.expected_return - short.expected_return;
+    if signal_strength <= 0.0 {
+        return Err(OrientationRejection::ModelDisagrees { signal_strength });
+    }
+
+    PairCandidate::new(
+        PairID::new(long.ticker.clone(), short.ticker.clone()),
+        model.hedge_ratio(),
+        z_score,
+        signal_strength,
+        long.price,
+        short.price,
+    )
+    .map_err(OrientationRejection::Candidate)
 }
 
 /// Greedily takes up to `limit` candidates that share no ticker with each other or with `held`,
 /// and that keep every sector within [`MAXIMUM_LEGS_PER_SECTOR`].
 ///
-/// Disjointness is why rejecting a candidate changes what is available below it: excluding one pair
-/// frees both of its tickers, so a pair further down that was skipped for a collision becomes
-/// selectable. Re-selecting is therefore not the same as taking the next item off the list. The
-/// sector cap behaves the same way and for the same reason.
-///
-/// **The cap is seeded from the book, not from this pass.** `held` carries the legs already open,
-/// so a sector at its limit stays at its limit rather than admitting a fresh allocation every time
-/// the evaluator runs. A held ticker whose sector is unknown — a name whose `equity_details` row
-/// went away, say — contributes to no sector rather than to a fabricated one; it still blocks
-/// re-entry through `used`.
+/// The sector cap is seeded from the book, not from this pass, so a sector at its limit stays there
+/// rather than being handed a fresh allowance every five minutes. A held ticker whose sector is
+/// unknown contributes to no sector rather than to a fabricated one, and still blocks re-entry.
 pub fn select_disjoint(
     candidates: &[PairCandidate],
     limit: usize,
@@ -641,34 +842,77 @@ pub fn select_disjoint(
     selected
 }
 
+/// Why an open pair has no spread model this pass.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ExitModelFailure {
+    /// One or both legs are absent from the session's close history.
+    MissingCloseHistory,
+    /// The history is present and the distribution could not be rebuilt from it.
+    Unfitted(SpreadFitFailure),
+}
+
+impl ExitModelFailure {
+    /// The stable name this failure is recorded under.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ExitModelFailure::MissingCloseHistory => "missing_close_history",
+            ExitModelFailure::Unfitted(failure) => failure.as_str(),
+        }
+    }
+
+    /// The name and, where there is one, the reading behind it.
+    pub fn detail(&self) -> String {
+        match self {
+            ExitModelFailure::MissingCloseHistory => "missing_close_history".to_string(),
+            ExitModelFailure::Unfitted(failure) => match failure.detail() {
+                Some(detail) => format!("{}: {detail}", failure.as_str()),
+                None => failure.as_str().to_string(),
+            },
+        }
+    }
+}
+
 /// Builds the exit models for open pairs, keyed by pair identifier.
 ///
-/// A pair whose legs are missing from `closes` gets no model and therefore no spread reading. The
-/// caller treats that as "no exit signal", not as "hold forever" — the pre-close liquidation closes
-/// it regardless, so the worst case is that it is held until 15:45 rather than exited on a signal.
+/// Every supplied pair gets an entry, successful or not: "held with no signal" and "held because
+/// its history went missing" are different operational facts, and a pair absent from the map would
+/// collapse them. The caller never reads a failure as "hold forever" — the pre-close liquidation
+/// closes it regardless.
 pub fn exit_models<'a>(
     pairs: impl IntoIterator<Item = (&'a PairID, f64)>,
     closes: &HashMap<Ticker, Vec<f64>>,
-) -> HashMap<PairID, SpreadModel> {
+) -> HashMap<PairID, Result<SpreadModel, ExitModelFailure>> {
     let mut models = HashMap::new();
     for (pair_id, hedge_ratio) in pairs {
-        let (Some(long_closes), Some(short_closes)) =
-            (closes.get(pair_id.long()), closes.get(pair_id.short()))
-        else {
-            continue;
+        let built = match (closes.get(pair_id.long()), closes.get(pair_id.short())) {
+            (Some(long_closes), Some(short_closes)) => {
+                SpreadModel::with_hedge_ratio(hedge_ratio, long_closes, short_closes)
+                    .map_err(ExitModelFailure::Unfitted)
+            }
+            (None, _) | (_, None) => Err(ExitModelFailure::MissingCloseHistory),
         };
-        if let Some(model) = SpreadModel::with_hedge_ratio(hedge_ratio, long_closes, short_closes) {
-            models.insert(pair_id.clone(), model);
-        }
+        models.insert(pair_id.clone(), built);
     }
     models
 }
 
-/// Takes the natural logarithm of two series, returning `None` unless both are the same usable
-/// length with no non-positive value.
-fn aligned_logs(long_closes: &[f64], short_closes: &[f64]) -> Option<(Vec<f64>, Vec<f64>)> {
-    if long_closes.len() != short_closes.len() || long_closes.len() < MINIMUM_SPREAD_OBSERVATIONS {
-        return None;
+/// Takes the natural logarithm of two series, refusing unless both are the same usable length with
+/// no non-positive value.
+fn aligned_logs(
+    long_closes: &[f64],
+    short_closes: &[f64],
+) -> Result<(Vec<f64>, Vec<f64>), SpreadFitFailure> {
+    if long_closes.len() != short_closes.len() {
+        return Err(SpreadFitFailure::MisalignedSeries {
+            long_sessions: long_closes.len(),
+            short_sessions: short_closes.len(),
+        });
+    }
+    if long_closes.len() < MINIMUM_SPREAD_OBSERVATIONS {
+        return Err(SpreadFitFailure::WindowTooShort {
+            sessions: long_closes.len(),
+            minimum: MINIMUM_SPREAD_OBSERVATIONS,
+        });
     }
     let to_logs = |closes: &[f64]| -> Option<Vec<f64>> {
         closes
@@ -676,7 +920,10 @@ fn aligned_logs(long_closes: &[f64], short_closes: &[f64]) -> Option<(Vec<f64>, 
             .map(|close| (close.is_finite() && *close > 0.0).then(|| close.ln()))
             .collect()
     };
-    Some((to_logs(long_closes)?, to_logs(short_closes)?))
+    match (to_logs(long_closes), to_logs(short_closes)) {
+        (Some(long_logs), Some(short_logs)) => Ok((long_logs, short_logs)),
+        (None, _) | (_, None) => Err(SpreadFitFailure::UnusableClose),
+    }
 }
 
 /// The window's largest single-session move, by magnitude, as a signed log return.
@@ -789,11 +1036,8 @@ mod tests {
     /// Both legs share a common factor; the follower's idiosyncratic component puts the correlation
     /// near 0.8 rather than 1.0 and gives the spread dispersion to revert within.
     ///
-    /// Two failure modes are avoided deliberately. A series with no idiosyncratic component
-    /// correlates at 1.0 and is rejected by `CORRELATION_MAXIMUM`; one whose spread has no variance
-    /// is rejected by [`SpreadModel::build`]. Either produces zero candidates and every test built
-    /// on it then asserts nothing, which is what
-    /// `test_the_fixture_yields_at_least_one_candidate` guards.
+    /// A series with no idiosyncratic component correlates at 1.0 and one whose spread has no
+    /// variance will not fit; either produces zero candidates and every test below asserts nothing.
     fn cointegrated_series(sessions: usize) -> (Vec<f64>, Vec<f64>) {
         let mut leader = Vec::with_capacity(sessions);
         let mut follower = Vec::with_capacity(sessions);
@@ -851,17 +1095,78 @@ mod tests {
     #[test]
     fn test_fit_rejects_a_spread_with_no_dispersion() {
         let closes = vec![100.0; CORRELATION_WINDOW_SESSIONS];
-        assert_eq!(SpreadModel::fit(&closes, &closes), None);
+        // The cause, not merely the refusal: a flat series is refused by two different tests on the
+        // way through, and only one of them is the degenerate distribution.
+        assert_eq!(
+            SpreadModel::fit(&closes, &closes).expect_err("a flat spread must be refused"),
+            SpreadFitFailure::HedgeRatioUnfittable
+        );
+
+        let (long_closes, _) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
+        let failure = SpreadModel::with_hedge_ratio(1.0, &long_closes, &long_closes)
+            .expect_err("a spread against itself has no dispersion");
+        let SpreadFitFailure::NoDispersion { standard_deviation } = failure else {
+            panic!("expected no dispersion, got {failure:?}");
+        };
+        assert_eq!(standard_deviation, 0.0);
     }
 
     #[test]
     fn test_fit_rejects_misaligned_or_non_positive_series() {
         let (long_closes, short_closes) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
-        assert_eq!(SpreadModel::fit(&long_closes[1..], &short_closes), None);
+        assert_eq!(
+            SpreadModel::fit(&long_closes[1..], &short_closes)
+                .expect_err("misaligned series must be refused"),
+            SpreadFitFailure::MisalignedSeries {
+                long_sessions: 59,
+                short_sessions: 60,
+            }
+        );
 
         let mut negative = long_closes.clone();
         negative[10] = -1.0;
-        assert_eq!(SpreadModel::fit(&negative, &short_closes), None);
+        assert_eq!(
+            SpreadModel::fit(&negative, &short_closes)
+                .expect_err("a non-positive close must be refused"),
+            SpreadFitFailure::UnusableClose
+        );
+    }
+
+    #[test]
+    fn test_every_spread_failure_has_a_stable_name_and_the_numbered_ones_carry_a_reading() {
+        assert_eq!(
+            SpreadFitFailure::MisalignedSeries {
+                long_sessions: 60,
+                short_sessions: 59,
+            }
+            .detail()
+            .expect("a misalignment reports both lengths"),
+            "long_sessions=60 short_sessions=59"
+        );
+        assert_eq!(
+            SpreadFitFailure::WindowTooShort {
+                sessions: 12,
+                minimum: 60,
+            }
+            .as_str(),
+            "window_too_short"
+        );
+        assert_eq!(SpreadFitFailure::UnusableClose.detail(), None);
+        assert_eq!(SpreadFitFailure::HedgeRatioUnfittable.detail(), None);
+        assert_eq!(
+            SpreadFitFailure::HedgeRatioUnusable {
+                hedge_ratio: f64::NAN,
+            }
+            .as_str(),
+            "hedge_ratio_unusable"
+        );
+        assert_eq!(
+            SpreadFitFailure::NoDispersion {
+                standard_deviation: 0.0,
+            }
+            .as_str(),
+            "no_dispersion"
+        );
     }
 
     /// The observation is intraday and the window is closed daily bars, so the point being scored
@@ -899,10 +1204,14 @@ mod tests {
                 1.0,
                 &long_closes[..short_history],
                 &short_closes[..short_history],
-            ),
-            None
+            )
+            .expect_err("a short series must be refused"),
+            SpreadFitFailure::WindowTooShort {
+                sessions: 59,
+                minimum: 60,
+            }
         );
-        assert!(SpreadModel::with_hedge_ratio(1.0, &long_closes, &short_closes).is_some());
+        assert!(SpreadModel::with_hedge_ratio(1.0, &long_closes, &short_closes).is_ok());
     }
 
     /// A longer history is trimmed to the window rather than fitted over all of it, so an exit
@@ -971,15 +1280,13 @@ mod tests {
         assert!(!score_candidates(&screenable_inputs()).is_empty());
     }
 
-    /// Three tickers in two sectors, with the short-leg candidate stretched away from its partner
-    /// so the spread reads above the entry threshold.
+    /// Two cointegrated names with the short-leg candidate stretched 1.2% away from its partner.
+    ///
+    /// The generated series is near-deterministic — its spread deviation is about 0.3% — so a
+    /// larger stretch scores a z the screen would never admit and every test built on it would
+    /// assert against a candidate that cannot exist. This lands at z ~ 3.0.
     fn screenable_inputs() -> Vec<ScreenInput> {
         let (leader, follower) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
-        // 1.2%, not the 50% this used to stretch by. The generated series is near-deterministic —
-        // its spread deviation is about 0.3%, two orders below a real pair's — so a 50% dislocation
-        // scored z = 128, a value the screen would never see and the exit rule would close
-        // instantly. Every test built on the fixture was therefore asserting against a candidate
-        // that could not exist. This lands at z ~ 3.0, inside the band the screen actually admits.
         let stretched = follower.last().unwrap() * 1.012;
         vec![
             input("AAAA", leader.clone(), *leader.last().unwrap(), 0.03),
@@ -989,12 +1296,16 @@ mod tests {
 
     /// Every candidate the screen emits must survive its own entry reading.
     ///
-    /// The screen and the exit rule were each internally consistent and never checked against one
-    /// another, which is how entries above the old absolute stop of 4.0 were admitted and then
-    /// closed by the next pass. Composing the two here is the only place that gap is visible.
+    /// Composing the screen and the exit rule is the only place a candidate born closable is
+    /// visible: each half is internally consistent about a threshold the other never sees.
     #[test]
     fn test_no_candidate_is_closable_at_its_own_entry() {
-        for candidate in score_candidates(&screenable_inputs()) {
+        let candidates = score_candidates(&screenable_inputs());
+        // The count before the readings. A loop over an empty reservoir asserts nothing, and the
+        // fixture produces exactly one pair from two names.
+        assert_eq!(candidates.len(), 1, "the fixture must produce a candidate");
+
+        for candidate in candidates {
             let entry = candidate.entry_z_score();
             assert!(
                 entry <= ENTRY_Z_SCORE_CAP,
@@ -1009,6 +1320,10 @@ mod tests {
     }
 
     /// The cap is an upper bound on what the screen will emit, not advice.
+    ///
+    /// The emptiness is the assertion, so it has to be attributed: the same two names produce a
+    /// candidate at a stretch inside the band, and the orientation names the cap as what refused
+    /// them. An empty reservoir on its own is equally consistent with a broken fixture.
     #[test]
     fn test_a_spread_beyond_the_cap_is_not_a_candidate() {
         let (leader, follower) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
@@ -1018,13 +1333,25 @@ mod tests {
             input("AAAA", leader.clone(), *leader.last().unwrap(), 0.03),
             input("BBBB", follower.clone(), dislocated, -0.02),
         ];
-        for candidate in score_candidates(&inputs) {
-            assert!(
-                candidate.entry_z_score() <= ENTRY_Z_SCORE_CAP,
-                "a dislocated spread at z={} cleared the cap",
-                candidate.entry_z_score()
-            );
-        }
+
+        assert_eq!(score_candidates(&screenable_inputs()).len(), 1);
+        assert_eq!(
+            score_candidates(&inputs).len(),
+            0,
+            "a dislocated spread is not a candidate"
+        );
+
+        // In the order tried: BBBB long is the mirror of the dislocation and reads below the
+        // floor; AAAA long is the stretched orientation, and the cap is what turns it away.
+        let [bbbb_long, aaaa_long] =
+            orient(&inputs[0], &inputs[1]).expect_err("the dislocation must be refused");
+        assert_eq!(bbbb_long.as_str(), "entry_below_threshold");
+
+        let OrientationRejection::EntryBeyondCap { z_score, cap } = aaaa_long else {
+            panic!("expected the cap to refuse it, got {aaaa_long:?}");
+        };
+        assert!(z_score > 5.0, "the fixture must sit beyond the cap");
+        assert_eq!(cap, 5.0, "the cap reported is the one in schema terms");
     }
 
     /// The spread decides which leg is expensive; the short leg is the expensive one, always. An
@@ -1038,11 +1365,14 @@ mod tests {
         assert!(candidate.entry_z_score() >= ENTRY_Z_SCORE);
     }
 
-    /// Every entry score is positive by construction, which is what lets convergence be "falls to
-    /// zero" and a stop be "rises past four" with no sign handling anywhere downstream.
+    /// Every entry score is positive by construction, which is what lets convergence be a fall to
+    /// zero with no sign handling anywhere downstream.
     #[test]
     fn test_every_candidate_carries_a_positive_entry_score() {
-        for candidate in score_candidates(&screenable_inputs()) {
+        let candidates = score_candidates(&screenable_inputs());
+        assert_eq!(candidates.len(), 1, "the fixture must produce a candidate");
+
+        for candidate in candidates {
             assert!(candidate.entry_z_score() > 0.0);
             assert!(candidate.signal_strength() > 0.0);
         }
@@ -1092,14 +1422,8 @@ mod tests {
 
     /// Two cointegrated names are a candidate, whatever sectors they are in.
     ///
-    /// This replaces a test asserting the reverse. A same-sector spread is the canonical statistical
-    /// arbitrage trade, and within-sector correlation is where the `[0.5, 0.95]` band is most
-    /// densely populated, so the old rule removed disproportionately many of the best candidates.
-    ///
-    /// Sector cannot even be *expressed* here any more: `ScreenInput` no longer carries one, because
-    /// nothing in scoring reads it. That is the strongest statement of the change — the screen has
-    /// no sector to consider. Concentration is bounded in `select_disjoint` instead, and the tests
-    /// for it are below.
+    /// Sector cannot even be expressed here: `ScreenInput` does not carry one, because nothing in
+    /// scoring reads it. Concentration is bounded in [`select_disjoint`] instead.
     #[test]
     fn test_scoring_does_not_consider_sector() {
         // The shared fixture rather than a second hand-rolled dislocation, so the entry score stays
@@ -1263,7 +1587,7 @@ mod tests {
         for close in broken.iter_mut().skip(CORRELATION_WINDOW_SESSIONS / 2) {
             *close *= 0.1;
         }
-        assert!(SpreadModel::with_hedge_ratio(0.9, &leader, &broken).is_some());
+        assert!(SpreadModel::with_hedge_ratio(0.9, &leader, &broken).is_ok());
     }
 
     #[test]
@@ -1338,7 +1662,7 @@ mod tests {
 
         assert_eq!(
             selected.len(),
-            MAXIMUM_LEGS_PER_SECTOR / 2,
+            3,
             "six legs allows three same-sector pairs, not six"
         );
         assert_eq!(
@@ -1372,7 +1696,7 @@ mod tests {
 
         assert_eq!(
             selected.len(),
-            MAXIMUM_LEGS_PER_SECTOR,
+            6,
             "one leg per sector per pair, so six pairs fit inside a six-leg cap"
         );
     }
@@ -1408,15 +1732,13 @@ mod tests {
 
         let selected = select_disjoint(&candidates, 10, &held, &sectors);
 
-        assert_eq!(selected.len(), MAXIMUM_LEGS_PER_SECTOR / 2);
+        assert_eq!(selected.len(), 3);
     }
 
     /// An empty sector map caps nothing.
     ///
-    /// Recorded as a property of this function, not as a claim about the system: `build_screen_inputs`
-    /// refuses a ticker with no sector before it can become a candidate, precisely so an unmeasurable
-    /// name cannot slip past the cap. What this pins is that the *cap* is the only thing doing the
-    /// capping — remove the upstream filter and concentration becomes unbounded, silently.
+    /// A property of this function, not a claim about the system: `build_screen_inputs` refuses a
+    /// ticker with no sector upstream, so what this pins is that the cap is the only thing capping.
     #[test]
     fn test_an_empty_sector_map_constrains_nothing() {
         let (candidates, _) = same_sector_candidates(5, "Technology");
@@ -1438,20 +1760,51 @@ mod tests {
         .expect("the test candidate must be constructible")
     }
 
+    /// Five distinct refusals, each naming itself and the number it refused. Collapsed into one
+    /// answer they are a candidate that "did not construct", which no bound can be moved from.
     #[test]
     fn test_candidate_rejects_a_backwards_orientation_or_a_contradicting_model() {
         let pair_id = PairID::new(ticker("AAAA"), ticker("BBBB"));
+        let refuse = |hedge_ratio, entry_z_score, signal_strength, long_price, short_price| {
+            PairCandidate::new(
+                pair_id.clone(),
+                hedge_ratio,
+                entry_z_score,
+                signal_strength,
+                long_price,
+                short_price,
+            )
+            .expect_err("the candidate must be refused")
+        };
+
         assert_eq!(
-            PairCandidate::new(pair_id.clone(), 1.0, -2.5, 0.02, 100.0, 100.0),
-            None
+            refuse(f64::NAN, 2.5, 0.02, 100.0, 100.0).as_str(),
+            "hedge_ratio_unusable"
         );
         assert_eq!(
-            PairCandidate::new(pair_id.clone(), 1.0, 2.5, -0.02, 100.0, 100.0),
-            None
+            refuse(1.0, -2.5, 0.02, 100.0, 100.0),
+            CandidateRejection::EntryZScoreNotPositive {
+                entry_z_score: -2.5
+            }
         );
         assert_eq!(
-            PairCandidate::new(pair_id, 1.0, 2.5, 0.02, 100.0, 0.0),
-            None
+            refuse(1.0, 2.5, -0.02, 100.0, 100.0),
+            CandidateRejection::SignalStrengthNotPositive {
+                signal_strength: -0.02
+            }
+        );
+        assert_eq!(
+            refuse(1.0, 2.5, 0.02, 0.0, 100.0),
+            CandidateRejection::LongPriceUnusable { long_price: 0.0 }
+        );
+        assert_eq!(
+            refuse(1.0, 2.5, 0.02, 100.0, 0.0),
+            CandidateRejection::ShortPriceUnusable { short_price: 0.0 }
+        );
+        // The whole string: the detail is aggregated out of the journal, so the format is contract.
+        assert_eq!(
+            refuse(1.0, -2.5, 0.02, 100.0, 100.0).detail(),
+            "entry_z_score=-2.5"
         );
     }
 
@@ -1495,18 +1848,32 @@ mod tests {
         assert!(select_disjoint(&candidates, 0, &HashSet::new(), &HashMap::new()).is_empty());
     }
 
+    /// A pair with no history is named rather than dropped: absent from the map it is
+    /// indistinguishable from a pair whose distribution genuinely would not fit.
     #[test]
-    fn test_exit_models_skips_a_pair_whose_history_is_missing() {
+    fn test_exit_models_names_a_pair_whose_history_is_missing() {
         let (long_closes, short_closes) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
         let mut closes = HashMap::new();
         closes.insert(ticker("AAAA"), long_closes);
         closes.insert(ticker("BBBB"), short_closes);
+        closes.insert(ticker("CCCC"), vec![100.0; CORRELATION_WINDOW_SESSIONS]);
 
         let present = PairID::new(ticker("AAAA"), ticker("BBBB"));
         let absent = PairID::new(ticker("AAAA"), ticker("ZZZZ"));
-        let models = exit_models([(&present, 1.0), (&absent, 1.0)], &closes);
+        let flat = PairID::new(ticker("CCCC"), ticker("CCCC"));
+        let models = exit_models([(&present, 1.0), (&absent, 1.0), (&flat, 1.0)], &closes);
 
-        assert!(models.contains_key(&present));
-        assert!(!models.contains_key(&absent));
+        assert_eq!(models.len(), 3, "every supplied pair gets an entry");
+        assert!(models[&present].is_ok());
+        assert_eq!(
+            models[&absent].expect_err("a pair with no history must say so"),
+            ExitModelFailure::MissingCloseHistory
+        );
+        assert_eq!(
+            models[&flat]
+                .expect_err("a flat spread must say so")
+                .as_str(),
+            "no_dispersion"
+        );
     }
 }

--- a/src/portfolio/size.rs
+++ b/src/portfolio/size.rs
@@ -4,7 +4,7 @@ use rust_decimal::Decimal;
 use std::num::NonZeroU32;
 use tracing::{debug, warn};
 
-use crate::common::types::Dollars;
+use crate::common::types::{Dollars, PairID};
 use crate::portfolio::screen::PairCandidate;
 
 /// Pairs the book will hold at once when full.
@@ -153,36 +153,122 @@ impl SizedPair {
     }
 }
 
+/// Why a selected candidate could not be sized.
+///
+/// Each variant carries the number that produced it, on the same terms as
+/// [`crate::portfolio::risk::RiskBlock`]: a candidate dropped without a cause is indistinguishable
+/// from one the ranking never reached.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SizingRefusal {
+    /// The account cannot support a per-leg budget at all.
+    NoPerLegBudget { equity: Decimal },
+    /// The short leg has no usable price to divide the budget by.
+    ShortPriceUnusable { short_price: f64 },
+    /// A whole share of the short leg costs more than the budget, and Alpaca has no fractional
+    /// short — so opening the long alone would be a naked directional position.
+    ShortRoundsToZeroShares { budget: f64, short_price: f64 },
+    /// More shares than an order can carry.
+    ShortQuantityUnrepresentable { whole_shares: f64 },
+    /// The realized short notional is not a representable amount.
+    ShortNotionalUnrepresentable { short_price: f64, short_shares: u32 },
+}
+
+impl SizingRefusal {
+    /// A stable short name for the event payload and the logs.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SizingRefusal::NoPerLegBudget { .. } => "no_per_leg_budget",
+            SizingRefusal::ShortPriceUnusable { .. } => "short_price_unusable",
+            SizingRefusal::ShortRoundsToZeroShares { .. } => "short_rounds_to_zero_shares",
+            SizingRefusal::ShortQuantityUnrepresentable { .. } => "short_quantity_unrepresentable",
+            SizingRefusal::ShortNotionalUnrepresentable { .. } => "short_notional_unrepresentable",
+        }
+    }
+}
+
+impl std::fmt::Display for SizingRefusal {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SizingRefusal::NoPerLegBudget { equity } => {
+                write!(formatter, "equity of {equity} supports no per-leg budget")
+            }
+            SizingRefusal::ShortPriceUnusable { short_price } => {
+                write!(formatter, "short price {short_price} is not usable")
+            }
+            SizingRefusal::ShortRoundsToZeroShares {
+                budget,
+                short_price,
+            } => write!(
+                formatter,
+                "a budget of {budget:.2} buys no whole share at {short_price:.4}"
+            ),
+            SizingRefusal::ShortQuantityUnrepresentable { whole_shares } => {
+                write!(
+                    formatter,
+                    "{whole_shares} shares is not an orderable quantity"
+                )
+            }
+            SizingRefusal::ShortNotionalUnrepresentable {
+                short_price,
+                short_shares,
+            } => write!(
+                formatter,
+                "{short_shares} shares at {short_price:.4} is not a representable amount"
+            ),
+        }
+    }
+}
+
+/// One candidate the sizer turned down, and why.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RefusedCandidate {
+    pub pair_id: PairID,
+    pub refusal: SizingRefusal,
+}
+
 /// Sizes one candidate against a per-leg budget.
 ///
-/// **Both legs get equal notional, not hedge-ratio-weighted notional**, which makes the book
-/// dollar-neutral rather than hedge-ratio-neutral. `None` when the short leg would round to zero
-/// shares, since opening the long alone would be a directional position rather than a spread.
-pub fn size_pair(candidate: &PairCandidate, notional_per_leg: Dollars) -> Option<SizedPair> {
+/// Both legs get equal notional, not hedge-ratio-weighted notional, which makes the book
+/// dollar-neutral rather than hedge-ratio-neutral.
+pub fn size_pair(
+    candidate: &PairCandidate,
+    notional_per_leg: Dollars,
+) -> Result<SizedPair, SizingRefusal> {
     let budget = notional_per_leg.value().as_f64();
     let short_price = candidate.short_price();
     if !short_price.is_finite() || short_price <= 0.0 {
-        return None;
+        return Err(SizingRefusal::ShortPriceUnusable { short_price });
     }
 
     let whole_shares = (budget / short_price).floor();
-    if !whole_shares.is_finite() || whole_shares < 1.0 || whole_shares > u32::MAX as f64 {
+    if !whole_shares.is_finite() || whole_shares > u32::MAX as f64 {
+        return Err(SizingRefusal::ShortQuantityUnrepresentable { whole_shares });
+    }
+    if whole_shares < 1.0 {
         debug!(
             pair_id = %candidate.pair_id(),
             short_price,
             budget,
             "Short leg does not round to a usable whole-share quantity"
         );
-        return None;
+        return Err(SizingRefusal::ShortRoundsToZeroShares {
+            budget,
+            short_price,
+        });
     }
-    let short_shares = NonZeroU32::new(whole_shares as u32)?;
+    let short_shares = NonZeroU32::new(whole_shares as u32)
+        .ok_or(SizingRefusal::ShortQuantityUnrepresentable { whole_shares })?;
 
-    let short_notional = Dollars::new(
-        (Decimal::from(short_shares.get()) * Decimal::from_f64_retain(short_price)?).round_dp(2),
-    )
-    .ok()?;
+    let unrepresentable = SizingRefusal::ShortNotionalUnrepresentable {
+        short_price,
+        short_shares: short_shares.get(),
+    };
+    let short_price_decimal = Decimal::from_f64_retain(short_price).ok_or(unrepresentable)?;
+    let short_notional =
+        Dollars::new((Decimal::from(short_shares.get()) * short_price_decimal).round_dp(2))
+            .map_err(|_| unrepresentable)?;
 
-    Some(SizedPair {
+    Ok(SizedPair {
         candidate: candidate.clone(),
         long_notional: notional_per_leg,
         short_shares,
@@ -190,29 +276,55 @@ pub fn size_pair(candidate: &PairCandidate, notional_per_leg: Dollars) -> Option
     })
 }
 
-/// Sizes a selection of candidates, dropping those that cannot be sized.
+/// Sizes a selection of candidates, returning what sized and what each refusal was.
+///
+/// Refusals carry the pair they refused, so a candidate the sizer turned down is recorded as
+/// precisely as one the risk gate did.
 pub fn size_pairs(
     candidates: &[PairCandidate],
     equity: Decimal,
     parameters: &SizingParameters,
-) -> Vec<SizedPair> {
+) -> (Vec<SizedPair>, Vec<RefusedCandidate>) {
     let Some(notional_per_leg) = parameters.notional_per_leg(equity) else {
         warn!(%equity, "Account equity does not support a position; nothing sized");
-        return Vec::new();
+        let refusals = candidates
+            .iter()
+            .map(|candidate| RefusedCandidate {
+                pair_id: candidate.pair_id().clone(),
+                refusal: SizingRefusal::NoPerLegBudget { equity },
+            })
+            .collect();
+        return (Vec::new(), refusals);
     };
 
-    let sized: Vec<SizedPair> = candidates
-        .iter()
-        .filter_map(|candidate| size_pair(candidate, notional_per_leg))
-        .collect();
+    let mut sized = Vec::with_capacity(candidates.len());
+    let mut refusals = Vec::new();
+    for candidate in candidates {
+        match size_pair(candidate, notional_per_leg) {
+            Ok(pair) => sized.push(pair),
+            Err(refusal) => {
+                warn!(
+                    pair_id = %candidate.pair_id(),
+                    refusal = refusal.as_str(),
+                    reason = %refusal,
+                    "Candidate refused by the sizer"
+                );
+                refusals.push(RefusedCandidate {
+                    pair_id: candidate.pair_id().clone(),
+                    refusal,
+                });
+            }
+        }
+    }
 
     debug!(
         supplied = candidates.len(),
         sized = sized.len(),
+        refused = refusals.len(),
         notional_per_leg = %notional_per_leg.value(),
         "Candidates sized"
     );
-    sized
+    (sized, refusals)
 }
 
 #[cfg(test)]
@@ -273,8 +385,8 @@ mod tests {
     }
 
     /// A multiple past `Decimal`'s range is finite and positive, so the two other checks admit it.
-    /// It used to reach `gross_exposure_cap`, whose conversion failed and answered zero — a cap of
-    /// zero refuses every entry, and nothing said why. Rejecting it here is what makes the cap
+    /// Reaching `gross_exposure_cap` with one fails the conversion and answers zero — a cap of zero
+    /// refuses every entry, and nothing says why. Rejecting it here is what makes the cap
     /// infallible.
     #[test]
     fn test_parameters_reject_a_multiple_no_decimal_can_hold() {
@@ -326,13 +438,54 @@ mod tests {
     /// of a market-neutral pair.
     #[test]
     fn test_a_short_leg_priced_above_the_budget_is_not_sized() {
+        // The cause and its two numbers, not merely the refusal: a budget that buys no share and a
+        // price that is not a number are different problems with different fixes.
         assert_eq!(
             size_pair(
                 &candidate(50.0, 6_000.0),
                 Dollars::new(Decimal::new(5_000, 0)).unwrap()
-            ),
-            None
+            )
+            .expect_err("a short priced above the budget must be refused"),
+            SizingRefusal::ShortRoundsToZeroShares {
+                budget: 5_000.0,
+                short_price: 6_000.0,
+            }
         );
+    }
+
+    #[test]
+    fn test_every_sizing_refusal_has_a_stable_name_and_renders() {
+        let refusals = [
+            SizingRefusal::NoPerLegBudget {
+                equity: Decimal::ZERO,
+            },
+            SizingRefusal::ShortPriceUnusable { short_price: 0.0 },
+            SizingRefusal::ShortRoundsToZeroShares {
+                budget: 100.0,
+                short_price: 500.0,
+            },
+            SizingRefusal::ShortQuantityUnrepresentable {
+                whole_shares: f64::INFINITY,
+            },
+            SizingRefusal::ShortNotionalUnrepresentable {
+                short_price: 1.0,
+                short_shares: 1,
+            },
+        ];
+        let names: Vec<&str> = refusals.iter().map(SizingRefusal::as_str).collect();
+        assert_eq!(
+            names,
+            vec![
+                "no_per_leg_budget",
+                "short_price_unusable",
+                "short_rounds_to_zero_shares",
+                "short_quantity_unrepresentable",
+                "short_notional_unrepresentable"
+            ]
+        );
+        for refusal in refusals {
+            assert!(!refusal.to_string().is_empty());
+        }
     }
 
     #[test]
@@ -345,24 +498,39 @@ mod tests {
         assert_eq!(sized.gross_exposure(), Decimal::new(10_000, 0));
     }
 
+    /// What the sizer drops it also names, so a candidate missing from the plan says which stage
+    /// removed it rather than leaving the ranking and the sizer indistinguishable.
     #[test]
-    fn test_size_pairs_drops_only_what_cannot_be_sized() {
+    fn test_size_pairs_names_what_it_cannot_size() {
         let candidates = vec![candidate(50.0, 250.0), candidate(50.0, 99_999.0)];
-        let sized = size_pairs(
+        let (sized, refusals) = size_pairs(
             &candidates,
             Decimal::new(100_000, 0),
             &SizingParameters::default(),
         );
         assert_eq!(sized.len(), 1);
+        assert_eq!(refusals.len(), 1);
+        assert_eq!(refusals[0].pair_id.as_str(), "AAAA-BBBB");
+        assert_eq!(
+            refusals[0].refusal.as_str(),
+            "short_rounds_to_zero_shares",
+            "a 99,999-dollar short against a 5,000-dollar budget buys no whole share"
+        );
     }
 
     #[test]
-    fn test_size_pairs_returns_nothing_for_an_empty_account() {
-        assert!(size_pairs(
+    fn test_size_pairs_refuses_every_candidate_for_an_empty_account() {
+        let (sized, refusals) = size_pairs(
             &[candidate(50.0, 250.0)],
             Decimal::ZERO,
-            &SizingParameters::default()
-        )
-        .is_empty());
+            &SizingParameters::default(),
+        );
+        assert!(sized.is_empty());
+        assert_eq!(
+            refusals[0].refusal,
+            SizingRefusal::NoPerLegBudget {
+                equity: Decimal::ZERO
+            }
+        );
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,9 +1,6 @@
-//! Shared fixtures for the integration suite.
-//!
-//! Everything here runs against the devenv-managed PostgreSQL, applying the real `schema.sql` to a
-//! database the suite owns outright. That matters more than it sounds: these tests exist precisely
-//! to exercise what the unit tests cannot — the hypertables, the CHECK constraints, the notify
-//! trigger, and the queries as PostgreSQL actually plans them.
+//! Shared fixtures for the integration suite, against the devenv-managed PostgreSQL with the real
+//! `schema.sql` applied to a database the suite owns outright — which is what makes the
+//! hypertables, the CHECK constraints, and the notify trigger reachable at all.
 
 #![allow(dead_code)]
 
@@ -16,13 +13,10 @@ const SCHEMA_SQL: &str = include_str!("../../schema.sql");
 
 /// Prefix for the databases the integration suite owns outright.
 ///
-/// Deliberately not the development database: these tests delete from every table, and pointing
-/// them at `fund` would destroy local data on every run.
-///
-/// One database *per test binary*, not one shared between them. `#[serial]` only serializes tests
-/// within a process, and cargo runs test binaries concurrently — so a shared database would have
-/// two binaries deleting from the same tables at the same time, with the flakes landing wherever
-/// the timing fell.
+/// Deliberately not the development database: these tests delete from every table, so pointing them
+/// at `fund` would destroy local data. One database *per test binary*, because `#[serial]` only
+/// serializes within a process while cargo runs test binaries concurrently, and a shared database
+/// would have two of them deleting from the same tables at once.
 const TEST_DATABASE_PREFIX: &str = "fund_test";
 
 /// Connections per test pool.
@@ -32,16 +26,10 @@ const TEST_POOL_MAX_CONNECTIONS: u32 = 4;
 
 /// Databases this process has already created and populated.
 ///
-/// Holds names rather than pools, and that is load-bearing. A `PgPool` is bound to the tokio runtime
-/// that created it, and every `#[tokio::test]` builds its own runtime; caching a pool here meant the
-/// second test to run inherited a handle whose background reaper had died with the first test's
-/// runtime, and every acquire from it failed with `PoolTimedOut`. This is the trap recorded in
-/// `rust_test_pitfalls`.
-///
-/// A set rather than a single `OnceCell`, so the readiness is keyed by database. A `OnceCell` is
-/// initialized once per *process*: a binary calling `test_pool` with two suffixes would create the
-/// first database, then skip the initializer for the second and connect to a database that was
-/// never created — surfacing as a bare connection error rather than as fixture misuse.
+/// Holds names rather than pools: a `PgPool` is bound to the tokio runtime that created it and every
+/// `#[tokio::test]` builds its own, so a cached pool leaves the next test acquiring against a dead
+/// reaper and failing with `PoolTimedOut`. A set rather than a single `OnceCell`, which initializes
+/// once per *process* and would let a second suffix connect to a database that was never created.
 static PREPARED_DATABASES: tokio::sync::Mutex<Option<std::collections::HashSet<String>>> =
     tokio::sync::Mutex::const_new(None);
 
@@ -52,19 +40,12 @@ fn database_url_base() -> String {
 
 /// Strips the parts of `schema.sql` that cannot be applied to a second database.
 ///
-/// Only pg_cron is removed, and not because it is unavailable in general: the extension is
-/// restricted by `cron.database_name` to a single database, so `CREATE EXTENSION` fails anywhere
-/// else. That covers the extension, the `DO` blocks that schedule jobs, and any function defined in
-/// the `cron` schema.
-///
-/// TimescaleDB is deliberately *not* stripped. It was, back when these tests ran against a vanilla
-/// Postgres container, which meant every assertion ran against a schema with no hypertables and no
-/// retention policies — measurably not the schema being shipped.
-///
-/// `DO` blocks are buffered rather than dropped on sight: the idiom is shared between pg_cron
-/// scheduling, which this database cannot run, and plain DDL such as the `events_notify` trigger,
-/// which it very much needs. Dropping every block took the trigger with it, leaving NOTIFY silent
-/// here and the listener untestable.
+/// Only pg_cron, because `cron.database_name` restricts the extension to a single database — that
+/// covers the extension, the `DO` blocks that schedule jobs, and anything in the `cron` schema.
+/// TimescaleDB is deliberately *not* stripped, since a schema with no hypertables and no retention
+/// policies is not the schema being shipped. `DO` blocks are buffered rather than dropped on sight,
+/// because the idiom is shared with plain DDL such as the `events_notify` trigger, and dropping
+/// every block leaves NOTIFY silent here and the listener untestable.
 fn filter_schema_for_test(schema: &str) -> String {
     let mut kept: Vec<&str> = Vec::new();
     let mut do_block: Vec<&str> = Vec::new();
@@ -129,14 +110,11 @@ fn filter_schema_for_test(schema: &str) -> String {
 
 /// Returns a pool to this binary's test database, recreating it on first use.
 ///
-/// `suffix` must be unique per test binary and must be a plain identifier — it is interpolated into
-/// `CREATE DATABASE`, which PostgreSQL will not accept as a bound parameter.
-///
-/// The database is **dropped and recreated**, not reused. `CREATE TABLE IF NOT EXISTS` is a no-op
-/// against a table that already exists with a different shape, so a test database left over from an
-/// earlier schema silently keeps its old columns and fails much later with a confusing error about
-/// a missing column in an index. That is the same property the production cutover has to respect;
-/// here it costs nothing to simply start clean.
+/// `suffix` must be unique per test binary and a plain identifier, since it is interpolated into
+/// `CREATE DATABASE`, which PostgreSQL will not accept as a bound parameter. The database is
+/// **dropped and recreated**, not reused: `CREATE TABLE IF NOT EXISTS` is a no-op against a table
+/// that already exists with a different shape, so a stale one keeps its old columns and fails much
+/// later with a confusing error about a missing column in an index.
 pub async fn test_pool(suffix: &str) -> PgPool {
     assert!(
         suffix
@@ -227,14 +205,10 @@ pub fn session_close(date: SessionDate) -> DateTime<Utc> {
 /// Inserts daily bars for each ticker over `sessions` consecutive **calendar** days ending today.
 ///
 /// Calendar days, not trading sessions: the loop applies no weekday filter, so the series includes
-/// weekends. The synthetic prices still satisfy the correlation property the screen needs, so this
-/// only matters to a reader sizing a window that must align with real sessions.
-///
-/// The two legs are driven by a shared factor plus an idiosyncratic one, so their log returns
-/// correlate around 0.8 — inside the screen's `[0.5, 0.95]` band — and the spread has real
-/// dispersion. A fixture whose legs correlate at 1.0 is rejected by the screen and yields zero
-/// pairs, which makes every test built on it pass while asserting nothing. That is the trap
-/// recorded in `statistical_arbitrage_test_fixtures`.
+/// weekends. The two legs are a shared factor plus an idiosyncratic one, so their log returns
+/// correlate around 0.8, inside the screen's `[0.5, 0.95]` band — legs correlating at 1.0 are
+/// rejected by the screen and yield zero pairs, which makes every test built on them pass while
+/// asserting nothing.
 pub async fn seed_correlated_bars(pool: &PgPool, tickers: &[&str], sessions: i64) {
     let today = SessionDate::at(Utc::now());
 

--- a/tests/test_dashboard.rs
+++ b/tests/test_dashboard.rs
@@ -1,14 +1,6 @@
-//! The dashboard's queries, run against the real schema.
-//!
-//! This target exists because the dashboard is the one part of the tree with no compile-time check
-//! on its SQL. Everything else uses `sqlx::query!`, which fails the build on a mistyped column;
-//! the dashboard uses raw `sqlx::query` so it adds no entries to the offline cache, and the price
-//! of that is that a wrong column name is a runtime error on a page nobody is watching when it
-//! breaks. Running every query once against a real database is what buys the guarantee back.
-//!
-//! The rows are written through the production writers wherever one exists — `record_open`,
-//! `record_close`, `store_snapshot` — rather than by hand. A dashboard test that seeds its own rows
-//! with its own INSERT proves the query parses, not that it reads what the service writes.
+//! The dashboard's queries, run against the real schema: raw `sqlx::query` carries no compile-time
+//! column check, so running each query once is the only one there is. Rows go in through the
+//! production writers, since seeding by hand proves the query parses, not that it reads our writes.
 
 mod common;
 

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -1,15 +1,6 @@
 //! Schema-level integration tests: the constraints, the trigger, and the queries as PostgreSQL
-//! actually runs them.
-//!
-//! Everything here is something a unit test cannot reach. The CHECK constraints only exist in the
-//! database; the notify trigger only fires in the database; the alignment guarantee in
-//! `load_aligned_closes` depends on how the query is planned, not on how the Rust reads.
-//!
-//! Session windows are always built with `SessionDate::at(now).bounds()`, never from
-//! `now.date_naive()`. The second is the UTC calendar date, which between 20:00 Eastern and
-//! midnight names *tomorrow* — so the window starts four hours in the future and excludes the rows
-//! the test just seeded. It is the trading day these queries are bounded by, and a test that
-//! assumes the two coincide fails for four hours every evening.
+//! actually plans them. Session windows are always built with `SessionDate::at(now).bounds()` and
+//! never `now.date_naive()`, which after 20:00 Eastern names tomorrow and excludes the seeded rows.
 
 mod common;
 
@@ -857,9 +848,9 @@ async fn test_the_bar_frame_is_restated_onto_todays_share_basis() {
     );
 }
 
-/// The window a loader reads and the basis it restates onto have to be the same day. Both bounds
-/// used to come off the wall clock while the factor came off `as_of`, so a replay would have loaded
-/// today's sessions and adjusted them to a past date.
+/// The window a loader reads and the basis it restates onto have to be the same day. Bounds taken
+/// off the wall clock while the factor comes off `as_of` let a replay load today's sessions and
+/// adjust them to a past date.
 #[tokio::test]
 #[serial]
 async fn test_the_loaded_window_follows_as_of_rather_than_the_clock() {

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -1,9 +1,6 @@
-//! Cross-module flows against a real database and a mocked broker.
-//!
-//! These are the tests that exercise the paths a unit test cannot assemble: the evaluation pass end
-//! to end, the pre-close liquidation, and the post-close account sync. Each one runs against the
-//! real `schema.sql` and a `mockito` server standing in for Alpaca, so the assertions cover the
-//! wiring between modules rather than any one module's arithmetic.
+//! Cross-module flows against the real `schema.sql` and a `mockito` server standing in for Alpaca:
+//! the evaluation pass end to end, the pre-close liquidation, and the post-close account sync. The
+//! assertions cover the wiring between modules rather than any one module's arithmetic.
 
 mod common;
 
@@ -115,14 +112,11 @@ fn of_type<'a>(records: &'a [serde_json::Value], event_type: &str) -> Vec<&'a se
 
 /// The five most recent weekday sessions ending at `session_date`.
 ///
-/// Weekends are filtered rather than taken as consecutive calendar days, so
-/// `previous_trading_day` answers what it would in production: Friday for a Monday session, not
-/// Sunday. Without the filter a Monday would silently exercise a calendar that cannot exist, and the
-/// gap test would pass while checking nothing real.
-///
-/// `is_weekend` rather than `is_trading_day` because this *builds* the calendar the latter consults;
-/// it is the case that method's own documentation names, "bounding a fetch range before the calendar
-/// is available". Holidays are not modelled — no test here turns on one.
+/// Weekends are filtered rather than taken as consecutive calendar days, so `previous_trading_day`
+/// answers Friday for a Monday session; without the filter a Monday exercises a calendar that cannot
+/// exist and the gap test passes while checking nothing real. `is_weekend` rather than
+/// `is_trading_day` because this *builds* the calendar the latter consults, and holidays are not
+/// modelled.
 fn calendar_ending_at(session_date: SessionDate) -> TradingCalendar {
     let days = (0..10)
         .map(|offset| session_date.plus_calendar_days(-offset))
@@ -154,6 +148,38 @@ async fn mock_no_return_activities(server: &mut mockito::ServerGuard) {
         .expect_at_least(1)
         .create_async()
         .await;
+}
+
+/// The activity types the sync asks for by session date, one request each.
+///
+/// Literals rather than `account::synced_activity_types()`: a mock built from the list under test
+/// moves with any edit to it, and an emptied list would leave the tests passing with no request made.
+const PER_SESSION_ACTIVITY_TYPES: [&str; 1] = ["FILL"];
+
+/// Answers each of [`PER_SESSION_ACTIVITY_TYPES`] with an empty list.
+///
+/// The returned mocks each expect `expected_requests` hits, so `assert_async` fails on a type the
+/// sync stopped asking for as well as on one it asked for twice.
+async fn mock_no_per_session_activities(
+    server: &mut mockito::ServerGuard,
+    expected_requests: usize,
+) -> Vec<mockito::Mock> {
+    let mut mocks = Vec::new();
+    for activity_type in PER_SESSION_ACTIVITY_TYPES {
+        mocks.push(
+            server
+                .mock(
+                    "GET",
+                    mockito::Matcher::Regex(format!("^/v2/account/activities/{activity_type}")),
+                )
+                .with_status(200)
+                .with_body("[]")
+                .expect(expected_requests)
+                .create_async()
+                .await,
+        );
+    }
+    mocks
 }
 
 /// A universe holding exactly the named tickers, every one of them shortable.
@@ -507,13 +533,10 @@ async fn test_a_pass_opens_a_pair_and_records_it() {
 /// The same fixture as above, with shutdown already requested: the pass must open nothing and say
 /// so, rather than submitting orders it may not survive to record.
 ///
-/// This is what makes the drain's timeout in `bin/fund.rs` a real bound. Opening a pair is two
-/// broker legs at `FILL_TIMEOUT` each, so a pass that keeps working through its approved list
-/// cannot be covered by any fixed timeout — the list's length is decided by the screen. Bounding
-/// the *start* of new pairs is what caps the worst case at the one pair already in flight.
-///
-/// `.expect(0)` on the order mock is the assertion that matters. Without it this test would pass on
-/// a summary that merely reported zero opens while orders went out anyway.
+/// This is what makes the drain's timeout in `bin/fund.rs` a real bound: opening a pair is two
+/// broker legs at `FILL_TIMEOUT` each, so bounding the *start* of new pairs is what caps the worst
+/// case at the one pair already in flight. `.expect(0)` on the order mock is the assertion that
+/// matters, since without it the test passes on a summary reporting zero opens while orders go out.
 #[tokio::test]
 #[serial]
 async fn test_a_pass_opens_nothing_once_shutdown_is_requested() {
@@ -1136,8 +1159,8 @@ async fn test_liquidation_flattens_the_book_and_marks_every_pair() {
 /// A liquidation that could not reach the broker still records that it was attempted.
 ///
 /// This is the last thing standing between an open book and an overnight position. A run that
-/// failed at the bulk close used to leave no trace of having happened at all, which reads exactly
-/// like a liquidation that was never scheduled.
+/// failed at the bulk close and left no trace would read exactly like a liquidation that was never
+/// scheduled.
 #[tokio::test]
 #[serial]
 async fn test_a_failed_liquidation_records_the_attempt() {
@@ -1455,17 +1478,7 @@ async fn test_the_account_sync_stores_transfers_without_attributing_them() {
         .with_body(account_body(30_000))
         .create_async()
         .await;
-    for activity_type in account::synced_activity_types() {
-        server
-            .mock(
-                "GET",
-                mockito::Matcher::Regex(format!("^/v2/account/activities/{activity_type}")),
-            )
-            .with_status(200)
-            .with_body("[]")
-            .create_async()
-            .await;
-    }
+    let per_session = mock_no_per_session_activities(&mut server, 1).await;
     // On the trailing window, which is the only request that can reach it: a transfer is dated and
     // created the morning after, so this session's own `date=` query returns the previous one's.
     let _deposit = server
@@ -1506,6 +1519,11 @@ async fn test_the_account_sync_stores_transfers_without_attributing_them() {
     .await
     .expect("the sync must run");
 
+    // Asserted before the loop, which proves nothing over an empty list of mocks.
+    assert_eq!(per_session.len(), 1);
+    for mock in &per_session {
+        mock.assert_async().await;
+    }
     assert_eq!(summary.activities_stored, 1);
     assert_eq!(
         summary.activities_unattributed, 0,
@@ -1554,17 +1572,8 @@ async fn test_the_account_sync_reports_a_missing_previous_session() {
         .with_body(account_body(100_000))
         .create_async()
         .await;
-    for activity_type in account::synced_activity_types() {
-        server
-            .mock(
-                "GET",
-                mockito::Matcher::Regex(format!("^/v2/account/activities/{activity_type}")),
-            )
-            .with_status(200)
-            .with_body("[]")
-            .create_async()
-            .await;
-    }
+    // Three syncs below, each asking once per type.
+    let per_session = mock_no_per_session_activities(&mut server, 3).await;
     mock_no_return_activities(&mut server).await;
 
     let trading = TradingClient::with_base_url(credentials(), server.url());
@@ -1607,6 +1616,12 @@ async fn test_the_account_sync_reports_a_missing_previous_session() {
     .await
     .expect("the sync must run");
     assert_eq!(repaired.previous_session_gap, None);
+
+    // Asserted before the loop, which proves nothing over an empty list of mocks.
+    assert_eq!(per_session.len(), 1);
+    for mock in &per_session {
+        mock.assert_async().await;
+    }
 }
 
 fn account_body(equity: i64) -> String {
@@ -1687,17 +1702,8 @@ async fn test_a_fee_from_an_earlier_session_is_stored_as_a_cost() {
         .with_body(account_body(30_000))
         .create_async()
         .await;
-    for activity_type in account::synced_activity_types() {
-        server
-            .mock(
-                "GET",
-                mockito::Matcher::Regex(format!("^/v2/account/activities/{activity_type}")),
-            )
-            .with_status(200)
-            .with_body("[]")
-            .create_async()
-            .await;
-    }
+    // Two syncs below, each asking once per type.
+    let per_session = mock_no_per_session_activities(&mut server, 2).await;
     let _fees = server
         .mock(
             "GET",
@@ -1774,4 +1780,10 @@ async fn test_a_fee_from_an_earlier_session_is_stored_as_a_cost() {
         2,
         "an overlapping window must not record a fee it already recorded"
     );
+
+    // Asserted before the loop, which proves nothing over an empty list of mocks.
+    assert_eq!(per_session.len(), 1);
+    for mock in &per_session {
+        mock.assert_async().await;
+    }
 }

--- a/tests/test_schedules.rs
+++ b/tests/test_schedules.rs
@@ -1,23 +1,6 @@
-//! The trading schedules in `schema.sql`, checked against the clock they claim to keep.
-//!
-//! Every job that matters fires on a **UTC** cron expression and gates on the **Eastern** wall
-//! clock in its own `WHERE` clause. That pairing is what makes a daylight-saving transition need no
-//! schema re-apply: the expression fires across both candidate UTC hours and the gate discards the
-//! one that is an hour off. It is also entirely a convention — nothing enforced it, and the
-//! reasoning lived in comments. Editing one half without the other produces a job that fires twice
-//! a day for half the year, or not at all for the other half, and neither shows up until it does.
-//!
-//! The test harness in `tests/common/mod.rs` strips `pg_cron` out of the schema before applying it,
-//! so these blocks were not merely untested but deliberately excluded. This file reads `schema.sql`
-//! as text instead, which needs no database and no extension.
-//!
-//! The invariant, stated once: **the set of Eastern times a job fires at is the same on every
-//! trading weekday of the year.** That is precisely what daylight-saving safety means, and it holds
-//! for a job firing once a day and for one firing every five minutes without special-casing either.
-//!
-//! Unrecognized syntax is rejected rather than skipped. A cron form this parser does not understand,
-//! or a job absent from the tables below, fails the test — otherwise the next schedule added here
-//! would be silently unverified, which is the state this file exists to end.
+//! The trading schedules in `schema.sql`, read as text so no database or `pg_cron` is needed.
+//! Each gated job fires on a UTC cron expression and gates on the Eastern wall clock, and the
+//! invariant checked here is that its Eastern firing times are identical on every day of the year.
 
 use std::collections::BTreeMap;
 
@@ -419,14 +402,26 @@ fn test_every_gated_schedule_keeps_the_same_eastern_clock_all_year() {
 /// A gated job must fire on trading weekdays and never on a weekend.
 #[test]
 fn test_gated_schedules_never_fire_on_a_weekend() {
-    for job in parse_jobs(SCHEMA) {
+    let jobs = parse_jobs(SCHEMA);
+    let mut checked = 0;
+    for job in &jobs {
         if UNGATED_JOBS.contains(&job.name.as_str()) {
             continue;
         }
         let expression = parse_expression(&job.expression, &job.name);
         let gate = parse_gate(&job.body, &job.name);
+        let by_eastern_date = firings_by_eastern_date(&expression, &gate);
 
-        let weekend_dates: Vec<NaiveDate> = firings_by_eastern_date(&expression, &gate)
+        // Checked before the weekend filter below, which finds nothing in a map that is empty for
+        // the opposite reason: a job that fires on no day at all also fires on no weekend.
+        assert_eq!(
+            by_eastern_date.keys().copied().collect::<Vec<NaiveDate>>(),
+            expected_eastern_dates(&expression),
+            "job '{}' does not fire on every day its schedule admits",
+            job.name
+        );
+
+        let weekend_dates: Vec<NaiveDate> = by_eastern_date
             .into_keys()
             .filter(|eastern_date| {
                 matches!(
@@ -441,7 +436,15 @@ fn test_gated_schedules_never_fire_on_a_weekend() {
             "job '{}' fires on {weekend_dates:?}, which are not trading days",
             job.name
         );
+
+        checked += 1;
     }
+
+    assert_eq!(
+        checked,
+        jobs.len() - UNGATED_JOBS.len(),
+        "every gated job must have been checked"
+    );
 }
 
 /// The specific defect the gate exists to prevent: a job firing twice on the same Eastern day.
@@ -458,6 +461,7 @@ fn test_a_once_daily_job_fires_exactly_once_per_session() {
         "market-data-sync-requested",
     ];
 
+    let mut checked = 0;
     for job in parse_jobs(SCHEMA) {
         if !once_daily.contains(&job.name.as_str()) {
             continue;
@@ -473,7 +477,18 @@ fn test_a_once_daily_job_fires_exactly_once_per_session() {
             job.name
         );
 
-        for (eastern_date, times) in firings_by_eastern_date(&expression, &gate) {
+        let by_eastern_date = firings_by_eastern_date(&expression, &gate);
+
+        // Checked before the per-day comparison below, because a day with no firing at all is
+        // absent from the map rather than present with the wrong count.
+        assert_eq!(
+            by_eastern_date.keys().copied().collect::<Vec<NaiveDate>>(),
+            expected_eastern_dates(&expression),
+            "job '{}' does not fire on every day its schedule admits",
+            job.name
+        );
+
+        for (eastern_date, times) in by_eastern_date {
             assert_eq!(
                 times.len(),
                 1,
@@ -482,7 +497,15 @@ fn test_a_once_daily_job_fires_exactly_once_per_session() {
                 times.len()
             );
         }
+
+        checked += 1;
     }
+
+    assert_eq!(
+        checked,
+        once_daily.len(),
+        "every once-daily job named above must have been found in the schema"
+    );
 }
 
 /// The parser refuses what it does not model, rather than reading it as "never fires".
@@ -513,11 +536,11 @@ fn test_the_parser_reads_the_forms_the_schema_uses() {
     assert_eq!(parse_field("13,14", 0, 23, "job"), vec![13, 14]);
     assert_eq!(
         parse_field("13-20", 0, 23, "job"),
-        (13..=20).collect::<Vec<u32>>()
+        vec![13, 14, 15, 16, 17, 18, 19, 20]
     );
     assert_eq!(
         parse_field("*/5", 0, 59, "job"),
-        (0..=55).step_by(5).collect::<Vec<u32>>()
+        vec![0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]
     );
     // Sunday is expressible as either 0 or 7, and both must normalize to the same day.
     assert_eq!(parse_expression("0 3 * * 0", "job").days_of_week, vec![0]);

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -184,9 +184,13 @@ FROM read_parquet(
 -- prices it read, the orders it sent, the fills they produced. Joining on it is how a duration
 -- becomes an answer about where the time went.
 --
--- schema_version is 3, 4, or 5; v1 and v2 were development and their objects are gone. Three
+-- schema_version is 3 through 6; v1 and v2 were development and their objects are gone. Four
 -- payload fields have changed shape, so a query reaching into any of them must branch on the
 -- version:
+--
+--   open_pair_reading.stop_at, through v5, was written beside entry_z_score. It is derivable from
+--   it and is now absent; a query wanting the stop line on any version should compute it from
+--   entry_z_score rather than read the field, which is the same number on every past record.
 --
 --   quote_rejection, at v4, was the bare reason string 'stale_quote' or 'wide_quote'. It is now an
 --   object whose 'reason' key holds that same string alongside the reading that produced it --


### PR DESCRIPTION
# Overview

Rewrites `CLAUDE.md` around how a measurement earns belief, then fixes the 37 places in the tree that violated the new rules. A guideline nothing obeys is a suggestion, so both halves ship together.

## Changes

- **`CLAUDE.md`: 64 -> 78 bullets.** Dropped the purely descriptive and the PostgreSQL-specific, merged six overlapping pairs, compressed the `SessionDate` and acronym rules. Added the evaluation discipline the laboratory has been applying inconsistently: state the trivial baseline, run the pipeline on an input that cannot contain the effect, test the difference between sample halves rather than their signs, report the undefined share, scope a kill precisely.
- **Three live defects.** `test_fetch_snapshots_retains_every_component` asserted the negation of its own name — `Snapshot` has no daily-bar fields, so serde dropped the bars the docstring called "a free end-of-day backfill". `Scaler::statistics_for` collapsed an unknown column to the identity pair while the predict path passed a string literal rather than `TARGET_COLUMN`, so a column rename would have served every prediction unscaled with nothing reporting it. One liquidity threshold was applied to three different quantities over two windows, making the traded, predicted and trained populations three different sets.
- **Three tests that asserted nothing.** An assertion inside a loop over a provably empty collection; a tautology admitting the `Some(0.0)` it claimed to forbid; an exit fixture whose constant long leg cancelled the hedge ratio out of every z-score algebraically, leaving five tests blind to the invariant they existed for.
- **Refusals now carry their cause.** `PairCandidate::new`, `SpreadModel::fit`, `size_pair` and `LiquidityFloor::admits` returned bare `Option`/`bool`, so a sizer refusal was indistinguishable in the journal from a candidate the ranking never chose.
- **Laboratory measurement discipline.** Target entropy so mutual information is compared as a share rather than in raw bits; a permutation null on the TiDE pipeline; across-seed dispersion; standard errors on the convergence curve and on the split-sample difference; undefined shares on the lag-two and Roll estimates.
- **Journal schema 5 -> 6.** `stop_at` removed as derivable from `entry_z_score`; `spread_model_failure` and `CandidateDecision::SizingRefused` added. Without the bump two record shapes would both claim v5. `SkipReason::MarketHalted` deleted — nothing in the tree detects a halt and no handler ever emitted the string.
- **Documentation obeys its own rules.** 32 over-length module docs and 73 over-length docstrings brought under the ceiling; 32 passages of archaeology removed.

## Context

**A failing test could not report itself.** Found while verifying, not on the audit list: any failing lib test died with `SIGSEGV` after printing its panic message, so the harness never named the assertion. It reproduced on a clean target directory in every module but not at `master` — the added code pushed the debug test binary past the size where macOS arm64 unwinding faults. `[profile.test] debug = "line-tables-only"` fixes it and keeps file-and-line backtraces. Every green run before that fix was unreliable, and the first honest run after it immediately caught a real breakage.

**Two docstrings were attached to the wrong function**, found independently in two passes — `attempt_tick_page` in `alpaca.rs` and `fetch_intraday` in `massive.rs`, the latter documenting `fetch_splits`' contract entirely. Both look like stale pastes that survived a reorder.

**Verification route.** Fixtures and unit tests only — no Alpaca call, no DuckDB read over the S3 parquet, no trainer rehearsal. 1,151 tests pass, coverage 81.02% against the 75% floor, clippy unchanged from `master` at 10 pre-existing warnings. New assertions were mutation-verified: the code they cover was broken, the test watched to fail, then restored.

**Two population changes ship unmeasured.** `predict` moved from a 120-day mean close to a 30-session minimum, and `fit` from a per-session screen to a per-ticker one. The predicted set should now equal the traded set rather than contain it, so the names lost are exactly the ones the universe already refuses to trade — but that is an argument, not a measurement. Both are recorded in the laboratory plan with the DuckDB query that settles them, and the third window (training still screens the whole frame) is deferred there rather than fixed in isolation.

**Deferred deliberately.** Five audit findings covering the absolute liquidity floors and the frozen cost literal are already owned by laboratory plan tasks 12 and 14, which retire them for a spread bound and a declared universe. `CONFIDENCE_FLOOR = 0.5` is inert — it admits the entire cross-section — but choosing its replacement is a research decision, so it went to the plan rather than into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W711PGqvpzDjDKQqCoW2E7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Laboratory reports now include session counts, standard errors, estimator coverage, and half-sample comparisons.
  * Information analysis ranks results by excess information relative to target entropy.
  * Tide model evaluations now include baseline comparisons, nominal coverage, and CRPS skill.
  * Liquidity screening provides clearer whole-ticker filtering and refusal details.
  * Portfolio workflows now record sizing, model-fitting, and candidate-rejection reasons.

* **Bug Fixes**
  * Invalid scaling, missing measurements, unusable liquidity data, and failed model fits are now surfaced instead of silently treated as valid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->